### PR TITLE
Prove arena region non-escape

### DIFF
--- a/docs/spec/STATUS.md
+++ b/docs/spec/STATUS.md
@@ -29,7 +29,7 @@ Legend:
 | Borrow-state machine | ✓ | partial | partial | ✓ | ✓ |  | explicit actions; valid transitions preserve state invariant and read/write authority stays exclusive |
 | Unsafe boundary | ✓ | partial | partial |  |  |  | unsafe must admit assumptions, not disable all checking |
 | Effects | ✓ | ✓ | ✓ | ✓ | ✓ |  | Semantic IR implements broad/scoped effect identity and conflict validation; `Oak.Effects` proves the abstract subsumption/overlap laws; refinement pending |
-| Arena semantics | ✓ | ✓ | ✓ |  |  |  | Semantic IR represents explicit arena identity/lifetime and validates required metadata; region non-escape proof pending |
+| Arena semantics | ✓ | ✓ | ✓ | ✓ | ✓ |  | Semantic IR represents explicit arena identity/lifetime; `Oak.RegionLifetime` proves lifetime containment, transitivity, alive-child implies alive-region, and that a region-bound value cannot remain alive after the region ends; refinement pending |
 | Slab allocator semantics | ✓ | ✓ | ✓ | ✓ | ✓ |  | Semantic IR validates explicit bounded slab/pool capacity and identity; `Oak.Slab` proves abstract capacity preservation; refinement pending |
 | Generational handles | ✓ |  |  | ✓ | ✓ |  | `Oak.Handles` proves stale handles cannot resolve after generation-changing reuse and cleared slots never resolve |
 | UTF-8 `string` validity | ✓ | partial | partial |  |  |  | legacy string code exists but must reconcile validation invariant |
@@ -54,16 +54,16 @@ The formal gate currently checks:
 - `Oak.Exhaustiveness`
 - `Oak.SourcePosition`
 - `Oak.Delimited`
+- `Oak.RegionLifetime`
 
 A green Lean build means the stated theorems type-check against the pinned proof kernel. It does **not** imply implementation refinement.
 
 ## Immediate formal-verification queue
 
-1. region/arena non-escape theorem;
-2. phantom-type zero-runtime representation law;
-3. record layout/alignment once target layout representation stabilizes;
-4. formal layout-normalizer balance/equivalence model;
-5. explicit implementation refinements for type lattice, effects, borrowing, exhaustiveness, source positions, and delimited parsing.
+1. phantom-type zero-runtime representation law;
+2. record layout/alignment once target layout representation stabilizes;
+3. formal layout-normalizer balance/equivalence model;
+4. explicit implementation refinements for type lattice, effects, borrowing, exhaustiveness, source positions, delimited parsing, and region lifetimes.
 
 ## Refinement policy
 

--- a/spec/lean/Oak.lean
+++ b/spec/lean/Oak.lean
@@ -6,3 +6,4 @@ import Oak.Slab
 import Oak.Exhaustiveness
 import Oak.SourcePosition
 import Oak.Delimited
+import Oak.RegionLifetime

