### PR TITLE
Project Oak type declarations into Semantic IR

### DIFF
--- a/compiler/semantic_types.go
+++ b/compiler/semantic_types.go
@@ -1,0 +1,300 @@
+package compiler
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/SCKelemen/oak/ast"
+	"github.com/SCKelemen/oak/semir"
+)
+
+// TypeModel projects the currently implemented Oak type declarations into the
+// Semantic IR after ordinary semantic analysis succeeds.
+//
+// This is intentionally narrower than the eventual full SemanticIR stage: it
+// lowers ADTs, records, aliases, generics, and interfaces, while executable
+// function bodies remain in the existing typed AST/lowering pipeline.
+func (comp Compilation) TypeModel() Stage[*semir.Module] {
+	return comp.Check().Then(func(model *SemanticModel) (*semir.Module, error) {
+		module, err := BuildTypeModel(model.Tree.Root)
+		if err != nil {
+			return nil, fmt.Errorf("semantic type projection failed: %w", err)
+		}
+		return module, nil
+	})
+}
+
+// BuildTypeModel projects type-level declarations from an already parsed Oak
+// program. It never invents representation information that the AST cannot
+// justify. In particular, record membership is preserved but field layout stays
+// unspecified because the historical AST stores record fields in a map.
+func BuildTypeModel(program *ast.Program) (*semir.Module, error) {
+	module := &semir.Module{}
+	for _, statement := range program.Statements {
+		switch declaration := statement.(type) {
+		case *ast.ADTType:
+			definition, err := buildADTDefinition(declaration)
+			if err != nil {
+				return nil, err
+			}
+			module.Definitions = append(module.Definitions, definition)
+		case *ast.InterfaceType:
+			definition, err := buildInterfaceDefinition(declaration)
+			if err != nil {
+				return nil, err
+			}
+			module.Definitions = append(module.Definitions, definition)
+		}
+	}
+	if err := module.Validate(); err != nil {
+		return nil, err
+	}
+	return module, nil
+}
+
+func buildADTDefinition(declaration *ast.ADTType) (semir.Definition, error) {
+	if declaration == nil || declaration.Name == nil || declaration.Name.Value == "" {
+		return semir.Definition{}, fmt.Errorf("ADT declaration has no name")
+	}
+
+	parameters, err := buildTypeParameters(declaration.TypeParams)
+	if err != nil {
+		return semir.Definition{}, fmt.Errorf("type %q: %w", declaration.Name.Value, err)
+	}
+
+	definition := semir.Definition{Name: declaration.Name.Value}
+	definition.Type.Parameters = parameters
+
+	if len(declaration.Variants) == 1 {
+		variant := declaration.Variants[0]
+		if variant == nil {
+			return semir.Definition{}, fmt.Errorf("type %q has nil variant", declaration.Name.Value)
+		}
+
+		if record, ok := variant.Literal.(*ast.RecordLiteral); ok && variant.Name != nil && variant.Name.Value == declaration.Name.Value {
+			fields, err := buildRecordFields(record)
+			if err != nil {
+				return semir.Definition{}, fmt.Errorf("record %q: %w", declaration.Name.Value, err)
+			}
+			definition.Type.Kind = semir.TypeRecord
+			definition.Type.Fields = fields
+			// Representation intentionally stays unspecified until source field
+			// order is preserved by the typed syntax representation.
+			return definition, nil
+		}
+
+		if variant.Literal == nil && variant.Payload != nil && variant.Name != nil && variant.Name.Value == declaration.Name.Value {
+			base, err := semanticTypeName(variant.Payload)
+			if err != nil {
+				return semir.Definition{}, fmt.Errorf("alias %q: %w", declaration.Name.Value, err)
+			}
+			definition.Type.Kind = semir.TypeAlias
+			definition.Type.Base = base
+			return definition, nil
+		}
+	}
+
+	definition.Type.Kind = semir.TypeSum
+	definition.Type.Variants = make([]semir.Variant, 0, len(declaration.Variants))
+	for _, variant := range declaration.Variants {
+		if variant == nil || variant.Name == nil || variant.Name.Value == "" {
+			return semir.Definition{}, fmt.Errorf("type %q has unnamed variant", declaration.Name.Value)
+		}
+		if variant.Literal != nil {
+			return semir.Definition{}, fmt.Errorf(
+				"type %q variant %q uses legacy literal syntax whose semantics are ambiguous; split payload/default/discriminant semantics before projecting it",
+				declaration.Name.Value,
+				variant.Name.Value,
+			)
+		}
+		semanticVariant := semir.Variant{Name: variant.Name.Value}
+		if variant.Payload != nil {
+			payload, err := semanticTypeName(variant.Payload)
+			if err != nil {
+				return semir.Definition{}, fmt.Errorf("type %q variant %q: %w", declaration.Name.Value, variant.Name.Value, err)
+			}
+			semanticVariant.Payload = payload
+		}
+		definition.Type.Variants = append(definition.Type.Variants, semanticVariant)
+	}
+	return definition, nil
+}
+
+func buildInterfaceDefinition(declaration *ast.InterfaceType) (semir.Definition, error) {
+	if declaration == nil || declaration.Name == nil || declaration.Name.Value == "" {
+		return semir.Definition{}, fmt.Errorf("interface declaration has no name")
+	}
+	parameters, err := buildTypeParameters(declaration.TypeParams)
+	if err != nil {
+		return semir.Definition{}, fmt.Errorf("interface %q: %w", declaration.Name.Value, err)
+	}
+	definition := semir.Definition{
+		Name: declaration.Name.Value,
+		Type: semir.Type{
+			Kind:       semir.TypeInterface,
+			Parameters: parameters,
+		},
+	}
+
+	for _, method := range declaration.Methods {
+		if method == nil || method.Name == nil || method.Name.Value == "" {
+			return semir.Definition{}, fmt.Errorf("interface %q has unnamed method", declaration.Name.Value)
+		}
+		semanticMethod := semir.Method{Name: method.Name.Value}
+		if method.ReceiverType != nil {
+			receiver, err := semanticTypeName(method.ReceiverType)
+			if err != nil {
+				return semir.Definition{}, fmt.Errorf("interface %q method %q receiver: %w", declaration.Name.Value, method.Name.Value, err)
+			}
+			semanticMethod.Receiver = receiver
+		}
+		for _, parameter := range method.Parameters {
+			if parameter == nil || parameter.Name == nil {
+				return semir.Definition{}, fmt.Errorf("interface %q method %q has invalid parameter", declaration.Name.Value, method.Name.Value)
+			}
+			parameterType, err := semanticTypeName(parameter.Type)
+			if err != nil {
+				return semir.Definition{}, fmt.Errorf("interface %q method %q parameter %q: %w", declaration.Name.Value, method.Name.Value, parameter.Name.Value, err)
+			}
+			semanticMethod.Parameters = append(semanticMethod.Parameters, semir.Field{
+				Name: parameter.Name.Value,
+				Type: parameterType,
+			})
+		}
+		returnType, err := semanticTypeName(method.ReturnType)
+		if err != nil {
+			return semir.Definition{}, fmt.Errorf("interface %q method %q return type: %w", declaration.Name.Value, method.Name.Value, err)
+		}
+		semanticMethod.Return = returnType
+		definition.Type.Methods = append(definition.Type.Methods, semanticMethod)
+	}
+	return definition, nil
+}
+
+func buildTypeParameters(parameters []*ast.TypeParameter) ([]semir.TypeParameter, error) {
+	result := make([]semir.TypeParameter, 0, len(parameters))
+	for _, parameter := range parameters {
+		if parameter == nil || parameter.Name == nil || parameter.Name.Value == "" {
+			return nil, fmt.Errorf("unnamed type parameter")
+		}
+		semanticParameter := semir.TypeParameter{Name: parameter.Name.Value}
+		if parameter.Constraint != nil {
+			constraint, err := semanticTypeName(parameter.Constraint)
+			if err != nil {
+				return nil, fmt.Errorf("type parameter %q constraint: %w", parameter.Name.Value, err)
+			}
+			semanticParameter.Constraint = constraint
+		}
+		// Whether a parameter is phantom is a checked semantic property, not
+		// something this syntax-only projection should guess.
+		result = append(result, semanticParameter)
+	}
+	return result, nil
+}
+
+func buildRecordFields(record *ast.RecordLiteral) ([]semir.Field, error) {
+	if record == nil {
+		return nil, fmt.Errorf("nil record")
+	}
+	names := make([]string, 0, len(record.Fields))
+	for name := range record.Fields {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	fields := make([]semir.Field, 0, len(names))
+	for _, name := range names {
+		fieldType, err := semanticTypeName(record.Fields[name])
+		if err != nil {
+			return nil, fmt.Errorf("field %q: %w", name, err)
+		}
+		fields = append(fields, semir.Field{Name: name, Type: fieldType})
+	}
+	return fields, nil
+}
+
+func semanticTypeName(expression ast.Expression) (string, error) {
+	switch expression := expression.(type) {
+	case *ast.Identifier:
+		if expression == nil || expression.Value == "" {
+			return "", fmt.Errorf("empty type identifier")
+		}
+		return expression.Value, nil
+
+	case *ast.PrefixExpression:
+		if expression == nil || expression.Operator != "*" {
+			return "", fmt.Errorf("unsupported type prefix %q", expression.Operator)
+		}
+		right, err := semanticTypeName(expression.Right)
+		if err != nil {
+			return "", err
+		}
+		return "*" + right, nil
+
+	case *ast.InfixExpression:
+		if expression == nil || expression.Operator != "&" {
+			return "", fmt.Errorf("unsupported type operator %q", expression.Operator)
+		}
+		left, err := semanticTypeName(expression.Left)
+		if err != nil {
+			return "", err
+		}
+		right, err := semanticTypeName(expression.Right)
+		if err != nil {
+			return "", err
+		}
+		return left + " & " + right, nil
+
+	case *ast.IndexExpression:
+		if expression == nil {
+			return "", fmt.Errorf("nil indexed type")
+		}
+		base, err := semanticTypeName(expression.Left)
+		if err != nil {
+			return "", err
+		}
+		switch index := expression.Index.(type) {
+		case *ast.Identifier:
+			if index.Value == "" {
+				return "[]" + base, nil
+			}
+			if index.Value == "*" {
+				return "[*]" + base, nil
+			}
+			return appendGenericArgument(base, index.Value), nil
+		case *ast.IntegerLiteral:
+			return "[" + strconv.FormatInt(index.Value, 10) + "]" + base, nil
+		default:
+			argument, err := semanticTypeName(expression.Index)
+			if err != nil {
+				return "", err
+			}
+			return appendGenericArgument(base, argument), nil
+		}
+
+	case *ast.RecordLiteral:
+		fields, err := buildRecordFields(expression)
+		if err != nil {
+			return "", err
+		}
+		parts := make([]string, 0, len(fields))
+		for _, field := range fields {
+			parts = append(parts, field.Name+": "+field.Type)
+		}
+		return "{" + strings.Join(parts, ", ") + "}", nil
+
+	default:
+		return "", fmt.Errorf("unsupported type expression %T", expression)
+	}
+}
+
+func appendGenericArgument(base, argument string) string {
+	if strings.HasSuffix(base, "]") {
+		if open := strings.LastIndex(base, "["); open >= 0 {
+			return base[:len(base)-1] + ", " + argument + "]"
+		}
+	}
+	return base + "[" + argument + "]"
+}

--- a/compiler/semantic_types_test.go
+++ b/compiler/semantic_types_test.go
@@ -1,0 +1,128 @@
+package compiler
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/SCKelemen/oak/ast"
+	"github.com/SCKelemen/oak/semir"
+)
+
+func TestCompilationTypeModelProjectsADT(t *testing.T) {
+	const source = `Color: type = Red | Green | Blue`
+
+	module, err := New().WithSource("color.oak", source).TypeModel().Get()
+	if err != nil {
+		t.Fatalf("type model projection failed: %v", err)
+	}
+	if len(module.Definitions) != 1 {
+		t.Fatalf("expected one semantic definition, got %d", len(module.Definitions))
+	}
+	color := module.Definitions[0]
+	if color.Name != "Color" || color.Type.Kind != semir.TypeSum {
+		t.Fatalf("unexpected Color definition: %#v", color)
+	}
+	if len(color.Type.Variants) != 3 {
+		t.Fatalf("expected three variants, got %d", len(color.Type.Variants))
+	}
+}
+
+func TestBuildTypeModelProjectsRecordWithoutInventingLayout(t *testing.T) {
+	program := &ast.Program{Statements: []ast.Statement{
+		&ast.ADTType{
+			Name: &ast.Identifier{Value: "Point"},
+			Variants: []*ast.ADTVariant{
+				{
+					Name: &ast.Identifier{Value: "Point"},
+					Literal: &ast.RecordLiteral{Fields: map[string]ast.Expression{
+						"y": &ast.Identifier{Value: "i32"},
+						"x": &ast.Identifier{Value: "i32"},
+					}},
+				},
+			},
+		},
+	}}
+
+	module, err := BuildTypeModel(program)
+	if err != nil {
+		t.Fatalf("record projection failed: %v", err)
+	}
+	point := module.Definitions[0]
+	if point.Type.Kind != semir.TypeRecord {
+		t.Fatalf("expected record semantic type, got %q", point.Type.Kind)
+	}
+	if point.Representation.Kind != semir.RepresentationUnspecified || len(point.Representation.Fields) != 0 {
+		t.Fatalf("projector invented representation from unordered AST: %#v", point.Representation)
+	}
+	if got := []string{point.Type.Fields[0].Name, point.Type.Fields[1].Name}; got[0] != "x" || got[1] != "y" {
+		t.Fatalf("expected deterministic semantic field order [x y], got %v", got)
+	}
+}
+
+func TestBuildTypeModelProjectsInterfaceMethods(t *testing.T) {
+	program := &ast.Program{Statements: []ast.Statement{
+		&ast.InterfaceType{
+			Name: &ast.Identifier{Value: "Readable"},
+			Methods: []*ast.InterfaceMethod{
+				{
+					Name:       &ast.Identifier{Value: "Read"},
+					ReturnType: &ast.Identifier{Value: "ReadResult"},
+					Parameters: []*ast.FunctionParameter{
+						{Name: &ast.Identifier{Value: "buf"}, Type: &ast.IndexExpression{Left: &ast.Identifier{Value: "u8"}, Index: &ast.Identifier{Value: ""}}},
+					},
+				},
+			},
+		},
+	}}
+
+	module, err := BuildTypeModel(program)
+	if err != nil {
+		t.Fatalf("interface projection failed: %v", err)
+	}
+	readable := module.Definitions[0]
+	if readable.Type.Kind != semir.TypeInterface || len(readable.Type.Methods) != 1 {
+		t.Fatalf("unexpected interface projection: %#v", readable.Type)
+	}
+	method := readable.Type.Methods[0]
+	if method.Name != "Read" || method.Parameters[0].Type != "[]u8" || method.Return != "ReadResult" {
+		t.Fatalf("unexpected method projection: %#v", method)
+	}
+}
+
+func TestBuildTypeModelRejectsAmbiguousLegacyVariantLiteral(t *testing.T) {
+	program := &ast.Program{Statements: []ast.Statement{
+		&ast.ADTType{
+			Name: &ast.Identifier{Value: "Status"},
+			Variants: []*ast.ADTVariant{
+				{
+					Name:    &ast.Identifier{Value: "Ok"},
+					Payload: &ast.Identifier{Value: "u16"},
+					Literal: &ast.IntegerLiteral{Value: 200},
+				},
+			},
+		},
+	}}
+
+	_, err := BuildTypeModel(program)
+	if err == nil || !strings.Contains(err.Error(), "legacy literal syntax") {
+		t.Fatalf("expected ambiguous-literal error, got %v", err)
+	}
+}
+
+func TestSemanticTypeNameFlattensGenericArguments(t *testing.T) {
+	expr := &ast.IndexExpression{
+		Left: &ast.IndexExpression{
+			Left:  &ast.Identifier{Value: "Result"},
+			Index: &ast.Identifier{Value: "T"},
+		},
+		Index: &ast.Identifier{Value: "E"},
+	}
+
+	got, err := semanticTypeName(expr)
+	if err != nil {
+		t.Fatalf("generic type projection failed: %v", err)
+	}
+	if got != "Result[T, E]" {
+		t.Fatalf("expected Result[T, E], got %q", got)
+	}
+}

