### PR TITLE
Prove layout normalization preservation and balance

### DIFF
--- a/docs/spec/STATUS.md
+++ b/docs/spec/STATUS.md
@@ -13,7 +13,7 @@ Legend:
 
 | Feature | S | I | T | M | P | R | Notes |
 | --- | :---: | :---: | :---: | :---: | :---: | :---: | --- |
-| Layout + explicit blocks | ✓ | ✓ | ✓ |  |  |  | parser/layout equivalence exists; formal layout normalization model pending |
+| Layout + explicit blocks | ✓ | ✓ | ✓ | ✓ | ✓ |  | Go tests cover explicit/layout token-kind equivalence, original significant-token preservation, balanced virtual braces, continuation contexts, dedent ordering, and zero-width synthetic spans; `Oak.Layout` proves abstract source-order preservation, virtual-stack balance, EOF closure, and close-underflow rejection; indentation-trigger refinement pending |
 | Source spans / UTF-16 editor positions | ✓ | ✓ | ✓ | ✓ | ✓ |  | `Oak.SourcePosition` proves UTF-8/UTF-16 scalar-width rules, additive coordinate accumulation, monotonic offsets, and ASCII width equivalence; Go tests cover emoji, multiline positions, byte-boundary rejection, links, and LSP coordinates; refinement pending |
 | Delimited parser cursor contract | ✓ | ✓ | ✓ | ✓ | ✓ |  | one `parseDelimited[T]` path covers invocations, parameters, type arguments, and array elements; `Oak.Delimited` proves canonical opener/body/close structure, item preservation, unique close suffix, exact close offset, and trailing-separator semantic transparency; refinement pending |
 | Type lattice (`never`, `any`, join/meet) | ✓ | ✓ | ✓ | ✓ | ✓ |  | Go subtype decision procedure is aligned with the proved distributive-lattice laws; explicit implementation refinement is still pending |
@@ -56,14 +56,15 @@ The formal gate currently checks:
 - `Oak.Delimited`
 - `Oak.RegionLifetime`
 - `Oak.PhantomRepresentation`
+- `Oak.Layout`
 
 A green Lean build means the stated theorems type-check against the pinned proof kernel. It does **not** imply implementation refinement.
 
 ## Immediate formal-verification queue
 
 1. record layout/alignment once target layout representation stabilizes;
-2. formal layout-normalizer balance/equivalence model;
-3. explicit implementation refinements for type lattice, effects, borrowing, exhaustiveness, source positions, delimited parsing, region lifetimes, and phantom representation.
+2. explicit implementation refinements for type lattice, effects, borrowing, exhaustiveness, source positions, delimited parsing, region lifetimes, phantom representation, and layout normalization;
+3. formalize additional resource/boundedness laws as the implementation surfaces stabilize.
 
 ## Refinement policy
 

