### PR TITLE
Formally specify finite ADT exhaustiveness

### DIFF
--- a/docs/spec/STATUS.md
+++ b/docs/spec/STATUS.md
@@ -15,13 +15,13 @@ Legend:
 | --- | :---: | :---: | :---: | :---: | :---: | :---: | --- |
 | Layout + explicit blocks | ✓ | ✓ | ✓ |  |  |  | parser/layout equivalence exists; formal cursor/layout model pending |
 | Source spans / UTF-16 editor positions | ✓ | ✓ | ✓ |  |  | canonical byte spans plus exact UTF-16/LSP and `filename:line:column`/VS Code projections |
-| Delimited parser cursor contract | ✓ | ✓ | ✓ |  |  | one `parseDelimited[T]` path covers invocations, parameters, type arguments, and array elements; formal cursor proof planned |
+| Delimited parser cursor contract | ✓ | ✓ | ✓ |  |  |  | one `parseDelimited[T]` path covers invocations, parameters, type arguments, and array elements; formal cursor proof planned |
 | Type lattice (`never`, `any`, join/meet) | ✓ | ✓ | ✓ | ✓ | ✓ |  | Go subtype decision procedure is aligned with the proved distributive-lattice laws; explicit implementation refinement is still pending |
 | Nominal records | ✓ | ✓ | ✓ |  |  |  | authoritative source field order is preserved; duplicate fields are rejected; ABI offsets remain a target-layout concern |
 | Record composition | ✓ | partial | partial |  |  |  | semantics now separated from subtyping |
 | ADTs | ✓ | ✓ | ✓ |  |  |  | old payload/default/tag meanings need compiler reconciliation |
 | Pattern matching | ✓ | ✓ | ✓ |  |  |  | canonical `=>`; legacy aliases remain implementation concern |
-| Exhaustiveness | ✓ | partial | partial | planned | planned |  | finite constructor-set proof target |
+| Exhaustiveness | ✓ | partial | partial | ✓ | ✓ |  | `Oak.Exhaustiveness` proves wildcard coverage, complete finite constructor coverage, missing-constructor rejection, and monotonicity under added arms; implementation refinement pending |
 | GADT-style refinements | direction |  |  |  |  |  | semantic direction specified; surface syntax intentionally not frozen |
 | Generic constraints/interfaces | ✓ | ✓ | ✓ |  |  |  | static predicate semantics; dynamic interface values not core |
 | Phantom types | ✓ | partial | partial |  |  |  | zero-runtime representation law to prove |
@@ -51,18 +51,18 @@ The formal gate currently checks:
 - `Oak.Borrowing`
 - `Oak.Handles`
 - `Oak.Slab`
+- `Oak.Exhaustiveness`
 
 A green Lean build means the stated theorems type-check against the pinned proof kernel. It does **not** imply implementation refinement.
 
 ## Immediate formal-verification queue
 
-1. finite ADT exhaustiveness;
-2. parser delimited-sequence cursor invariant;
-3. source byte-span ↔ UTF-16 coordinate correctness;
-4. region/arena non-escape theorem;
-5. phantom-type zero-runtime representation law;
-6. record layout/alignment once target layout representation stabilizes;
-7. explicit implementation refinements for type lattice, effects, and borrowing.
+1. parser delimited-sequence cursor invariant;
+2. source byte-span ↔ UTF-16 coordinate correctness;
+3. region/arena non-escape theorem;
+4. phantom-type zero-runtime representation law;
+5. record layout/alignment once target layout representation stabilizes;
+6. explicit implementation refinements for type lattice, effects, borrowing, and exhaustiveness.
 
 ## Refinement policy
 

--- a/spec/lean/Oak.lean
+++ b/spec/lean/Oak.lean
@@ -3,3 +3,4 @@ import Oak.Effects
 import Oak.Borrowing
 import Oak.Handles
 import Oak.Slab
+import Oak.Exhaustiveness

--- a/spec/lean/Oak/Exhaustiveness.lean
+++ b/spec/lean/Oak/Exhaustiveness.lean
@@ -1,0 +1,57 @@
+namespace Oak.Exhaustiveness
+
+/-- A finite ADT is represented abstractly by its closed constructor set. -/
+def Exhaustive [DecidableEq α]
+    (constructors arms : List α) (hasWildcard : Bool) : Prop :=
+  hasWildcard = true ∨ ∀ ctor, ctor ∈ constructors → ctor ∈ arms
+
+/-- A wildcard arm makes a finite match exhaustive regardless of listed arms. -/
+theorem wildcard_is_exhaustive [DecidableEq α]
+    (constructors arms : List α) :
+    Exhaustive constructors arms true := by
+  exact Or.inl rfl
+
+/-- Listing every constructor is sufficient when there is no wildcard. -/
+theorem all_constructors_are_exhaustive [DecidableEq α]
+    (constructors arms : List α)
+    (h : ∀ ctor, ctor ∈ constructors → ctor ∈ arms) :
+    Exhaustive constructors arms false := by
+  exact Or.inr h
+
+/-- Without a wildcard, one missing constructor is enough to reject a match. -/
+theorem missing_constructor_is_not_exhaustive [DecidableEq α]
+    (constructors arms : List α) (missing : α)
+    (hctor : missing ∈ constructors)
+    (hmissing : missing ∉ arms) :
+    ¬ Exhaustive constructors arms false := by
+  intro hexhaustive
+  cases hexhaustive with
+  | inl hwildcard => simp at hwildcard
+  | inr hall => exact hmissing (hall missing hctor)
+
+/-- Adding arms cannot make an already exhaustive match non-exhaustive. -/
+theorem adding_arms_preserves_exhaustiveness [DecidableEq α]
+    (constructors arms extra : List α) (wildcard : Bool)
+    (h : Exhaustive constructors arms wildcard) :
+    Exhaustive constructors (arms ++ extra) wildcard := by
+  cases h with
+  | inl hwildcard => exact Or.inl hwildcard
+  | inr hall =>
+      exact Or.inr (by
+        intro ctor hctor
+        exact List.mem_append_left extra (hall ctor hctor))
+
+/-- Constructor order is irrelevant to the coverage condition. -/
+theorem constructor_membership_drives_coverage [DecidableEq α]
+    (constructors arms : List α) :
+    Exhaustive constructors arms false ↔
+      ∀ ctor, ctor ∈ constructors → ctor ∈ arms := by
+  constructor
+  · intro h
+    cases h with
+    | inl hwildcard => simp at hwildcard
+    | inr hall => exact hall
+  · intro h
+    exact Or.inr h
+
+end Oak.Exhaustiveness


### PR DESCRIPTION
## Summary

Add the next mechanically checked Oak language feature: finite ADT match exhaustiveness.

### Lean model
`Oak.Exhaustiveness` defines coverage over a closed finite constructor set and proves:
- wildcard coverage is exhaustive
- listing every constructor is exhaustive
- one missing constructor rejects a non-wildcard match
- adding arms cannot destroy exhaustiveness
- constructor membership, not declaration order, drives coverage

### Status discipline
- marks exhaustiveness **M/P** only for the abstract finite-constructor model
- leaves **R** blank: the current Go typechecker has tests for exhaustiveness, but no machine-checked implementation refinement is claimed
- keeps the actual parser cursor proof and UTF-8/UTF-16 coordinate proof next in the queue

## Verification

Go CI and the Lean 4.33.1 formal gate must both pass before merge. The historical golden corpus remains separate known debt.