### PR TITLE
Consolidate Oak language specification and formal verification

### DIFF
--- a/.github/workflows/formal.yml
+++ b/.github/workflows/formal.yml
@@ -1,0 +1,34 @@
+name: Formal Verification
+
+on:
+  push:
+    branches:
+      - specification
+      - docs/spec-consolidation
+  pull_request:
+    branches:
+      - specification
+
+permissions:
+  contents: read
+
+jobs:
+  lean:
+    name: Lean 4
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install elan
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -sSfL https://github.com/leanprover/elan/releases/download/v4.2.2/elan-x86_64-unknown-linux-gnu.tar.gz -o /tmp/elan.tar.gz
+          tar -xzf /tmp/elan.tar.gz -C /tmp
+          /tmp/elan-init -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+
+      - name: Build formal specification
+        working-directory: spec/lean
+        run: lake build

--- a/docs/spec/00-constitution.md
+++ b/docs/spec/00-constitution.md
@@ -1,0 +1,120 @@
+# Oak Language Constitution
+
+## Priorities
+
+Oak makes design trade-offs in this order:
+
+1. **Correctness**
+2. **Performance**
+3. **Simplicity**
+
+Safety and ergonomics constrain every choice rather than forming lower-priority afterthoughts.
+
+A design is not acceptable merely because it is simpler if it destroys semantic information needed for correctness. A faster design is not acceptable if its invariants cannot be stated and checked. Once correctness and material performance requirements are satisfied, choose the smallest and most orthogonal mechanism.
+
+## Tight surface
+
+Oak should feel lightweight. The language should prefer a small algebra of reusable constructs over a large catalog of special forms.
+
+The core vocabulary is intended to center on:
+
+- functions and expressions;
+- records (product types);
+- ADTs and eventually GADT-style result refinements (sum types);
+- pattern matching;
+- generics and constraints;
+- phantom/refined semantic types;
+- ownership, borrowing, and effects;
+- explicit unsafe boundaries.
+
+Domain concepts such as arenas, slabs, handles, encodings, protocols, serializers, intrusive lists, and capabilities should normally be expressible as ordinary types plus semantic facts rather than new syntax.
+
+## One fact, many projections
+
+A semantic fact should have one authoritative representation and be reused wherever possible.
+
+Examples:
+
+```text
+field order
+  -> type semantics
+  -> machine layout
+  -> serializer schema
+  -> debugger rendering
+
+refinement
+  -> type checking
+  -> SMT/Lean assumption
+  -> runtime check when not statically discharged
+  -> generated boundary tests
+
+protocol transition
+  -> typestate API
+  -> model checker action
+  -> DST action
+  -> debugger state diagram
+```
+
+The compiler must not reconstruct lost facts by guesswork.
+
+## Five semantic axes
+
+Oak separates five orthogonal questions:
+
+1. **Type** — what values mean and which values inhabit the type.
+2. **Representation** — what bits/layout encode those values.
+3. **Authority / Effect** — what code holding a value may do.
+4. **Proposition** — what facts are statically known.
+5. **Protocol** — how state may legally evolve.
+
+A feature should not overload one axis to smuggle in another. For example, a documentation tag must not silently alter ABI representation; a payload default must not double as a wire discriminant.
+
+## Safe by default
+
+Safe Oak code must not have undefined behavior from ordinary language operations.
+
+Potentially unsafe operations—raw pointer dereference, unchecked reinterpretation, unproven device/MMIO assumptions, unchecked aliasing, and similar operations—must cross a visible unsafe boundary.
+
+`unsafe` does not disable the type checker. It introduces narrowly scoped assumptions that the compiler cannot establish itself; all unrelated invariants remain checked.
+
+## No hidden work
+
+The language and standard library should make material runtime work visible. In particular, ordinary operations must not silently:
+
+- allocate;
+- block;
+- perform I/O;
+- acquire contended locks;
+- invoke unbounded dynamic dispatch;
+- copy unbounded data.
+
+Such behavior belongs in explicit effects/APIs.
+
+## Machine semantics are real semantics
+
+Fixed-width integers, overflow behavior, alignment, endianness, pointer width, atomics, volatile/MMIO operations, and layout constraints are part of the language's semantic model rather than backend accidents.
+
+Mathematical integers may exist in proofs/compile-time reasoning, but they must never be silently confused with machine integers.
+
+## Syntax equivalence
+
+Layout-delimited and explicitly braced blocks are two spellings of one syntax tree and one semantics. There is no global syntax mode.
+
+Surface sugar must normalize to a smaller core; it must not create parallel semantics.
+
+## Verification discipline
+
+A formal model proves the model, not automatically the compiler implementation.
+
+For every important feature we track separately:
+
+```text
+specified
+implemented
+unit/property tested
+formally modeled
+proved
+refined to implementation
+```
+
+The strongest early refinement targets are foundational laws whose implementation is small enough to relate directly to the model.

--- a/docs/spec/05-ergonomics-and-cost.md
+++ b/docs/spec/05-ergonomics-and-cost.md
@@ -1,0 +1,161 @@
+# Functional Ergonomics, Systems Cost Model
+
+Oak aims for the day-to-day ergonomics of ML-family languages, Elm, and the best parts of TypeScript tooling, while preserving the runtime cost model of Zig/C.
+
+This is a semantic requirement, not a marketing analogy.
+
+## Functional surface
+
+Oak should make these patterns natural:
+
+- expression-oriented functions and blocks;
+- local type inference;
+- algebraic data types;
+- exhaustive pattern matching;
+- generic functions and types;
+- small pure functions;
+- immutable/read-only views by default;
+- explicit mutation where mutation is the clearest model;
+- first-class function values when their representation/capture cost is known;
+- structural interface/constraint satisfaction for generic ergonomics;
+- strong editor/compiler feedback with exact source locations.
+
+The common case should not require repetitive type annotations, constructor qualification, lifetime syntax, or ceremony that the compiler can infer unambiguously.
+
+## Systems cost model
+
+Ergonomic abstraction must not imply a hidden runtime system.
+
+Oak has no mandatory:
+
+- garbage collector;
+- hidden heap allocation;
+- implicit boxing;
+- exception unwinding runtime;
+- runtime interface vtables for ordinary generic constraints;
+- reference counting;
+- hidden asynchronous scheduler;
+- implicit buffer copying.
+
+A language feature that requires one of these costs must make that representation/effect explicit.
+
+## Expressions do not imply allocation
+
+Expression-oriented code lowers to ordinary control flow.
+
+```oak
+result := value ?
+  | .Some(x) => x + 1
+  | .None    => 0
+```
+
+should normally lower to a tag test plus branches and scalar operations. The expression-oriented syntax is not permission to materialize temporary heap objects.
+
+## ADTs are concrete values
+
+ADTs have a statically known representation chosen by the representation layer. A conventional closed ADT can lower to:
+
+```text
+tag + maximum payload storage
+```
+
+or to a smaller representation when a proof-preserving representation optimization applies.
+
+Pattern matching should lower to direct tag/literal tests and branches. Exhaustiveness is compile-time information.
+
+## Generics specialize by default
+
+Generic constraints are compile-time predicates. Executable lowering should normally specialize/monomorphize generic code so that:
+
+```oak
+fn max[T: Ord[T]](a: T, b: T): T
+```
+
+can become direct operations on the chosen concrete `T` without an implicit interface object.
+
+Code-size trade-offs from specialization are real and may later admit explicitly selected alternatives, but dynamic dispatch is never silently introduced just to implement a generic constraint.
+
+## Function values and closures
+
+Plain function values may use a direct function pointer representation.
+
+A capturing closure conceptually contains:
+
+```text
+code pointer + environment
+```
+
+The environment's storage/lifetime must be established explicitly by ownership analysis. Capturing a local variable must not silently heap-promote that variable.
+
+A closure is legal when its environment can be represented safely using known storage, such as:
+
+- stack lifetime that does not escape;
+- caller-owned storage;
+- an explicit arena/region;
+- static storage;
+- another explicit owner.
+
+If escape requires allocation, that allocation is an effect and must be explicit/allowed.
+
+## Iterators and functional combinators
+
+Libraries may offer `map`, `filter`, folds, iterators, and pipelines, but their semantics must preserve the cost model.
+
+For bounded/slice-like inputs, optimized lowering should be capable of producing a simple loop with no intermediate allocation when the abstraction is statically known.
+
+APIs that inherently construct new storage must accept or identify their allocator rather than allocate invisibly.
+
+## Mutation is explicit, not stigmatized
+
+Oak is not purely functional. Mutation is appropriate for:
+
+- state machines;
+- parsers/lexers;
+- DMA buffers;
+- intrusive structures;
+- realtime DSP;
+- device drivers;
+- bounded in-place algorithms.
+
+The language should make mutation locally obvious and ownership-safe, while keeping pure computation easy to recognize and reason about.
+
+## TypeScript-inspired ergonomics without JavaScript semantics
+
+Useful TypeScript-like qualities include:
+
+- excellent language-server discoverability;
+- lightweight local inference;
+- structural satisfaction of compile-time interfaces;
+- fast incremental feedback;
+- easy navigation/refactoring;
+- precise diagnostics.
+
+Oak does not inherit JavaScript's dynamic object model, implicit coercions, boxed values, prototype semantics, or GC cost model.
+
+## Elm/ML-inspired ergonomics without mandatory persistent allocation
+
+Useful ML/Elm qualities include:
+
+- ADTs as ordinary design vocabulary;
+- matching as the primary way to consume sums;
+- expression-oriented APIs;
+- inference that removes annotation noise;
+- pure functions as the easy/default reasoning unit.
+
+Oak does not require persistent heap data structures or a garbage-collected runtime to obtain those ergonomics.
+
+## Performance transparency
+
+For core language constructs, a competent systems programmer should be able to predict the broad machine shape from the Oak source:
+
+```text
+record          -> fields in known storage
+ADT             -> tag/payload representation
+match           -> tests/branches
+specialized fn  -> direct call/inlined code
+view/span       -> pointer + length (subject to target representation)
+raw pointer     -> machine pointer
+arena/slab op   -> explicit bounded allocator operation
+```
+
+When that correspondence is not obvious, compiler tooling should expose the lowering rather than rely on folklore.