--- a/layout/invariants_test.go
+++ b/layout/invariants_test.go
@@ -1,0 +1,171 @@
+package layout
+
+import (
+	"testing"
+
+	"github.com/SCKelemen/oak/scanner"
+	"github.com/SCKelemen/oak/token"
+)
+
+func sourceSignificant(input string) []token.Token {
+	return significant(scanner.New(input))
+}
+
+func normalizedSignificant(input string) []token.Token {
+	return significant(New(scanner.New(input)))
+}
+
+func originalTokens(tokens []token.Token) []token.Token {
+	out := make([]token.Token, 0, len(tokens))
+	for _, tok := range tokens {
+		if !tok.Synthetic {
+			out = append(out, tok)
+		}
+	}
+	return out
+}
+
+func assertOriginalTokensEqual(t *testing.T, want, got []token.Token) {
+	t.Helper()
+	if len(want) != len(got) {
+		t.Fatalf("original token count changed: want=%d got=%d\nwant=%#v\ngot=%#v", len(want), len(got), want, got)
+	}
+	for i := range want {
+		w := want[i]
+		g := got[i]
+		if w.TokenKind != g.TokenKind ||
+			w.Literal != g.Literal ||
+			w.Line != g.Line ||
+			w.Column != g.Column ||
+			w.EndLine != g.EndLine ||
+			w.EndColumn != g.EndColumn ||
+			w.ByteStart != g.ByteStart ||
+			w.ByteEnd != g.ByteEnd {
+			t.Fatalf("original token %d changed:\nwant=%#v\ngot =%#v", i, w, g)
+		}
+		if g.Synthetic {
+			t.Fatalf("original token %d became synthetic: %#v", i, g)
+		}
+	}
+}
+
+func assertSyntheticBracesBalanced(t *testing.T, tokens []token.Token) {
+	t.Helper()
+	depth := 0
+	for i, tok := range tokens {
+		if !tok.Synthetic {
+			continue
+		}
+		switch tok.TokenKind {
+		case token.LBRACE:
+			depth++
+		case token.RBRACE:
+			depth--
+			if depth < 0 {
+				t.Fatalf("synthetic close at token %d has no matching open", i)
+			}
+		}
+	}
+	if depth != 0 {
+		t.Fatalf("synthetic braces are unbalanced: remaining depth=%d", depth)
+	}
+}
+
+func TestNormalizationPreservesOriginalSignificantTokens(t *testing.T) {
+	tests := map[string]string{
+		"function": `fn answer(): u32
+  x := 40
+  x + 2
+`,
+		"nested while": `fn countdown(n: u32): u32
+  x := n
+  while x > 0
+    x = x - 1
+  x
+`,
+		"explicit block": `fn f(): u32 {
+  x := 1
+  x
+}
+`,
+		"expression body": `fn add(a: u32, b: u32): u32 = a + b
+`,
+		"multiline parameters": `fn add(
+  a: u32,
+  b: u32,
+): u32
+  a + b
+`,
+		"unsafe body": `fn f(): u32
+  unsafe
+    x := 1
+    x
+`,
+	}
+
+	for name, input := range tests {
+		t.Run(name, func(t *testing.T) {
+			want := sourceSignificant(input)
+			got := originalTokens(normalizedSignificant(input))
+			assertOriginalTokensEqual(t, want, got)
+		})
+	}
+}
+
+func TestNormalizationBalancesSyntheticBraces(t *testing.T) {
+	tests := map[string]string{
+		"empty function body shape": `fn f(): u32
+  x
+`,
+		"nested while": `fn f(): u32
+  x := 2
+  while x > 0
+    x = x - 1
+  x
+`,
+		"multiple dedents": `fn f(): u32
+  while true
+    while true
+      x := 1
+    x
+  x
+`,
+		"explicit block": `fn f(): u32 {
+  x
+}
+`,
+		"expression body": `fn f(): u32 = 1
+`,
+		"multiline parameters": `fn add(
+  a: u32,
+  b: u32,
+): u32
+  a + b
+`,
+	}
+
+	for name, input := range tests {
+		t.Run(name, func(t *testing.T) {
+			assertSyntheticBracesBalanced(t, normalizedSignificant(input))
+		})
+	}
+}
+
+func TestSyntheticBracesAreZeroWidth(t *testing.T) {
+	input := `fn f(): u32
+  while true
+    x := 1
+  x
+`
+	for _, tok := range normalizedSignificant(input) {
+		if !tok.Synthetic || (tok.TokenKind != token.LBRACE && tok.TokenKind != token.RBRACE) {
+			continue
+		}
+		if tok.ByteStart != tok.ByteEnd {
+			t.Fatalf("synthetic brace has non-zero byte width: %#v", tok)
+		}
+		if tok.Line != tok.EndLine || tok.Column != tok.EndColumn {
+			t.Fatalf("synthetic brace has non-zero source range: %#v", tok)
+		}
+	}
+}

--- a/spec/lean/Oak.lean
+++ b/spec/lean/Oak.lean
@@ -8,3 +8,4 @@ import Oak.SourcePosition
 import Oak.Delimited
 import Oak.RegionLifetime
 import Oak.PhantomRepresentation