--- a/spec/lean/Oak/RegionLifetime.lean
+++ b/spec/lean/Oak/RegionLifetime.lean
@@ -1,0 +1,78 @@
+namespace Oak.RegionLifetime
+
+/-- A half-open lifetime interval [start, finish). -/
+structure Lifetime where
+  start : Nat
+  finish : Nat
+  deriving DecidableEq, Repr
+
+/-- A lifetime is internally consistent when its start does not follow its end. -/
+def WellFormed (lifetime : Lifetime) : Prop :=
+  lifetime.start ≤ lifetime.finish
+
+/-- `child` is wholly contained within `parent`. This is the abstract region
+    relation used for values tied to arena/region identity R. -/
+def Within (child parent : Lifetime) : Prop :=
+  parent.start ≤ child.start ∧ child.finish ≤ parent.finish
+
+/-- A value/region is alive at an instant when the instant lies in its
+    half-open lifetime interval. -/
+def AliveAt (lifetime : Lifetime) (instant : Nat) : Prop :=
+  lifetime.start ≤ instant ∧ instant < lifetime.finish
+
+theorem within_refl (lifetime : Lifetime) :
+    Within lifetime lifetime := by
+  constructor <;> exact Nat.le_refl _
+
+theorem within_trans (inner middle outer : Lifetime)
+    (him : Within inner middle) (hmo : Within middle outer) :
+    Within inner outer := by
+  constructor
+  · exact Nat.le_trans hmo.1 him.1
+  · exact Nat.le_trans him.2 hmo.2
+
+/-- If a region-bound value is alive, the region containing it must also be
+    alive at the same instant. -/
+theorem within_preserves_alive (value region : Lifetime) (instant : Nat)
+    (hwithin : Within value region) (hvalue : AliveAt value instant) :
+    AliveAt region instant := by
+  constructor
+  · exact Nat.le_trans hwithin.1 hvalue.1
+  · exact Nat.lt_of_lt_of_le hvalue.2 hwithin.2
+
+/-- Once the containing region has ended, a region-bound value cannot remain
+    alive. This is the abstract non-escape law for T[R]. -/
+theorem no_escape_after_region_finish (value region : Lifetime) (instant : Nat)
+    (hwithin : Within value region) (hended : region.finish ≤ instant) :
+    ¬ AliveAt value instant := by
+  intro hvalue
+  have hregion := within_preserves_alive value region instant hwithin hvalue
+  omega
+
+/-- A value cannot begin before the region to which it is bound. -/
+theorem no_escape_before_region_start (value region : Lifetime)
+    (hwithin : Within value region) :
+    region.start ≤ value.start := by
+  exact hwithin.1
+
+/-- A value cannot finish after the region to which it is bound. -/
+theorem value_finishes_within_region (value region : Lifetime)
+    (hwithin : Within value region) :
+    value.finish ≤ region.finish := by
+  exact hwithin.2
+
+/-- Nested region/value containment composes: if a value is within an inner
+    region and the inner region is within an outer region, the value is also
+    within the outer region. -/
+theorem nested_region_non_escape (value inner outer : Lifetime)
+    (hvalue : Within value inner) (hinner : Within inner outer) :
+    Within value outer := by
+  exact within_trans value inner outer hvalue hinner
+
+/-- A well-formed live value necessarily has a non-empty lifetime. -/
+theorem alive_implies_start_before_finish (lifetime : Lifetime) (instant : Nat)
+    (halive : AliveAt lifetime instant) :
+    lifetime.start < lifetime.finish := by
+  omega
+
+end Oak.RegionLifetime

--- a/spec/lean/Oak/RegionLifetime.lean
+++ b/spec/lean/Oak/RegionLifetime.lean
@@ -47,7 +47,7 @@ theorem no_escape_after_region_finish (value region : Lifetime) (instant : Nat)
     ¬ AliveAt value instant := by
   intro hvalue
   have hregion := within_preserves_alive value region instant hwithin hvalue
-  omega
+  exact (Nat.not_lt_of_ge hended) hregion.2
 
 /-- A value cannot begin before the region to which it is bound. -/
 theorem no_escape_before_region_start (value region : Lifetime)
@@ -69,10 +69,10 @@ theorem nested_region_non_escape (value inner outer : Lifetime)
     Within value outer := by
   exact within_trans value inner outer hvalue hinner
 
-/-- A well-formed live value necessarily has a non-empty lifetime. -/
+/-- A live interval necessarily has positive extent. -/
 theorem alive_implies_start_before_finish (lifetime : Lifetime) (instant : Nat)
     (halive : AliveAt lifetime instant) :
     lifetime.start < lifetime.finish := by
-  omega
+  exact Nat.lt_of_le_of_lt halive.1 halive.2
 
 end Oak.RegionLifetime


### PR DESCRIPTION
## Summary

Add the abstract lifetime proof behind Oak arena/region safety.

### Lean model
`Oak.RegionLifetime` models half-open lifetimes `[start, finish)` and proves:
- lifetime containment is reflexive and transitive
- if a region-bound value is alive, its containing region is alive at the same instant
- a region-bound value cannot remain alive after the region finishes
- a value cannot begin before or finish after its region
- nested region containment composes
- a live interval has positive extent

This is the formal version of the normative `T[R]` non-escape rule in `docs/spec/60-effects-allocation.md`.

### Status discipline
The arena row is marked **M/P** for the abstract lifetime model only. **R** remains blank: the current Semantic IR carries arena region identity and validates allocator metadata, but there is no machine-checked refinement from Go IR/lifetime checking to this Lean model yet.

## Verification
Go 1.27.1 CI and Lean 4.33.1 formal verification must both pass before merge. Golden corpus debt remains separate.