--- a/docs/spec/10-syntax.md
+++ b/docs/spec/10-syntax.md
@@ -1,0 +1,221 @@
+# Oak Surface Syntax
+
+This document defines the canonical surface conventions. Compatibility spellings in older documents are not normative.
+
+## 1. Punctuation has one job
+
+Oak prefers a tight syntactic surface in which punctuation carries a stable meaning.
+
+| Syntax | Meaning |
+| --- | --- |
+| `x: T` | type annotation |
+| `x = e` | initialization with explicit type context or reassignment |
+| `x := e` | local declaration with inferred type |
+| `(A, B) -> C` | function type |
+| `pattern => expr` | match arm |
+| `Type.Case` | qualified ADT constructor |
+| `.Case` | context-inferred ADT constructor |
+| `T[E]` | generic/type application |
+| `[]T` | read-only view |
+| `[*]T` | writable span |
+| `[N]T` | fixed-size owned array |
+
+`->` is not a match-arm spelling. `=>` is not a function-type spelling.
+
+`Type::Case` is legacy syntax and not canonical.
+
+## 2. Declarations
+
+Explicitly typed declaration:
+
+```oak
+count: u32 = 0
+```
+
+Inferred local declaration:
+
+```oak
+count := u32(0)
+```
+
+Reassignment:
+
+```oak
+count = count + 1
+```
+
+Safe Oak does not assign an implicit `NULL` value to an uninitialized declaration. A declaration such as:
+
+```oak
+x: T
+```
+
+is not part of the safe core until definite-initialization semantics are specified and mechanically checked. Prefer initialization at declaration or an explicit `Option[T]`/state ADT.
+
+## 3. Functions
+
+Canonical return annotation uses `:`:
+
+```oak
+fn add(a: i32, b: i32): i32 = a + b
+```
+
+Layout body:
+
+```oak
+fn add(a: i32, b: i32): i32
+  sum := a + b
+  sum
+```
+
+Explicit body:
+
+```oak
+fn add(a: i32, b: i32): i32 {
+  sum := a + b
+  sum
+}
+```
+
+These forms have one block/expression semantics. `=` is useful for an explicitly expression-bodied function; a following layout block or brace block is the ordinary body form.
+
+Function types use `->`:
+
+```oak
+(i32, i32) -> i32
+```
+
+## 4. Blocks and layout
+
+Statement/expression blocks may be delimited by indentation or explicit braces. Both normalize to the same structural token stream and AST.
+
+```oak
+while ready
+  work()
+  advance()
+```
+
+is equivalent to:
+
+```oak
+while ready {
+  work()
+  advance()
+}
+```
+
+There is no file-wide syntax mode. Explicit braces dominate indentation inside the explicit block.
+
+Data-construction braces remain explicit:
+
+```oak
+Point { x: 1, y: 2 }
+```
+
+Layout indentation never changes a record literal into a statement block or vice versa.
+
+## 5. Separators
+
+Commas delimit elements inside data/parameter/type argument lists:
+
+```oak
+f(a, b, c)
+Point { x: 1, y: 2 }
+Result[T, E]
+```
+
+A trailing comma may be allowed for multiline delimited data/lists when the corresponding grammar production explicitly permits it. The parser uses one delimited-sequence cursor contract regardless of the element kind.
+
+Semicolons may separate statements in explicit single-line blocks, but normal Oak formatting uses line structure and does not require semicolons after ordinary statements.
+
+## 6. ADTs
+
+```oak
+Option[T]: type =
+  | Some: T
+  | None
+```
+
+Constructors:
+
+```oak
+x: Option[i32] = Option.Some(42)
+y: Option[i32] = .None
+```
+
+## 7. Pattern matching
+
+```oak
+value ?
+  | .Some(x) => x
+  | .None    => fallback
+```
+
+Explicit braces:
+
+```oak
+value ? {
+  | .Some(x) => x
+  | .None    => fallback
+}
+```
+
+The leading `|` is canonical in multiline form because it visually exposes the closed set of alternatives. Inline formatters may omit redundant whitespace but not change semantics.
+
+## 8. Records
+
+Type:
+
+```oak
+Point: type = {
+  x: i32
+  y: i32
+}
+```
+
+Value:
+
+```oak
+p := Point { x: 1, y: 2 }
+```
+
+Anonymous record values/types may be supported where context makes the type unambiguous, but named construction is preferred at boundaries because it preserves nominal intent.
+
+## 9. Generics and constraints
+
+```oak
+fn map[A, B](xs: []A, f: (A) -> B): ()
+  ...
+```
+
+Constraints use `:` and conjunction:
+
+```oak
+fn copy[T: Reader & Writer](x: T): ()
+  ...
+```
+
+`&` in a generic constraint means “satisfies both constraints.” Record composition, if retained, is a separate definition-time operation despite sharing the token.
+
+## 10. Unsafe
+
+Unsafe code is visibly scoped:
+
+```oak
+unsafe {
+  p.* = value
+}
+```
+
+or an explicitly unsafe function/operation where the syntax is later finalized. `unsafe` does not disable normal typing; it marks a boundary where additional assumptions are admitted.
+
+## 11. Canonical formatting
+
+`oak fmt` is responsible for choosing canonical whitespace while preserving semantics. It should support at least:
+
+```text
+--style=layout
+--style=explicit
+```
+
+Both styles format the same AST. The formatter should not preserve obsolete punctuation aliases merely because the parser temporarily accepts them for migration.

--- a/docs/spec/20-types.md
+++ b/docs/spec/20-types.md
@@ -1,0 +1,176 @@
+# Oak Type System
+
+This document is normative for Oak's type universe and subtyping laws.
+
+## 1. Semantic view
+
+For static reasoning, a type denotes a set/predicate of admissible values. We write `A <= B` when every value admitted by `A` is admitted by `B` without a runtime check.
+
+Subtyping is a partial order over semantic types:
+
+- reflexive: `A <= A`;
+- transitive: `A <= B` and `B <= C` imply `A <= C`;
+- antisymmetric up to semantic equivalence.
+
+Nominal identity is separate from structural representation. Two named record declarations can have identical fields/layout and still be distinct nominal types.
+
+## 2. Bottom, unit, and top
+
+### `never`
+
+`never` has no inhabitants and is bottom:
+
+```text
+never <= T
+```
+
+for every type `T`.
+
+It is the result type of computations that cannot return normally.
+
+### `()` / Unit
+
+Unit has exactly one semantic value. `()` is the canonical surface spelling.
+
+An empty record value/type may have the same zero-field representation, but representation equality does not by itself create nominal type equality.
+
+### `any`
+
+`any` is a restricted top type:
+
+```text
+T <= any
+```
+
+for every type `T`.
+
+Using `any` as a runtime value requires an explicit dynamic representation strategy. The type checker must not silently introduce boxing, allocation, RTTI, or hidden runtime type tags merely because `any` appears in a static lattice computation.
+
+Typecase patterns over a runtime `any` are therefore **not part of the core language until that representation is specified explicitly**.
+
+## 3. Joins and meets
+
+The semantic join `A join B` is the least type containing both; the semantic meet `A meet B` is the greatest type contained by both.
+
+Required laws include:
+
+```text
+A <= A join B
+B <= A join B
+
+A meet B <= A
+A meet B <= B
+
+join/meet are commutative
+join/meet are associative
+join/meet are idempotent
+
+A join never = A
+A meet any    = A
+A join any    = any
+A meet never  = never
+
+A join (A meet B) = A
+A meet (A join B) = A
+```
+
+The compiler may canonicalize joins/meets internally. Surface syntax need not expose arbitrary union/intersection values merely because the checker uses these operations.
+
+## 4. ADTs are tagged sums, not ordinary union values
+
+An Oak declaration such as:
+
+```oak
+Option[T]: type =
+  | Some: T
+  | None
+```
+
+defines one **nominal tagged sum type** `Option[T]` with constructors `Some` and `None`.
+
+The `|` in an ADT declaration enumerates constructors. It does not mean that `Option[T]` is an untagged runtime union of `T` and Unit, nor does it grant arbitrary implicit conversion between payload types and the ADT.
+
+Pattern matching can narrow an ADT value to a constructor case because the constructor tag is part of the value's semantics.
+
+## 5. Records are products
+
+A record is an ordered product of named fields:
+
+```oak
+Point: type = {
+  x: i32
+  y: i32
+}
+```
+
+Source field order is semantically preserved. It may influence an explicitly chosen ABI/layout, formatting, generated schemas, and tooling.
+
+Field order alone does not determine target offsets: size, alignment, padding, packing, and ABI rules belong to the representation axis.
+
+Named records are nominal by default. Equal structure does not imply mutual subtyping.
+
+## 6. Record composition is not subtyping
+
+Definition-time record composition combines fields to form a new nominal product. It is a construction operation, not width subtyping.
+
+If surface `&` is retained for record composition, its meaning is context-specific:
+
+```oak
+Point3: type = Point2 & { z: i32 }
+```
+
+means “define a new record from these components,” not `Point3 <= Point2`.
+
+Duplicate fields are legal only when their types and required semantic attributes agree exactly; otherwise composition fails.
+
+No automatic structural record subtyping is part of the core language.
+
+## 7. Interface constraints are predicates
+
+An interface constraint describes requirements on a type's operations. It is best understood as a predicate over types, not as a runtime interface object.
+
+```oak
+fn copy[T: Reader & Writer](x: T): ()
+```
+
+uses `&` as **constraint conjunction**: `T` must satisfy both predicates.
+
+Core Oak interfaces are compile-time constraints and are erased/specialized during executable lowering. Dynamic existential/interface values require a separate explicit feature and representation.
+
+## 8. Phantom types
+
+A type parameter may distinguish semantic identities without changing runtime representation.
+
+```oak
+Id[T]: type = u64
+```
+
+can make `Id[User]` distinct from `Id[Order]` while both lower to the same machine representation.
+
+Phantom identity belongs to the type axis. It must not silently add runtime fields.
+
+## 9. Refinements and GADT direction
+
+Refinements add propositions to a base type:
+
+```text
+{x : u16 | x < N}
+```
+
+Exact surface syntax is not yet normative, but the semantic rule is: a refined type denotes the subset of its base type satisfying the proposition.
+
+GADT-style constructors extend the same idea to constructor-specific result refinements. They should be introduced by enriching ADTs and propositions rather than by creating a separate object system.
+
+## 10. Machine types
+
+Fixed-width integer types (`u8`..`u64`, `i8`..`i64`) have exact machine-width semantics. Target-width integer/pointer-sized types are distinct semantic types whose widths are supplied by the target.
+
+Mathematical proof integers are never silently substituted for machine integers. Overflow, conversion, division, and shift semantics must be specified for each machine operation.
+
+## 11. Formal obligations
+
+The executable type lattice must satisfy the laws in §3.
+
+The initial Lean model in `spec/lean/Oak/TypeLattice.lean` proves those laws over semantic type denotations. Go property/unit tests must exercise the implementation against the same laws.
+
+An implementation is not called refined until we explicitly relate `typechecker.Type`/`IsSubtype`/`Join`/`Meet` to the formal denotation model.

--- a/docs/spec/30-adts-patterns.md
+++ b/docs/spec/30-adts-patterns.md
@@ -1,0 +1,214 @@
+# ADTs and Pattern Matching
+
+This document is normative for Oak algebraic data types and matching.
+
+## 1. Closed nominal sums
+
+A declaration such as:
+
+```oak
+Option[T]: type =
+  | Some: T
+  | None
+```
+
+defines one closed nominal sum type `Option[T]` with constructors `Some` and `None`.
+
+A bare constructor has Unit payload. A payload-bearing constructor has exactly the payload type written after `:`.
+
+ADTs are not ordinary untagged unions. The constructor identity/tag is part of the semantic value.
+
+## 2. Construction
+
+Canonical qualified form:
+
+```oak
+Option.Some(42)
+Option.None
+```
+
+Context-inferred shorthand:
+
+```oak
+x: Option[i32] = .Some(42)
+y: Option[i32] = .None
+```
+
+The shorthand is accepted only when the expected ADT is uniquely determined.
+
+## 3. Payload defaults
+
+A constructor may define a default payload:
+
+```oak
+Comparison: type =
+  | Less:    i8 = -1
+  | Equal:   i8 = 0
+  | Greater: i8 = 1
+```
+
+The right-hand side after `=` means **payload default only**.
+
+It does not mean:
+
+- runtime discriminant;
+- C enum numeric value;
+- wire code;
+- serializer tag;
+- arbitrary metadata.
+
+Those are separate representation/metadata facts.
+
+When an inferred-default form is retained, `:= expr` means exactly “infer this constructor payload type from `expr`.”
+
+```oak
+Comparison: type =
+  | Less    := -1
+  | Equal   := 0
+  | Greater := 1
+```
+
+This is type-inference sugar, not a new ADT category.
+
+Whether an explicitly supplied payload may override a constructor default is not yet normative. The compiler should not silently invent override semantics.
+
+## 4. Pattern algebra
+
+The core pattern language is deliberately small:
+
+```text
+_                  wildcard
+x                  binding
+literal            literal equality
+.Case              constructor without payload
+.Case(pattern)     constructor with payload pattern
+```
+
+Nested constructor patterns compose recursively.
+
+Record destructuring may extend the same algebra later rather than adding a parallel pattern system.
+
+Typed binding annotations are optional where inference is complete and may be used where they constrain or document an otherwise ambiguous match.
+
+## 5. Match expression
+
+```oak
+value ?
+  | .Some(x) => x
+  | .None    => fallback
+```
+
+Evaluation semantics:
+
+1. evaluate the scrutinee exactly once;
+2. consider arms in source order;
+3. choose the first matching arm;
+4. evaluate only that arm;
+5. the selected arm's value is the value of the whole match expression.
+
+The right side of an arm is an expression and may be a block expression.
+
+## 6. Branch typing
+
+Every reachable arm result must be compatible with a common result type.
+
+The type checker may compute that common type using its semantic join operation. It must not silently introduce runtime boxing or `any` simply to force unrelated branch types to agree.
+
+When no safe representable common type exists, the match is ill-typed unless the programmer explicitly requests an appropriate sum/dynamic representation.
+
+`never` arms participate naturally: a non-returning arm does not force the other arms to widen.
+
+## 7. Exhaustiveness
+
+A match over a closed ADT must be exhaustive.
+
+The checker accepts a match when either:
+
+- every constructor is covered; or
+- an otherwise valid wildcard/binding catch-all covers the remainder.
+
+A missing constructor is a compile-time error.
+
+For large scalar domains such as `u32` or strings, finite literal arms are not exhaustive without a wildcard/binding remainder.
+
+Redundant/unreachable arms should be diagnosed.
+
+## 8. Constructor narrowing
+
+Inside a constructor arm, the scrutinee is known to be that constructor and payload bindings have the constructor's payload type/refinement.
+
+Conceptually:
+
+```oak
+x: Option[T]
+
+x ?
+  | .Some(v) => ... // v: T
+  | .None    => ...
+```
+
+For future GADT-style constructors, matching may additionally introduce constructor-specific propositions/equalities into the arm's proof context.
+
+This should extend ordinary ADT matching rather than create separate GADT match syntax.
+
+## 9. GADT direction
+
+Oak's long-term GADT feature should be understood as **ADTs whose constructors refine type indices/result propositions**.
+
+For example, a length-indexed vector constructor conceptually proves facts about the resulting length index. Exact surface syntax is not yet normative.
+
+The design requirements are:
+
+- constructor-specific refinements enter the branch context;
+- impossible branches can reduce to `never`;
+- pattern matching is the elimination form;
+- runtime representation need not carry proof-only indices when they are erasable;
+- proof erasure must preserve executable semantics.
+
+## 10. Representation separation
+
+The semantic ADT does not prescribe one fixed ABI.
+
+A representation pass may choose a conventional tag + payload layout or a smaller equivalent representation if it can preserve the semantic constructor distinction and all observable operations.
+
+Compile-time metadata/default values do not silently become representation discriminants.
+
+## 11. Metadata separation
+
+Legacy documents sometimes overloaded constructor defaults/literals as protocol codes, human labels, or static lookup metadata. Those concepts are separated now.
+
+Conceptually:
+
+```oak
+Status: type =
+  | NotFound: StatusPayload = defaultPayload
+      @wire.code(404)
+      @doc.label("Not Found")
+```
+
+The precise attribute syntax is defined by the metadata spec; the important semantic rule is that payload, representation, and metadata are distinct axes.
+
+## 12. Runtime typecase
+
+A pattern such as:
+
+```oak
+x: any
+x ?
+  | n: i32 => ...
+```
+
+requires an explicit runtime representation for `any`/type identity. It is not part of the core pattern language until that representation is specified. Static type narrowing in generic/proof contexts does not imply runtime RTTI.
+
+## 13. Formal verification targets
+
+Initial formal obligations include:
+
+- constructor coverage/exhaustiveness for finite ADTs;
+- match selection is deterministic;
+- only the selected branch is evaluated;
+- constructor narrowing yields the declared payload type/refinement;
+- `never` branches do not widen a match result;
+- erased proof/index information does not alter runtime constructor semantics.
+
+The first Lean model should formalize finite constructor sets and exhaustiveness independently of parser syntax. Later refinement work can relate compiler constructor tables/match checking to that model.