+import Oak.Layout

--- a/spec/lean/Oak/Layout.lean
+++ b/spec/lean/Oak/Layout.lean
@@ -1,0 +1,214 @@
+namespace Oak.Layout
+
+/-- Abstract input events for the layout normalizer. `source` events represent
+    original significant tokens; open/close events represent virtual block
+    decisions made by the indentation layer. -/
+inductive Event where
+  | source : Nat -> Event
+  | open
+  | close
+  deriving DecidableEq, Repr
+
+/-- Abstract normalized output. Source tokens remain distinguishable from
+    synthetic braces so erasure can state the no-reordering/no-fabrication law. -/
+inductive Token where
+  | source : Nat -> Token
+  | open
+  | close
+  deriving DecidableEq, Repr
+
+/-- Project only original source-token identities from normalized output. -/
+def sourceValues : List Token -> List Nat
+  | [] => []
+  | .source value :: rest => value :: sourceValues rest
+  | _ :: rest => sourceValues rest
+
+/-- Project source-token identities from the input event stream. -/
+def sourceEvents : List Event -> List Nat
+  | [] => []
+  | .source value :: rest => value :: sourceEvents rest
+  | _ :: rest => sourceEvents rest
+
+def opens : List Token -> Nat
+  | [] => 0
+  | .open :: rest => 1 + opens rest
+  | _ :: rest => opens rest
+
+def closes : List Token -> Nat
+  | [] => 0
+  | .close :: rest => 1 + closes rest
+  | _ :: rest => closes rest
+
+/-- Execute abstract layout decisions from an initial virtual-block depth.
+    A close at depth zero is invalid. -/
+def renderFrom : Nat -> List Event -> Option (Nat × List Token)
+  | depth, [] => some (depth, [])
+  | depth, .source value :: rest =>
+      match renderFrom depth rest with
+      | none => none
+      | some (finalDepth, output) =>
+          some (finalDepth, .source value :: output)
+  | depth, .open :: rest =>
+      match renderFrom (depth + 1) rest with
+      | none => none
+      | some (finalDepth, output) =>
+          some (finalDepth, .open :: output)
+  | 0, .close :: _ => none
+  | depth + 1, .close :: rest =>
+      match renderFrom depth rest with
+      | none => none
+      | some (finalDepth, output) =>
+          some (finalDepth, .close :: output)
+
+/-- EOF closes every still-open virtual block. -/
+def finishTokens (depth : Nat) (output : List Token) : List Token :=
+  output ++ List.replicate depth .close
+
+theorem sourceValues_append (left right : List Token) :
+    sourceValues (left ++ right) = sourceValues left ++ sourceValues right := by
+  induction left with
+  | nil => rfl
+  | cons token rest ih =>
+      cases token <;> simp [sourceValues, ih]
+
+theorem opens_append (left right : List Token) :
+    opens (left ++ right) = opens left + opens right := by
+  induction left with
+  | nil => rfl
+  | cons token rest ih =>
+      cases token <;> simp [opens, ih, Nat.add_assoc]
+
+theorem closes_append (left right : List Token) :
+    closes (left ++ right) = closes left + closes right := by
+  induction left with
+  | nil => rfl
+  | cons token rest ih =>
+      cases token <;> simp [closes, ih, Nat.add_assoc]
+
+theorem sourceValues_replicate_close (count : Nat) :
+    sourceValues (List.replicate count Token.close) = [] := by
+  induction count with
+  | zero => rfl
+  | succ count ih => simp [List.replicate_succ, sourceValues, ih]
+
+theorem opens_replicate_close (count : Nat) :
+    opens (List.replicate count Token.close) = 0 := by
+  induction count with
+  | zero => rfl
+  | succ count ih => simp [List.replicate_succ, opens, ih]
+
+theorem closes_replicate_close (count : Nat) :
+    closes (List.replicate count Token.close) = count := by
+  induction count with
+  | zero => rfl
+  | succ count ih => simp [List.replicate_succ, closes, ih]
+
+/-- Successful normalization preserves every original significant token in
+    exactly the same order after synthetic braces are erased. -/
+theorem render_preserves_source_order
+    (events : List Event) (depth finalDepth : Nat) (output : List Token)
+    (h : renderFrom depth events = some (finalDepth, output)) :
+    sourceValues output = sourceEvents events := by
+  induction events generalizing depth finalDepth output with
+  | nil =>
+      simp [renderFrom] at h
+      cases h
+      rfl
+  | cons event rest ih =>
+      cases event with
+      | source value =>
+          cases hr : renderFrom depth rest with
+          | none => simp [renderFrom, hr] at h
+          | some result =>
+              rcases result with ⟨nextDepth, nextOutput⟩
+              simp [renderFrom, hr] at h
+              cases h
+              simp [sourceValues, sourceEvents, ih rest depth nextDepth nextOutput hr]
+      | open =>
+          cases hr : renderFrom (depth + 1) rest with
+          | none => simp [renderFrom, hr] at h
+          | some result =>
+              rcases result with ⟨nextDepth, nextOutput⟩
+              simp [renderFrom, hr] at h
+              cases h
+              simp [sourceValues, sourceEvents, ih rest (depth + 1) nextDepth nextOutput hr]
+      | close =>
+          cases depth with
+          | zero => simp [renderFrom] at h
+          | succ depth =>
+              cases hr : renderFrom depth rest with
+              | none => simp [renderFrom, hr] at h
+              | some result =>
+                  rcases result with ⟨nextDepth, nextOutput⟩
+                  simp [renderFrom, hr] at h
+                  cases h
+                  simp [sourceValues, sourceEvents, ih rest depth nextDepth nextOutput hr]
+
+/-- For every successful trace, virtual opens minus virtual closes equals the
+    change in stack depth. This is the core balance invariant. -/
+theorem render_balance
+    (events : List Event) (depth finalDepth : Nat) (output : List Token)
+    (h : renderFrom depth events = some (finalDepth, output)) :
+    opens output + depth = closes output + finalDepth := by
+  induction events generalizing depth finalDepth output with
+  | nil =>
+      simp [renderFrom] at h
+      cases h
+      simp [opens, closes]
+  | cons event rest ih =>
+      cases event with
+      | source value =>
+          cases hr : renderFrom depth rest with
+          | none => simp [renderFrom, hr] at h
+          | some result =>
+              rcases result with ⟨nextDepth, nextOutput⟩
+              simp [renderFrom, hr] at h
+              cases h
+              simpa [opens, closes] using ih rest depth nextDepth nextOutput hr
+      | open =>
+          cases hr : renderFrom (depth + 1) rest with
+          | none => simp [renderFrom, hr] at h
+          | some result =>
+              rcases result with ⟨nextDepth, nextOutput⟩
+              simp [renderFrom, hr] at h
+              cases h
+              have hrest := ih rest (depth + 1) nextDepth nextOutput hr
+              simp [opens, closes]
+              omega
+      | close =>
+          cases depth with
+          | zero => simp [renderFrom] at h
+          | succ depth =>
+              cases hr : renderFrom depth rest with
+              | none => simp [renderFrom, hr] at h
+              | some result =>
+                  rcases result with ⟨nextDepth, nextOutput⟩
+                  simp [renderFrom, hr] at h
+                  cases h
+                  have hrest := ih rest depth nextDepth nextOutput hr
+                  simp [opens, closes]
+                  omega
+
+/-- EOF closure cannot change or reorder source tokens. -/
+theorem finish_preserves_source_order (depth : Nat) (output : List Token) :
+    sourceValues (finishTokens depth output) = sourceValues output := by
+  simp [finishTokens, sourceValues_append, sourceValues_replicate_close]
+
+/-- Starting at depth zero, EOF closure produces a balanced synthetic-brace
+    stream for every successful trace. -/
+theorem finish_balances
+    (events : List Event) (finalDepth : Nat) (output : List Token)
+    (h : renderFrom 0 events = some (finalDepth, output)) :
+    opens (finishTokens finalDepth output) =
+      closes (finishTokens finalDepth output) := by
+  have hbalance := render_balance events 0 finalDepth output h
+  simp [finishTokens, opens_append, closes_append,
+    opens_replicate_close, closes_replicate_close]
+  omega
+
+/-- A synthetic close without an open block is rejected rather than silently
+    fabricating stack state. -/
+theorem close_underflow_rejected : renderFrom 0 [.close] = none := by
+  rfl
+
+end Oak.Layout

