### PR TITLE
Prove phantom types erase from runtime representation

### DIFF
--- a/docs/spec/STATUS.md
+++ b/docs/spec/STATUS.md
@@ -24,7 +24,7 @@ Legend:
 | Exhaustiveness | ✓ | partial | partial | ✓ | ✓ |  | `Oak.Exhaustiveness` proves wildcard coverage, complete finite constructor coverage, missing-constructor rejection, and monotonicity under added arms; implementation refinement pending |
 | GADT-style refinements | direction |  |  |  |  |  | semantic direction specified; surface syntax intentionally not frozen |
 | Generic constraints/interfaces | ✓ | ✓ | ✓ |  |  |  | static predicate semantics; dynamic interface values not core |
-| Phantom types | ✓ | partial | partial |  |  |  | zero-runtime representation law to prove |
+| Phantom types | ✓ | partial | partial | ✓ | ✓ |  | `Oak.PhantomRepresentation` proves phantom rebinding changes static identity while preserving the entire runtime representation record, including size, alignment, and bit width; implementation refinement/inference pending |
 | Views / spans | ✓ | ✓ | ✓ | ✓ | ✓ |  | `Oak.Borrowing` proves the local authority-state laws; compiler correspondence is not yet proved |
 | Borrow-state machine | ✓ | partial | partial | ✓ | ✓ |  | explicit actions; valid transitions preserve state invariant and read/write authority stays exclusive |
 | Unsafe boundary | ✓ | partial | partial |  |  |  | unsafe must admit assumptions, not disable all checking |
@@ -55,15 +55,15 @@ The formal gate currently checks:
 - `Oak.SourcePosition`
 - `Oak.Delimited`
 - `Oak.RegionLifetime`
+- `Oak.PhantomRepresentation`
 
 A green Lean build means the stated theorems type-check against the pinned proof kernel. It does **not** imply implementation refinement.
 
 ## Immediate formal-verification queue
 
-1. phantom-type zero-runtime representation law;
-2. record layout/alignment once target layout representation stabilizes;
-3. formal layout-normalizer balance/equivalence model;
-4. explicit implementation refinements for type lattice, effects, borrowing, exhaustiveness, source positions, delimited parsing, and region lifetimes.
+1. record layout/alignment once target layout representation stabilizes;
+2. formal layout-normalizer balance/equivalence model;
+3. explicit implementation refinements for type lattice, effects, borrowing, exhaustiveness, source positions, delimited parsing, region lifetimes, and phantom representation.
 
 ## Refinement policy
 

--- a/spec/lean/Oak.lean
+++ b/spec/lean/Oak.lean
@@ -7,3 +7,4 @@ import Oak.Exhaustiveness
 import Oak.SourcePosition
 import Oak.Delimited
 import Oak.RegionLifetime
+import Oak.PhantomRepresentation

--- a/spec/lean/Oak/PhantomRepresentation.lean
+++ b/spec/lean/Oak/PhantomRepresentation.lean
@@ -30,13 +30,13 @@ def instantiate (template : PhantomTemplate) (phantom : Nat) : Instance :=
     runtime := template.runtime }
 
 /-- Runtime lowering erases phantom identity completely. -/
-def erasePhantom (instance : Instance) : RuntimeRepresentation :=
-  instance.runtime
+def erasePhantom (inst : Instance) : RuntimeRepresentation :=
+  inst.runtime
 
 /-- Rebinding only the phantom parameter leaves all other semantic/runtime facts
     unchanged. -/
-def rebindPhantom (instance : Instance) (phantom : Nat) : Instance :=
-  { instance with phantom := phantom }
+def rebindPhantom (inst : Instance) (phantom : Nat) : Instance :=
+  { inst with phantom := phantom }
 
 /-- All instantiations of one phantom template have exactly the same runtime
     representation. -/
@@ -47,8 +47,8 @@ theorem instantiate_runtime_invariant (template : PhantomTemplate)
   rfl
 
 /-- Rebinding phantom identity is representation-preserving. -/
-theorem rebind_runtime_invariant (instance : Instance) (phantom : Nat) :
-    erasePhantom (rebindPhantom instance phantom) = erasePhantom instance := by
+theorem rebind_runtime_invariant (inst : Instance) (phantom : Nat) :
+    erasePhantom (rebindPhantom inst phantom) = erasePhantom inst := by
   rfl
 
 /-- Phantom identity still participates in static type identity. -/
@@ -61,28 +61,28 @@ theorem different_phantoms_are_distinct (template : PhantomTemplate)
 
 /-- The zero-runtime law covers the whole representation record, therefore size
     is unchanged under phantom rebinding. -/
-theorem rebind_preserves_size (instance : Instance) (phantom : Nat) :
-    (erasePhantom (rebindPhantom instance phantom)).size =
-      (erasePhantom instance).size := by
+theorem rebind_preserves_size (inst : Instance) (phantom : Nat) :
+    (erasePhantom (rebindPhantom inst phantom)).size =
+      (erasePhantom inst).size := by
   rfl
 
 /-- Alignment is likewise independent of phantom identity. -/
-theorem rebind_preserves_alignment (instance : Instance) (phantom : Nat) :
-    (erasePhantom (rebindPhantom instance phantom)).alignment =
-      (erasePhantom instance).alignment := by
+theorem rebind_preserves_alignment (inst : Instance) (phantom : Nat) :
+    (erasePhantom (rebindPhantom inst phantom)).alignment =
+      (erasePhantom inst).alignment := by
   rfl
 
 /-- Machine bit width is likewise independent of phantom identity. -/