--- a/docs/spec/40-records.md
+++ b/docs/spec/40-records.md
@@ -1,0 +1,149 @@
+# Records
+
+Records are Oak's product types.
+
+## 1. Product semantics
+
+```oak
+Point: type = {
+  x: i32
+  y: i32
+}
+```
+
+A `Point` value contains one `i32` value for `x` and one for `y`.
+
+Named record declarations are nominal types. Two records with the same fields are not interchangeable merely because their shapes match.
+
+## 2. Field order
+
+Source field order is preserved as semantic input.
+
+```oak
+Header: type = {
+  kind: u8
+  len:  u16
+  flags: u8
+}
+```
+
+The compiler may not reconstruct this order from an unordered map.
+
+Preserved order may be consumed by:
+
+- an ABI/layout projection;
+- serialization schemas;
+- debugger/UI display;
+- documentation;
+- reflection/metadata tooling.
+
+Preserved order does not itself determine byte offsets.
+
+## 3. Representation is separate
+
+Record meaning and record ABI are separate axes.
+
+A target representation pass determines:
+
+- field offsets;
+- field alignment;
+- record alignment;
+- padding;
+- total size;
+- packing/ABI rules.
+
+A type-level record may therefore be known before its exact machine layout is known.
+
+The compiler must fail closed when a backend requires a representation fact that has not been established.
+
+## 4. Construction
+
+Canonical named construction:
+
+```oak
+p := Point { x: 1, y: 2 }
+```
+
+Field order in a literal need not be the same as declaration order if every field is named and the language can prove the mapping unambiguously. The resulting runtime layout follows the type's representation, not literal spelling order.
+
+Duplicate fields are errors. Missing required fields are errors unless a separately specified field-default rule supplies them.
+
+## 5. Defaults
+
+A field default, if supported, means only a construction default:
+
+```oak
+Config: type = {
+  retries: u8 = 3
+}
+```
+
+It does not affect field offset, wire encoding, database schema, or UI metadata unless a separate projection explicitly uses it.
+
+## 6. Record composition
+
+Definition-time composition may form a new nominal record from existing record components:
+
+```oak
+Point3: type = Point2 & { z: i32 }
+```
+
+This means “compose these fields into the definition of `Point3`.”
+
+It does not imply:
+
+```text
+Point3 <= Point2
+```
+
+and does not introduce general width subtyping.
+
+Composition flattens the field sequence in component order.
+
+Duplicate field names are accepted only if their semantic type and correctness-critical attributes agree exactly. Otherwise composition fails.
+
+## 7. Shape constraints
+
+General structural record subtyping is not core Oak.
+
+If a future API needs “has at least these fields,” that should be expressed as an explicit shape/interface constraint feature rather than silently making all records structurally subtype one another.
+
+This preserves nominal identity and predictable layout while still leaving room for local structural constraints.
+
+## 8. Empty records and Unit
+
+An empty record has one value and zero fields. It may share the same semantic cardinality/representation as Unit.
+
+The canonical language spelling for procedure-like return values is `()`.
+
+Named empty marker types remain nominally useful as phantom tags even if their runtime representation is zero-sized.
+
+## 9. Metadata
+
+Field metadata is not part of the runtime record value unless a projection explicitly requests it.
+
+A field may carry compile-time attributes such as serializer field numbers, DB names, units, debugger labels, or documentation, but those facts live in the metadata axis.
+
+Correctness-critical representation properties should use typed representation constructs rather than arbitrary string-valued tags.
+
+## 10. Borrowing and fields
+
+Borrowing a field must preserve ownership/aliasing facts about the containing storage.
+
+A view/span of a field or subrange cannot manufacture an independent owner. Derived borrows retain provenance to the owning object/region.
+
+The exact borrow rules are specified in `50-borrowing.md`.
+
+## 11. Formal verification targets
+
+Initial proof targets:
+
+- field-name uniqueness after composition;
+- composition preserves declared source order;
+- compatible composition is deterministic;
+- incompatible duplicate fields are rejected;
+- field lookup returns the field associated with that name;
+- target layout, when computed, gives non-overlapping ordinary fields unless explicit overlay/union representation is requested;
+- layout offsets satisfy alignment and size constraints.
+
+The semantic record proof should not assume a specific ABI. ABI-specific layout theorems belong to representation/backend models.

--- a/docs/spec/50-borrowing.md
+++ b/docs/spec/50-borrowing.md
@@ -1,0 +1,149 @@
+# Ownership and Borrowing
+
+Oak's borrowing model is intentionally small: make common contiguous-memory ownership safe without requiring explicit lifetime syntax in ordinary code.
+
+## 1. Core storage shapes
+
+```oak
+[N]T   // owned fixed-size array
+[]T    // read-only borrowed view
+[*]T   // writable borrowed span
+*T     // raw pointer; unsafe authority
+```
+
+A view/span is non-owning. It identifies a contiguous region of another owner.
+
+A conventional runtime representation for views/spans is pointer + length, but the semantic borrow rules do not depend on a particular field spelling.
+
+## 2. Owner provenance
+
+Every safe view/span has an owner/provenance relation established by construction.
+
+Derived slicing does not create a new independent owner:
+
+```text
+OwnerOf(subslice(v)) = OwnerOf(v)
+```
+
+The compiler must not forget this relation merely because the derived value has its own pointer/length representation.
+
+## 3. Borrow states
+
+For one owner, the core abstract states are:
+
+```text
+Free
+SharedRead(n), n > 0
+UniqueWrite
+```
+
+Allowed creation transitions:
+
+```text
+Free          --view--> SharedRead(1)
+SharedRead(n) --view--> SharedRead(n+1)
+Free          --span--> UniqueWrite
+```
+
+Disallowed:
+
+```text
+SharedRead(_) --span--> error
+UniqueWrite   --view--> error
+UniqueWrite   --span--> error
+```
+
+Releasing the last shared reader returns to `Free`; releasing the unique writer returns to `Free`.
+
+## 4. Lexical v1 lifetimes
+
+The first safe implementation may conservatively keep a borrow live until the end of its lexical block.
+
+This is intentionally simpler than general lifetime inference and is sound when borrows cannot escape their owner scope.
+
+The compiler may later shorten borrows using liveness/NLL-style analysis without changing program meaning, because that is an acceptance optimization over the same ownership rules.
+
+## 5. Escape
+
+A borrowed value may not outlive its owner.
+
+Initially, returning/storing a borrow beyond the lexical region that proves the owner lifetime is rejected.
+
+Future region-indexed forms can make escape explicit:
+
+```oak
+Arena[R]
+View[T, R]
+Span[T, R]
+```
+
+or equivalent compiler-internal regions, but ordinary code should not require manual lifetime punctuation when the relation is inferable.
+
+## 6. Disjoint mutable regions
+
+The conservative rule treats two writable regions of one owner as conflicting.
+
+Oak may admit simultaneous mutable subspans when the compiler proves their byte/element ranges are disjoint.
+
+The proof obligation is semantic range disjointness, not programmer assertion. If disjointness cannot be established, the operation is rejected in safe code or requires an explicit unsafe boundary.
+
+## 7. Slicing
+
+Slicing preserves access mode:
+
+```text
+owned array slice -> read-only view by default
+view slice        -> read-only view
+span slice        -> writable span
+```
+
+Obtaining writable access from owned storage is explicit (`span`, an equivalent borrow operation, or a mutable binding rule later specified).
+
+Bounds must be proved statically or checked dynamically in safe code. Out-of-range access is never undefined behavior.
+
+Exact index-normalization policy (including whether negative indices remain in Oak) is a separate sequence/indexing decision; it does not alter the ownership model.
+
+## 8. Raw pointers
+
+Raw pointers do not automatically participate in safe borrow tracking because arbitrary pointer arithmetic/aliasing can destroy provenance facts.
+
+Creating/dereferencing/reinterpreting raw pointers therefore requires the relevant unsafe authority unless the compiler can prove a safe derived-pointer operation.
+
+`unsafe` introduces assumptions; it does not disable unrelated typing/bounds/effect checks.
+
+## 9. DMA and ownership states
+
+The same ownership vocabulary should extend to machine/device custody without special pointer syntax.
+
+Conceptually:
+
+```text
+Buffer[CpuOwned]
+    --submit--> Buffer[DeviceOwned]
+    --complete--> Buffer[CpuOwned]
+```
+
+CPU code cannot safely access a device-owned buffer because it lacks the corresponding authority/state, not because the pointer has disappeared.
+
+This is a protocol/typestate refinement layered on the core borrow model.
+
+## 10. Strings and wrappers
+
+A type containing a view/span inherits its borrow lifetime. Wrapping `[]u8` in `Str[Utf8]` does not sever provenance or extend lifetime.
+
+No special string escape rule is needed if semantic wrappers preserve ownership facts.
+
+## 11. Formal verification targets
+
+The core borrow state machine must prove:
+
+- no state contains simultaneous read and write authority;
+- at most one unique writer exists;
+- creating a span succeeds only from `Free`;
+- creating a view never produces write authority;
+- release cannot underflow a reader count;
+- derived views/spans preserve owner provenance;
+- safe borrow values cannot outlive owners;
+- disjoint mutable borrowing, when enabled, relies on proved disjoint ranges.
+
+`spec/lean/Oak/Borrowing.lean` models the local borrow-state laws. Temporal ownership transfer across asynchronous actors may additionally use TLA+ when introduced.

