### PR TITLE
Add semantic architecture and optional layout blocks

### DIFF
--- a/docs/SEMANTIC_ARCHITECTURE.md
+++ b/docs/SEMANTIC_ARCHITECTURE.md
@@ -1,0 +1,281 @@
+# Oak Semantic Architecture
+
+Oak's central design goal is to define semantic facts once and reuse them everywhere that can benefit from them.
+
+A type, protocol, ownership rule, refinement, effect, or layout fact should not be independently re-written for the compiler, verifier, serializer, debugger, model checker, and documentation. Oak should preserve one checked semantic representation and derive projections from it.
+
+## Core principle
+
+> Define a fact once; project it many ways.
+
+```text
+Oak source
+    |
+    v
+parser
+    |
+    v
+typed AST
+    |
+    v
+Semantic IR
+    |
+    +--> executable lowering / C / native backend
+    +--> machine layout / ABI metadata
+    +--> serialization and wire schemas
+    +--> debugger metadata
+    +--> documentation / UI schemas
+    +--> SMT proof obligations
+    +--> Lean definitions and theorem skeletons
+    +--> temporal/state-machine models
+    +--> property-test generators
+    +--> deterministic simulation actions
+```
+
+The Semantic IR is the source of truth for all projections.
+
+## Semantic IR responsibilities
+
+The IR must preserve more than ordinary compiler types. It should be able to represent:
+
+- nominal and algebraic type identity;
+- fixed-width and mathematical numeric domains;
+- record/sum structure;
+- exact target representation, size, alignment, offsets, and endianness where specified;
+- ownership, borrowing, mutability, and linear/affine state;
+- phantom parameters and zero-runtime semantic distinctions;
+- refinements and predicates;
+- effects and forbidden effects;
+- boundedness/resource facts;
+- compile-time tags and namespaced metadata;
+- protocol states and transitions;
+- invariants, preconditions, and postconditions;
+- temporal assumptions and guarantees;
+- source locations and documentation.
+
+Not every type needs every category.
+
+## Types drive multiple projections
+
+Example:
+
+```oak
+IrqId[N]: type = u16
+  where value < N
+
+Irq: type =
+  enabled: bool
+  priority: u8
+  latched_pending: bool
+  level_asserted: bool
+  active: bool
+```
+
+The same semantic declarations should be sufficient to derive:
+
+- the machine representation;
+- bounds checks or their elimination when statically proved;
+- Lean definitions;
+- SMT assumptions/obligations;
+- structured debugger descriptions;
+- serialization schemas where requested;
+- property-test generators;
+- human-readable documentation.
+
+## Machine integers and mathematical integers are different
+
+Oak must never silently identify an unbounded mathematical integer with a machine integer.
+
+Examples:
+
+```text
+Nat / Int       mathematical domains
+u8..u64         fixed-width machine domains
+uint / int      target-word machine domains
+uptr / ptr      target-pointer-width machine domains
+```
+
+Conversions are explicit semantic operations with explicit proof obligations where overflow or truncation is possible.
+
+This lets proofs reason accurately about wrapping, checked arithmetic, address widths, wire layouts, and target-specific representation.
+
+## Layout is a semantic fact
+
+Machine layout is not merely a backend implementation detail.
+
+For a representation-constrained type, the compiler should be able to expose facts such as:
+
+```text
+size(T)
+align(T)
+offset(T.field)
+endianness(T.field)
+```
+
+These facts should be consumable by verification and tooling.
+
+A wire or MMIO layout can therefore use the same checked type definition as executable code rather than maintaining a duplicate schema.
+
+## Refinements
+
+Oak should support refinements as semantic predicates over values.
+
+Conceptual syntax:
+
+```oak
+PageIndex[N]: type = u32 where value < N
+AlignedPage: type = uptr where value % PageSize == 0
+```
+
+The exact syntax remains open. The semantic requirement does not: a refinement becomes a fact available to the type checker, SMT solver, Lean projection, optimizer, test generator, and documentation.
+
+## Ownership and typestate
+
+Ownership is part of semantics, not linting.
+
+Examples:
+
+```text
+CpuOwned[Buffer]
+DeviceOwned[Buffer]
+SharedRead[Buffer]
+```
+
+A DMA submission may be modeled as a transition:
+
+```text
+CpuOwned[Buffer] -> DeviceOwned[Buffer]
+```
+
+and completion as:
+
+```text
+DeviceOwned[Buffer] -> CpuOwned[Buffer]
+```
+
+The executable checker prevents illegal use, while protocol/state projections can reason about the same transitions globally.
+
+## Effects
+
+Effects should be explicit enough to express systems constraints.
+
+Conceptual examples:
+
+```oak
+fn irq_entry(...)
+  effects { CpuLocal, Mmio[Aic] }
+
+realtime fn process(...)
+  effects { AudioRead, AudioWrite }
+  forbids { Allocate, Block, Syscall }
+```
+
+The exact syntax remains open.
+
+Effects should power:
+
+- compile-time capability restrictions;
+- realtime/no-allocation guarantees;
+- call-graph checks;
+- proof assumptions;
+- documentation;
+- security review.
+
+## Protocols and temporal semantics
+
+Executable functions describe what one step does. Concurrent systems also need a description of which sequences of steps are legal.
+
+Oak should therefore support protocol/state-machine declarations with a semantics capable of projection into temporal/model-checking tools.
+
+Conceptual example:
+
+```oak
+protocol VirtualIrq
+  state Idle
+  state Pending
+  state Active
+
+  transition inject Idle -> Pending
+  transition acknowledge Pending -> Active
+  transition eoi Active -> Idle
+
+  invariant active_is_known_irq
+```
+
+The same declaration should eventually be able to drive:
+
+- typestate APIs;
+- state-machine implementation scaffolding;
+- model checking;
+- Lean transition definitions;
+- deterministic simulator actions;
+- state diagrams;
+- debugger decoding.
+
+Temporal liveness properties must state environmental assumptions explicitly. For example, eventual completion may depend on scheduler fairness, device progress, or peer behavior.
+
+## Verification backends have different jobs
+
+Oak should not pretend one solver is ideal for every property.
+
+```text
+ordinary type facts       -> type checker
+ownership/linearity       -> ownership checker
+arithmetic refinements    -> SMT
+finite state protocols    -> model checker
+mathematical theorems     -> Lean / interactive proof
+implementation behavior   -> generated property tests / DST
+unproved debug contracts  -> runtime assertions where requested
+```
+
+All backends consume the same Semantic IR rather than independent hand-written models whenever possible.
+
+## Proof status is explicit
+
+Oak tooling should distinguish at least:
+
+- **specified**: a property exists in the semantic model;
+- **checked**: discharged by ordinary static checking;
+- **proved-smt**: discharged by an SMT solver;
+- **proved-kernel**: checked by a proof assistant kernel;
+- **model-checked**: explored by a finite-state/temporal checker under stated bounds;
+- **tested**: exercised against generated or user tests;
+- **refined**: a formal correspondence to a lower-level implementation/model has been established.
+
+The compiler and documentation must never collapse these into a vague "verified" label.
+
+## Tags remain extensible metadata
+
+Oak's existing compile-time tag system remains useful for metadata that does not change core language semantics:
+
+```oak
+field: u64 `{ wire.field: 7, ui.unit: "bytes" }`
+```
+
+Correctness-critical concepts such as ownership, effects, refinements, alignment, and protocol transitions should graduate to typed language constructs rather than relying on arbitrary stringly metadata.
+
+## Syntax and semantics are separate
+
+Oak supports both layout and explicit-brace styles. Both normalize into one AST before semantic analysis.
+
+No proof, type rule, ownership rule, effect, or backend may depend on which surface style was used.
+
+See `SYNTAX_DIRECTION.md`.
+
+## Development strategy
+
+Oak should earn these features incrementally using real systems code as pressure.
+
+Recommended sequence:
+
+1. dual layout/explicit block syntax;
+2. stable Semantic IR for existing Oak types, tags, ownership, views/spans, and layout;
+3. one multi-projection experiment using the OS interrupt types;
+4. refinements and SMT obligations;
+5. Lean projection for local invariants;
+6. protocol/state-machine representation and temporal projection;
+7. generated property/DST tests;
+8. effects and bounded/realtime contracts;
+9. stronger refinement between generated/executable code and proof models.
+
+The OS remains implemented in Zig while Oak proves that its semantic model can eliminate duplication around real core subsystems. Oak should replace the implementation language only if and when its generated code, machine control, ergonomics, and verification story are demonstrably better.