-theorem rebind_preserves_bits (instance : Instance) (phantom : Nat) :
-    (erasePhantom (rebindPhantom instance phantom)).bits =
-      (erasePhantom instance).bits := by
+theorem rebind_preserves_bits (inst : Instance) (phantom : Nat) :
+    (erasePhantom (rebindPhantom inst phantom)).bits =
+      (erasePhantom inst).bits := by
   rfl
 
 /-- Rebinding twice keeps only the final static phantom identity while retaining
     the original runtime representation. -/
-theorem rebind_last_wins (instance : Instance) (first second : Nat) :
-    rebindPhantom (rebindPhantom instance first) second =
-      rebindPhantom instance second := by
+theorem rebind_last_wins (inst : Instance) (first second : Nat) :
+    rebindPhantom (rebindPhantom inst first) second =
+      rebindPhantom inst second := by
   rfl
 
 end Oak.PhantomRepresentation

--- a/spec/lean/Oak/PhantomRepresentation.lean
+++ b/spec/lean/Oak/PhantomRepresentation.lean
@@ -1,0 +1,88 @@
+namespace Oak.PhantomRepresentation
+
+/-- Runtime representation facts are intentionally independent of phantom
+    identity. This mirrors Semantic IR's separation between Type.Parameters and
+    Definition.Representation. -/
+structure RuntimeRepresentation where
+  bits : Nat
+  size : Nat
+  alignment : Nat
+  deriving DecidableEq, Repr
+
+/-- A generic definition whose parameter is phantom: the template fixes nominal
+    identity and machine representation, while each instantiation chooses only
+    a static phantom identity. -/
+structure PhantomTemplate where
+  nominal : Nat
+  runtime : RuntimeRepresentation
+  deriving DecidableEq, Repr
+
+/-- One static instantiation of a phantom-parameterized type. -/
+structure Instance where
+  nominal : Nat
+  phantom : Nat
+  runtime : RuntimeRepresentation
+  deriving DecidableEq, Repr
+
+def instantiate (template : PhantomTemplate) (phantom : Nat) : Instance :=
+  { nominal := template.nominal
+    phantom := phantom
+    runtime := template.runtime }
+
+/-- Runtime lowering erases phantom identity completely. -/
+def erasePhantom (instance : Instance) : RuntimeRepresentation :=
+  instance.runtime
+
+/-- Rebinding only the phantom parameter leaves all other semantic/runtime facts
+    unchanged. -/
+def rebindPhantom (instance : Instance) (phantom : Nat) : Instance :=
+  { instance with phantom := phantom }
+
+/-- All instantiations of one phantom template have exactly the same runtime
+    representation. -/
+theorem instantiate_runtime_invariant (template : PhantomTemplate)
+    (left right : Nat) :
+    erasePhantom (instantiate template left) =
+      erasePhantom (instantiate template right) := by
+  rfl
+
+/-- Rebinding phantom identity is representation-preserving. -/
+theorem rebind_runtime_invariant (instance : Instance) (phantom : Nat) :
+    erasePhantom (rebindPhantom instance phantom) = erasePhantom instance := by
+  rfl
+
+/-- Phantom identity still participates in static type identity. -/
+theorem different_phantoms_are_distinct (template : PhantomTemplate)
+    (left right : Nat) (hne : left ≠ right) :
+    instantiate template left ≠ instantiate template right := by
+  intro heq
+  apply hne
+  exact congrArg Instance.phantom heq
+
+/-- The zero-runtime law covers the whole representation record, therefore size
+    is unchanged under phantom rebinding. -/
+theorem rebind_preserves_size (instance : Instance) (phantom : Nat) :
+    (erasePhantom (rebindPhantom instance phantom)).size =
+      (erasePhantom instance).size := by
+  rfl
+
+/-- Alignment is likewise independent of phantom identity. -/
+theorem rebind_preserves_alignment (instance : Instance) (phantom : Nat) :
+    (erasePhantom (rebindPhantom instance phantom)).alignment =
+      (erasePhantom instance).alignment := by
+  rfl
+
+/-- Machine bit width is likewise independent of phantom identity. -/
+theorem rebind_preserves_bits (instance : Instance) (phantom : Nat) :
+    (erasePhantom (rebindPhantom instance phantom)).bits =
+      (erasePhantom instance).bits := by
+  rfl
+
+/-- Rebinding twice keeps only the final static phantom identity while retaining
+    the original runtime representation. -/
+theorem rebind_last_wins (instance : Instance) (first second : Nat) :
+    rebindPhantom (rebindPhantom instance first) second =
+      rebindPhantom instance second := by
+  rfl
+
+end Oak.PhantomRepresentation


### PR DESCRIPTION
## Summary

Add the formal zero-runtime-representation law for Oak phantom type parameters.

### Lean model
`Oak.PhantomRepresentation` separates static phantom identity from runtime representation and proves:
- all instantiations of one phantom template have identical runtime representation
- rebinding only the phantom parameter preserves the whole runtime representation
- distinct phantom arguments still produce distinct static type instances
- size, alignment, and bit width are unchanged by phantom rebinding
- repeated rebinding keeps only the final static phantom identity while retaining the original runtime representation

This matches the normative rule in `docs/spec/20-types.md`: phantom identity belongs to the type axis and must not silently add runtime fields.

### Status discipline
The phantom row is marked **M/P** for the abstract erasure model. **R** remains blank because the compiler does not yet machine-check phantom inference/erasure against this Lean model.

## Verification
Go 1.27.1 CI and Lean 4.33.1 formal verification must both pass before merge. Golden corpus debt remains separate.