--- a/docs/spec/60-effects-allocation.md
+++ b/docs/spec/60-effects-allocation.md
@@ -1,0 +1,195 @@
+# Effects and Allocation
+
+Oak makes material runtime behavior explicit in the semantic model.
+
+## 1. Effects
+
+An effect names an operation class that is observable for correctness, authority, scheduling, or cost analysis.
+
+Conceptually:
+
+```text
+Memory.Allocate[allocator]
+Thread.Block
+Os.Syscall
+Mmio[device]
+Io[channel]
+```
+
+Effects may be parameterized by a semantic identity such as an allocator, device, channel, or authority.
+
+An unparameterized effect denotes the whole class:
+
+```text
+Memory.Allocate
+```
+
+therefore overlaps every `Memory.Allocate[x]`.
+
+## 2. Requires and forbids
+
+A function may require effects/authority and may forbid classes of effect.
+
+Conceptually:
+
+```oak
+fn build[R](arena: Arena[R]): Graph[R]
+  effects { Memory.Allocate[arena] }
+```
+
+Realtime code can prohibit broad classes:
+
+```oak
+realtime fn process(...)
+  forbids { Memory.Allocate, Thread.Block, Os.Syscall }
+```
+
+Exact surface syntax is not yet frozen. The semantic rule is normative.
+
+A required effect and a forbidden overlapping effect is a static contradiction.
+
+## 3. No hidden allocation
+
+Ordinary language constructs do not allocate unless their semantics explicitly carry an allocation effect.
+
+This includes:
+
+- generic dispatch;
+- pattern matching;
+- conversions;
+- interface constraints;
+- iterator/combinator use;
+- closure capture;
+- string conversion;
+- collection construction beyond fixed/caller-provided storage.
+
+If an implementation strategy would require allocation, either another allocation-free lowering must be used or the operation must expose/require an allocator effect.
+
+## 4. Allocation strategies are ordinary types
+
+Oak should not need special grammar for common allocation policies.
+
+Examples:
+
+```oak
+Arena[R]
+Slab[T, N]
+Pool[T, N]
+Handle[T]
+```
+
+These are ordinary semantic/library types whose parameters carry facts that the checker/proof system can use.
+
+## 5. Arenas / regions
+
+An arena groups many allocations under one lifetime identity `R`.
+
+```text
+Arena[R]
+```
+
+Properties:
+
+- allocation is cheap and monotonic or otherwise region-governed;
+- individual objects normally do not have independent deallocation;
+- all region-bound values must die before or with `R`;
+- resetting/freeing the arena invalidates values tied to the region.
+
+An arena operation has an allocation effect scoped to that arena identity.
+
+The type/proof system should be able to express that `T[R]` cannot safely escape `R`.
+
+## 6. Slabs / pools
+
+A bounded typed slab:
+
+```oak
+Slab[T, N]
+```
+
+owns storage for at most `N` live `T` slots.
+
+Static capacity is a semantic fact and can support proofs of:
+
+- occupancy never exceeds `N`;
+- allocation failure is explicit when full;
+- no allocation outside pre-owned backing storage;
+- slot reuse obeys generation rules when handles are used.
+
+No general heap behavior is implied.
+
+## 7. Handles
+
+`Handle[T]` is object identity, not a pointer synonym and not an allocator.
+
+A common representation is:
+
+```text
+slot + generation
+```
+
+with the safety law:
+
+```text
+generation mismatch -> lookup fails
+```
+
+After a slot is freed/reused, stale handles must not resolve to the new object.
+
+Pointer values may locate bytes; handles identify logical objects.
+
+## 8. Caller-provided storage
+
+For many systems APIs, caller-owned storage should be the ergonomic default:
+
+```oak
+fn encode(dst: [*]u8, value: T): Result[[]u8, Error]
+```
+
+rather than a result type that implies hidden allocation.
+
+This makes ownership, capacity, and failure behavior visible.
+
+## 9. Stack/static storage
+
+Stack and static storage are also explicit lifetime/storage strategies even when they require no allocator object.
+
+The compiler may choose stack placement for non-escaping values as an optimization/refinement of explicit value semantics. It must not silently move an escaping value to the heap.
+
+## 10. Closures
+
+A capturing closure has an environment whose storage must be justified by ownership analysis.
+
+Non-escaping captures can use stack/static/caller-owned storage.
+
+If capture escape requires arena/slab/heap allocation, the effect is explicit and subject to `forbids` checks.
+
+## 11. Realtime/bounded code
+
+A realtime/bounded function should be able to establish structural properties such as:
+
+```text
+no allocation
+no blocking
+no syscall
+bounded loops / bounded recursion policy
+bounded queue operations
+```
+
+These are stronger than merely “lock-free.”
+
+The effect system is one source of evidence; boundedness/resource proofs are additional propositions.
+
+## 12. Formal verification targets
+
+Initial Lean proof targets:
+
+- effect overlap is symmetric;
+- unparameterized effect class overlaps all parameterized instances of the same class;
+- distinct parameterized instances do not overlap unless parameters are equal;
+- required/forbidden overlap is rejected;
+- slab occupancy cannot exceed static capacity under valid transitions;
+- stale generation cannot resolve after slot reuse;
+- region-bound values cannot outlive their region in the abstract lifetime model.
+
+`spec/lean/Oak/Effects.lean` begins with the effect-overlap laws. Slab/handle proofs should be added once their implementation representation is stabilized.

--- a/docs/spec/70-strings.md
+++ b/docs/spec/70-strings.md
@@ -1,0 +1,164 @@
+# Strings and Text Encodings
+
+Oak treats text encoding as a semantic type distinction over explicit borrowed storage.
+
+## 1. Bytes are not text
+
+Arbitrary bytes are not automatically valid text.
+
+```oak
+[]u8
+```
+
+is a read-only byte view.
+
+A UTF-8 string is conceptually:
+
+```oak
+Str[Utf8]
+```
+
+with an invariant that the referenced code units are valid for the declared encoding.
+
+`string` is the canonical alias for validated UTF-8 text:
+
+```oak
+string: type = Str[Utf8]
+```
+
+This may have the same machine representation as `[]u8`, but it is not semantically interchangeable with arbitrary bytes.
+
+## 2. Representation
+
+An immutable encoded string view contains non-owning storage plus length. A mutable text buffer contains writable borrowed storage plus length.
+
+Conceptually:
+
+```oak
+Str[E, Unit]: type = {
+  units: []Unit
+}
+
+StrBuf[E, Unit]: type = {
+  units: [*]Unit
+}
+```
+
+Convenience aliases may fix the code-unit type for known encodings.
+
+Examples:
+
+```text
+UTF-8 / ASCII  -> u8 code units
+UTF-16         -> u16 code units
+UTF-32         -> u32/rune code units
+```
+
+Encoding and code-unit type are semantic/representation parameters; there is no hidden allocation or runtime encoding object.
+
+## 3. Phantom encoding identity
+
+Encoding tags are zero-runtime semantic types when no runtime data is required.
+
+```oak
+Utf8: type = {}
+Utf16: type = {}
+Ascii: type = {}
+```
+
+The type checker distinguishes `Str[Utf8]` from `Str[Ascii]` even when both use byte storage.
+
+Libraries may define additional encoding tags.
+
+## 4. Validation
+
+Converting arbitrary bytes/code units to validated text is a fallible operation unless validity is already proved by context.
+
+Conceptually:
+
+```oak
+fn validate[E](units: []CodeUnit[E]): Result[Str[E], EncodingError]
+```
+
+A safe API must not expose:
+
+```oak
+fn from_bytes[E](b: []u8): Str[E]
+```
+
+without either validation or a proof/unsafe precondition.
+
+When external protocol guarantees establish validity, an explicit unsafe/proof-bearing conversion may exist.
+
+## 5. Borrowing
+
+A string view preserves the provenance/lifetime of its underlying view. Wrapping bytes as text does not extend storage lifetime.
+
+A mutable `StrBuf` follows the same unique-write rules as its underlying span.
+
+No string-specific aliasing escape hatch exists.
+
+## 6. Conversion
+
+Re-encoding may require new storage because the output can differ in code-unit width/length.
+
+Therefore allocation is never hidden.
+
+Preferred forms are caller-provided or explicit allocator APIs:
+
+```oak
+fn recode[E, F](dst: [*]CodeUnit[F], src: Str[E]): Result[Str[F], Error]
+```
+
+or an explicitly allocator/effect-bearing variant.
+
+Conversions that are representation-preserving and validity-preserving may be zero-copy.
+
+## 7. Indexing
+
+String indexing semantics must distinguish:
+
+- code-unit index;
+- Unicode scalar/rune index;
+- grapheme-cluster index.
+
+Oak must not pretend these are the same operation.
+
+Low-level encoded strings should expose code-unit operations explicitly. Scalar/grapheme iteration belongs to encoding/Unicode libraries and may have different complexity.
+
+A generic `len` or indexing operator should not hide an O(n) scan where programmers expect O(1) code-unit access.
+
+## 8. Literals
+
+Ordinary source string literals are UTF-8 semantic strings after the source decoder validates them.
+
+The compiler may emit their bytes in readonly static storage.
+
+Other encoding literals should be compile-time conversions/projections when possible rather than runtime allocation.
+
+## 9. Canonical `rune`
+
+A Unicode scalar value should use an unsigned value domain capable of representing Unicode scalar values; exact alias (`u32` vs a refined `u32`) should be specified explicitly rather than inheriting older conflicting `i32`/`u32` notes.
+
+The preferred semantic model is a refined scalar type excluding surrogate code points and values above `0x10FFFF`, with `u32` representation.
+
+## 10. Writer/reader APIs
+
+Encoding-specific I/O should use ordinary generic constraints/types rather than special syntax.
+
+A writer that accepts `Str[E]` is explicit about its input encoding. Transcoding is a separate operation/effect when needed.
+
+## 11. Formal verification targets
+
+Initial proof targets:
+
+- validated `Str[E]` construction implies the encoding validity predicate;
+- zero-copy retyping is allowed only when representation and validity implications hold;
+- slicing preserves borrow provenance;
+- UTF-8 decoding never reads beyond the input span;
+- successful decode consumes a valid code-unit sequence and returns a valid scalar;
+- UTF-16 surrogate-pair rules are respected;
+- encoding conversion never writes beyond destination capacity;
+- reported output length equals produced code units.
+
+Encoding algorithm proofs can be added independently of the language type-system proofs and then connected through refinement tests.

--- a/docs/spec/80-metadata.md
+++ b/docs/spec/80-metadata.md
@@ -1,0 +1,147 @@
+# Phantom Types and Compile-Time Metadata
+
+Oak distinguishes semantic type identity from descriptive/tooling metadata.
+
+## 1. Phantom types
+
+A phantom parameter changes static meaning without changing runtime representation.
+
+```oak
+Id[T]: type = u64
+```
+
+allows:
+
+```oak
+UserId: type = Id[User]
+OrderId: type = Id[Order]
+```
+
+with identical machine representation but distinct static types.
+
+Phantom parameters belong to the **type axis** and may participate in proofs, overload resolution, capability distinctions, and schema generation.
+
+They must not silently add storage.
+
+## 2. Metadata
+
+Metadata is compile-time information attached to semantic declarations or members for use by projections/tooling.
+
+Examples:
+
+```text
+serializer field number
+database column name
+UI label / unit
+debugger display hint
+documentation category
+protocol documentation text
+```
+
+Metadata does not change runtime representation unless a specific projection explicitly interprets it to generate runtime data.
+
+## 3. Typed vs untyped metadata
+
+Correctness-critical metadata must not be an arbitrary string dictionary.
+
+Oak should distinguish:
+
+1. **language semantics** — ownership, effects, representation, refinements;
+2. **typed attributes** — extensible but schema-checked metadata;
+3. **free annotations** — descriptive data with no correctness authority.
+
+A typed attribute definition must specify:
+
+- valid attachment targets;
+- field/value schema;
+- uniqueness/repeatability;
+- whether it affects any projection;
+- whether conflicting attributes are an error.
+
+## 4. Legacy backtick tags
+
+Older Oak documents use syntax such as:
+
+```oak
+id: u64 `{ db_column: "user_id", primary_key: 1 }`
+```
+
+and similar tags on ADT variants.
+
+The semantic concept is retained, but this surface syntax is **not yet normative**. We should select the final attribute syntax only after the type/schema model is clear.
+
+The parser may temporarily accept legacy tags for migration.
+
+## 5. Payload/defaults are not metadata
+
+ADT payload defaults and record field defaults are semantic construction facts.
+
+They are not the same as:
+
+```text
+wire code
+JSON field number
+documentation label
+database column
+```
+
+Those belong to metadata or representation.
+
+This prevents historical ambiguity such as interpreting:
+
+```oak
+| NotFound: u16 = 404
+```
+
+as both a payload default and an enum/wire discriminant.
+
+## 6. Representation attributes
+
+Attributes that constrain memory/wire representation require stronger typing and validation than ordinary metadata.
+
+Examples might include:
+
+```text
+repr integer width
+alignment
+packing
+endianness
+wire field number
+```
+
+These should project into the representation axis, where consistency and layout laws are checked. They must not remain opaque strings by the time code generation relies on them.
+
+## 7. Reflection
+
+Compile-time tooling may inspect types and metadata.
+
+Runtime reflection is not implied. If metadata must exist at runtime, the projection must explicitly emit a table/object and its storage cost must be visible.
+
+This preserves Oak's no-hidden-work rule.
+
+## 8. Metadata-driven generation
+
+One declaration may drive multiple artifacts:
+
+```text
+Oak type
+  -> C ABI declaration
+  -> serializer schema
+  -> debugger schema
+  -> protocol docs
+  -> UI forms
+  -> database schema
+```
+
+Each projection consumes the same checked type + metadata model rather than reparsing source tags independently.
+
+## 9. Formal verification targets
+
+Initial proof/checking targets:
+
+- phantom parameters do not alter declared machine representation;
+- metadata attachment does not alter runtime value semantics unless explicitly projected;
+- typed attributes satisfy their declared schemas;
+- duplicate/conflicting singleton attributes are rejected;
+- representation-affecting attributes produce a consistent representation or fail;
+- generated schema field identities are unique where the target format requires uniqueness.