--- a/spec/lean/Oak/Layout.lean
+++ b/spec/lean/Oak/Layout.lean
@@ -1,20 +1,20 @@
 namespace Oak.Layout
 
 /-- Abstract input events for the layout normalizer. `source` events represent
-    original significant tokens; open/close events represent virtual block
+    original significant tokens; push/pop events represent virtual block
     decisions made by the indentation layer. -/
 inductive Event where
   | source : Nat -> Event
-  | open
-  | close
+  | push
+  | pop
   deriving DecidableEq, Repr
 
 /-- Abstract normalized output. Source tokens remain distinguishable from
     synthetic braces so erasure can state the no-reordering/no-fabrication law. -/
 inductive Token where
   | source : Nat -> Token
-  | open
-  | close
+  | push
+  | pop
   deriving DecidableEq, Repr
 
 /-- Project only original source-token identities from normalized output. -/
@@ -31,16 +31,16 @@ def sourceEvents : List Event -> List Nat
 
 def opens : List Token -> Nat
   | [] => 0
-  | .open :: rest => 1 + opens rest
+  | .push :: rest => 1 + opens rest
   | _ :: rest => opens rest
 
 def closes : List Token -> Nat
   | [] => 0
-  | .close :: rest => 1 + closes rest
+  | .pop :: rest => 1 + closes rest
   | _ :: rest => closes rest
 
 /-- Execute abstract layout decisions from an initial virtual-block depth.
