### PR TITLE
Formally specify delimited parser structure

### DIFF
--- a/docs/spec/STATUS.md
+++ b/docs/spec/STATUS.md
@@ -13,9 +13,9 @@ Legend:
 
 | Feature | S | I | T | M | P | R | Notes |
 | --- | :---: | :---: | :---: | :---: | :---: | :---: | --- |
-| Layout + explicit blocks | ✓ | ✓ | ✓ |  |  |  | parser/layout equivalence exists; formal cursor/layout model pending |
+| Layout + explicit blocks | ✓ | ✓ | ✓ |  |  |  | parser/layout equivalence exists; formal layout normalization model pending |
 | Source spans / UTF-16 editor positions | ✓ | ✓ | ✓ | ✓ | ✓ |  | `Oak.SourcePosition` proves UTF-8/UTF-16 scalar-width rules, additive coordinate accumulation, monotonic offsets, and ASCII width equivalence; Go tests cover emoji, multiline positions, byte-boundary rejection, links, and LSP coordinates; refinement pending |
-| Delimited parser cursor contract | ✓ | ✓ | ✓ |  |  |  | one `parseDelimited[T]` path covers invocations, parameters, type arguments, and array elements; formal cursor proof planned |
+| Delimited parser cursor contract | ✓ | ✓ | ✓ | ✓ | ✓ |  | one `parseDelimited[T]` path covers invocations, parameters, type arguments, and array elements; `Oak.Delimited` proves canonical opener/body/close structure, item preservation, unique close suffix, exact close offset, and trailing-separator semantic transparency; refinement pending |
 | Type lattice (`never`, `any`, join/meet) | ✓ | ✓ | ✓ | ✓ | ✓ |  | Go subtype decision procedure is aligned with the proved distributive-lattice laws; explicit implementation refinement is still pending |
 | Nominal records | ✓ | ✓ | ✓ |  |  |  | authoritative source field order is preserved; duplicate fields are rejected; ABI offsets remain a target-layout concern |
 | Record composition | ✓ | partial | partial |  |  |  | semantics now separated from subtyping |
@@ -53,16 +53,17 @@ The formal gate currently checks:
 - `Oak.Slab`
 - `Oak.Exhaustiveness`
 - `Oak.SourcePosition`
+- `Oak.Delimited`
 
 A green Lean build means the stated theorems type-check against the pinned proof kernel. It does **not** imply implementation refinement.
 
 ## Immediate formal-verification queue
 
-1. parser delimited-sequence cursor invariant;
-2. region/arena non-escape theorem;
-3. phantom-type zero-runtime representation law;
-4. record layout/alignment once target layout representation stabilizes;
-5. explicit implementation refinements for type lattice, effects, borrowing, exhaustiveness, and source positions.
+1. region/arena non-escape theorem;
+2. phantom-type zero-runtime representation law;
+3. record layout/alignment once target layout representation stabilizes;
+4. formal layout-normalizer balance/equivalence model;
+5. explicit implementation refinements for type lattice, effects, borrowing, exhaustiveness, source positions, and delimited parsing.
 
 ## Refinement policy
 

--- a/spec/lean/Oak.lean
+++ b/spec/lean/Oak.lean
@@ -5,3 +5,4 @@ import Oak.Handles
 import Oak.Slab
 import Oak.Exhaustiveness
 import Oak.SourcePosition
+import Oak.Delimited

--- a/spec/lean/Oak/Delimited.lean
+++ b/spec/lean/Oak/Delimited.lean
@@ -75,9 +75,9 @@ theorem encode_starts_with_open (items : List Nat) (trailing : Bool) :
   rfl
 
 /-- Dropping an entire syntactic prefix reaches the exact suffix. -/
-theorem drop_prefix (prefix suffix : List Token) :
-    List.drop prefix.length (prefix ++ suffix) = suffix := by
-  induction prefix with
+theorem drop_prefix_tokens (pre suffix : List Token) :
+    List.drop pre.length (pre ++ suffix) = suffix := by
+  induction pre with
   | nil => rfl
   | cons token rest ih =>
       simp [ih]
@@ -86,12 +86,13 @@ theorem drop_prefix (prefix suffix : List Token) :
     exactly with the closing delimiter. -/
 theorem drop_to_close (items : List Nat) (trailing : Bool) :
     List.drop (closeOffset items trailing) (encode items trailing) = [.close] := by
-  simp [closeOffset, encode, drop_prefix]
+  simp [closeOffset, encode, drop_prefix_tokens]
 
 /-- The closing-delimiter cursor is always a valid token position. -/
 theorem close_offset_in_bounds (items : List Nat) (trailing : Bool) :
     closeOffset items trailing < (encode items trailing).length := by
   simp [closeOffset, encode]