--- a/docs/spec/90-backend.md
+++ b/docs/spec/90-backend.md
@@ -1,0 +1,143 @@
+# Executable Lowering and Backends
+
+Oak's semantics are not defined by C, but the C backend is an important executable projection and cost-model oracle.
+
+## 1. Backend-independent semantics
+
+The typed/Semantic IR defines program meaning before a backend chooses concrete machine representation.
+
+A backend must preserve:
+
+- value semantics;
+- control-flow semantics;
+- ownership/effect constraints;
+- integer behavior;
+- ADT constructor distinctions;
+- pattern-match selection;
+- required layout/ABI constraints;
+- safe bounds and pointer rules.
+
+A backend may optimize representation only when those observations remain equivalent.
+
+## 2. C as bootstrap/reference backend
+
+Generated C should be intentionally straightforward and debuggable.
+
+For systems code, a competent C programmer should recognize the expected machine shape:
+
+```text
+record          -> struct / fields
+closed ADT      -> tag + payload or proved equivalent compact representation
+match           -> switch/if branches
+specialized fn  -> direct C function / inlineable code
+view/span       -> pointer + length representation
+raw pointer     -> C pointer
+fixed array     -> fixed storage
+arena/slab      -> explicit allocator calls/storage
+```
+
+C is not Oak's semantic definition and should not prevent future native/LLVM/etc. backends.
+
+## 3. No hidden runtime
+
+The backend may not silently introduce:
+
+- heap allocation;
+- garbage collection;
+- reference counting;
+- exception unwinding;
+- interface vtables for static generic constraints;
+- boxing to a dynamic object representation;
+- hidden string/data copying;
+- unbounded callback dispatch.
+
+If a selected language feature requires such machinery, the semantic model must expose the corresponding representation/effect.
+
+## 4. Generics
+
+Generic functions/types specialize by default.
+
+Monomorphization should erase compile-time constraints and phantom parameters that have no runtime representation.
+
+Specialization must preserve type/effect semantics and must not introduce dynamic dispatch merely for compiler convenience.
+
+A future explicitly selected code-size/dynamic-dispatch strategy may exist, but it is a distinct representation choice.
+
+## 5. ADTs
+
+The ordinary representation is conceptually:
+
+```text
+tag + payload storage
+```
+
+A backend can select tag width from the number/representation constraints of constructors.
+
+Payload defaults/metadata are not automatically discriminant values.
+
+A compact enum-like representation is valid only when constructor payload semantics allow it and the representation mapping is injective over observable constructor values.
+
+## 6. Records
+
+Target layout computes sizes, alignment, padding and offsets from ordered semantic fields plus explicit representation constraints.
+
+The backend must not derive field order from unordered maps.
+
+FFI/wire/persisted layouts require explicit stable representation contracts rather than relying on incidental target ABI layout.
+
+## 7. Integer semantics
+
+Backend operations must implement Oak's specified fixed-width behavior exactly.
+
+C undefined/implementation-defined behavior must not leak into safe Oak semantics. Code generation may need unsigned operations, explicit casts, intrinsics, checks, or helper routines to preserve Oak's rules.
+
+The formal specification of overflow/division/shifts/conversions must precede relying on them for verification.
+
+## 8. Bounds
+
+When the compiler proves an index/range safe, a backend may eliminate the corresponding dynamic check.
+
+When safety is not proved, safe Oak must retain a defined check/failure path rather than compile to out-of-bounds undefined behavior.
+
+## 9. Function values/closures
+
+A plain function value may lower to a function pointer.
+
+A capturing closure requires an explicit environment representation whose storage lifetime has been established by ownership/effect analysis.
+
+The backend may not silently heap-promote escaping captures.
+
+## 10. Source/debug information
+
+Backend output should preserve mappings from generated operations to canonical Oak source spans and stable semantic identities.
+
+The compiler's source model should power:
+
+- C `#line` / debug mappings where useful;
+- DWARF/native debug metadata in future backends;
+- diagnostics and IDE navigation;
+- semantic debugger schemas.
+
+## 11. Verification strategy
+
+Backend verification proceeds in layers:
+
+```text
+semantic operation
+  -> lowering rule
+  -> backend representation/code
+  -> executable equivalence/property test
+  -> formal refinement for critical rules
+```
+
+Early formal-refinement candidates:
+
+- fixed-width integer lowering;
+- record layout calculation;
+- ADT tag/payload lowering;
+- match lowering;
+- view/span representation and bounds;
+- erased phantom/proof parameters;
+- effect-free generic specialization.
+
+The C backend should maintain golden/compile/run tests in addition to formal models. Formal models do not replace generated-code testing.

--- a/docs/spec/LEGACY_RECONCILIATION.md
+++ b/docs/spec/LEGACY_RECONCILIATION.md
@@ -1,0 +1,143 @@
+# Legacy Specification Reconciliation
+
+The top-level Oak documents below are retained as design history and examples until their useful content has been fully migrated. They are **not authoritative** when they disagree with `docs/spec/`.
+
+| Legacy document | Normative destination | Reconciliation notes |
+| --- | --- | --- |
+| `SPEC.md` | entire `docs/spec/` tree | foundational design source; several syntax/semantic choices were later contradicted by newer docs |
+| `ADT_AND_PATTERN_MATCHING.md` | `10-syntax.md`, `30-adts-patterns.md` | preserves ADTs/patterns; canonicalizes `=>`, `Type.Case`, `.Case`; separates payload defaults from representation/metadata |
+| `tags_and_phantoms.md` | `30-adts-patterns.md`, `80-metadata.md` | valuable split between phantom identity and metadata; old default/tag syntax no longer normative |
+| `TAGGING_AND_LABELING.md` | `80-metadata.md` | semantic concept retained; backtick surface syntax remains unresolved/legacy |
+| `type_universe.md` | `20-types.md` | core bottom/top/join/meet ideas retained; ADTs separated from arbitrary unions; record composition separated from subtyping; implementation laws must be fixed to match the spec |
+| `INTRUSIVE_STRUCTURES.md` | `20-types.md`, `40-records.md`, acceptance tests | intrusive structures remain an important zero-cost language benchmark; record `&` is composition, interface `&` is constraint conjunction |
+| `borrow_checker.md` | `50-borrowing.md` | many-readers/one-writer and views/spans retained; negative-index policy moved out of borrow semantics; future regions integrated with allocation/effect model |
+| `STRINGS_ENCODING_SPEC.md` | `70-strings.md` | encoding tags and zero-overhead views retained; arbitrary bytes may not become valid text without validation |
+| `STRINGS_INTEGRATION.md` | `50-borrowing.md`, `70-strings.md` | borrow-preserving wrappers retained; unsafe reinterpretation language tightened |
+| `STRINGS_UTF16_UTF32_SPEC.md` | `70-strings.md` | code-unit-parametric text retained; exact `rune` semantics need one canonical refined `u32` decision |
+| `C_BACKEND_SPEC.md` | `90-backend.md` | readable C remains bootstrap/reference backend; C no longer defines Oak semantics |
+| `json_lexer.md` | acceptance/workload tests + `90-backend.md` | retained as a language benchmark for zero-allocation parsing/state machines, not a core language spec |
+| `VARIABLE_SYNTAX.md` | `10-syntax.md` | `x:T=e`, `x:=e`, `x=e` retained; implicit NULL/uninitialized safe variables rejected pending definite-init semantics |
+| `TOUR_OF_OAK.md` | future generated/curated language tour | examples contain multiple historical syntaxes; should be regenerated only from normative syntax after consolidation |
+| `REPL_FEATURES.md` | implementation docs/tests | useful historical behavior examples; not normative grammar/semantics |
+| `FEATURES_COMPLETE.md` | `STATUS.md` | historical completion claim replaced by evidence-based S/I/T/M/P/R matrix |
+| `IMPLEMENTATION_STATUS.md` | `STATUS.md` | historical implementation snapshot only |
+| `IMPLEMENTATION_SUMMARY.md` | `STATUS.md` | historical implementation snapshot; contains known stale statements such as future C backend work |
+
+## Major conflicts resolved so far
+
+### Match arrows
+
+Legacy docs accept both `->` and `=>` for match arms.
+
+Normative decision:
+
+```text
+-> function type
+=> match arm
+```
+
+### Constructor qualification
+
+Legacy docs contain `.Case`, `Type.Case`, and `Type::Case`.
+
+Normative decision:
+
+```text
+Type.Case canonical qualified form
+.Case context-inferred shorthand
+Type::Case legacy only
+```
+
+### Function return syntax
+
+Legacy docs contain both:
+
+```text
+fn f(...): T
+fn f(...) -> T
+```
+
+Normative decision:
+
+```text
+:  declaration/type annotation
+-> function type
+```
+
+so function declarations use `: T`.
+
+### ADT literal/default/tag semantics
+
+Legacy documents variously interpret a value attached to an ADT arm as:
+
+- a payload default;
+- a raw/literal view;
+- an enum-like numeric value;
+- protocol metadata.
+
+Normative decision: these are separate axes.
+
+```text
+payload default      -> ADT construction semantics
+runtime discriminant -> representation
+wire/protocol code   -> typed metadata/representation projection
+human/docs labels    -> metadata
+```
+
+### Union/intersection terminology
+
+Legacy type-universe prose treats `A|B` and `A&B` as general lattice join/meet types while other docs use the same punctuation for ADT constructor lists, record composition, and interface conjunction.
+
+Normative decision:
+
+- semantic checker may internally use joins/meets;
+- ADT `|` enumerates constructors of one nominal sum;
+- record `&` is definition-time composition, not subtyping;
+- constraint `&` means predicate conjunction;
+- arbitrary runtime union/intersection values are not implied.
+
+### Record order
+
+Legacy type-universe text suggested canonical sorting of record fields.
+
+Normative decision: **source declaration order is preserved**. A canonical internal lookup order may exist separately, but it cannot replace source order for layout/schema/tooling projections.
+
+### `any`
+
+Legacy pattern docs use runtime typecase over `any`, while the type-universe document also describes `any` as an optional top.
+
+Normative decision: static `any` as a top in type reasoning does not imply a dynamic boxed runtime value. Runtime `any`/typecase remains out of core until its representation/effects are explicitly specified.
+
+### Strings
+
+Legacy documents sometimes equate `string` with raw `[]u8`.
+
+Normative decision: `string` is validated UTF-8 text with a view-like representation. Equal representation does not erase the validity invariant.
+
+### Uninitialized variables
+
+Legacy `VARIABLE_SYNTAX.md` says uninitialized declarations become `NULL`.
+
+Normative decision: safe Oak has no implicit null initialization. Definite initialization must be proved if uninitialized declarations are ever admitted.
+
+## Remaining unresolved design decisions
+
+These require focused feature RFC/spec work rather than accidental parser behavior:
+
+- exact final typed-attribute syntax;
+- whether ADT constructor defaults can be overridden explicitly;
+- exact GADT refinement surface syntax;
+- whether negative indices remain part of sequence indexing;
+- exact safe integer overflow/division/shift semantics;
+- final `rune` spelling/refinement;
+- dynamic existential/interface values, if any;
+- runtime `any`, if any;
+- closures that escape and how allocator choice is expressed;
+- stable FFI/wire representation syntax;
+- protocol/typestate surface syntax.
+
+## Cleanup policy
+
+Once all useful content from a legacy document has been migrated and its remaining statements are either obsolete or duplicated, replace it with a short pointer to the normative spec or remove it in a dedicated cleanup commit.
+
+Do not mass-delete the historical corpus before reconciliation; it still contains useful examples and design intent.

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -1,0 +1,96 @@
+# Oak Language Specification
+
+This directory is the **normative specification** of Oak.
+
+Older top-level design documents remain valuable design history and implementation notes, but they are not authoritative when they disagree with this directory. A legacy document is retired only after its useful decisions have been reconciled here.
+
+## Language priorities
+
+Oak optimizes for, in order:
+
+1. **Correctness**
+2. **Performance**
+3. **Simplicity**
+
+Safety and ergonomics are cross-cutting constraints.
+
+The language should have a tight, lightweight, orthogonal surface. Prefer composition from a small number of powerful constructs—records, ADTs/GADT-style refinements, functions, generics, pattern matching, ownership/effects, and ordinary library types—over domain-specific syntax.
+
+## Specification layers
+
+Every feature may have up to five linked layers:
+
+```text
+surface syntax
+    ↓
+static semantics
+    ↓
+dynamic / machine semantics
+    ↓
+formal model + theorems
+    ↓
+implementation correspondence
+```
+
+A feature is not called “formally verified” merely because a mathematical model exists. We distinguish specification proof from implementation refinement.
+
+## Verification vocabulary
+
+Use these terms precisely:
+
+- **specified** — normative syntax and semantics exist;
+- **implemented** — compiler/runtime behavior exists;
+- **tested** — executable implementation tests cover stated properties;
+- **modeled** — a machine-checkable formal model exists;
+- **proved** — stated theorem/invariant is mechanically checked in the formal model;
+- **refined** — an explicit machine-checked correspondence connects implementation representation/operations to the formal model.
+
+## Authoritative documents
+
+- `00-constitution.md` — values, design constraints, semantic axes
+- `10-syntax.md` — lexical/layout/block rules and canonical punctuation
+- `20-types.md` — type universe, subtyping, joins/meets, nominal identity
+- `30-adts-patterns.md` — ADTs, GADT direction, constructors, matching, exhaustiveness
+- `40-records.md` — products, record identity, composition, order, layout separation
+- `50-borrowing.md` — ownership, views, spans, safe/unsafe boundaries
+- `60-effects-allocation.md` — effects, arenas, slabs, handles, realtime prohibitions
+- `70-strings.md` — encoded text, validation, borrowing and representation
+- `80-metadata.md` — typed attributes/tags and phantom semantic types
+- `90-backend.md` — executable lowering and C-backend requirements
+- `STATUS.md` — implementation and proof coverage matrix
+
+The files above are introduced incrementally. Until a feature has an authoritative document here, its legacy document remains design input rather than normative law.
+
+## Formal verification layout
+
+```text
+spec/
+  lean/
+    Oak/
+      TypeLattice.lean
+      Effects.lean
+      Borrowing.lean
+      ...
+  tla/
+    ...
+```
+
+Lean is the primary proof layer for local algebraic and semantic laws: type lattices, refinements, effect subsumption, bounds, ownership facts, and representation-independent compiler invariants.
+
+TLA+ (or another explicit state-machine model checker) is appropriate when the property is fundamentally temporal/concurrent: ownership transfer across actors, asynchronous protocols, scheduler/queue interaction, or other behavior over traces.
+
+## Proof/code relationship
+
+The default maturity path is:
+
+```text
+normative spec
+    ↓
+Lean/TLA+ model + proofs
+    ↓
+implementation property tests against the same laws
+    ↓
+explicit refinement for load-bearing compiler/runtime components
+```
+
+The first refinement targets should be small and foundational: the type lattice, delimited parser cursor contract, borrow-state transitions, effect subsumption, and exact source-span conversions.

