### PR TITLE
Formally specify UTF-8 and UTF-16 source positions

### DIFF
--- a/docs/spec/STATUS.md
+++ b/docs/spec/STATUS.md
@@ -14,7 +14,7 @@ Legend:
 | Feature | S | I | T | M | P | R | Notes |
 | --- | :---: | :---: | :---: | :---: | :---: | :---: | --- |
 | Layout + explicit blocks | ✓ | ✓ | ✓ |  |  |  | parser/layout equivalence exists; formal cursor/layout model pending |
-| Source spans / UTF-16 editor positions | ✓ | ✓ | ✓ |  |  | canonical byte spans plus exact UTF-16/LSP and `filename:line:column`/VS Code projections |
+| Source spans / UTF-16 editor positions | ✓ | ✓ | ✓ | ✓ | ✓ |  | `Oak.SourcePosition` proves UTF-8/UTF-16 scalar-width rules, additive coordinate accumulation, monotonic offsets, and ASCII width equivalence; Go tests cover emoji, multiline positions, byte-boundary rejection, links, and LSP coordinates; refinement pending |
 | Delimited parser cursor contract | ✓ | ✓ | ✓ |  |  |  | one `parseDelimited[T]` path covers invocations, parameters, type arguments, and array elements; formal cursor proof planned |
 | Type lattice (`never`, `any`, join/meet) | ✓ | ✓ | ✓ | ✓ | ✓ |  | Go subtype decision procedure is aligned with the proved distributive-lattice laws; explicit implementation refinement is still pending |
 | Nominal records | ✓ | ✓ | ✓ |  |  |  | authoritative source field order is preserved; duplicate fields are rejected; ABI offsets remain a target-layout concern |
@@ -52,17 +52,17 @@ The formal gate currently checks:
 - `Oak.Handles`
 - `Oak.Slab`
 - `Oak.Exhaustiveness`
+- `Oak.SourcePosition`
 
 A green Lean build means the stated theorems type-check against the pinned proof kernel. It does **not** imply implementation refinement.
 
 ## Immediate formal-verification queue
 
 1. parser delimited-sequence cursor invariant;
-2. source byte-span ↔ UTF-16 coordinate correctness;
-3. region/arena non-escape theorem;
-4. phantom-type zero-runtime representation law;
-5. record layout/alignment once target layout representation stabilizes;
-6. explicit implementation refinements for type lattice, effects, borrowing, and exhaustiveness.
+2. region/arena non-escape theorem;
+3. phantom-type zero-runtime representation law;
+4. record layout/alignment once target layout representation stabilizes;
+5. explicit implementation refinements for type lattice, effects, borrowing, exhaustiveness, and source positions.
 
 ## Refinement policy
 

--- a/spec/lean/Oak.lean
+++ b/spec/lean/Oak.lean
@@ -4,3 +4,4 @@ import Oak.Borrowing
 import Oak.Handles
 import Oak.Slab
 import Oak.Exhaustiveness
+import Oak.SourcePosition

