### PR TITLE
Establish Oak's five-axis Semantic IR

### DIFF
--- a/docs/LANGUAGE_MODEL.md
+++ b/docs/LANGUAGE_MODEL.md
@@ -1,0 +1,289 @@
+# Oak Language Model
+
+Oak is a systems language in which one checked semantic definition should drive every projection that can soundly reuse it.
+
+> Define a fact once; project it many ways.
+
+The language is organized around five orthogonal semantic axes.
+
+## 1. Type: what does this value mean?
+
+Types carry semantic identity independent of representation.
+
+Examples:
+
+```oak
+UserId: type = Id[User]
+OrderId: type = Id[Order]
+PhysAddr: type = Address[Physical]
+VirtAddr: type = Address[Virtual]
+```
+
+Two types may have identical bits and still be different values to the type checker, proof system, debugger, and schema tools.
+
+The type axis includes:
+
+- scalar and nominal identity;
+- records/products;
+- sums/ADTs;
+- functions;
+- generic parameters and constraints;
+- phantom parameters;
+- aliases and opaque types.
+
+Algebraic data types and pattern matching remain the center of ordinary Oak programming.
+
+## 2. Representation: what bits represent it?
+
+Representation is separate from type meaning.
+
+A semantic type may specify or derive:
+
+```text
+bit width
+size
+alignment
+field offsets
+tag/discriminant layout
+endianness
+calling/ABI representation
+```
+
+Machine integers (`u8`, `u16`, ..., `int`, `uint`, `iptr`, `uptr`) are not silently identified with mathematical integers.
+
+A type with no explicit representation constraint leaves representation to the executable backend. A wire/MMIO/ABI type may constrain it exactly.
+
+### ADT payloads, discriminants, and defaults are distinct
+
+These concepts must not share ambiguous syntax or semantics:
+
+- a variant payload;
+- a machine discriminant/value;
+- a default field value;
+- arbitrary metadata.
+
+Conceptually:
+
+```oak
+Result[T, E]: type =
+  | Ok(T)
+  | Err(E)
+
+Status: type @repr(u16) =
+  | Ok       @value(200)
+  | NotFound @value(404)
+
+Config: type =
+  retries: u8 = 3
+```
+
+Exact surface syntax remains open, but the Semantic IR must distinguish these facts now.
+
+### Record composition, not accidental structural subtyping
+
+Oak's existing `A & B` record-definition feature is representation/type composition. The resulting type remains nominal unless structural subtyping is explicitly designed later.
+
+Constraint conjunction such as `T: Reader & Writer` means that `T` satisfies both constraints. These are separate semantic operations even if surface syntax eventually shares `&`.
+
+## 3. Authority and effects: what may code holding it do?
+
+Ownership, borrowing, capabilities, effects, and unsafe boundaries belong to one authority axis.
+
+Existing Oak concepts:
+
+```text
+[N]T    owned fixed storage
+[]T     shared read-only view
+[*]T    unique writable span
+*T      raw pointer
+```
+
+should evolve into explicit semantic states rather than merely syntax conventions.
+
+Examples:
+
+```text
+CpuOwned[Buffer]
+DeviceOwned[Buffer]
+SharedRead[Buffer]
+UniqueWrite[Buffer]
+```
+
+A DMA transfer can therefore be one checked state transition:
+
+```text
+CpuOwned[Buffer] -> DeviceOwned[Buffer] -> CpuOwned[Buffer]
+```
+
+Effects are also authority facts:
+
+```oak
+realtime fn process(...)
+  effects { Audio.Read, Audio.Write }
+  forbids { Memory.Allocate, Thread.Block, Os.Syscall }
+```
+
+A required effect and a forbidden effect may not be the same semantic effect.
+
+### `unsafe` is a boundary, not an off switch
+
+`unsafe` means Oak cannot establish one or more normal safety invariants for the operation. It does not disable type checking, layout checking, effect checking, or unrelated proofs.
+
+Unsafe primitives should eventually state the assumptions they introduce so that higher-level code can contain and discharge those assumptions explicitly.
+
+## 4. Proposition: what facts are known?
+
+Refinements, preconditions, postconditions, invariants, and derived facts are structured propositions.
+
+Conceptually:
+
+```oak
+IrqId[N]: type = u16 where value < N
+AlignedPage: type = uptr where value % PageSize == 0
+```
+
+The compiler should preserve proposition structure rather than converting it to an opaque annotation string. The same proposition can then drive:
+
+- ordinary static checking;
+- bounds-check elimination;
+- SMT obligations;
+- Lean definitions/theorems;
+- generated boundary/property tests;
+- documentation.
+
+Proof status is explicit:
+
+```text
+specified
+checked
+proved-smt
+proved-kernel
+model-checked
+tested
+refined
+```
+
+Oak must never collapse these statuses into a vague `verified` bit.
+
+## 5. Protocol: how may state evolve over time?
+
+A function describes one computation. Systems code also needs to describe legal state evolution and concurrent behavior.
+
+Conceptually:
+
+```oak
+protocol VirtualIrq
+  state Idle
+  state Pending
+  state Active
+
+  transition inject Idle -> Pending
+  transition acknowledge Pending -> Active
+  transition eoi Active -> Idle
+```
+
+One protocol definition should eventually drive:
+
+- local typestate APIs;
+- executable state-machine scaffolding;
+- temporal/model-checker projection;
+- Lean transition definitions;
+- deterministic simulator actions;
+- state diagrams;
+- debugger state decoding.
+
+Liveness properties must state environmental assumptions such as scheduler fairness, device progress, or peer behavior.
+
+## One semantic definition, many projections
+
+```text
+                         +-> executable code / C / native
+                         +-> machine layout / ABI
+                         +-> serialization / wire schema
+Oak source -> Semantic IR +-> debugger metadata
+                         +-> SMT
+                         +-> Lean
+                         +-> temporal model checker
+                         +-> property tests / DST
+                         +-> documentation / UI schema
+```
+
+The Semantic IR, not any one backend, is the semantic source of truth.
+
+## Existing features in this model
+
+Oak already has useful precursors for all five axes:
+
+| Existing feature | Semantic role |
+| --- | --- |
+| ADTs / records / generics | Type |
+| fixed-width integers / pointers / C layout | Representation |
+| views / spans / borrow checking / `unsafe` | Authority |
+| phantom types / constraints | Type + Proposition |
+| struct tags | Extensible projection metadata |
+| pattern matching / ADT transitions in code | Seed for Protocol |
+
+Struct tags remain useful, but correctness-critical concepts graduate from arbitrary metadata into typed semantic constructs.
+
+## String validity
+
+Encoding is a semantic property, not just a phantom label on arbitrary bytes.
+
+Conceptually:
+
+```text
+Bytes
+ValidatedBytes[Utf8]
+Str[Utf8]
+```
+
+Converting arbitrary bytes to `Str[E]` must validate the encoding or require an explicit unsafe assumption. A safe `from_bytes` cannot simply assert that arbitrary bytes are valid UTF-8/UTF-16/etc.
+
+## Interfaces and dynamic dispatch
+
+Interface constraints are compile-time capabilities by default:
+
+```oak
+fn copy[R: Readable, W: Writable](r: R, w: W): ()
+```
+
+should not imply a hidden vtable or heap allocation.
+
+If Oak later supports runtime existential/interface values, that dynamic representation must be explicit in the type and representation axes.
+
+## C is a backend, not the definition of Oak
+
+Readable C remains a valuable bootstrap backend and audit surface. Oak's language semantics must not be defined as "whatever the C backend happens to do."
+
+The long-term pipeline is:
+
+```text
+Oak source
+  -> syntax tree
+  -> semantic analysis
+  -> Semantic IR
+      -> C
+      -> native lowering
+      -> Lean
+      -> temporal model
+      -> schemas/tooling
+```
+
+## Syntax remains orthogonal
+
+Oak has one language grammar with two equivalent block spellings:
+
+- layout/indentation style;
+- explicit brace style.
+
+Both normalize before semantic analysis. None of the five semantic axes may depend on which style the programmer used.
+
+## Implementation rule
+
+The Semantic IR should fail closed when the compiler has lost information.
+
+For example, the current syntax AST historically stores record fields in a Go map. A backend may not invent a deterministic machine field order from that map and claim it is source layout. Exact representation facts become available only after the syntax/typed AST preserves the ordering needed to justify them.
+
+This principle applies generally:
+
+> Missing semantic information remains unknown; it is never reconstructed by guesswork.