--- a/docs/spec/STATUS.md
+++ b/docs/spec/STATUS.md
@@ -1,0 +1,57 @@
+# Oak Feature and Verification Status
+
+This matrix is intentionally conservative. A historical document saying “complete” is not sufficient evidence for current implementation/proof status.
+
+Legend:
+
+- **S** specified normatively in `docs/spec/`
+- **I** implementation exists and is intended to implement the normative feature
+- **T** implementation tests exercise the normative laws
+- **M** machine-checkable formal model exists
+- **P** stated formal properties are mechanically proved/model-checked
+- **R** implementation-to-model refinement/correspondence is machine-checked
+
+| Feature | S | I | T | M | P | R | Notes |
+| --- | :---: | :---: | :---: | :---: | :---: | :---: | --- |
+| Layout + explicit blocks | ✓ | ✓ | ✓ |  |  |  | parser/layout equivalence exists; formal cursor/layout model pending |
+| Source spans / UTF-16 editor positions | ✓ | draft | draft |  |  |  | implementation is in draft PR #6 |
+| Delimited parser cursor contract | ✓ | draft | draft |  |  |  | implementation is in draft PR #6; formal cursor proof planned |
+| Type lattice (`never`, `any`, join/meet) | ✓ | ✓ | ✓ | planned in this branch | planned |  | current `IsSubtype` intersection law needs reconciliation |
+| Nominal records | ✓ | ✓ | ✓ |  |  |  | ordered field semantics implementation is in draft PR #6 |
+| Record composition | ✓ | partial | partial |  |  |  | semantics now separated from subtyping |
+| ADTs | ✓ | ✓ | ✓ |  |  |  | old payload/default/tag meanings need compiler reconciliation |
+| Pattern matching | ✓ | ✓ | ✓ | planned | planned |  | canonical `=>`; legacy aliases remain implementation concern |
+| Exhaustiveness | ✓ | partial | partial | planned | planned |  | finite constructor-set proof target |
+| GADT-style refinements | direction |  |  |  |  |  | semantic direction specified; surface syntax intentionally not frozen |
+| Generic constraints/interfaces | ✓ | ✓ | ✓ |  |  |  | static predicate semantics; dynamic interface values not core |
+| Phantom types | ✓ | partial | partial |  |  |  | zero-runtime representation law to prove |
+| Views / spans | ✓ | ✓ | ✓ | planned | planned |  | borrowing implementation/spec reconciliation needed |
+| Borrow-state machine | ✓ | partial | partial | planned | planned |  | local formal model planned |
+| Unsafe boundary | ✓ | partial | partial |  |  |  | unsafe must admit assumptions, not disable all checking |
+| Effects | ✓ | draft | draft | planned | planned |  | parameterized effect implementation in draft PR #6 |
+| Arena / slab allocator semantics | ✓ | draft | draft |  |  |  | semantic IR in draft PR #6; surface library types pending |
+| Generational handles | ✓ |  |  | planned | planned |  | semantics only; implementation representation not stabilized |
+| UTF-8 `string` validity | ✓ | partial | partial |  |  |  | legacy string code exists but must reconcile validation invariant |
+| UTF-16 / UTF-32 encoded views | ✓ | partial | partial |  |  |  | legacy library/spec work exists; no proof yet |
+| Compile-time metadata | ✓ | partial | partial |  |  |  | legacy backtick syntax is not yet normative |
+| C backend | ✓ | ✓ | ✓ |  |  |  | golden corpus currently has known stale/missing debt |
+| Functional generic specialization | ✓ | partial | partial |  |  |  | no-hidden-dispatch/boxing law needs tests/proofs |
+| Closure capture/storage effects | ✓ |  |  |  |  |  | semantics specified; implementation pending |
+| Protocol/typestate semantic axis | direction |  |  |  |  |  | will receive its own normative spec before implementation |
+
+## Immediate formal-verification queue
+
+1. type-lattice algebra;
+2. effect overlap/subsumption;
+3. local borrow-state safety;
+4. finite ADT exhaustiveness;
+5. parser delimited-sequence cursor invariant;
+6. source byte-span ↔ UTF-16 coordinate correctness;
+7. generational-handle stale-reference theorem;
+8. record layout/alignment once target layout representation stabilizes.
+
+## Refinement policy
+
+Do not mark a feature **R** merely because Go/Zig tests mirror theorem examples.
+
+`R` requires an explicit formal relation between concrete implementation state/operations and the formal model, with preservation proved by the proof system.

--- a/docs/spec/STATUS.md
+++ b/docs/spec/STATUS.md
@@ -16,21 +16,22 @@ Legend:
 | Layout + explicit blocks | ✓ | ✓ | ✓ |  |  |  | parser/layout equivalence exists; formal cursor/layout model pending |
 | Source spans / UTF-16 editor positions | ✓ | draft | draft |  |  |  | implementation is in draft PR #6 |
 | Delimited parser cursor contract | ✓ | draft | draft |  |  |  | implementation is in draft PR #6; formal cursor proof planned |
-| Type lattice (`never`, `any`, join/meet) | ✓ | ✓ | ✓ | planned in this branch | planned |  | current `IsSubtype` intersection law needs reconciliation |
+| Type lattice (`never`, `any`, join/meet) | ✓ | ✓ | ✓ | ✓ | ✓ |  | abstract laws proved in `Oak.TypeLattice`; current Go `IsSubtype` intersection behavior still needs reconciliation/refinement |
 | Nominal records | ✓ | ✓ | ✓ |  |  |  | ordered field semantics implementation is in draft PR #6 |
 | Record composition | ✓ | partial | partial |  |  |  | semantics now separated from subtyping |
 | ADTs | ✓ | ✓ | ✓ |  |  |  | old payload/default/tag meanings need compiler reconciliation |
-| Pattern matching | ✓ | ✓ | ✓ | planned | planned |  | canonical `=>`; legacy aliases remain implementation concern |
+| Pattern matching | ✓ | ✓ | ✓ |  |  |  | canonical `=>`; legacy aliases remain implementation concern |
 | Exhaustiveness | ✓ | partial | partial | planned | planned |  | finite constructor-set proof target |
 | GADT-style refinements | direction |  |  |  |  |  | semantic direction specified; surface syntax intentionally not frozen |
 | Generic constraints/interfaces | ✓ | ✓ | ✓ |  |  |  | static predicate semantics; dynamic interface values not core |
 | Phantom types | ✓ | partial | partial |  |  |  | zero-runtime representation law to prove |
-| Views / spans | ✓ | ✓ | ✓ | planned | planned |  | borrowing implementation/spec reconciliation needed |
-| Borrow-state machine | ✓ | partial | partial | planned | planned |  | local formal model planned |
+| Views / spans | ✓ | ✓ | ✓ | ✓ | ✓ |  | `Oak.Borrowing` proves the local authority-state laws; compiler correspondence is not yet proved |
+| Borrow-state machine | ✓ | partial | partial | ✓ | ✓ |  | explicit actions; valid transitions preserve state invariant and read/write authority stays exclusive |
 | Unsafe boundary | ✓ | partial | partial |  |  |  | unsafe must admit assumptions, not disable all checking |
-| Effects | ✓ | draft | draft | planned | planned |  | parameterized effect implementation in draft PR #6 |
-| Arena / slab allocator semantics | ✓ | draft | draft |  |  |  | semantic IR in draft PR #6; surface library types pending |
-| Generational handles | ✓ |  |  | planned | planned |  | semantics only; implementation representation not stabilized |
+| Effects | ✓ | draft | draft | ✓ | ✓ |  | `Oak.Effects` proves broad/scoped subsumption and overlap laws; implementation is in draft PR #6 |
+| Arena semantics | ✓ | draft | draft |  |  |  | semantic IR in draft PR #6; region escape proof pending |
+| Slab allocator semantics | ✓ | draft | draft | ✓ | ✓ |  | `Oak.Slab` proves capacity preservation and rejects allocation from a full slab |
+| Generational handles | ✓ |  |  | ✓ | ✓ |  | `Oak.Handles` proves stale handles cannot resolve after generation-changing reuse and cleared slots never resolve |
 | UTF-8 `string` validity | ✓ | partial | partial |  |  |  | legacy string code exists but must reconcile validation invariant |
 | UTF-16 / UTF-32 encoded views | ✓ | partial | partial |  |  |  | legacy library/spec work exists; no proof yet |
 | Compile-time metadata | ✓ | partial | partial |  |  |  | legacy backtick syntax is not yet normative |
@@ -39,16 +40,29 @@ Legend:
 | Closure capture/storage effects | ✓ |  |  |  |  |  | semantics specified; implementation pending |
 | Protocol/typestate semantic axis | direction |  |  |  |  |  | will receive its own normative spec before implementation |
 