--- a/spec/lean/Oak/SourcePosition.lean
+++ b/spec/lean/Oak/SourcePosition.lean
@@ -1,0 +1,115 @@
+namespace Oak.SourcePosition
+
+/-- UTF-8 width for a valid Unicode scalar value, modeled by scalar range. -/
+def utf8Width (scalar : Nat) : Nat :=
+  if scalar ≤ 127 then 1
+  else if scalar ≤ 2047 then 2
+  else if scalar ≤ 65535 then 3
+  else 4
+
+/-- UTF-16 code-unit width for a valid Unicode scalar value. -/
+def utf16Width (scalar : Nat) : Nat :=
+  if scalar ≤ 65535 then 1 else 2
+
+structure Position where
+  byteOffset : Nat
+  utf16Column : Nat
+  deriving DecidableEq, Repr
+
+def advance (p : Position) (scalar : Nat) : Position :=
+  { byteOffset := p.byteOffset + utf8Width scalar
+    utf16Column := p.utf16Column + utf16Width scalar }
+
+def advanceText : Position -> List Nat -> Position
+  | p, [] => p
+  | p, scalar :: rest => advanceText (advance p scalar) rest
+
+def utf8Bytes : List Nat -> Nat
+  | [] => 0
+  | scalar :: rest => utf8Width scalar + utf8Bytes rest
+
+def utf16Units : List Nat -> Nat
+  | [] => 0
+  | scalar :: rest => utf16Width scalar + utf16Units rest
+
+theorem ascii_utf8_width (scalar : Nat) (h : scalar ≤ 127) :
+    utf8Width scalar = 1 := by
+  simp [utf8Width, h]
+
+theorem two_byte_utf8_width (scalar : Nat)
+    (hlo : 127 < scalar) (hhi : scalar ≤ 2047) :
+    utf8Width scalar = 2 := by
+  have hn : ¬ scalar ≤ 127 := Nat.not_le_of_lt hlo
+  simp [utf8Width, hn, hhi]
+
+theorem three_byte_utf8_width (scalar : Nat)
+    (hlo : 2047 < scalar) (hhi : scalar ≤ 65535) :
+    utf8Width scalar = 3 := by
+  have h127 : ¬ scalar ≤ 127 := by omega
+  have h2047 : ¬ scalar ≤ 2047 := Nat.not_le_of_lt hlo
+  simp [utf8Width, h127, h2047, hhi]
+
+theorem four_byte_utf8_width (scalar : Nat)
+    (hlo : 65535 < scalar) :
+    utf8Width scalar = 4 := by
+  have h127 : ¬ scalar ≤ 127 := by omega
+  have h2047 : ¬ scalar ≤ 2047 := by omega
+  have h65535 : ¬ scalar ≤ 65535 := Nat.not_le_of_lt hlo
+  simp [utf8Width, h127, h2047, h65535]
+
+theorem bmp_utf16_width (scalar : Nat) (h : scalar ≤ 65535) :
+    utf16Width scalar = 1 := by
+  simp [utf16Width, h]
+
+theorem supplementary_utf16_width (scalar : Nat) (h : 65535 < scalar) :
+    utf16Width scalar = 2 := by
+  have hn : ¬ scalar ≤ 65535 := Nat.not_le_of_lt h
+  simp [utf16Width, hn]
+
+theorem advanceText_append (p : Position) (left right : List Nat) :
+    advanceText p (left ++ right) = advanceText (advanceText p left) right := by
+  induction left generalizing p with
+  | nil => rfl
+  | cons scalar rest ih =>
+      simp [advanceText, ih]
+
+theorem advanceText_byteOffset (p : Position) (text : List Nat) :
+    (advanceText p text).byteOffset = p.byteOffset + utf8Bytes text := by
+  induction text generalizing p with
+  | nil => simp [advanceText, utf8Bytes]
+  | cons scalar rest ih =>
+      simp [advanceText, advance, utf8Bytes, ih, Nat.add_assoc]
+
+theorem advanceText_utf16Column (p : Position) (text : List Nat) :
+    (advanceText p text).utf16Column = p.utf16Column + utf16Units text := by
+  induction text generalizing p with
+  | nil => simp [advanceText, utf16Units]
+  | cons scalar rest ih =>
+      simp [advanceText, advance, utf16Units, ih, Nat.add_assoc]
+
+theorem byteOffset_monotone (p : Position) (text : List Nat) :
+    p.byteOffset ≤ (advanceText p text).byteOffset := by
+  rw [advanceText_byteOffset]
+  exact Nat.le_add_right p.byteOffset (utf8Bytes text)
+
+theorem utf16Column_monotone (p : Position) (text : List Nat) :
+    p.utf16Column ≤ (advanceText p text).utf16Column := by
+  rw [advanceText_utf16Column]
+  exact Nat.le_add_right p.utf16Column (utf16Units text)
+
+/-- ASCII prefixes have identical byte and UTF-16 widths. -/
+def AllAscii : List Nat -> Prop
+  | [] => True
+  | scalar :: rest => scalar ≤ 127 ∧ AllAscii rest
+
+theorem ascii_widths_equal (text : List Nat) (h : AllAscii text) :
+    utf8Bytes text = utf16Units text := by
+  induction text with
+  | nil => rfl
+  | cons scalar rest ih =>
+      simp [AllAscii] at h
+      simp [utf8Bytes, utf16Units, ascii_utf8_width scalar h.1,
+        bmp_utf16_width scalar (Nat.le_trans h.1 (by decide : 127 ≤ 65535)),
+        ih h.2]
+
+end Oak.SourcePosition

--- a/spec/lean/Oak/SourcePosition.lean
+++ b/spec/lean/Oak/SourcePosition.lean
@@ -45,15 +45,18 @@ theorem two_byte_utf8_width (scalar : Nat)
 theorem three_byte_utf8_width (scalar : Nat)
     (hlo : 2047 < scalar) (hhi : scalar ≤ 65535) :
     utf8Width scalar = 3 := by
-  have h127 : ¬ scalar ≤ 127 := by omega
+  have h127lt : 127 < scalar := Nat.lt_trans (by decide : 127 < 2047) hlo
+  have h127 : ¬ scalar ≤ 127 := Nat.not_le_of_lt h127lt
   have h2047 : ¬ scalar ≤ 2047 := Nat.not_le_of_lt hlo
   simp [utf8Width, h127, h2047, hhi]
 
 theorem four_byte_utf8_width (scalar : Nat)
     (hlo : 65535 < scalar) :
     utf8Width scalar = 4 := by
-  have h127 : ¬ scalar ≤ 127 := by omega
-  have h2047 : ¬ scalar ≤ 2047 := by omega
+  have h127lt : 127 < scalar := Nat.lt_trans (by decide : 127 < 65535) hlo
+  have h2047lt : 2047 < scalar := Nat.lt_trans (by decide : 2047 < 65535) hlo
+  have h127 : ¬ scalar ≤ 127 := Nat.not_le_of_lt h127lt
+  have h2047 : ¬ scalar ≤ 2047 := Nat.not_le_of_lt h2047lt
   have h65535 : ¬ scalar ≤ 65535 := Nat.not_le_of_lt hlo
   simp [utf8Width, h127, h2047, h65535]
 


### PR DESCRIPTION
## Summary

Formally specify the source-coordinate rules behind Oak diagnostics/LSP/VS Code locations.

### Lean model
`Oak.SourcePosition` models valid Unicode scalar widths and proves:
- UTF-8 widths for 1/2/3/4-byte scalar ranges
- UTF-16 width 1 for BMP scalars and 2 for supplementary scalars
- text position advancement composes over concatenation
- byte offsets equal the accumulated UTF-8 width
- editor columns equal the accumulated UTF-16 code-unit width
- both coordinates are monotone while advancing text
- ASCII prefixes have identical byte and UTF-16 widths

### Implementation correspondence evidence
Existing Go tests already exercise:
- supplementary characters (`😀`)
- exact UTF-8 byte spans
- UTF-16 editor columns/LSP positions
- multiline positions
- rejection of byte offsets inside a rune
- `filename:line:column` and `vscode://file/...` projections

This PR does **not** mark refinement: the Lean model is abstract and valid-scalar based; the Go UTF-8 decoder/source table is not yet related to it by a machine-checked refinement proof.

## Verification
Go 1.27.1 CI and Lean 4.33.1 formal verification must both pass before merge. Golden corpus debt remains separate.