-    A close at depth zero is invalid. -/
+    A pop at depth zero is invalid. -/
 def renderFrom : Nat -> List Event -> Option (Nat × List Token)
   | depth, [] => some (depth, [])
   | depth, .source value :: rest =>
@@ -48,21 +48,21 @@ def renderFrom : Nat -> List Event -> Option (Nat × List Token)
       | none => none
       | some (finalDepth, output) =>
           some (finalDepth, .source value :: output)
-  | depth, .open :: rest =>
+  | depth, .push :: rest =>
       match renderFrom (depth + 1) rest with
       | none => none
       | some (finalDepth, output) =>
-          some (finalDepth, .open :: output)
-  | 0, .close :: _ => none
-  | depth + 1, .close :: rest =>
+          some (finalDepth, .push :: output)
+  | 0, .pop :: _ => none
+  | depth + 1, .pop :: rest =>
       match renderFrom depth rest with
       | none => none
       | some (finalDepth, output) =>
-          some (finalDepth, .close :: output)
+          some (finalDepth, .pop :: output)
 
 /-- EOF closes every still-open virtual block. -/
 def finishTokens (depth : Nat) (output : List Token) : List Token :=
-  output ++ List.replicate depth .close
+  output ++ List.replicate depth .pop
 
 theorem sourceValues_append (left right : List Token) :
     sourceValues (left ++ right) = sourceValues left ++ sourceValues right := by
@@ -74,34 +74,36 @@ theorem sourceValues_append (left right : List Token) :
 theorem opens_append (left right : List Token) :
     opens (left ++ right) = opens left + opens right := by
   induction left with
-  | nil => rfl
+  | nil => simp [opens]
   | cons token rest ih =>
       cases token <;> simp [opens, ih, Nat.add_assoc]
 
 theorem closes_append (left right : List Token) :
     closes (left ++ right) = closes left + closes right := by
   induction left with