+## Formal verification gate
+
+`spec/lean` is pinned to Lean 4.33.1 and built by `.github/workflows/formal.yml`.
+
+The formal gate currently checks:
+
+- `Oak.TypeLattice`
+- `Oak.Effects`
+- `Oak.Borrowing`
+- `Oak.Handles`
+- `Oak.Slab`
+
+A green Lean build means the stated theorems type-check against the pinned proof kernel. It does **not** imply implementation refinement.
+
 ## Immediate formal-verification queue
 
-1. type-lattice algebra;
-2. effect overlap/subsumption;
-3. local borrow-state safety;
-4. finite ADT exhaustiveness;
-5. parser delimited-sequence cursor invariant;
-6. source byte-span ↔ UTF-16 coordinate correctness;
-7. generational-handle stale-reference theorem;
-8. record layout/alignment once target layout representation stabilizes.
+1. finite ADT exhaustiveness;
+2. parser delimited-sequence cursor invariant;
+3. source byte-span ↔ UTF-16 coordinate correctness;
+4. region/arena non-escape theorem;
+5. phantom-type zero-runtime representation law;
+6. record layout/alignment once target layout representation stabilizes;
+7. explicit implementation refinements for type lattice, effects, and borrowing.
 
 ## Refinement policy
 

--- a/spec/lean/Oak.lean
+++ b/spec/lean/Oak.lean
@@ -1,3 +1,5 @@
 import Oak.TypeLattice
 import Oak.Effects
 import Oak.Borrowing
+import Oak.Handles
+import Oak.Slab

--- a/spec/lean/Oak.lean
+++ b/spec/lean/Oak.lean
@@ -1,0 +1,3 @@
+import Oak.TypeLattice
+import Oak.Effects
+import Oak.Borrowing

--- a/spec/lean/Oak/Borrowing.lean
+++ b/spec/lean/Oak/Borrowing.lean
@@ -6,6 +6,13 @@ inductive State where
   | unique
   deriving DecidableEq, Repr
 
+inductive Action where
+  | acquireRead
+  | acquireWrite
+  | releaseRead
+  | releaseWrite
+  deriving DecidableEq, Repr
+
 /-- Shared states must contain at least one live reader. -/
 def Valid : State -> Prop
   | .free => True
@@ -13,51 +20,53 @@ def Valid : State -> Prop
   | .unique => True
 
 /-- The only valid local ownership transitions for one owner. -/
-inductive Step : State -> State -> Prop where
-  | acquireReadFree : Step .free (.shared 1)
-  | acquireReadShared (n : Nat) : Step (.shared (n + 1)) (.shared (n + 2))
-  | acquireWrite : Step .free .unique
-  | releaseLastRead : Step (.shared 1) .free
-  | releaseRead (n : Nat) : Step (.shared (n + 2)) (.shared (n + 1))
-  | releaseWrite : Step .unique .free
+inductive Step : Action -> State -> State -> Prop where
+  | acquireReadFree : Step .acquireRead .free (.shared 1)
+  | acquireReadShared (n : Nat) :
+      Step .acquireRead (.shared (n + 1)) (.shared (n + 2))
+  | acquireWrite : Step .acquireWrite .free .unique
+  | releaseLastRead : Step .releaseRead (.shared 1) .free
+  | releaseRead (n : Nat) :
+      Step .releaseRead (.shared (n + 2)) (.shared (n + 1))
+  | releaseWrite : Step .releaseWrite .unique .free
 
 /-- Every legal transition preserves the representation invariant. -/
-theorem step_preserves_valid {before after : State}
-    (hvalid : Valid before) (hstep : Step before after) : Valid after := by
+theorem step_preserves_valid {action : Action} {before after : State}
+    (hvalid : Valid before) (hstep : Step action before after) : Valid after := by
   cases hstep <;> simp [Valid]
 
 /-- Writable authority can only be acquired from the free state. -/
-theorem acquire_write_only_from_free {before : State}
-    (h : Step before .unique) : before = .free := by
+theorem acquire_write_only_from_free {before after : State}
+    (h : Step .acquireWrite before after) : before = .free ∧ after = .unique := by
   cases h
-  rfl
+  exact ⟨rfl, rfl⟩
 
 /-- A read acquisition never creates unique-write authority. -/
-theorem read_acquisition_not_unique {before : State}
-    (h : Step before (.shared 1)) : before = .free := by
-  cases h
-  rfl
+theorem acquire_read_not_unique {before after : State}
+    (h : Step .acquireRead before after) : after ≠ .unique := by
+  cases h <;> simp
 
-/-- No legal transition acquires a writer while readers remain live. -/
-theorem shared_cannot_step_to_unique (n : Nat) :
-    ¬ Step (.shared (n + 1)) .unique := by
+/-- No writer can be acquired while readers remain live. -/
+theorem shared_cannot_acquire_write (n : Nat) :
+    ¬ Step .acquireWrite (.shared (n + 1)) .unique := by
   intro h
   cases h
 
 /-- Unique-write state cannot acquire another writer. -/
-theorem unique_cannot_step_to_unique : ¬ Step .unique .unique := by
+theorem unique_cannot_acquire_write :
+    ¬ Step .acquireWrite .unique .unique := by
   intro h
   cases h
 
 /-- Unique-write state cannot acquire a read borrow. -/
-theorem unique_cannot_step_to_shared (n : Nat) :
-    ¬ Step .unique (.shared n) := by
+theorem unique_cannot_acquire_read (after : State) :
+    ¬ Step .acquireRead .unique after := by
   intro h
   cases h
 
 /-- Releasing a reader never produces an invalid zero-reader shared state. -/
-theorem no_shared_zero_after_step {before after : State}
-    (hvalid : Valid before) (hstep : Step before after) : after ≠ .shared 0 := by
+theorem no_shared_zero_after_step {action : Action} {before after : State}
+    (hvalid : Valid before) (hstep : Step action before after) : after ≠ .shared 0 := by
   intro hz
   have havalid := step_preserves_valid hvalid hstep
   rw [hz] at havalid

--- a/spec/lean/Oak/Borrowing.lean
+++ b/spec/lean/Oak/Borrowing.lean
@@ -1,0 +1,79 @@
+namespace Oak.Borrowing
+
+inductive State where
+  | free
+  | shared : Nat -> State
+  | unique
+  deriving DecidableEq, Repr
+
+/-- Shared states must contain at least one live reader. -/
+def Valid : State -> Prop
+  | .free => True
+  | .shared n => 0 < n
+  | .unique => True
+
+/-- The only valid local ownership transitions for one owner. -/
+inductive Step : State -> State -> Prop where
+  | acquireReadFree : Step .free (.shared 1)
+  | acquireReadShared (n : Nat) : Step (.shared (n + 1)) (.shared (n + 2))
+  | acquireWrite : Step .free .unique
+  | releaseLastRead : Step (.shared 1) .free
+  | releaseRead (n : Nat) : Step (.shared (n + 2)) (.shared (n + 1))
+  | releaseWrite : Step .unique .free
+
+/-- Every legal transition preserves the representation invariant. -/
+theorem step_preserves_valid {before after : State}
+    (hvalid : Valid before) (hstep : Step before after) : Valid after := by
+  cases hstep <;> simp [Valid]
+
+/-- Writable authority can only be acquired from the free state. -/
+theorem acquire_write_only_from_free {before : State}
+    (h : Step before .unique) : before = .free := by
+  cases h
+  rfl
+
+/-- A read acquisition never creates unique-write authority. -/
+theorem read_acquisition_not_unique {before : State}
+    (h : Step before (.shared 1)) : before = .free := by
+  cases h
+  rfl
+
+/-- No legal transition acquires a writer while readers remain live. -/
+theorem shared_cannot_step_to_unique (n : Nat) :
+    ¬ Step (.shared (n + 1)) .unique := by
+  intro h
+  cases h
+
+/-- Unique-write state cannot acquire another writer. -/
+theorem unique_cannot_step_to_unique : ¬ Step .unique .unique := by
+  intro h
+  cases h
+
+/-- Unique-write state cannot acquire a read borrow. -/
+theorem unique_cannot_step_to_shared (n : Nat) :
+    ¬ Step .unique (.shared n) := by
+  intro h
+  cases h
+
+/-- Releasing a reader never produces an invalid zero-reader shared state. -/
+theorem no_shared_zero_after_step {before after : State}
+    (hvalid : Valid before) (hstep : Step before after) : after ≠ .shared 0 := by
+  intro hz
+  have havalid := step_preserves_valid hvalid hstep
+  rw [hz] at havalid
+  simp [Valid] at havalid
+
+/-- The abstract state never represents simultaneous shared-read and unique-write authority. -/
+def HasReaders : State -> Prop
+  | .shared n => 0 < n
+  | _ => False
+
+def HasWriter : State -> Prop
+  | .unique => True
+  | _ => False
+
+theorem readers_and_writer_exclusive (s : State) :
+    ¬ (HasReaders s ∧ HasWriter s) := by
+  cases s <;> simp [HasReaders, HasWriter]
+
+end Oak.Borrowing

--- a/spec/lean/Oak/Effects.lean
+++ b/spec/lean/Oak/Effects.lean
@@ -1,0 +1,86 @@
+namespace Oak.Effects
+
+inductive Family where
+  | memoryAllocate
+  | threadBlock
+  | osSyscall
+  | mmio
+  | io
+  | user : Nat -> Family
+  deriving DecidableEq, Repr
+
+inductive Effect where
+  | broad : Family -> Effect
+  | scoped : Family -> Nat -> Effect
+  deriving DecidableEq, Repr
+
+/-- `Subsumes forbidden required` means the forbidden effect covers the required one. -/
+def Subsumes : Effect -> Effect -> Prop
+  | .broad f, .broad g => f = g
+  | .broad f, .scoped g _ => f = g
+  | .scoped f s, .scoped g t => f = g ∧ s = t
+  | .scoped _ _, .broad _ => False
+
+/-- Two effects overlap when either one semantically subsumes the other. -/
+def Overlaps (a b : Effect) : Prop :=
+  Subsumes a b ∨ Subsumes b a
+
+theorem broad_subsumes_scoped (f : Family) (scope : Nat) :
+    Subsumes (.broad f) (.scoped f scope) := by
+  rfl
+
+theorem broad_subsumes_broad (f : Family) :
+    Subsumes (.broad f) (.broad f) := by
+  rfl
+
+theorem scoped_subsumes_same (f : Family) (scope : Nat) :
+    Subsumes (.scoped f scope) (.scoped f scope) := by
+  exact ⟨rfl, rfl⟩
+
+theorem scoped_does_not_subsume_broad (f : Family) (scope : Nat) :
+    ¬ Subsumes (.scoped f scope) (.broad f) := by
+  intro h
+  exact h
+
+theorem scoped_subsumes_scoped_iff (f g : Family) (s t : Nat) :
+    Subsumes (.scoped f s) (.scoped g t) ↔ f = g ∧ s = t := by
+  rfl
+
+theorem broad_subsumes_scoped_iff (f g : Family) (scope : Nat) :
+    Subsumes (.broad f) (.scoped g scope) ↔ f = g := by
+  rfl
+
+theorem overlaps_symm (a b : Effect) : Overlaps a b ↔ Overlaps b a := by
+  constructor
+  · intro h
+    cases h with
+    | inl hab => exact Or.inr hab
+    | inr hba => exact Or.inl hba
+  · intro h
+    cases h with
+    | inl hba => exact Or.inr hba
+    | inr hab => exact Or.inl hab
+
+theorem broad_overlaps_scoped (f : Family) (scope : Nat) :
+    Overlaps (.broad f) (.scoped f scope) := by
+  exact Or.inl (broad_subsumes_scoped f scope)
+
+theorem distinct_scopes_do_not_overlap
+    (f : Family) (s t : Nat) (hne : s ≠ t) :
+    ¬ Overlaps (.scoped f s) (.scoped f t) := by
+  intro h
+  cases h with
+  | inl hst => exact hne hst.2
+  | inr hts => exact hne hts.2.symm
+
+/-- A requirement is statically contradictory with a forbidden effect when they overlap. -/
+def Contradicts (required forbidden : Effect) : Prop :=
+  Overlaps required forbidden
+
+theorem broad_forbid_rejects_scoped_requirement
+    (f : Family) (scope : Nat) :
+    Contradicts (.scoped f scope) (.broad f) := by
+  exact (overlaps_symm (.broad f) (.scoped f scope)).mp
+    (broad_overlaps_scoped f scope)
+
+end Oak.Effects