--- a/docs/SEMANTIC_ARCHITECTURE.md
+++ b/docs/SEMANTIC_ARCHITECTURE.md
@@ -1,21 +1,27 @@
 # Oak Semantic Architecture
 
-Oak's central design goal is to define semantic facts once and reuse them everywhere that can benefit from them.
-
-A type, protocol, ownership rule, refinement, effect, or layout fact should not be independently re-written for the compiler, verifier, serializer, debugger, model checker, and documentation. Oak should preserve one checked semantic representation and derive projections from it.
-
-## Core principle
+Oak's central design goal is to define semantic facts once and reuse them everywhere that can soundly benefit from them.
 
 > Define a fact once; project it many ways.
+
+The normative language model is organized around five orthogonal axes described in `LANGUAGE_MODEL.md`:
+
+1. **Type** — what does this value mean?
+2. **Representation** — what bits represent it?
+3. **Authority / effects** — what may code holding it do?
+4. **Proposition** — what facts are statically known?
+5. **Protocol** — how may state evolve over time?
+
+These axes are kept separate deliberately. Two values may share representation but have different semantic types. A type may have propositions without constraining layout. A protocol can refer to authority transitions without baking scheduler policy into the type.
 
 ```text
 Oak source
     |
     v
-parser
+parser / layout normalization
     |
     v
-typed AST
+typed syntax
     |
     v
 Semantic IR
@@ -32,104 +38,83 @@ Semantic IR
     +--> deterministic simulation actions
 ```
 
-The Semantic IR is the source of truth for all projections.
+The Semantic IR is the semantic source of truth for all projections.
 
-## Semantic IR responsibilities
+## Current executable foundation
 
-The IR must preserve more than ordinary compiler types. It should be able to represent:
+The Go package `semir` is the first executable representation of this design. It deliberately starts smaller than the eventual language:
+
+- `Definition` contains the five axes independently;
+- proposition expressions are structured trees, not strings;
+- temporal formulas are structured trees;
+- proof status is explicit;
+- authority validation rejects contradictory effect contracts;
+- protocol validation rejects missing states and malformed transitions;
+- representation validation rejects impossible alignment claims;
+- module validation rejects duplicate definitions/protocols and unknown protocol references.
+
+The current `semir` package is a host compiler data model, not yet a promise that every proposed Oak surface syntax exists. Surface syntax should be added only after its semantic meaning is stable in the IR.
+
+## Type axis
+
+The type axis preserves:
 
 - nominal and algebraic type identity;
 - fixed-width and mathematical numeric domains;
-- record/sum structure;
-- exact target representation, size, alignment, offsets, and endianness where specified;
-- ownership, borrowing, mutability, and linear/affine state;
-- phantom parameters and zero-runtime semantic distinctions;
-- refinements and predicates;
-- effects and forbidden effects;
-- boundedness/resource facts;
-- compile-time tags and namespaced metadata;
-- protocol states and transitions;
-- invariants, preconditions, and postconditions;
-- temporal assumptions and guarantees;
-- source locations and documentation.
-
-Not every type needs every category.
-
-## Types drive multiple projections
+- record/product structure;
+- sum/ADT structure;
+- functions;
+- generic constraints;
+- phantom parameters and zero-runtime semantic distinctions.
 
 Example:
 
 ```oak
 IrqId[N]: type = u16
   where value < N
-
-Irq: type =
-  enabled: bool
-  priority: u8
-  latched_pending: bool
-  level_asserted: bool
-  active: bool
 ```
 