+  omega
 
 /-- No closing delimiter can occur before the canonical close position. -/
 theorem close_unique_to_suffix (items : List Nat) (trailing : Bool) :

--- a/spec/lean/Oak/Delimited.lean
+++ b/spec/lean/Oak/Delimited.lean
@@ -86,7 +86,11 @@ theorem drop_prefix_tokens (pre suffix : List Token) :
     exactly with the closing delimiter. -/
 theorem drop_to_close (items : List Nat) (trailing : Bool) :
     List.drop (closeOffset items trailing) (encode items trailing) = [.close] := by
-  simp [closeOffset, encode, drop_prefix_tokens]
+  have hoff :
+      closeOffset items trailing = Nat.succ (body items trailing).length := by
+    simp [closeOffset]
+  rw [hoff]
+  simp [encode, drop_prefix_tokens]
 
 /-- The closing-delimiter cursor is always a valid token position. -/
 theorem close_offset_in_bounds (items : List Nat) (trailing : Bool) :

--- a/spec/lean/Oak/Delimited.lean
+++ b/spec/lean/Oak/Delimited.lean
@@ -1,0 +1,100 @@
+namespace Oak.Delimited
+
+inductive Token where
+  | open
+  | close
+  | separator
+  | item : Nat -> Token
+  deriving DecidableEq, Repr
+
+/-- Canonical token body between opening and closing delimiters. -/
+def body : List Nat -> Bool -> List Token
+  | [], _ => []
+  | [x], false => [.item x]
+  | [x], true => [.item x, .separator]
+  | x :: y :: rest, trailing =>
+      .item x :: .separator :: body (y :: rest) trailing
+
+/-- A complete delimited sequence. -/
+def encode (items : List Nat) (trailing : Bool) : List Token :=
+  .open :: (body items trailing ++ [.close])
+
+/-- Cursor offset of the closing delimiter when the cursor enters on `open`. -/
+def closeOffset (items : List Nat) (trailing : Bool) : Nat :=
+  1 + (body items trailing).length
+
+/-- Extract semantic items while ignoring delimiters and separators. -/
+def itemValues : List Token -> List Nat
+  | [] => []
+  | .item x :: rest => x :: itemValues rest
+  | _ :: rest => itemValues rest
+
+theorem body_contains_no_open (items : List Nat) (trailing : Bool) :
+    .open ∉ body items trailing := by
+  induction items generalizing trailing with
+  | nil => simp [body]
+  | cons x rest ih =>
+      cases rest with
+      | nil => cases trailing <;> simp [body]
+      | cons y ys =>
+          simp [body, ih]
+
+theorem body_contains_no_close (items : List Nat) (trailing : Bool) :
+    .close ∉ body items trailing := by
+  induction items generalizing trailing with
+  | nil => simp [body]
+  | cons x rest ih =>
+      cases rest with
+      | nil => cases trailing <;> simp [body]
+      | cons y ys =>
+          simp [body, ih]
+
+theorem body_preserves_items (items : List Nat) (trailing : Bool) :
+    itemValues (body items trailing) = items := by
+  induction items generalizing trailing with
+  | nil => simp [body, itemValues]
+  | cons x rest ih =>
+      cases rest with
+      | nil => cases trailing <;> simp [body, itemValues]
+      | cons y ys =>
+          simp [body, itemValues, ih]
+
+theorem encode_preserves_items (items : List Nat) (trailing : Bool) :
+    itemValues (encode items trailing) = items := by
+  simp [encode, itemValues, body_preserves_items]
+
+theorem encode_starts_with_open (items : List Nat) (trailing : Bool) :
+    encode items trailing = .open :: (body items trailing ++ [.close]) := by
+  rfl
+
+/-- At the specified postcondition offset, the remaining token stream begins
+    exactly with the closing delimiter. -/
+theorem drop_to_close (items : List Nat) (trailing : Bool) :
+    List.drop (closeOffset items trailing) (encode items trailing) = [.close] := by
+  simp [closeOffset, encode]
+
+/-- The closing-delimiter cursor is always a valid token position. -/
+theorem close_offset_in_bounds (items : List Nat) (trailing : Bool) :
+    closeOffset items trailing < (encode items trailing).length := by
+  have hlen :
+      (encode items trailing).length = closeOffset items trailing + 1 := by
+    simp [encode, closeOffset, Nat.add_assoc]
+  rw [hlen]
+  exact Nat.lt_succ_self _
+
+/-- No closing delimiter can occur before the canonical close position. -/
+theorem close_unique_to_suffix (items : List Nat) (trailing : Bool) :
+    .close ∉ (.open :: body items trailing) := by
+  simp [body_contains_no_close]
+
+/-- Empty delimited sequences are structurally unambiguous. -/
+theorem empty_encoding (trailing : Bool) :
+    encode [] trailing = [.open, .close] := by
+  simp [encode, body]
+
+/-- A trailing separator changes only syntax, never the semantic item list. -/
+theorem trailing_separator_semantically_transparent (items : List Nat) :
+    itemValues (encode items false) = itemValues (encode items true) := by
+  simp [encode_preserves_items]
+
+end Oak.Delimited