--- a/spec/lean/Oak/Handles.lean
+++ b/spec/lean/Oak/Handles.lean
@@ -1,0 +1,43 @@
+namespace Oak.Handles
+
+structure Handle where
+  slot : Nat
+  generation : Nat
+  deriving DecidableEq, Repr
+
+structure Slot where
+  generation : Nat
+  occupied : Bool
+  deriving DecidableEq, Repr
+
+/-- A handle resolves only when the slot is occupied and the generation matches. -/
+def Resolves (h : Handle) (s : Slot) : Prop :=
+  s.occupied = true ∧ h.generation = s.generation
+
+/-- Reusing a slot advances its generation before making the new object live. -/
+def reuse (s : Slot) : Slot :=
+  { generation := s.generation + 1, occupied := true }
+
+/-- A handle that resolved before slot reuse cannot resolve to the replacement object. -/
+theorem stale_handle_cannot_resolve_after_reuse
+    (h : Handle) (s : Slot) (hres : Resolves h s) :
+    ¬ Resolves h (reuse s) := by
+  intro hnew
+  have hold : h.generation = s.generation := hres.2
+  have hnext : h.generation = s.generation + 1 := by
+    simpa [reuse] using hnew.2
+  have impossible : s.generation = s.generation + 1 := by
+    calc
+      s.generation = h.generation := hold.symm
+      _ = s.generation + 1 := hnext
+  exact (Nat.ne_of_lt (Nat.lt_succ_self s.generation)) impossible
+
+/-- Marking a slot unoccupied makes every handle fail resolution. -/
+def clear (s : Slot) : Slot := { s with occupied := false }
+
+theorem cleared_slot_never_resolves (h : Handle) (s : Slot) :
+    ¬ Resolves h (clear s) := by
+  intro hres
+  simp [Resolves, clear] at hres
+
+end Oak.Handles

--- a/spec/lean/Oak/Slab.lean
+++ b/spec/lean/Oak/Slab.lean
@@ -1,0 +1,44 @@
+namespace Oak.Slab
+
+structure State where
+  live : Nat
+  capacity : Nat
+  deriving DecidableEq, Repr
+
+def Valid (s : State) : Prop := s.live ≤ s.capacity
+
+inductive Action where
+  | allocate
+  | free
+  deriving DecidableEq, Repr
+
+/-- Slab transitions are only admitted when their explicit capacity/precondition holds. -/
+inductive Step : Action -> State -> State -> Prop where
+  | allocate (live capacity : Nat) (h : live < capacity) :
+      Step .allocate
+        { live := live, capacity := capacity }
+        { live := live + 1, capacity := capacity }
+  | free (live capacity : Nat) :
+      Step .free
+        { live := live + 1, capacity := capacity }
+        { live := live, capacity := capacity }
+
+/-- No valid slab transition can exceed its fixed capacity. -/
+theorem step_preserves_capacity {action : Action} {before after : State}
+    (hvalid : Valid before) (hstep : Step action before after) : Valid after := by
+  cases hstep with
+  | allocate live capacity hlt =>
+      exact Nat.succ_le_of_lt hlt
+  | free live capacity =>
+      exact Nat.le_trans (Nat.le_succ live) hvalid
+
+/-- Allocation from a full slab has no legal transition. -/
+theorem full_slab_cannot_allocate (capacity : Nat) :
+    ¬ Step .allocate
+      { live := capacity, capacity := capacity }
+      { live := capacity + 1, capacity := capacity } := by
+  intro h
+  cases h with
+  | allocate _ _ hlt => exact (Nat.lt_irrefl capacity hlt)
+
+end Oak.Slab

--- a/spec/lean/Oak/TypeLattice.lean
+++ b/spec/lean/Oak/TypeLattice.lean
@@ -1,0 +1,197 @@
+namespace Oak.TypeLattice
+
+universe u
+
+abbrev Ty (α : Type u) := α → Prop
+
+def Subtype {α : Type u} (a b : Ty α) : Prop :=
+  ∀ x, a x → b x
+
+infix:50 " ≤ₜ " => Subtype
+
+def bottom {α : Type u} : Ty α := fun _ => False
+
+def top {α : Type u} : Ty α := fun _ => True
+
+def join {α : Type u} (a b : Ty α) : Ty α := fun x => a x ∨ b x
+
+def meet {α : Type u} (a b : Ty α) : Ty α := fun x => a x ∧ b x
+
+theorem subtype_refl {α : Type u} (a : Ty α) : a ≤ₜ a := by
+  intro x hx
+  exact hx
+
+theorem subtype_trans {α : Type u} {a b c : Ty α}
+    (hab : a ≤ₜ b) (hbc : b ≤ₜ c) : a ≤ₜ c := by
+  intro x hx
+  exact hbc x (hab x hx)
+
+theorem bottom_le {α : Type u} (a : Ty α) : bottom ≤ₜ a := by
+  intro x hx
+  exact False.elim hx
+
+theorem le_top {α : Type u} (a : Ty α) : a ≤ₜ top := by
+  intro _ _
+  trivial
+
+theorem le_join_left {α : Type u} (a b : Ty α) : a ≤ₜ join a b := by
+  intro x hx
+  exact Or.inl hx
+
+theorem le_join_right {α : Type u} (a b : Ty α) : b ≤ₜ join a b := by
+  intro x hx
+  exact Or.inr hx
+
+theorem join_least {α : Type u} {a b c : Ty α}
+    (hac : a ≤ₜ c) (hbc : b ≤ₜ c) : join a b ≤ₜ c := by
+  intro x hx
+  cases hx with
+  | inl ha => exact hac x ha
+  | inr hb => exact hbc x hb
+
+theorem meet_le_left {α : Type u} (a b : Ty α) : meet a b ≤ₜ a := by
+  intro x hx
+  exact hx.1
+
+theorem meet_le_right {α : Type u} (a b : Ty α) : meet a b ≤ₜ b := by
+  intro x hx
+  exact hx.2
+
+theorem meet_greatest {α : Type u} {a b c : Ty α}
+    (hca : c ≤ₜ a) (hcb : c ≤ₜ b) : c ≤ₜ meet a b := by
+  intro x hx
+  exact ⟨hca x hx, hcb x hx⟩
+
+theorem join_comm {α : Type u} (a b : Ty α) : join a b = join b a := by
+  funext x
+  apply propext
+  constructor
+  · intro h
+    cases h with
+    | inl ha => exact Or.inr ha
+    | inr hb => exact Or.inl hb
+  · intro h
+    cases h with
+    | inl hb => exact Or.inr hb
+    | inr ha => exact Or.inl ha
+
+theorem meet_comm {α : Type u} (a b : Ty α) : meet a b = meet b a := by
+  funext x
+  apply propext
+  constructor
+  · intro h
+    exact ⟨h.2, h.1⟩
+  · intro h
+    exact ⟨h.2, h.1⟩
+
+theorem join_assoc {α : Type u} (a b c : Ty α) :
+    join a (join b c) = join (join a b) c := by
+  funext x
+  apply propext
+  constructor
+  · intro h
+    cases h with
+    | inl ha => exact Or.inl (Or.inl ha)
+    | inr hbc =>
+      cases hbc with
+      | inl hb => exact Or.inl (Or.inr hb)
+      | inr hc => exact Or.inr hc
+  · intro h
+    cases h with
+    | inl hab =>
+      cases hab with
+      | inl ha => exact Or.inl ha
+      | inr hb => exact Or.inr (Or.inl hb)
+    | inr hc => exact Or.inr (Or.inr hc)
+
+theorem meet_assoc {α : Type u} (a b c : Ty α) :
+    meet a (meet b c) = meet (meet a b) c := by
+  funext x
+  apply propext
+  constructor
+  · intro h
+    exact ⟨⟨h.1, h.2.1⟩, h.2.2⟩
+  · intro h
+    exact ⟨h.1.1, ⟨h.1.2, h.2⟩⟩
+
+theorem join_idem {α : Type u} (a : Ty α) : join a a = a := by
+  funext x
+  apply propext
+  constructor
+  · intro h
+    cases h with
+    | inl ha => exact ha
+    | inr ha => exact ha
+  · intro ha
+    exact Or.inl ha
+
+theorem meet_idem {α : Type u} (a : Ty α) : meet a a = a := by
+  funext x
+  apply propext
+  constructor
+  · intro h
+    exact h.1
+  · intro ha
+    exact ⟨ha, ha⟩
+
+theorem join_bottom {α : Type u} (a : Ty α) : join a bottom = a := by
+  funext x
+  apply propext
+  constructor
+  · intro h
+    cases h with
+    | inl ha => exact ha
+    | inr hf => exact False.elim hf
+  · intro ha
+    exact Or.inl ha
+
+theorem meet_top {α : Type u} (a : Ty α) : meet a top = a := by
+  funext x
+  apply propext
+  constructor
+  · intro h
+    exact h.1
+  · intro ha
+    exact ⟨ha, trivial⟩
+
+theorem join_top {α : Type u} (a : Ty α) : join a top = top := by
+  funext x
+  apply propext
+  constructor
+  · intro _
+    trivial
+  · intro _
+    exact Or.inr trivial
+
+theorem meet_bottom {α : Type u} (a : Ty α) : meet a bottom = bottom := by
+  funext x
+  apply propext
+  constructor
+  · intro h
+    exact h.2
+  · intro hf
+    exact False.elim hf
+
+theorem join_absorption {α : Type u} (a b : Ty α) :
+    join a (meet a b) = a := by
+  funext x
+  apply propext
+  constructor
+  · intro h
+    cases h with
+    | inl ha => exact ha
+    | inr hab => exact hab.1
+  · intro ha
+    exact Or.inl ha
+
+theorem meet_absorption {α : Type u} (a b : Ty α) :
+    meet a (join a b) = a := by
+  funext x
+  apply propext
+  constructor
+  · intro h
+    exact h.1
+  · intro ha
+    exact ⟨ha, Or.inl ha⟩
+
+end Oak.TypeLattice

--- a/spec/lean/lakefile.toml
+++ b/spec/lean/lakefile.toml
@@ -1,0 +1,6 @@
+name = "oak-spec"
+version = "0.1.0"
+defaultTargets = ["Oak"]
+
+[[lean_lib]]
+name = "Oak"

--- a/spec/lean/lean-toolchain
+++ b/spec/lean/lean-toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:v4.33.1


### PR DESCRIPTION
## Summary

This establishes one authoritative Oak language specification under `docs/spec/` and stops the older design canvases/status documents from competing as simultaneous sources of truth.

### Language constitution
- Correctness → Performance → Simplicity
- safety and ergonomics as cross-cutting constraints
- functional ergonomics with a Zig/C-style explicit cost model
- tight orthogonal surface: records, ADTs/GADT-style refinements, functions, generics, pattern matching, ownership/effects, and ordinary library types do most of the work

### Canonical surface
- `:` for annotations and function return types
- `:=` for inferred declarations
- `=` for assignment / explicit initialization
- `->` reserved for function types
- `=>` reserved for match arms
- `Type.Case` / `.Case` constructors
- layout and explicit-brace bodies are equivalent surface forms

### Semantic cleanup
- ADTs are nominal tagged sums, not ordinary runtime union values
- record composition is definition-time product composition, not structural subtyping
- interface `&` is constraint conjunction
- semantic joins/meets are distinct from surface record/interface operators
- metadata, payload defaults, representation/discriminants, effects, and propositions are separate axes
- string encoding is distinct from validation
- runtime `any`/typecase is not core until an explicit representation exists

### Formal verification
Adds a Lean 4.33.1 project and CI gate with mechanically checked models/proofs for:
- type-lattice subtype/join/meet algebra
- broad/scoped effect subsumption and overlap
- local borrow-state safety and read/write exclusivity
- generational stale-handle rejection
- bounded slab occupancy

The status matrix distinguishes **specified / implemented / tested / modeled / proved / refined**. A green Lean build is not called implementation refinement.

### Legacy reconciliation
`docs/spec/LEGACY_RECONCILIATION.md` maps the historical top-level specs into the new normative feature contracts and records contradictions/decisions that require compiler reconciliation.

## Important implementation finding

The formal/type-universe review exposed a current implementation mismatch: the normative meet law requires `A ∧ B ≤ A` and `A ∧ B ≤ B`, while the current Go `IsSubtype` handling of `IntersectionType` does not implement that law in general. This PR documents/proves the intended semantics; implementation repair/refinement follows separately.

## Verification
- dedicated `.github/workflows/formal.yml`
- latest branch formal build is green under Lean 4.33.1
- normal Go CI and formal CI are both required on this PR

PR #6 remains draft until these normative semantics are landed/reconciled.