-The same semantic declarations should be sufficient to derive:
+`IrqId[N]` is not merely an alias for `u16`; it is a semantic type whose machine representation may be `u16` and whose proposition axis contains `value < N`.
 
-- the machine representation;
-- bounds checks or their elimination when statically proved;
-- Lean definitions;
-- SMT assumptions/obligations;
-- structured debugger descriptions;
-- serialization schemas where requested;
-- property-test generators;
-- human-readable documentation.
+## Representation axis
+
+Machine layout is not merely a backend implementation detail. A representation-constrained definition may expose:
+
+```text
+bits(T)
+size(T)
+align(T)
+offset(T.field)
+endianness(T.field)
+tag-layout(T)
+```
+
+These facts should be consumable by verification and tooling.
+
+A wire/MMIO/ABI type can therefore use the same checked definition as executable code rather than maintaining a duplicate schema.
+
+### Unknown representation stays unknown
+
+The IR must fail closed when earlier compiler phases lost information. It must never invent semantic facts for convenience.
+
+For example, Oak's historical AST stores record fields in a Go map. Exact source field order therefore cannot yet be justified from that node. Semantic record membership can be projected; exact machine field layout must remain unspecified until the syntax/typed representation preserves order.
+
+This is intentional: missing information is represented as missing information, not reconstructed by guesswork.
 
 ## Machine integers and mathematical integers are different
 
 Oak must never silently identify an unbounded mathematical integer with a machine integer.
 
-Examples:
-
 ```text
 Nat / Int       mathematical domains
 u8..u64         fixed-width machine domains
 uint / int      target-word machine domains
-uptr / ptr      target-pointer-width machine domains
+uptr / iptr     target-pointer-width machine domains
 ```
 
 Conversions are explicit semantic operations with explicit proof obligations where overflow or truncation is possible.
 
-This lets proofs reason accurately about wrapping, checked arithmetic, address widths, wire layouts, and target-specific representation.
-
-## Layout is a semantic fact
-
-Machine layout is not merely a backend implementation detail.
-
-For a representation-constrained type, the compiler should be able to expose facts such as:
-
-```text
-size(T)
-align(T)
-offset(T.field)
-endianness(T.field)
-```
-
-These facts should be consumable by verification and tooling.
-
-A wire or MMIO layout can therefore use the same checked type definition as executable code rather than maintaining a duplicate schema.
-
-## Refinements
-
-Oak should support refinements as semantic predicates over values.
-
-Conceptual syntax:
-
-```oak
-PageIndex[N]: type = u32 where value < N
-AlignedPage: type = uptr where value % PageSize == 0
-```
-
-The exact syntax remains open. The semantic requirement does not: a refinement becomes a fact available to the type checker, SMT solver, Lean projection, optimizer, test generator, and documentation.
-
-## Ownership and typestate
+## Authority and effects
 
 Ownership is part of semantics, not linting.
 
@@ -139,9 +124,10 @@ Examples:
 CpuOwned[Buffer]
 DeviceOwned[Buffer]
 SharedRead[Buffer]
+UniqueWrite[Buffer]
 ```
 
-A DMA submission may be modeled as a transition:
+DMA submission may be modeled as:
 
 ```text
 CpuOwned[Buffer] -> DeviceOwned[Buffer]
@@ -153,39 +139,46 @@ and completion as:
 DeviceOwned[Buffer] -> CpuOwned[Buffer]
 ```
 
-The executable checker prevents illegal use, while protocol/state projections can reason about the same transitions globally.
+Effects express systems constraints:
 
-## Effects
+```oak
+fn irq_entry(...)
+  effects { Cpu.Local, Mmio.Aic }
 
-Effects should be explicit enough to express systems constraints.
+realtime fn process(...)
+  effects { Audio.Read, Audio.Write }
+  forbids { Memory.Allocate, Thread.Block, Os.Syscall }
+```
+
+Required and forbidden effects must be internally consistent. The same effect cannot be both.
+
+`unsafe` is an explicit authority/proof boundary, not a switch that disables all checking.
+
+## Proposition axis
+
+Refinements, preconditions, postconditions, and invariants are structured propositions.
 
 Conceptual examples:
 
 ```oak
-fn irq_entry(...)
-  effects { CpuLocal, Mmio[Aic] }
-
-realtime fn process(...)
-  effects { AudioRead, AudioWrite }
-  forbids { Allocate, Block, Syscall }
+PageIndex[N]: type = u32 where value < N
+AlignedPage: type = uptr where value % PageSize == 0
 ```
 
-The exact syntax remains open.
+A proposition becomes one fact available to:
 
-Effects should power:
+- the type checker;
+- SMT;
+- Lean projection;
+- optimizer/bounds-check elimination;
+- test generation;
+- documentation.
 
-- compile-time capability restrictions;
-- realtime/no-allocation guarantees;
-- call-graph checks;
-- proof assumptions;
-- documentation;
-- security review.
+The `semir.Expr` tree exists specifically so proof backends do not have to parse arbitrary annotation strings.
 
-## Protocols and temporal semantics
+## Protocol axis
 
 Executable functions describe what one step does. Concurrent systems also need a description of which sequences of steps are legal.
-
-Oak should therefore support protocol/state-machine declarations with a semantics capable of projection into temporal/model-checking tools.
 
 Conceptual example:
 
@@ -198,21 +191,21 @@ protocol VirtualIrq
   transition inject Idle -> Pending
   transition acknowledge Pending -> Active
   transition eoi Active -> Idle
-
-  invariant active_is_known_irq
 ```
 
-The same declaration should eventually be able to drive:
+The same declaration should eventually drive:
 
 - typestate APIs;