--- a/spec/lean/Oak/Delimited.lean
+++ b/spec/lean/Oak/Delimited.lean
@@ -29,6 +29,13 @@ def itemValues : List Token -> List Nat
   | .item x :: rest => x :: itemValues rest
   | _ :: rest => itemValues rest
 
+theorem itemValues_append (left right : List Token) :
+    itemValues (left ++ right) = itemValues left ++ itemValues right := by
+  induction left with
+  | nil => rfl
+  | cons token rest ih =>
+      cases token <;> simp [itemValues, ih]
+
 theorem body_contains_no_open (items : List Nat) (trailing : Bool) :
     .open ∉ body items trailing := by
   induction items generalizing trailing with
@@ -61,26 +68,30 @@ theorem body_preserves_items (items : List Nat) (trailing : Bool) :
 
 theorem encode_preserves_items (items : List Nat) (trailing : Bool) :
     itemValues (encode items trailing) = items := by
-  simp [encode, itemValues, body_preserves_items]
+  simp [encode, itemValues, itemValues_append, body_preserves_items]
 
 theorem encode_starts_with_open (items : List Nat) (trailing : Bool) :
     encode items trailing = .open :: (body items trailing ++ [.close]) := by
   rfl
 
+/-- Dropping an entire syntactic prefix reaches the exact suffix. -/
+theorem drop_prefix (prefix suffix : List Token) :
+    List.drop prefix.length (prefix ++ suffix) = suffix := by
+  induction prefix with
+  | nil => rfl
+  | cons token rest ih =>
+      simp [ih]
+
 /-- At the specified postcondition offset, the remaining token stream begins
     exactly with the closing delimiter. -/
 theorem drop_to_close (items : List Nat) (trailing : Bool) :
     List.drop (closeOffset items trailing) (encode items trailing) = [.close] := by
-  simp [closeOffset, encode]
+  simp [closeOffset, encode, drop_prefix]
 
 /-- The closing-delimiter cursor is always a valid token position. -/
 theorem close_offset_in_bounds (items : List Nat) (trailing : Bool) :
     closeOffset items trailing < (encode items trailing).length := by
-  have hlen :
-      (encode items trailing).length = closeOffset items trailing + 1 := by
-    simp [encode, closeOffset, Nat.add_assoc]
-  rw [hlen]
-  exact Nat.lt_succ_self _
+  simp [closeOffset, encode]
 
 /-- No closing delimiter can occur before the canonical close position. -/
 theorem close_unique_to_suffix (items : List Nat) (trailing : Bool) :

--- a/spec/lean/Oak/Delimited.lean
+++ b/spec/lean/Oak/Delimited.lean
@@ -89,8 +89,9 @@ theorem drop_to_close (items : List Nat) (trailing : Bool) :
   have hoff :
       closeOffset items trailing = Nat.succ (body items trailing).length := by
     simp [closeOffset]
+    omega
   rw [hoff]
-  simp [encode, drop_prefix_tokens]
+  simp [encode]
 
 /-- The closing-delimiter cursor is always a valid token position. -/
 theorem close_offset_in_bounds (items : List Nat) (trailing : Bool) :


### PR DESCRIPTION
## Summary

Add a machine-checked structural specification for the generic delimited-sequence parser contract used by invocation arguments, parameters, generic arguments, and array elements.

### Lean model
`Oak.Delimited` specifies:
- one opening delimiter
- zero or more semantic items separated by delimiters
- optional trailing separator
- one unique closing delimiter
- semantic item extraction independent of delimiters/separators
- the exact cursor offset of the closing delimiter when entering on `open`

Proved properties:
- the body contains no `open`/`close`
- encoding preserves item order and count
- the token stream begins on `open`
- dropping exactly `closeOffset` reaches `[close]`
- the close offset is in bounds
- no earlier close exists in the prefix
- empty sequences are `[open, close]`
- trailing separators do not change semantic items

### Status discipline
This marks the delimited parser contract **M/P**, but leaves **R** blank. The Go `parseDelimited[T]` implementation and its tests are correspondence evidence, not a machine-checked refinement proof.

## Verification
Go 1.27.1 CI and Lean 4.33.1 formal verification must pass before merge. Golden corpus debt remains separate.