-  | nil => rfl
+  | nil => simp [closes]
   | cons token rest ih =>
       cases token <;> simp [closes, ih, Nat.add_assoc]
 
-theorem sourceValues_replicate_close (count : Nat) :
-    sourceValues (List.replicate count Token.close) = [] := by
+theorem sourceValues_replicate_pop (count : Nat) :
+    sourceValues (List.replicate count Token.pop) = [] := by
   induction count with
   | zero => rfl
   | succ count ih => simp [List.replicate_succ, sourceValues, ih]
 
-theorem opens_replicate_close (count : Nat) :
-    opens (List.replicate count Token.close) = 0 := by
+theorem opens_replicate_pop (count : Nat) :
+    opens (List.replicate count Token.pop) = 0 := by
   induction count with
   | zero => rfl
   | succ count ih => simp [List.replicate_succ, opens, ih]
 
-theorem closes_replicate_close (count : Nat) :
-    closes (List.replicate count Token.close) = count := by
+theorem closes_replicate_pop (count : Nat) :
+    closes (List.replicate count Token.pop) = count := by
   induction count with
   | zero => rfl
-  | succ count ih => simp [List.replicate_succ, closes, ih]
+  | succ count ih =>
+      simp [List.replicate_succ, closes, ih]
+      omega
 
 /-- Successful normalization preserves every original significant token in
     exactly the same order after synthetic braces are erased. -/
@@ -112,7 +114,9 @@ theorem render_preserves_source_order
   induction events generalizing depth finalDepth output with
   | nil =>
       simp [renderFrom] at h
-      cases h
+      obtain ⟨hdepth, houtput⟩ := h
+      subst finalDepth
+      subst output
       rfl
   | cons event rest ih =>
       cases event with
@@ -122,17 +126,22 @@ theorem render_preserves_source_order
           | some result =>
               rcases result with ⟨nextDepth, nextOutput⟩
               simp [renderFrom, hr] at h
-              cases h
-              simp [sourceValues, sourceEvents, ih rest depth nextDepth nextOutput hr]
-      | open =>
+              obtain ⟨hdepth, houtput⟩ := h
+              subst finalDepth
+              subst output
+              simp [sourceValues, sourceEvents, ih depth nextDepth nextOutput hr]
+      | push =>
           cases hr : renderFrom (depth + 1) rest with
           | none => simp [renderFrom, hr] at h
           | some result =>
               rcases result with ⟨nextDepth, nextOutput⟩
               simp [renderFrom, hr] at h
-              cases h
-              simp [sourceValues, sourceEvents, ih rest (depth + 1) nextDepth nextOutput hr]
-      | close =>
+              obtain ⟨hdepth, houtput⟩ := h
+              subst finalDepth
+              subst output
+              simp [sourceValues, sourceEvents,
+                ih (depth + 1) nextDepth nextOutput hr]
+      | pop =>
           cases depth with
           | zero => simp [renderFrom] at h
           | succ depth =>
@@ -141,8 +150,11 @@ theorem render_preserves_source_order
               | some result =>
                   rcases result with ⟨nextDepth, nextOutput⟩
                   simp [renderFrom, hr] at h
-                  cases h
-                  simp [sourceValues, sourceEvents, ih rest depth nextDepth nextOutput hr]
+                  obtain ⟨hdepth, houtput⟩ := h
+                  subst finalDepth
+                  subst output
+                  simp [sourceValues, sourceEvents,
+                    ih depth nextDepth nextOutput hr]
 
 /-- For every successful trace, virtual opens minus virtual closes equals the
     change in stack depth. This is the core balance invariant. -/
@@ -153,7 +165,9 @@ theorem render_balance
   induction events generalizing depth finalDepth output with
   | nil =>
       simp [renderFrom] at h
-      cases h
+      obtain ⟨hdepth, houtput⟩ := h
+      subst finalDepth
+      subst output
       simp [opens, closes]
   | cons event rest ih =>
       cases event with