--- a/layout/layout.go
+++ b/layout/layout.go
@@ -1,0 +1,184 @@
+// Package layout normalizes Oak's optional indentation-delimited statement bodies
+// into the same brace-delimited token structure consumed by the parser.
+//
+// Layout is syntax sugar only. Synthetic tokens use the ordinary LBRACE/RBRACE
+// kinds and are marked Token.Synthetic so later tooling can preserve source style.
+package layout
+
+import "github.com/SCKelemen/oak/token"
+
+// Source is the minimal token source shared by the scanner and normalizer.
+type Source interface {
+	NextToken() token.Token
+}
+
+// Normalizer presents a normalized token stream.
+type Normalizer struct {
+	tokens []token.Token
+	index  int
+}
+
+// New consumes source once and constructs a deterministic normalized stream.
+// The compiler-side allocation here is intentional: normalization is tooling,
+// not target runtime code, and a materialized stream makes equivalence testing
+// and diagnostics straightforward.
+func New(source Source) *Normalizer {
+	raw := make([]token.Token, 0, 256)
+	for {
+		tok := source.NextToken()
+		raw = append(raw, tok)
+		if tok.TokenKind == token.EOF {
+			break
+		}
+	}
+	return &Normalizer{tokens: normalize(raw)}
+}
+
+// NextToken implements Source.
+func (n *Normalizer) NextToken() token.Token {
+	if n.index >= len(n.tokens) {
+		return token.Token{TokenKind: token.EOF}
+	}
+	tok := n.tokens[n.index]
+	n.index++
+	return tok
+}
+
+type pendingBody struct {
+	active bool
+	kind   token.TokenKind
+	indent int
+	line   int
+}
+
+func normalize(raw []token.Token) []token.Token {
+	out := make([]token.Token, 0, len(raw)+8)
+	layoutIndents := make([]int, 0, 8)
+
+	var pending pendingBody
+	var previous token.Token
+	havePrevious := false
+	parenDepth := 0
+	bracketDepth := 0
+	line := 0
+	lineIndent := 1
+
+	for _, tok := range raw {
+		if tok.TokenKind == token.TRIVIA || tok.TokenKind == token.COMMENT {
+			out = append(out, tok)
+			continue
+		}
+
+		if tok.TokenKind == token.EOF {
+			for len(layoutIndents) > 0 {
+				out = append(out, synthetic(token.RBRACE, tok))
+				layoutIndents = layoutIndents[:len(layoutIndents)-1]
+			}
+			out = append(out, tok)
+			break
+		}
+
+		newLine := havePrevious && tok.Line > previous.Line
+		if tok.Line != line {
+			line = tok.Line
+			lineIndent = tok.Column
+		}
+
+		// Parenthesized and bracketed forms are continuation contexts. Indentation
+		// inside them never opens or closes a statement body.
+		continuation := parenDepth > 0 || bracketDepth > 0
+
+		if newLine && !continuation {
+			if pending.active && !headerContinues(pending.kind, tok) {
+				if tok.Column <= pending.indent {
+					out = append(out, token.Token{
+						TokenKind: token.ILLEGAL,
+						Literal:   "expected indented body",
+						Line:      tok.Line,
+						Column:    tok.Column,
+						ByteStart: tok.ByteStart,
+						ByteEnd:   tok.ByteStart,
+						Synthetic: true,
+					})
+					pending.active = false
+				} else {
+					out = append(out, synthetic(token.LBRACE, tok))
+					layoutIndents = append(layoutIndents, tok.Column)
+					pending.active = false
+				}
+			} else if !pending.active {
+				for len(layoutIndents) > 0 && tok.Column < layoutIndents[len(layoutIndents)-1] {
+					out = append(out, synthetic(token.RBRACE, tok))
+					layoutIndents = layoutIndents[:len(layoutIndents)-1]
+				}
+			}
+		}
+
+		// An explicit block always wins. It cancels layout synthesis for the body
+		// currently being introduced but remains an ordinary source token.
+		if tok.TokenKind == token.LBRACE && pending.active {
+			pending.active = false
+		}
+
+		// Oak currently permits expression-bodied functions using '='. Do not
+		// synthesize a block for those functions.
+		if tok.TokenKind == token.ASSIGN && pending.active && pending.kind == token.FN {
+			pending.active = false
+		}
+
+		out = append(out, tok)
+
+		switch tok.TokenKind {
+		case token.FN, token.WHILE, token.UNSAFE:
+			pending = pendingBody{
+				active: true,
+				kind:   tok.TokenKind,
+				indent: lineIndent,
+				line:   tok.Line,
+			}
+		case token.LPAREN:
+			parenDepth++
+		case token.RPAREN:
+			if parenDepth > 0 {
+				parenDepth--
+			}
+		case token.LBRACK:
+			bracketDepth++
+		case token.RBRACK:
+			if bracketDepth > 0 {
+				bracketDepth--
+			}
+		}
+
+		previous = tok
+		havePrevious = true
+	}
+
+	return out
+}
+
+func headerContinues(kind token.TokenKind, next token.Token) bool {
+	// A function return annotation may start on the line after its parameter
+	// list. Keeping this tiny and explicit is preferable to a second parser in
+	// the layout layer.
+	if kind == token.FN && next.TokenKind == token.COLON {
+		return true
+	}
+	return false
+}
+
+func synthetic(kind token.TokenKind, at token.Token) token.Token {
+	literal := "{"
+	if kind == token.RBRACE {
+		literal = "}"
+	}
+	return token.Token{
+		TokenKind: kind,
+		Literal:   literal,
+		Line:      at.Line,
+		Column:    at.Column,
+		ByteStart: at.ByteStart,
+		ByteEnd:   at.ByteStart,
+		Synthetic: true,
+	}
+}