-- state-machine implementation scaffolding;
+- executable state-machine scaffolding;
 - model checking;
 - Lean transition definitions;
 - deterministic simulator actions;
 - state diagrams;
 - debugger decoding.
 
-Temporal liveness properties must state environmental assumptions explicitly. For example, eventual completion may depend on scheduler fairness, device progress, or peer behavior.
+Temporal liveness properties must state environmental assumptions explicitly. Eventual completion may depend on scheduler fairness, device progress, or peer behavior.
+
+The `semir.TemporalExpr` tree is the shared representation for these formulas; temporal backends should consume that rather than independent handwritten models whenever possible.
 
 ## Verification backends have different jobs
 
@@ -228,54 +221,78 @@ implementation behavior   -> generated property tests / DST
 unproved debug contracts  -> runtime assertions where requested
 ```
 
-All backends consume the same Semantic IR rather than independent hand-written models whenever possible.
+All backends should consume the same Semantic IR facts where possible.
 
 ## Proof status is explicit
 
-Oak tooling should distinguish at least:
+Oak tooling distinguishes at least:
 
-- **specified**: a property exists in the semantic model;
-- **checked**: discharged by ordinary static checking;
-- **proved-smt**: discharged by an SMT solver;
-- **proved-kernel**: checked by a proof assistant kernel;
-- **model-checked**: explored by a finite-state/temporal checker under stated bounds;
-- **tested**: exercised against generated or user tests;
-- **refined**: a formal correspondence to a lower-level implementation/model has been established.
+- **specified** — property exists in the semantic model;
+- **checked** — discharged by ordinary static checking;
+- **proved-smt** — discharged by an SMT solver;
+- **proved-kernel** — checked by a proof assistant kernel;
+- **model-checked** — explored by a finite-state/temporal checker under stated bounds;
+- **tested** — exercised against generated or user tests;
+- **refined** — formal correspondence to a lower-level implementation/model has been established.
 
-The compiler and documentation must never collapse these into a vague "verified" label.
+The compiler and documentation must never collapse these into a vague `verified` label.
 
 ## Tags remain extensible metadata
 
-Oak's existing compile-time tag system remains useful for metadata that does not change core language semantics:
+Oak's existing compile-time tags remain useful for projection metadata that does not define core language correctness:
 
 ```oak
 field: u64 `{ wire.field: 7, ui.unit: "bytes" }`
 ```
 
-Correctness-critical concepts such as ownership, effects, refinements, alignment, and protocol transitions should graduate to typed language constructs rather than relying on arbitrary stringly metadata.
+Correctness-critical concepts such as ownership, effects, refinements, alignment, discriminants, and protocol transitions graduate to typed language constructs and typed Semantic IR nodes.
+
+## Existing Oak features map naturally
+
+```text
+ADTs / records / generics               -> Type
+machine ints / pointers / layouts       -> Representation
+views / spans / borrow checker / unsafe -> Authority
+phantom types / constraints             -> Type + Proposition
+struct tags                             -> extensible attributes
+pattern-driven state changes            -> seed for Protocol
+```
+
+The architecture extends Oak's strongest existing ideas rather than replacing them.
+
+## Strings and validity
+
+Encoding is a semantic validity fact. Arbitrary bytes cannot safely become `Str[Utf8]` merely by attaching a phantom encoding parameter.
+
+A future safe API should distinguish raw bytes from validated strings and make validation/unsafe assumption explicit.
+
+## Interfaces
+
+Interface constraints are compile-time capabilities by default and should not imply hidden vtables or allocation. Runtime existential/interface values, if added, must have explicit type and representation semantics.
+
+## C is one projection
+
+Readable C remains a valuable bootstrap backend and audit surface, but Oak semantics are not defined by C. The Semantic IR is above executable backends and proof/tooling projections alike.
 
 ## Syntax and semantics are separate
 
-Oak supports both layout and explicit-brace styles. Both normalize into one AST before semantic analysis.
+Oak supports both layout and explicit-brace styles. Both normalize into one parser path before semantic analysis.
 
-No proof, type rule, ownership rule, effect, or backend may depend on which surface style was used.
+No proof, type rule, ownership rule, effect, representation, or protocol may depend on which surface style was used.
 
 See `SYNTAX_DIRECTION.md`.
 
-## Development strategy
+## Development sequence
 
-Oak should earn these features incrementally using real systems code as pressure.
-
-Recommended sequence:
-
-1. dual layout/explicit block syntax;
-2. stable Semantic IR for existing Oak types, tags, ownership, views/spans, and layout;
-3. one multi-projection experiment using the OS interrupt types;
-4. refinements and SMT obligations;
-5. Lean projection for local invariants;
-6. protocol/state-machine representation and temporal projection;
-7. generated property/DST tests;
-8. effects and bounded/realtime contracts;
-9. stronger refinement between generated/executable code and proof models.
+1. stabilize dual layout/explicit block syntax;
+2. establish the five-axis Semantic IR and validation rules;
+3. preserve enough typed/source structure to derive existing Oak definitions without information loss;
+4. perform one multi-projection experiment using OS interrupt types;
+5. add refinements and SMT obligations;
+6. add Lean projection for local invariants;
+7. add protocol/state-machine syntax and temporal projection;
+8. generate property/DST tests;
+9. add effects and bounded/realtime contracts;
+10. strengthen refinement between executable lowering and proof models.
 
 The OS remains implemented in Zig while Oak proves that its semantic model can eliminate duplication around real core subsystems. Oak should replace the implementation language only if and when its generated code, machine control, ergonomics, and verification story are demonstrably better.

--- a/semir/ir.go
+++ b/semir/ir.go
@@ -1,0 +1,264 @@
+package semir
+
+// Module is Oak's checked semantic representation. Syntax, executable lowering,
+// verification backends, schema tooling, and documentation should project from
+// this model rather than independently reconstructing semantic facts.
+type Module struct {
+	Definitions []Definition
+	Protocols   []Protocol
+}
+
+// Definition keeps Oak's five semantic axes orthogonal. A declaration can use
+// only the axes it needs, but a fact should have one authoritative home.
+type Definition struct {
+	Name           string
+	Type           Type
+	Representation Representation
+	Authority      Authority
+	Propositions   []Proposition
+	Protocol       string
+	Attributes     []Attribute
+}
+
+// Type describes what a value means, independently of how it is represented.
+type Type struct {
+	Kind       TypeKind
+	Base       string
+	Parameters []TypeParameter
+	Fields     []Field
+	Variants   []Variant
+}
+
+type TypeKind string
+
+const (
+	TypeInvalid  TypeKind = ""
+	TypeScalar   TypeKind = "scalar"
+	TypeAlias    TypeKind = "alias"
+	TypeRecord   TypeKind = "record"
+	TypeSum      TypeKind = "sum"
+	TypeFunction TypeKind = "function"
+	TypeOpaque   TypeKind = "opaque"
+)
+
+type TypeParameter struct {
+	Name       string
+	Constraint string
+	Phantom    bool
+}
+
+type Field struct {
+	Name string
+	Type string
+}
+
+type Variant struct {
+	Name    string
+	Payload string
+}
+
+// Representation describes the bits/layout chosen for a semantic type. Empty
+// Representation means the declaration has no representation constraint yet.
+type Representation struct {
+	Kind       RepresentationKind
+	Bits       uint16
+	Size       uint32
+	Alignment  uint32
+	Endianness Endianness
+	Fields     []FieldLayout
+	Tag        *TagLayout
+}
+
+type RepresentationKind string
+
+const (
+	RepresentationUnspecified RepresentationKind = ""
+	RepresentationMachineInt  RepresentationKind = "machine-int"
+	RepresentationFloat       RepresentationKind = "float"
+	RepresentationPointer     RepresentationKind = "pointer"
+	RepresentationRecord      RepresentationKind = "record"
+	RepresentationTaggedUnion RepresentationKind = "tagged-union"
+	RepresentationView        RepresentationKind = "view"
+	RepresentationSpan        RepresentationKind = "span"
+	RepresentationOpaque      RepresentationKind = "opaque"
+)
+
+type Endianness string
+
+const (
+	EndianNative Endianness = ""
+	EndianLittle Endianness = "little"
+	EndianBig    Endianness = "big"
+)
+
+type FieldLayout struct {
+	Name   string
+	Offset uint32
+	Size   uint32
+}
+
+type TagLayout struct {
+	Bits   uint16
+	Offset uint32
+}
+
+// Authority describes what code holding a value may do with it. Ownership,
+// capabilities, and effects are semantic facts, not comments or tags.
+type Authority struct {
+	Ownership       Ownership
+	Capabilities    []Capability
+	RequiredEffects []Effect
+	ForbiddenEffects []Effect
+	UnsafeBoundary  bool
+}
+
+type Ownership string
+
+const (
+	OwnershipUnspecified Ownership = ""
+	OwnershipOwned       Ownership = "owned"
+	OwnershipSharedRead  Ownership = "shared-read"
+	OwnershipUniqueWrite Ownership = "unique-write"
+	OwnershipMoved       Ownership = "moved"
+	OwnershipExternal    Ownership = "external"
+)
+
+type Capability struct {
+	Namespace string
+	Name      string
+}
+
+type Effect struct {
+	Namespace string
+	Name      string
+}
+
+// Proposition is a structured fact suitable for multiple proof backends. The
+// expression is intentionally not an arbitrary source string: projections can
+// inspect its operators and terms without reparsing Oak syntax.
+type Proposition struct {
+	Name   string
+	Expr   Expr
+	Status ProofStatus
+}
+
+type ProofStatus string
+
+const (
+	ProofSpecified    ProofStatus = "specified"
+	ProofChecked      ProofStatus = "checked"
+	ProofSMT          ProofStatus = "proved-smt"
+	ProofKernel       ProofStatus = "proved-kernel"
+	ProofModelChecked ProofStatus = "model-checked"
+	ProofTested       ProofStatus = "tested"
+	ProofRefined      ProofStatus = "refined"
+)
+
+type Expr struct {
+	Kind ExprKind
+	Ref  string
+	Int  int64
+	Bool bool
+	Op   Operator
+	Args []Expr
+}
+
+type ExprKind string
+
+const (
+	ExprInvalid ExprKind = ""
+	ExprRef     ExprKind = "ref"
+	ExprInt     ExprKind = "int"
+	ExprBool    ExprKind = "bool"
+	ExprApply   ExprKind = "apply"
+)
+
+type Operator string
+
+const (
+	OpNot Operator = "not"
+	OpAnd Operator = "and"
+	OpOr  Operator = "or"
+	OpEq  Operator = "eq"
+	OpNe  Operator = "ne"
+	OpLt  Operator = "lt"
+	OpLe  Operator = "le"
+	OpGt  Operator = "gt"
+	OpGe  Operator = "ge"
+	OpAdd Operator = "add"
+	OpSub Operator = "sub"
+	OpMul Operator = "mul"
+	OpDiv Operator = "div"
+	OpMod Operator = "mod"
+)
+
+func Ref(name string) Expr { return Expr{Kind: ExprRef, Ref: name} }
+func Int(value int64) Expr { return Expr{Kind: ExprInt, Int: value} }
+func Bool(value bool) Expr { return Expr{Kind: ExprBool, Bool: value} }
+func Apply(op Operator, args ...Expr) Expr {
+	return Expr{Kind: ExprApply, Op: op, Args: args}
+}
+
+// Protocol describes legal state evolution. Local typestate, temporal-model
+// projection, generated DST actions, and debugger state diagrams should all use
+// the same transition vocabulary.
+type Protocol struct {
+	Name        string
+	States      []State
+	Initial     string
+	Transitions []Transition
+	Invariants  []Proposition
+	Assumptions []TemporalProperty
+	Guarantees  []TemporalProperty
+}
+
+type State struct {
+	Name string
+}
+
+type Transition struct {
+	Name       string
+	From       string
+	To         string
+	Requires   []Proposition
+	Effects    []Effect
+}
+
+type TemporalProperty struct {
+	Name    string
+	Formula TemporalExpr
+}
+
+type TemporalExpr struct {
+	Kind TemporalKind
+	Atom string
+	Args []TemporalExpr
+}
+
+type TemporalKind string
+
+const (
+	TemporalInvalid    TemporalKind = ""
+	TemporalAtom       TemporalKind = "atom"
+	TemporalNot        TemporalKind = "not"
+	TemporalAnd        TemporalKind = "and"
+	TemporalOr         TemporalKind = "or"
+	TemporalAlways     TemporalKind = "always"
+	TemporalEventually TemporalKind = "eventually"
+	TemporalNext       TemporalKind = "next"
+	TemporalUntil      TemporalKind = "until"
+	TemporalImplies    TemporalKind = "implies"
+)
+
+func Atom(name string) TemporalExpr { return TemporalExpr{Kind: TemporalAtom, Atom: name} }
+func Temporal(kind TemporalKind, args ...TemporalExpr) TemporalExpr {
+	return TemporalExpr{Kind: kind, Args: args}
+}
+
+// Attribute is extensible metadata. Correctness-critical semantics belong in
+// the typed axes above rather than in this escape hatch.
+type Attribute struct {
+	Namespace string
+	Name      string
+	Value     string
+}

--- a/semir/ir_test.go
+++ b/semir/ir_test.go
@@ -1,0 +1,143 @@
+package semir
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIrqDefinitionsExerciseFiveAxes(t *testing.T) {
+	module := Module{
+		Definitions: []Definition{
+			{
+				Name: "IrqId",
+				Type: Type{
+					Kind: TypeScalar,
+					Parameters: []TypeParameter{
+						{Name: "N", Phantom: true},
+					},
+				},
+				Representation: Representation{
+					Kind:      RepresentationMachineInt,
+					Bits:      16,
+					Size:      2,
+					Alignment: 2,
+				},
+				Propositions: []Proposition{
+					{
+						Name:   "in_range",
+						Status: ProofSpecified,
+						Expr:   Apply(OpLt, Ref("value"), Ref("N")),
+					},
+				},
+			},
+			{
+				Name: "Irq",
+				Type: Type{
+					Kind: TypeRecord,
+					Fields: []Field{
+						{Name: "enabled", Type: "bool"},
+						{Name: "priority", Type: "u8"},
+						{Name: "latched_pending", Type: "bool"},
+						{Name: "level_asserted", Type: "bool"},
+						{Name: "active", Type: "bool"},
+					},
+				},
+				Representation: Representation{
+					Kind:      RepresentationRecord,
+					Alignment: 1,
+				},
+				Authority: Authority{
+					Ownership: OwnershipOwned,
+					RequiredEffects: []Effect{
+						{Namespace: "irq", Name: "mutate_local"},
+					},
+					ForbiddenEffects: []Effect{
+						{Namespace: "memory", Name: "allocate"},
+						{Namespace: "thread", Name: "block"},
+					},
+				},
+				Protocol: "VirtualIrq",
+			},
+		},
+		Protocols: []Protocol{
+			{
+				Name:    "VirtualIrq",
+				Initial: "Idle",
+				States: []State{
+					{Name: "Idle"},
+					{Name: "Pending"},
+					{Name: "Active"},
+				},
+				Transitions: []Transition{
+					{Name: "inject", From: "Idle", To: "Pending"},
+					{Name: "acknowledge", From: "Pending", To: "Active"},
+					{Name: "eoi", From: "Active", To: "Idle"},
+				},
+				Guarantees: []TemporalProperty{
+					{
+						Name: "active_was_pending",
+						Formula: Temporal(
+							TemporalAlways,
+							Temporal(TemporalImplies, Atom("active"), Atom("was_pending")),
+						),
+					},
+				},
+			},
+		},
+	}
+
+	if err := module.Validate(); err != nil {
+		t.Fatalf("valid semantic module rejected: %v", err)
+	}
+}
+
+func TestAuthorityRejectsRequiredForbiddenConflict(t *testing.T) {
+	authority := Authority{
+		RequiredEffects:  []Effect{{Namespace: "memory", Name: "allocate"}},
+		ForbiddenEffects: []Effect{{Namespace: "memory", Name: "allocate"}},
+	}
+
+	err := authority.Validate()
+	if err == nil || !strings.Contains(err.Error(), "both required and forbidden") {
+		t.Fatalf("expected required/forbidden conflict, got %v", err)
+	}
+}
+
+func TestProtocolRejectsUnknownTransitionState(t *testing.T) {
+	protocol := Protocol{
+		Name:    "Broken",
+		Initial: "Idle",
+		States:  []State{{Name: "Idle"}},
+		Transitions: []Transition{
+			{Name: "wake", From: "Idle", To: "Running"},
+		},
+	}
+
+	err := protocol.Validate()
+	if err == nil || !strings.Contains(err.Error(), "unknown target state") {
+		t.Fatalf("expected unknown-state error, got %v", err)
+	}
+}
+
+func TestExpressionValidationRejectsWrongArity(t *testing.T) {
+	err := Apply(OpLt, Ref("value")).Validate()
+	if err == nil || !strings.Contains(err.Error(), "expects 2 arguments") {
+		t.Fatalf("expected arity error, got %v", err)
+	}
+}
+
+func TestDefinitionRejectsNonPowerOfTwoAlignment(t *testing.T) {
+	definition := Definition{
+		Name: "BadLayout",
+		Type: Type{Kind: TypeRecord},
+		Representation: Representation{
+			Kind:      RepresentationRecord,
+			Alignment: 3,
+		},
+	}
+
+	err := definition.Validate()
+	if err == nil || !strings.Contains(err.Error(), "not a power of two") {
+		t.Fatalf("expected alignment error, got %v", err)
+	}
+}

--- a/semir/validate.go
+++ b/semir/validate.go
@@ -1,0 +1,315 @@
+package semir
+
+import "fmt"
+
+func (m Module) Validate() error {
+	definitions := make(map[string]struct{}, len(m.Definitions))
+	for _, definition := range m.Definitions {
+		if definition.Name == "" {
+			return fmt.Errorf("semantic definition has empty name")
+		}
+		if _, exists := definitions[definition.Name]; exists {
+			return fmt.Errorf("duplicate semantic definition %q", definition.Name)
+		}
+		definitions[definition.Name] = struct{}{}
+		if err := definition.Validate(); err != nil {
+			return fmt.Errorf("definition %q: %w", definition.Name, err)
+		}
+	}
+
+	protocols := make(map[string]struct{}, len(m.Protocols))
+	for _, protocol := range m.Protocols {
+		if protocol.Name == "" {
+			return fmt.Errorf("protocol has empty name")
+		}
+		if _, exists := protocols[protocol.Name]; exists {
+			return fmt.Errorf("duplicate protocol %q", protocol.Name)
+		}
+		protocols[protocol.Name] = struct{}{}
+		if err := protocol.Validate(); err != nil {
+			return fmt.Errorf("protocol %q: %w", protocol.Name, err)
+		}
+	}
+
+	for _, definition := range m.Definitions {
+		if definition.Protocol == "" {
+			continue
+		}
+		if _, exists := protocols[definition.Protocol]; !exists {
+			return fmt.Errorf("definition %q references unknown protocol %q", definition.Name, definition.Protocol)
+		}
+	}
+	return nil
+}
+
+func (d Definition) Validate() error {
+	if d.Type.Kind == TypeInvalid {
+		return fmt.Errorf("type axis is unspecified")
+	}
+	if err := validateUniqueNames("type parameter", typeParameterNames(d.Type.Parameters)); err != nil {
+		return err
+	}
+	if err := validateUniqueNames("field", fieldNames(d.Type.Fields)); err != nil {
+		return err
+	}
+	if err := validateUniqueNames("variant", variantNames(d.Type.Variants)); err != nil {
+		return err
+	}
+	if d.Representation.Alignment != 0 && !isPowerOfTwo(d.Representation.Alignment) {
+		return fmt.Errorf("representation alignment %d is not a power of two", d.Representation.Alignment)
+	}
+	if err := d.Authority.Validate(); err != nil {
+		return err
+	}
+	if err := validatePropositions(d.Propositions); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (a Authority) Validate() error {
+	required := make(map[string]struct{}, len(a.RequiredEffects))
+	for _, effect := range a.RequiredEffects {
+		key, err := effectKey(effect)
+		if err != nil {
+			return err
+		}
+		if _, exists := required[key]; exists {
+			return fmt.Errorf("duplicate required effect %q", key)
+		}
+		required[key] = struct{}{}
+	}
+
+	forbidden := make(map[string]struct{}, len(a.ForbiddenEffects))
+	for _, effect := range a.ForbiddenEffects {
+		key, err := effectKey(effect)
+		if err != nil {
+			return err
+		}
+		if _, exists := forbidden[key]; exists {
+			return fmt.Errorf("duplicate forbidden effect %q", key)
+		}
+		if _, exists := required[key]; exists {
+			return fmt.Errorf("effect %q is both required and forbidden", key)
+		}
+		forbidden[key] = struct{}{}
+	}
+
+	capabilities := make(map[string]struct{}, len(a.Capabilities))
+	for _, capability := range a.Capabilities {
+		if capability.Name == "" {
+			return fmt.Errorf("capability has empty name")
+		}
+		key := qualified(capability.Namespace, capability.Name)
+		if _, exists := capabilities[key]; exists {
+			return fmt.Errorf("duplicate capability %q", key)
+		}
+		capabilities[key] = struct{}{}
+	}
+	return nil
+}
+
+func (p Protocol) Validate() error {
+	if p.Name == "" {
+		return fmt.Errorf("empty name")
+	}
+	states := make(map[string]struct{}, len(p.States))
+	for _, state := range p.States {
+		if state.Name == "" {
+			return fmt.Errorf("state has empty name")
+		}
+		if _, exists := states[state.Name]; exists {
+			return fmt.Errorf("duplicate state %q", state.Name)
+		}
+		states[state.Name] = struct{}{}
+	}
+	if len(states) == 0 {
+		return fmt.Errorf("has no states")
+	}
+	if _, exists := states[p.Initial]; !exists {
+		return fmt.Errorf("initial state %q does not exist", p.Initial)
+	}
+
+	transitions := make(map[string]struct{}, len(p.Transitions))
+	for _, transition := range p.Transitions {
+		if transition.Name == "" {
+			return fmt.Errorf("transition has empty name")
+		}
+		if _, exists := transitions[transition.Name]; exists {
+			return fmt.Errorf("duplicate transition %q", transition.Name)
+		}
+		transitions[transition.Name] = struct{}{}
+		if _, exists := states[transition.From]; !exists {
+			return fmt.Errorf("transition %q references unknown source state %q", transition.Name, transition.From)
+		}
+		if _, exists := states[transition.To]; !exists {
+			return fmt.Errorf("transition %q references unknown target state %q", transition.Name, transition.To)
+		}
+		if err := validatePropositions(transition.Requires); err != nil {
+			return fmt.Errorf("transition %q: %w", transition.Name, err)
+		}
+		for _, effect := range transition.Effects {
+			if _, err := effectKey(effect); err != nil {
+				return fmt.Errorf("transition %q: %w", transition.Name, err)
+			}
+		}
+	}
+	if err := validatePropositions(p.Invariants); err != nil {
+		return fmt.Errorf("invariant: %w", err)
+	}
+	for _, property := range append(append([]TemporalProperty{}, p.Assumptions...), p.Guarantees...) {
+		if property.Name == "" {
+			return fmt.Errorf("temporal property has empty name")
+		}
+		if err := property.Formula.Validate(); err != nil {
+			return fmt.Errorf("temporal property %q: %w", property.Name, err)
+		}
+	}
+	return nil
+}
+
+func (e Expr) Validate() error {
+	switch e.Kind {
+	case ExprRef:
+		if e.Ref == "" {
+			return fmt.Errorf("reference expression has empty name")
+		}
+		return nil
+	case ExprInt, ExprBool:
+		return nil
+	case ExprApply:
+		arity, ok := operatorArity(e.Op)
+		if !ok {
+			return fmt.Errorf("unknown operator %q", e.Op)
+		}
+		if len(e.Args) != arity {
+			return fmt.Errorf("operator %q expects %d arguments, got %d", e.Op, arity, len(e.Args))
+		}
+		for i, arg := range e.Args {
+			if err := arg.Validate(); err != nil {
+				return fmt.Errorf("argument %d: %w", i, err)
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("invalid expression kind %q", e.Kind)
+	}
+}
+
+func (t TemporalExpr) Validate() error {
+	switch t.Kind {
+	case TemporalAtom:
+		if t.Atom == "" {
+			return fmt.Errorf("temporal atom has empty name")
+		}
+		if len(t.Args) != 0 {
+			return fmt.Errorf("temporal atom cannot have arguments")
+		}
+		return nil
+	case TemporalNot, TemporalAlways, TemporalEventually, TemporalNext:
+		return t.validateArity(1)
+	case TemporalAnd, TemporalOr, TemporalUntil, TemporalImplies:
+		return t.validateArity(2)
+	default:
+		return fmt.Errorf("invalid temporal expression kind %q", t.Kind)
+	}
+}
+
+func (t TemporalExpr) validateArity(arity int) error {
+	if len(t.Args) != arity {
+		return fmt.Errorf("temporal operator %q expects %d arguments, got %d", t.Kind, arity, len(t.Args))
+	}
+	for i, arg := range t.Args {
+		if err := arg.Validate(); err != nil {
+			return fmt.Errorf("argument %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+func validatePropositions(propositions []Proposition) error {
+	names := make(map[string]struct{}, len(propositions))
+	for _, proposition := range propositions {
+		if proposition.Name == "" {
+			return fmt.Errorf("proposition has empty name")
+		}
+		if _, exists := names[proposition.Name]; exists {
+			return fmt.Errorf("duplicate proposition %q", proposition.Name)
+		}
+		names[proposition.Name] = struct{}{}
+		if proposition.Status == "" {
+			return fmt.Errorf("proposition %q has no proof status", proposition.Name)
+		}
+		if err := proposition.Expr.Validate(); err != nil {
+			return fmt.Errorf("proposition %q: %w", proposition.Name, err)
+		}
+	}
+	return nil
+}
+
+func operatorArity(op Operator) (int, bool) {
+	switch op {
+	case OpNot:
+		return 1, true
+	case OpAnd, OpOr, OpEq, OpNe, OpLt, OpLe, OpGt, OpGe, OpAdd, OpSub, OpMul, OpDiv, OpMod:
+		return 2, true
+	default:
+		return 0, false
+	}
+}
+
+func effectKey(effect Effect) (string, error) {
+	if effect.Name == "" {
+		return "", fmt.Errorf("effect has empty name")
+	}
+	return qualified(effect.Namespace, effect.Name), nil
+}
+
+func qualified(namespace, name string) string {
+	if namespace == "" {
+		return name
+	}
+	return namespace + "." + name
+}
+
+func isPowerOfTwo(value uint32) bool {
+	return value != 0 && value&(value-1) == 0
+}
+
+func validateUniqueNames(kind string, names []string) error {
+	seen := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		if name == "" {
+			return fmt.Errorf("%s has empty name", kind)
+		}
+		if _, exists := seen[name]; exists {
+			return fmt.Errorf("duplicate %s %q", kind, name)
+		}
+		seen[name] = struct{}{}
+	}
+	return nil
+}
+
+func typeParameterNames(parameters []TypeParameter) []string {
+	names := make([]string, len(parameters))
+	for i, parameter := range parameters {
+		names[i] = parameter.Name
+	}
+	return names
+}
+
+func fieldNames(fields []Field) []string {
+	names := make([]string, len(fields))
+	for i, field := range fields {
+		names[i] = field.Name
+	}
+	return names
+}
+
+func variantNames(variants []Variant) []string {
+	names := make([]string, len(variants))
+	for i, variant := range variants {
+		names[i] = variant.Name
+	}
+	return names
+}


### PR DESCRIPTION
## Summary

- makes Oak's semantic model explicit around five orthogonal axes: type, representation, authority/effects, proposition, and protocol
- adds `docs/LANGUAGE_MODEL.md` with the language decisions that follow from that model
- updates `docs/SEMANTIC_ARCHITECTURE.md` so executable code, proof backends, model checking, schemas, debugger metadata, and documentation all project from one Semantic IR
- adds a new `semir` Go package as the first executable host-side representation
- keeps proposition and temporal formulas structured instead of string annotations
- tracks proof status explicitly (`specified`, `checked`, `proved-smt`, `proved-kernel`, `model-checked`, `tested`, `refined`)
- validates contradictory authority contracts, duplicate semantic identities, invalid alignment claims, malformed propositions, unknown protocol states/transitions, and missing protocol references
- adds an IRQ-oriented test that exercises all five axes together
- explicitly refuses to invent exact machine layout when earlier compiler phases have lost information (for example record source order in the historical map-backed AST)

## Verification

A local checkout could not reach GitHub from the execution environment, so the repository's Go 1.27 CI is the execution gate for this PR. The new package has focused unit tests and does not alter the existing parser/typechecker/codegen paths.

The separate golden-file workflow is still expected to reflect the previously documented stale/incomplete corpus; this PR does not weaken that gate.