### PR TITLE
Formalize representation-blind record shape constraints

### DIFF
--- a/docs/spec/STATUS.md
+++ b/docs/spec/STATUS.md
@@ -18,7 +18,7 @@ Legend:
 | Delimited parser cursor contract | ✓ | ✓ | ✓ | ✓ | ✓ |  | one `parseDelimited[T]` path covers invocations, parameters, type arguments, and array elements; `Oak.Delimited` proves canonical opener/body/close structure, item preservation, unique close suffix, exact close offset, and trailing-separator semantic transparency; refinement pending |
 | Type lattice (`never`, `any`, join/meet) | ✓ | ✓ | ✓ | ✓ | ✓ |  | Go subtype decision procedure is aligned with the proved distributive-lattice laws; explicit implementation refinement is still pending |
 | Semantic records/products | ✓ | ✓ | ✓ |  |  |  | plain `{ ... }` is parsed as a semantic product and projects semantic fields while leaving representation unspecified; source order is preserved as declaration metadata; duplicate fields are rejected |
-| Record shape constraints | ✓ |  |  |  |  |  | normative direction: `T: Shape` checks required semantic members without layout equality or runtime interface objects; implementation/formal relation pending |
+| Record shape constraints | ✓ | partial | partial | ✓ | ✓ |  | Semantic IR implements representation-blind required-field satisfaction with exact field-type identity, extra fields allowed, and order ignored; `Oak.RecordShape` proves reflexivity, extension/transitivity, order independence, missing-field rejection, and representation irrelevance; generic `T: Shape` typechecker integration and refinement remain pending |
 | Natural struct representation selection | ✓ | ✓ | ✓ |  |  |  | parser preserves `struct { ... }` distinctly from `{ ... }`; `type = struct { ... }` selects `RepresentationRecord + natural-ordered` while remaining unresolved until target field representations are known |
 | Natural struct layout | ✓ | ✓ | ✓ | ✓ | ✓ |  | `NaturalRecordLayout` computes checked ordered non-packed layout with power-of-two alignment and uint32 overflow rejection; `Oak.RecordLayout` proves identity/order preservation, field alignment, non-overlap, and final-size alignment in the unbounded arithmetic model; implementation refinement pending |
 | Record composition | ✓ | partial | partial |  |  |  | semantic composition is separated from subtyping and from representation composition |
@@ -61,14 +61,15 @@ The formal gate currently checks:
 - `Oak.PhantomRepresentation`
 - `Oak.Layout`
 - `Oak.RecordLayout`
+- `Oak.RecordShape`
 
 A green Lean build means the stated theorems type-check against the pinned proof kernel. It does **not** imply implementation refinement.
 
 ## Immediate formal-verification queue
 
-1. semantic record-shape satisfaction laws, independent of representation;
+1. generic-constraint integration for semantic record shapes without global width subtyping;
 2. explicit refinement from selected/resolved struct representation to `Oak.RecordLayout`;
-3. explicit implementation refinements for type lattice, effects, borrowing, exhaustiveness, source positions, delimited parsing, region lifetimes, phantom representation, and layout normalization;
+3. explicit implementation refinements for record-shape satisfaction, type lattice, effects, borrowing, exhaustiveness, source positions, delimited parsing, region lifetimes, phantom representation, and layout normalization;
 4. formalize additional resource/boundedness laws as the implementation surfaces stabilize;
 5. add ABI-specific representation profiles only when an actual backend requires semantics beyond the natural ordered profile.
 