--- a/layout/layout_test.go
+++ b/layout/layout_test.go
@@ -1,0 +1,137 @@
+package layout
+
+import (
+	"testing"
+
+	"github.com/SCKelemen/oak/scanner"
+	"github.com/SCKelemen/oak/token"
+)
+
+func significant(source Source) []token.Token {
+	var result []token.Token
+	for {
+		tok := source.NextToken()
+		if tok.TokenKind != token.TRIVIA && tok.TokenKind != token.COMMENT {
+			result = append(result, tok)
+		}
+		if tok.TokenKind == token.EOF {
+			return result
+		}
+	}
+}
+
+func kinds(tokens []token.Token) []token.TokenKind {
+	out := make([]token.TokenKind, len(tokens))
+	for i, tok := range tokens {
+		out[i] = tok.TokenKind
+	}
+	return out
+}
+
+func assertKindsEqual(t *testing.T, a, b []token.Token) {
+	t.Helper()
+	ak := kinds(a)
+	bk := kinds(b)
+	if len(ak) != len(bk) {
+		t.Fatalf("token length differs:\nlayout:   %v\nexplicit: %v", ak, bk)
+	}
+	for i := range ak {
+		if ak[i] != bk[i] {
+			t.Fatalf("token %d differs: layout=%s explicit=%s\nlayout:   %v\nexplicit: %v", i, ak[i], bk[i], ak, bk)
+		}
+	}
+}
+
+func TestFunctionLayoutEqualsExplicitBlock(t *testing.T) {
+	layoutSource := `fn answer(): u32
+  x := 40
+  x + 2
+`
+	explicitSource := `fn answer(): u32 {
+  x := 40
+  x + 2
+}`
+
+	got := significant(New(scanner.New(layoutSource)))
+	want := significant(New(scanner.New(explicitSource)))
+	assertKindsEqual(t, got, want)
+
+	if got[6].TokenKind != token.LBRACE || !got[6].Synthetic {
+		t.Fatalf("expected synthetic opening brace, got %#v", got[6])
+	}
+	if got[len(got)-2].TokenKind != token.RBRACE || !got[len(got)-2].Synthetic {
+		t.Fatalf("expected synthetic closing brace, got %#v", got[len(got)-2])
+	}
+}
+
+func TestNestedWhileLayoutEqualsExplicitBlocks(t *testing.T) {
+	layoutSource := `fn countdown(n: u32): u32
+  x := n
+  while x > 0
+    x = x - 1
+  x
+`
+	explicitSource := `fn countdown(n: u32): u32 {
+  x := n
+  while x > 0 {
+    x = x - 1
+  }
+  x
+}`
+
+	got := significant(New(scanner.New(layoutSource)))
+	want := significant(New(scanner.New(explicitSource)))
+	assertKindsEqual(t, got, want)
+}
+
+func TestExpressionBodiedFunctionDoesNotOpenLayoutBlock(t *testing.T) {
+	source := `fn add(a: u32, b: u32): u32 = a + b
+`
+	tokens := significant(New(scanner.New(source)))
+	for _, tok := range tokens {
+		if tok.Synthetic && (tok.TokenKind == token.LBRACE || tok.TokenKind == token.RBRACE) {
+			t.Fatalf("expression-bodied function synthesized block token: %#v", tok)
+		}
+	}
+}
+
+func TestMultilineParametersDoNotOpenLayoutBlock(t *testing.T) {
+	source := `fn add(
+  a: u32,
+  b: u32,
+): u32
+  a + b
+`
+	tokens := significant(New(scanner.New(source)))
+
+	opens := 0
+	closes := 0
+	for _, tok := range tokens {
+		if tok.Synthetic && tok.TokenKind == token.LBRACE {
+			opens++
+		}
+		if tok.Synthetic && tok.TokenKind == token.RBRACE {
+			closes++
+		}
+	}
+	if opens != 1 || closes != 1 {
+		t.Fatalf("expected one virtual block, got opens=%d closes=%d", opens, closes)
+	}
+}
+
+func TestDedentClosesNestedBlockBeforeOuterStatement(t *testing.T) {
+	source := `fn f(): u32
+  x := 2
+  while x > 0
+    x = x - 1
+  x
+`
+	tokens := significant(New(scanner.New(source)))
+
+	for i := 0; i+1 < len(tokens); i++ {
+		if tokens[i].Synthetic && tokens[i].TokenKind == token.RBRACE && tokens[i+1].Literal == "x" {
+			return
+		}
+	}
+	t.Fatal("expected nested virtual block to close before outer x expression")
+}