--- a/semir/ir.go
+++ b/semir/ir.go
@@ -27,18 +27,20 @@ type Type struct {
 	Parameters []TypeParameter
 	Fields     []Field
 	Variants   []Variant
+	Methods    []Method
 }
 
 type TypeKind string
 
 const (
-	TypeInvalid  TypeKind = ""
-	TypeScalar   TypeKind = "scalar"
-	TypeAlias    TypeKind = "alias"
-	TypeRecord   TypeKind = "record"
-	TypeSum      TypeKind = "sum"
-	TypeFunction TypeKind = "function"
-	TypeOpaque   TypeKind = "opaque"
+	TypeInvalid   TypeKind = ""
+	TypeScalar    TypeKind = "scalar"
+	TypeAlias     TypeKind = "alias"
+	TypeRecord    TypeKind = "record"
+	TypeSum       TypeKind = "sum"
+	TypeFunction  TypeKind = "function"
+	TypeInterface TypeKind = "interface"
+	TypeOpaque    TypeKind = "opaque"
 )
 
 type TypeParameter struct {
@@ -55,6 +57,13 @@ type Field struct {
 type Variant struct {
 	Name    string
 	Payload string
+}
+
+type Method struct {
+	Name       string
+	Receiver   string
+	Parameters []Field
+	Return     string
 }
 
 // Representation describes the bits/layout chosen for a semantic type. Empty
@@ -105,11 +114,11 @@ type TagLayout struct {
 // Authority describes what code holding a value may do with it. Ownership,
 // capabilities, and effects are semantic facts, not comments or tags.
 type Authority struct {
-	Ownership       Ownership
-	Capabilities    []Capability
-	RequiredEffects []Effect
+	Ownership        Ownership
+	Capabilities     []Capability
+	RequiredEffects  []Effect
 	ForbiddenEffects []Effect
-	UnsafeBoundary  bool
+	UnsafeBoundary   bool
 }
 
 type Ownership string
@@ -217,11 +226,11 @@ type State struct {
 }
 
 type Transition struct {
-	Name       string
-	From       string
-	To         string
-	Requires   []Proposition
-	Effects    []Effect
+	Name     string
+	From     string
+	To       string
+	Requires []Proposition
+	Effects  []Effect
 }
 
 type TemporalProperty struct {

--- a/semir/validate.go
+++ b/semir/validate.go
@@ -43,8 +43,8 @@ func (m Module) Validate() error {
 }
 
 func (d Definition) Validate() error {
-	if d.Type.Kind == TypeInvalid {
-		return fmt.Errorf("type axis is unspecified")
+	if !validTypeKind(d.Type.Kind) {
+		return fmt.Errorf("invalid type kind %q", d.Type.Kind)
 	}
 	if err := validateUniqueNames("type parameter", typeParameterNames(d.Type.Parameters)); err != nil {
 		return err
@@ -52,8 +52,29 @@ func (d Definition) Validate() error {
 	if err := validateUniqueNames("field", fieldNames(d.Type.Fields)); err != nil {
 		return err
 	}
+	for _, field := range d.Type.Fields {
+		if field.Type == "" {
+			return fmt.Errorf("field %q has empty type", field.Name)
+		}
+	}
 	if err := validateUniqueNames("variant", variantNames(d.Type.Variants)); err != nil {
 		return err
+	}
+	if err := validateUniqueNames("method", methodNames(d.Type.Methods)); err != nil {
+		return err
+	}
+	for _, method := range d.Type.Methods {
+		if method.Return == "" {
+			return fmt.Errorf("method %q has empty return type", method.Name)
+		}
+		if err := validateUniqueNames("method parameter", fieldNames(method.Parameters)); err != nil {
+			return fmt.Errorf("method %q: %w", method.Name, err)
+		}
+		for _, parameter := range method.Parameters {
+			if parameter.Type == "" {
+				return fmt.Errorf("method %q parameter %q has empty type", method.Name, parameter.Name)
+			}
+		}
 	}
 	if d.Representation.Alignment != 0 && !isPowerOfTwo(d.Representation.Alignment) {
 		return fmt.Errorf("representation alignment %d is not a power of two", d.Representation.Alignment)
@@ -237,14 +258,32 @@ func validatePropositions(propositions []Proposition) error {
 			return fmt.Errorf("duplicate proposition %q", proposition.Name)
 		}
 		names[proposition.Name] = struct{}{}
-		if proposition.Status == "" {
-			return fmt.Errorf("proposition %q has no proof status", proposition.Name)
+		if !validProofStatus(proposition.Status) {
+			return fmt.Errorf("proposition %q has invalid proof status %q", proposition.Name, proposition.Status)
 		}
 		if err := proposition.Expr.Validate(); err != nil {
 			return fmt.Errorf("proposition %q: %w", proposition.Name, err)
 		}
 	}
 	return nil
+}
+
+func validTypeKind(kind TypeKind) bool {
+	switch kind {
+	case TypeScalar, TypeAlias, TypeRecord, TypeSum, TypeFunction, TypeInterface, TypeOpaque:
+		return true
+	default:
+		return false
+	}
+}
+
+func validProofStatus(status ProofStatus) bool {
+	switch status {
+	case ProofSpecified, ProofChecked, ProofSMT, ProofKernel, ProofModelChecked, ProofTested, ProofRefined:
+		return true
+	default:
+		return false
+	}
 }
 
 func operatorArity(op Operator) (int, bool) {
@@ -310,6 +349,14 @@ func variantNames(variants []Variant) []string {
 	names := make([]string, len(variants))
 	for i, variant := range variants {
 		names[i] = variant.Name
+	}
+	return names
+}
+
+func methodNames(methods []Method) []string {
+	names := make([]string, len(methods))
+	for i, method := range methods {
+		names[i] = method.Name
 	}
 	return names
 }


### PR DESCRIPTION
## Summary

- adds `Compilation.TypeModel()` as the first real compiler projection into `semir`
- lowers existing Oak ADTs, records, aliases, generic constraints, and interfaces after ordinary semantic analysis succeeds
- extends the Semantic IR type axis with interface methods rather than throwing that information away
- canonicalizes existing type expressions for semantic use (pointers, arrays/slices/spans, generic applications, constraint composition, anonymous records)
- keeps record representation/layout unspecified because the historical AST has already lost source field order
- rejects the old `Variant: T = value` form during projection rather than guessing whether `value` is a default payload, discriminant, or singleton/literal semantics
- adds tests for end-to-end ADT projection, record fail-closed layout behavior, interface methods, generic type canonicalization, and ambiguous legacy literals
- strengthens Semantic IR validation for method signatures, type kinds, proof-status values, and empty semantic field types

## Verification

PR CI is the execution gate. The change is additive to the existing typed compiler pipeline: `TypeModel()` runs from `Check()` and does not alter code generation.