--- a/semir/shape.go
+++ b/semir/shape.go
@@ -1,0 +1,61 @@
+package semir
+
+import "fmt"
+
+// SatisfiesRecordShape reports whether candidate provides every semantic field
+// required by shape. It is intentionally representation-blind: offsets, size,
+// alignment, packing, and representation policy do not participate.
+//
+// The initial relation requires exact semantic field type identity. Richer field
+// compatibility (for example refinements or variance) can be layered on later
+// through the type relation without changing shape membership itself.
+func SatisfiesRecordShape(candidate, shape Type) (bool, error) {
+	if candidate.Kind != TypeRecord {
+		return false, fmt.Errorf("candidate type kind %q is not a record", candidate.Kind)
+	}
+	if shape.Kind != TypeRecord {
+		return false, fmt.Errorf("shape type kind %q is not a record", shape.Kind)
+	}
+	if err := validateShapeFields("candidate", candidate.Fields); err != nil {
+		return false, err
+	}
+	if err := validateShapeFields("shape", shape.Fields); err != nil {
+		return false, err
+	}
+
+	available := make(map[string]string, len(candidate.Fields))
+	for _, field := range candidate.Fields {
+		available[field.Name] = field.Type
+	}
+	for _, required := range shape.Fields {
+		actual, ok := available[required.Name]
+		if !ok || actual != required.Type {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// DefinitionSatisfiesRecordShape is the definition-level relation used by
+// semantic passes. Representation is deliberately ignored: rebinding a record
+// to a different storage policy cannot change whether it satisfies a shape.
+func DefinitionSatisfiesRecordShape(candidate, shape Definition) (bool, error) {
+	return SatisfiesRecordShape(candidate.Type, shape.Type)
+}
+
+func validateShapeFields(kind string, fields []Field) error {
+	seen := make(map[string]struct{}, len(fields))
+	for _, field := range fields {
+		if field.Name == "" {
+			return fmt.Errorf("%s record shape has empty field name", kind)
+		}
+		if field.Type == "" {
+			return fmt.Errorf("%s record shape field %q has empty type", kind, field.Name)
+		}
+		if _, exists := seen[field.Name]; exists {
+			return fmt.Errorf("%s record shape has duplicate field %q", kind, field.Name)
+		}
+		seen[field.Name] = struct{}{}
+	}
+	return nil
+}

--- a/semir/shape_test.go
+++ b/semir/shape_test.go
@@ -1,0 +1,117 @@
+package semir
+
+import "testing"
+
+func recordType(fields ...Field) Type {
+	return Type{Kind: TypeRecord, Fields: fields}
+}
+
+func TestRecordShapeSatisfactionAllowsExtraFieldsAndIgnoresOrder(t *testing.T) {
+	shape := recordType(
+		Field{Name: "x", Type: "f32"},
+		Field{Name: "y", Type: "f32"},
+	)
+	candidate := recordType(
+		Field{Name: "label", Type: "string"},
+		Field{Name: "y", Type: "f32"},
+		Field{Name: "x", Type: "f32"},
+	)
+
+	ok, err := SatisfiesRecordShape(candidate, shape)
+	if err != nil {
+		t.Fatalf("SatisfiesRecordShape failed: %v", err)
+	}
+	if !ok {
+		t.Fatal("candidate with required fields plus extras should satisfy shape")
+	}
+}
+
+func TestRecordShapeSatisfactionRejectsMissingOrWrongType(t *testing.T) {
+	shape := recordType(
+		Field{Name: "x", Type: "f32"},
+		Field{Name: "y", Type: "f32"},
+	)
+
+	tests := []Type{
+		recordType(Field{Name: "x", Type: "f32"}),
+		recordType(Field{Name: "x", Type: "f32"}, Field{Name: "y", Type: "u32"}),
+	}
+	for _, candidate := range tests {
+		ok, err := SatisfiesRecordShape(candidate, shape)
+		if err != nil {
+			t.Fatalf("SatisfiesRecordShape failed: %v", err)
+		}
+		if ok {
+			t.Fatalf("candidate %#v unexpectedly satisfied shape %#v", candidate.Fields, shape.Fields)
+		}
+	}
+}
+
+func TestRecordShapeSatisfactionIgnoresRepresentation(t *testing.T) {
+	shape := Definition{
+		Name: "XY",
+		Type: recordType(
+			Field{Name: "x", Type: "f32"},
+			Field{Name: "y", Type: "f32"},
+		),
+	}
+	candidate := Definition{
+		Name: "Point",
+		Type: recordType(
+			Field{Name: "x", Type: "f32"},
+			Field{Name: "y", Type: "f32"},
+			Field{Name: "z", Type: "f32"},
+		),
+		Representation: Representation{
+			Kind:      RepresentationRecord,
+			Policy:    RepresentationPolicyNaturalOrdered,
+			Resolved:  true,
+			Size:      12,
+			Alignment: 4,
+			Fields: []FieldLayout{
+				{Name: "x", Offset: 0, Size: 4},
+				{Name: "y", Offset: 4, Size: 4},
+				{Name: "z", Offset: 8, Size: 4},
+			},
+		},
+	}
+
+	before, err := DefinitionSatisfiesRecordShape(candidate, shape)
+	if err != nil {
+		t.Fatalf("shape check failed: %v", err)
+	}
+	candidate.Representation = Representation{
+		Kind:      RepresentationRecord,
+		Policy:    RepresentationPolicyNaturalOrdered,
+		Resolved:  false,
+	}
+	after, err := DefinitionSatisfiesRecordShape(candidate, shape)
+	if err != nil {
+		t.Fatalf("shape check after representation change failed: %v", err)
+	}
+	if !before || !after {
+		t.Fatalf("representation changed semantic shape result: before=%v after=%v", before, after)
+	}
+}
+
+func TestRecordShapeSatisfactionRejectsMalformedShapes(t *testing.T) {
+	valid := recordType(Field{Name: "x", Type: "f32"})
+	tests := []Type{
+		{Kind: TypeScalar},
+		recordType(Field{Name: "", Type: "f32"}),
+		recordType(Field{Name: "x", Type: ""}),
+		recordType(Field{Name: "x", Type: "f32"}, Field{Name: "x", Type: "f32"}),
+	}
+	for _, candidate := range tests {
+		if _, err := SatisfiesRecordShape(candidate, valid); err == nil {
+			t.Fatalf("expected malformed candidate error for %#v", candidate)
+		}
+	}
+
+	if _, err := SatisfiesRecordShape(valid, recordType(
+		Field{Name: "x", Type: "f32"},
+		Field{Name: "x", Type: "f32"},
+	)); err == nil {
+		t.Fatal("expected duplicate required-field error")
+	}
+}

--- a/spec/lean/Oak.lean
+++ b/spec/lean/Oak.lean
@@ -10,3 +10,4 @@ import Oak.RegionLifetime
 import Oak.PhantomRepresentation
 import Oak.Layout
 import Oak.RecordLayout
+import Oak.RecordShape

--- a/spec/lean/Oak/RecordShape.lean
+++ b/spec/lean/Oak/RecordShape.lean
@@ -1,0 +1,95 @@
+namespace Oak.RecordShape
+
+/-- A semantic field is identified by its member name and semantic type.
+    Runtime offsets and representation are deliberately absent. -/
+structure Field where
+  name : Nat
+  ty : Nat
+  deriving DecidableEq, Repr
+
+abbrev Shape := List Field
+
+/-- A candidate satisfies a required shape when every required semantic field is
+    present in the candidate. Extra candidate fields are allowed. -/
+def Satisfies (candidate required : Shape) : Prop :=
+  ∀ field, field ∈ required → field ∈ candidate
+
+/-- Every shape satisfies itself. -/
+theorem reflexive (shape : Shape) : Satisfies shape shape := by
+  intro field hfield
+  exact hfield
+
+/-- An empty requirement is satisfied by every candidate. -/
+theorem empty_required (candidate : Shape) : Satisfies candidate [] := by
+  intro field hfield
+  simp at hfield
+
+/-- Adding an extra candidate field cannot destroy shape satisfaction. -/
+theorem candidate_extension (candidate required : Shape) (extra : Field)
+    (h : Satisfies candidate required) :
+    Satisfies (extra :: candidate) required := by
+  intro field hrequired
+  exact List.mem_cons_of_mem extra (h field hrequired)
+
+/-- Shape satisfaction composes: if A provides everything B requires, and B
+    provides everything C requires, then A provides everything C requires. -/
+theorem transitive (a b c : Shape)
+    (hab : Satisfies a b) (hbc : Satisfies b c) :
+    Satisfies a c := by
+  intro field hc
+  exact hab field (hbc field hc)
+
+/-- Required-field order has no semantic effect. -/
+theorem required_reverse_iff (candidate required : Shape) :
+    Satisfies candidate required.reverse ↔ Satisfies candidate required := by
+  constructor
+  · intro h field hrequired
+    apply h field
+    simpa using hrequired
+  · intro h field hrequired
+    apply h field
+    simpa using hrequired
+
+/-- Candidate-field order has no semantic effect. -/
+theorem candidate_reverse_iff (candidate required : Shape) :
+    Satisfies candidate.reverse required ↔ Satisfies candidate required := by
+  constructor
+  · intro h field hrequired
+    have hmem := h field hrequired
+    simpa using hmem
+  · intro h field hrequired
+    have hmem := h field hrequired
+    simpa using hmem
+
+/-- A specifically missing required field is enough to reject satisfaction. -/
+theorem missing_required_rejected (candidate required : Shape) (field : Field)
+    (hrequired : field ∈ required) (hmissing : field ∉ candidate) :
+    ¬ Satisfies candidate required := by
+  intro h
+  exact hmissing (h field hrequired)
+
+/-- Runtime representation is modeled as an independent axis. Its contents are
+    abstract here because no representation fact participates in satisfaction. -/
+structure SemanticRecord where
+  fields : Shape
+  representation : Nat
+  deriving DecidableEq, Repr
+
+def RecordSatisfies (candidate required : SemanticRecord) : Prop :=
+  Satisfies candidate.fields required.fields
+
+/-- Rebinding runtime representation cannot alter semantic shape satisfaction. -/
+theorem representation_irrelevant
+    (candidate required : SemanticRecord) (representation : Nat) :
+    RecordSatisfies { candidate with representation := representation } required ↔
+      RecordSatisfies candidate required := by
+  rfl
+
+/-- Required representation is likewise irrelevant to semantic shape checking. -/
+theorem required_representation_irrelevant
+    (candidate required : SemanticRecord) (representation : Nat) :
+    RecordSatisfies candidate { required with representation := representation } ↔
+      RecordSatisfies candidate required := by
+  rfl
+
+end Oak.RecordShape


### PR DESCRIPTION
## Summary

Add the semantic relation behind using record shapes as compile-time interfaces, without conflating shape with runtime representation.

### Semantic IR
`SatisfiesRecordShape` now checks whether a candidate record provides every required semantic field:
- required field name/type pairs must be present
- extra candidate fields are allowed
- declaration order is irrelevant to satisfaction
- representation/layout/offsets/size/alignment are excluded from the relation
- malformed/duplicate fields fail closed
- initial field compatibility is exact semantic type identity; richer refinement/subtyping compatibility can be layered on later

`DefinitionSatisfiesRecordShape` deliberately reads only the type axis, so changing a candidate's representation cannot alter shape satisfaction.

### Tests
Go tests cover:
- extra fields
- required/candidate order independence
- missing fields
- wrong field type
- representation rebinding
- malformed and duplicate shapes

### Lean
`Oak.RecordShape` models satisfaction as required-field containment and proves:
- reflexivity
- empty requirements
- candidate extension monotonicity
- transitivity
- required-field order irrelevance
- candidate-field order irrelevance
- missing required field rejection
- candidate and required representation irrelevance

### Scope
This PR defines and proves the semantic relation only. It does **not** yet make `T: Shape` work end-to-end in the generic typechecker, and it does not introduce global structural/width subtyping or runtime interface objects.

### Status discipline
Record-shape constraints become partial I/T plus M/P. **R** remains blank until the concrete compiler relation is explicitly refined to the Lean model.

## Verification
Go 1.27.1 CI and Lean 4.33.1 formal verification must both pass before merge. Golden corpus debt remains separate.