--- a/token/token.go
+++ b/token/token.go
@@ -11,6 +11,7 @@ type Token struct {
 	Column    int // 1-based column number
 	ByteStart int // UTF-8 byte offset where token starts
 	ByteEnd   int // UTF-8 byte offset where token ends (exclusive)
+	Synthetic bool // true when introduced by normalization rather than source text
 }
 
 const (


### PR DESCRIPTION
## Summary

Begins Oak's evolution toward a single semantic language that can drive executable code, proof/model projections, tests, schemas, debugger metadata, and documentation.

### Syntax
- documents one grammar with two equivalent surface styles: ML-like indentation and explicit C-style braces
- adds a `layout` token normalizer that synthesizes ordinary brace tokens from indentation
- marks synthesized tokens explicitly so formatting/source tooling can preserve style
- keeps data-construction braces explicit for now to avoid ambiguity
- adds equivalence tests for function bodies, nested while blocks, dedents, multiline parameters, and expression-bodied functions

### Semantic architecture
- defines a Semantic IR as the source of truth for machine representation, ownership, refinements, effects, protocols, and metadata
- defines intended projections to executable lowering, SMT, Lean, temporal/model checking, property/DST generation, debugger metadata, schemas, and docs
- distinguishes proof/checking status rather than using a vague 'verified' label

This is intentionally the foundation. The next parser change can consume the normalizer transparently after these token semantics are validated by CI.