@@ -163,19 +177,23 @@ theorem render_balance
           | some result =>
               rcases result with ⟨nextDepth, nextOutput⟩
               simp [renderFrom, hr] at h
-              cases h
-              simpa [opens, closes] using ih rest depth nextDepth nextOutput hr
-      | open =>
+              obtain ⟨hdepth, houtput⟩ := h
+              subst finalDepth
+              subst output
+              simpa [opens, closes] using ih depth nextDepth nextOutput hr
+      | push =>
           cases hr : renderFrom (depth + 1) rest with
           | none => simp [renderFrom, hr] at h
           | some result =>
               rcases result with ⟨nextDepth, nextOutput⟩
               simp [renderFrom, hr] at h
-              cases h
-              have hrest := ih rest (depth + 1) nextDepth nextOutput hr
+              obtain ⟨hdepth, houtput⟩ := h
+              subst finalDepth
+              subst output
+              have hrest := ih (depth + 1) nextDepth nextOutput hr
               simp [opens, closes]
               omega
-      | close =>
+      | pop =>
           cases depth with
           | zero => simp [renderFrom] at h
           | succ depth =>
@@ -184,15 +202,17 @@ theorem render_balance
               | some result =>
                   rcases result with ⟨nextDepth, nextOutput⟩
                   simp [renderFrom, hr] at h
-                  cases h
-                  have hrest := ih rest depth nextDepth nextOutput hr
+                  obtain ⟨hdepth, houtput⟩ := h
+                  subst finalDepth
+                  subst output
+                  have hrest := ih depth nextDepth nextOutput hr
                   simp [opens, closes]
                   omega
 
 /-- EOF closure cannot change or reorder source tokens. -/
 theorem finish_preserves_source_order (depth : Nat) (output : List Token) :
     sourceValues (finishTokens depth output) = sourceValues output := by
-  simp [finishTokens, sourceValues_append, sourceValues_replicate_close]
+  simp [finishTokens, sourceValues_append, sourceValues_replicate_pop]
 
 /-- Starting at depth zero, EOF closure produces a balanced synthetic-brace
     stream for every successful trace. -/
@@ -203,12 +223,12 @@ theorem finish_balances
       closes (finishTokens finalDepth output) := by
   have hbalance := render_balance events 0 finalDepth output h
   simp [finishTokens, opens_append, closes_append,
-    opens_replicate_close, closes_replicate_close]
+    opens_replicate_pop, closes_replicate_pop]
   omega
 
 /-- A synthetic close without an open block is rejected rather than silently
     fabricating stack state. -/
-theorem close_underflow_rejected : renderFrom 0 [.close] = none := by
+theorem pop_underflow_rejected : renderFrom 0 [.pop] = none := by
   rfl
 
 end Oak.Layout


### PR DESCRIPTION
## Summary

Strengthen Oak layout normalization on both sides of the implementation/formal boundary.

### Go invariant tests
The layout test suite now checks that normalization:
- preserves every original significant token in order
- preserves kind, literal, UTF-16 coordinates, and UTF-8 byte span of original tokens
- never relabels an original token as synthetic
- balances every synthetic `{` with a synthetic `}` on valid inputs
- never emits a synthetic close before its matching open
- emits synthetic braces as zero-width source spans

The corpus covers simple functions, nested loops, multiple dedents, explicit blocks, expression-bodied functions, multiline parameters, and unsafe bodies.

### Lean model
`Oak.Layout` models source-token events plus virtual open/close decisions with an explicit block-depth stack and proves:
- erasing virtual braces preserves original source-token order exactly
- successful traces maintain the open/close/depth balance equation
- EOF closure preserves source tokens
- EOF closure balances all remaining virtual opens
- close-underflow is rejected

### Status discipline
This marks layout normalization **M/P** for the abstract stack/order model. **R** remains blank: the Go indentation/header decision logic is tested against these laws but is not yet machine-refined to the Lean event model.

## Verification
Go 1.27.1 CI and Lean 4.33.1 formal verification must both pass before merge. Golden corpus debt remains separate.