### PR TITLE
Prove record-shape checker refinement

### DIFF
--- a/docs/spec/STATUS.md
+++ b/docs/spec/STATUS.md
@@ -18,7 +18,7 @@ Legend:
 | Delimited parser cursor contract | ✓ | ✓ | ✓ | ✓ | ✓ |  | one `parseDelimited[T]` path covers invocations, parameters, type arguments, and array elements; `Oak.Delimited` proves canonical opener/body/close structure, item preservation, unique close suffix, exact close offset, and trailing-separator semantic transparency; refinement pending |
 | Type lattice (`never`, `any`, join/meet) | ✓ | ✓ | ✓ | ✓ | ✓ |  | Go subtype decision procedure is aligned with the proved distributive-lattice laws; explicit implementation refinement is still pending |
 | Semantic records/products | ✓ | ✓ | ✓ |  |  |  | plain `{ ... }` is parsed as a semantic product and projects semantic fields while leaving representation unspecified; source order is preserved as declaration metadata; duplicate fields are rejected |
-| Record shape constraints | ✓ | ✓ | ✓ | ✓ | ✓ |  | Semantic IR implements representation-blind required-field satisfaction; generic `T: Shape` checking now binds real type variables, exposes only guaranteed shape fields inside generic bodies, accepts extra candidate fields, rejects missing/wrong fields, supports intersected shape requirements, and substitutes inferred generic return types. `Oak.RecordShape` proves the abstract containment/order/representation laws; implementation refinement remains pending |
+| Record shape constraints | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | Semantic IR and the generic checker implement representation-blind required-field satisfaction. `Oak.RecordShapeRefinement` models the concrete name-lookup/exact-type decision procedure and proves soundness, completeness, and equivalence with `Oak.RecordShape.Satisfies` for well-formed unique-name records. **R applies to the shape-satisfaction decision relation only**; generic inference/substitution and whole constraint-discharge refinement remain pending. |
 | Natural struct representation selection | ✓ | ✓ | ✓ |  |  |  | parser preserves `struct { ... }` distinctly from `{ ... }`; `type = struct { ... }` selects `RepresentationRecord + natural-ordered` while remaining unresolved until target field representations are known |
 | Natural struct layout | ✓ | ✓ | ✓ | ✓ | ✓ |  | `NaturalRecordLayout` computes checked ordered non-packed layout with power-of-two alignment and uint32 overflow rejection; `Oak.RecordLayout` proves identity/order preservation, field alignment, non-overlap, and final-size alignment in the unbounded arithmetic model; implementation refinement pending |
 | Record composition | ✓ | partial | partial |  |  |  | semantic composition is separated from subtyping and from representation composition |
@@ -62,17 +62,17 @@ The formal gate currently checks:
 - `Oak.Layout`
 - `Oak.RecordLayout`
 - `Oak.RecordShape`
+- `Oak.RecordShapeRefinement`
 
-A green Lean build means the stated theorems type-check against the pinned proof kernel. It does **not** imply implementation refinement.
+A green Lean build means the stated theorems type-check against the pinned proof kernel. It does **not** imply implementation refinement except where an explicit refinement theorem is identified in this matrix.
 
 ## Immediate formal-verification queue
 
-1. explicit refinement from the generic typechecker record-shape relation to `Oak.RecordShape`;
+1. formalize generic inference/substitution and whole constraint-discharge preservation around the now-refined record-shape decision relation;
 2. explicit refinement from selected/resolved struct representation to `Oak.RecordLayout`;
 3. explicit implementation refinements for type lattice, effects, borrowing, exhaustiveness, source positions, delimited parsing, region lifetimes, phantom representation, and layout normalization;
-4. formalize generic substitution/constraint-discharge preservation laws;
-5. formalize additional resource/boundedness laws as the implementation surfaces stabilize;
-6. add ABI-specific representation profiles only when an actual backend requires semantics beyond the natural ordered profile.
+4. formalize additional resource/boundedness laws as the implementation surfaces stabilize;
+5. add ABI-specific representation profiles only when an actual backend requires semantics beyond the natural ordered profile.
 
 ## Refinement policy
 

--- a/spec/lean/Oak.lean
+++ b/spec/lean/Oak.lean
@@ -11,3 +11,4 @@ import Oak.PhantomRepresentation
 import Oak.Layout
 import Oak.RecordLayout
 import Oak.RecordShape
+import Oak.RecordShapeRefinement

--- a/spec/lean/Oak/RecordShapeRefinement.lean
+++ b/spec/lean/Oak/RecordShapeRefinement.lean
@@ -6,7 +6,7 @@ open Oak.RecordShape
 
 /-- Concrete checker-side record fields. This mirrors the implementation's
     name -> semantic-type lookup behavior while remaining independent of runtime
-    representation. Well-formed shapes have unique field names. -/
+    representation. -/
 abbrev ConcreteShape := List Field
 
 def Lookup (name : Nat) : ConcreteShape → Option Nat
@@ -14,8 +14,12 @@ def Lookup (name : Nat) : ConcreteShape → Option Nat
   | field :: rest =>
       if field.name = name then some field.ty else Lookup name rest
 
-def UniqueNames (shape : ConcreteShape) : Prop :=
-  ∀ a, a ∈ shape → ∀ b, b ∈ shape → a.name = b.name → a = b
+/-- The implementation represents fields as a name-keyed map, so a well-formed
+    concrete record cannot contain the same field name twice. -/
+def UniqueNames : ConcreteShape → Prop
+  | [] => True
+  | field :: rest =>
+      (∀ other, other ∈ rest → other.name ≠ field.name) ∧ UniqueNames rest
 
 /-- Executable relation corresponding to Go's recordSatisfiesShape loop:
     each required name must resolve in the candidate and its semantic type must
@@ -48,29 +52,25 @@ private theorem lookup_of_mem_unique
   induction shape with
   | nil => simp at hfield
   | cons head rest ih =>
+      rcases hunique with ⟨hheadUnique, hrestUnique⟩
       simp only [List.mem_cons] at hfield
       rcases hfield with rfl | hrest
       · simp [Lookup]
       · have hne : head.name ≠ field.name := by
           intro hname
-          have heq := hunique head (by simp) field (by simp [hrest]) hname
-          exact (by
-            subst field
-            exact (List.not_mem_of_mem_tail hrest) rfl)
-        have hrestUnique : UniqueNames rest := by
-          intro a ha b hb hname
-          exact hunique a (by simp [ha]) b (by simp [hb]) hname
+          exact hheadUnique field hrest hname.symm
         simp [Lookup, hne, ih hrestUnique hrest]
 
 private theorem all_eq_true_iff {xs : List α} {p : α → Bool} :
     xs.all p = true ↔ ∀ x ∈ xs, p x = true := by
   induction xs with
   | nil => simp
-  | cons head tail ih =>
-      simp [List.all, ih]
+  | cons head tail ih => simp [List.all, ih]
 
-/-- Soundness: if the executable checker accepts a well-formed candidate shape,
-    the abstract semantic satisfaction relation holds. -/
+/-- Soundness: if the executable checker accepts, the abstract semantic
+    satisfaction relation holds. Unique-name assumptions are carried because
+    they are part of concrete record well-formedness, although soundness itself
+    does not depend on them. -/
 theorem satisfiesBool_sound
     (candidate required : ConcreteShape)
     (_hcandidate : UniqueNames candidate)
@@ -78,14 +78,13 @@ theorem satisfiesBool_sound
     (hcheck : SatisfiesBool candidate required = true) :
     Satisfies candidate required := by
   intro field hfield
-  have hlookupCheck :=
-    (all_eq_true_iff.mp hcheck) field hfield
+  have hlookupCheck := (all_eq_true_iff.mp hcheck) field hfield
   cases hlookup : Lookup field.name candidate with
   | none =>
-      simp [SatisfiesBool, hlookup] at hlookupCheck
+      simp [hlookup] at hlookupCheck
   | some ty =>
       have hty : ty = field.ty := by
-        simpa [SatisfiesBool, hlookup] using hlookupCheck
+        simpa [hlookup] using hlookupCheck
       obtain ⟨candidateField, hmem, hname, hcandidateTy⟩ :=
         lookup_mem candidate field.name ty hlookup
       have hsame : candidateField = field := by
@@ -94,8 +93,8 @@ theorem satisfiesBool_sound
         simp_all
       simpa [hsame] using hmem
 
-/-- Completeness: the abstract relation over unique-name records is accepted by
-    the executable lookup-and-equality checker. -/
+/-- Completeness: abstract satisfaction is accepted by the executable checker
+    when the concrete candidate obeys the implementation's unique-name invariant. -/
 theorem satisfiesBool_complete
     (candidate required : ConcreteShape)
     (hcandidate : UniqueNames candidate)
@@ -106,7 +105,7 @@ theorem satisfiesBool_complete
   intro field hfield
   have hcandidateField : field ∈ candidate := hsatisfies field hfield
   have hlookup := lookup_of_mem_unique candidate hcandidate field hcandidateField
-  simp [SatisfiesBool, hlookup]
+  simp [hlookup]
 
 /-- The concrete decision procedure and abstract semantic relation coincide on
     well-formed record shapes. This is the refinement theorem used for Oak's R

--- a/spec/lean/Oak/RecordShapeRefinement.lean
+++ b/spec/lean/Oak/RecordShapeRefinement.lean
@@ -33,12 +33,11 @@ private theorem lookup_mem
   induction shape with
   | nil => simp [Lookup] at h
   | cons field rest ih =>
-      simp only [Lookup] at h
       by_cases heq : field.name = name
-      · simp [heq] at h
+      · simp [Lookup, heq] at h
         subst ty
         exact ⟨field, by simp, heq, rfl⟩
-      · simp [heq] at h
+      · simp [Lookup, heq] at h
         obtain ⟨found, hmem, hname, hty⟩ := ih h
         exact ⟨found, by simp [hmem], hname, hty⟩
 
@@ -55,8 +54,9 @@ private theorem lookup_of_mem_unique
       · have hne : head.name ≠ field.name := by
           intro hname
           have heq := hunique head (by simp) field (by simp [hrest]) hname
-          subst field
-          simp at hrest
+          exact (by
+            subst field
+            exact (List.not_mem_of_mem_tail hrest) rfl)
         have hrestUnique : UniqueNames rest := by
           intro a ha b hb hname
           exact hunique a (by simp [ha]) b (by simp [hb]) hname
@@ -67,48 +67,46 @@ private theorem all_eq_true_iff {xs : List α} {p : α → Bool} :
   induction xs with
   | nil => simp
   | cons head tail ih =>
-      simp [List.all, ih, and_left_comm, and_assoc]
+      simp [List.all, ih]
 
-/-- Soundness: if the executable checker accepts two well-formed shapes, the
-    abstract semantic satisfaction relation holds. -/
+/-- Soundness: if the executable checker accepts a well-formed candidate shape,
+    the abstract semantic satisfaction relation holds. -/
 theorem satisfiesBool_sound
     (candidate required : ConcreteShape)
-    (hcandidate : UniqueNames candidate)
-    (hrequired : UniqueNames required)
+    (_hcandidate : UniqueNames candidate)
+    (_hrequired : UniqueNames required)
     (hcheck : SatisfiesBool candidate required = true) :
     Satisfies candidate required := by
   intro field hfield
-  have hall := (all_eq_true_iff.mp hcheck) field hfield
-  simp only [SatisfiesBool] at hcheck
-  unfold SatisfiesBool at hcheck
-  have hlookupCheck := (all_eq_true_iff.mp hcheck) field hfield
+  have hlookupCheck :=
+    (all_eq_true_iff.mp hcheck) field hfield
   cases hlookup : Lookup field.name candidate with
-  | none => simp [hlookup] at hlookupCheck
+  | none =>
+      simp [SatisfiesBool, hlookup] at hlookupCheck
   | some ty =>
-      simp [hlookup] at hlookupCheck
       have hty : ty = field.ty := by
-        exact of_decide_eq_true hlookupCheck
+        simpa [SatisfiesBool, hlookup] using hlookupCheck
       obtain ⟨candidateField, hmem, hname, hcandidateTy⟩ :=
         lookup_mem candidate field.name ty hlookup
       have hsame : candidateField = field := by
-        apply hrequired field hfield field hfield rfl
-      subst candidateField
-      exact hmem
+        cases candidateField
+        cases field
+        simp_all
+      simpa [hsame] using hmem
 
 /-- Completeness: the abstract relation over unique-name records is accepted by
     the executable lookup-and-equality checker. -/
 theorem satisfiesBool_complete
     (candidate required : ConcreteShape)
     (hcandidate : UniqueNames candidate)
-    (hrequired : UniqueNames required)
+    (_hrequired : UniqueNames required)
     (hsatisfies : Satisfies candidate required) :
     SatisfiesBool candidate required = true := by
-  unfold SatisfiesBool
   apply all_eq_true_iff.mpr
   intro field hfield
   have hcandidateField : field ∈ candidate := hsatisfies field hfield
   have hlookup := lookup_of_mem_unique candidate hcandidate field hcandidateField
-  simp [hlookup]
+  simp [SatisfiesBool, hlookup]
 
 /-- The concrete decision procedure and abstract semantic relation coincide on
     well-formed record shapes. This is the refinement theorem used for Oak's R

--- a/spec/lean/Oak/RecordShapeRefinement.lean
+++ b/spec/lean/Oak/RecordShapeRefinement.lean
@@ -1,0 +1,125 @@
+import Oak.RecordShape
+
+namespace Oak.RecordShapeRefinement
+
+open Oak.RecordShape
+
+/-- Concrete checker-side record fields. This mirrors the implementation's
+    name -> semantic-type lookup behavior while remaining independent of runtime
+    representation. Well-formed shapes have unique field names. -/
+abbrev ConcreteShape := List Field
+
+def Lookup (name : Nat) : ConcreteShape → Option Nat
+  | [] => none
+  | field :: rest =>
+      if field.name = name then some field.ty else Lookup name rest
+
+def UniqueNames (shape : ConcreteShape) : Prop :=
+  ∀ a, a ∈ shape → ∀ b, b ∈ shape → a.name = b.name → a = b
+
+/-- Executable relation corresponding to Go's recordSatisfiesShape loop:
+    each required name must resolve in the candidate and its semantic type must
+    be exactly equal. -/
+def SatisfiesBool (candidate required : ConcreteShape) : Bool :=
+  required.all fun requiredField =>
+    match Lookup requiredField.name candidate with
+    | some candidateTy => candidateTy == requiredField.ty
+    | none => false
+
+private theorem lookup_mem
+    (shape : ConcreteShape) (name ty : Nat)
+    (h : Lookup name shape = some ty) :
+    ∃ field ∈ shape, field.name = name ∧ field.ty = ty := by
+  induction shape with
+  | nil => simp [Lookup] at h
+  | cons field rest ih =>
+      simp only [Lookup] at h
+      by_cases heq : field.name = name
+      · simp [heq] at h
+        subst ty
+        exact ⟨field, by simp, heq, rfl⟩
+      · simp [heq] at h
+        obtain ⟨found, hmem, hname, hty⟩ := ih h
+        exact ⟨found, by simp [hmem], hname, hty⟩
+
+private theorem lookup_of_mem_unique
+    (shape : ConcreteShape) (hunique : UniqueNames shape)
+    (field : Field) (hfield : field ∈ shape) :
+    Lookup field.name shape = some field.ty := by
+  induction shape with
+  | nil => simp at hfield
+  | cons head rest ih =>
+      simp only [List.mem_cons] at hfield
+      rcases hfield with rfl | hrest
+      · simp [Lookup]
+      · have hne : head.name ≠ field.name := by
+          intro hname
+          have heq := hunique head (by simp) field (by simp [hrest]) hname
+          subst field
+          simp at hrest
+        have hrestUnique : UniqueNames rest := by
+          intro a ha b hb hname
+          exact hunique a (by simp [ha]) b (by simp [hb]) hname
+        simp [Lookup, hne, ih hrestUnique hrest]
+
+private theorem all_eq_true_iff {xs : List α} {p : α → Bool} :
+    xs.all p = true ↔ ∀ x ∈ xs, p x = true := by
+  induction xs with
+  | nil => simp
+  | cons head tail ih =>
+      simp [List.all, ih, and_left_comm, and_assoc]
+
+/-- Soundness: if the executable checker accepts two well-formed shapes, the
+    abstract semantic satisfaction relation holds. -/
+theorem satisfiesBool_sound
+    (candidate required : ConcreteShape)
+    (hcandidate : UniqueNames candidate)
+    (hrequired : UniqueNames required)
+    (hcheck : SatisfiesBool candidate required = true) :
+    Satisfies candidate required := by
+  intro field hfield
+  have hall := (all_eq_true_iff.mp hcheck) field hfield
+  simp only [SatisfiesBool] at hcheck
+  unfold SatisfiesBool at hcheck
+  have hlookupCheck := (all_eq_true_iff.mp hcheck) field hfield
+  cases hlookup : Lookup field.name candidate with
+  | none => simp [hlookup] at hlookupCheck
+  | some ty =>
+      simp [hlookup] at hlookupCheck
+      have hty : ty = field.ty := by
+        exact of_decide_eq_true hlookupCheck
+      obtain ⟨candidateField, hmem, hname, hcandidateTy⟩ :=
+        lookup_mem candidate field.name ty hlookup
+      have hsame : candidateField = field := by
+        apply hrequired field hfield field hfield rfl
+      subst candidateField
+      exact hmem
+
+/-- Completeness: the abstract relation over unique-name records is accepted by
+    the executable lookup-and-equality checker. -/
+theorem satisfiesBool_complete
+    (candidate required : ConcreteShape)
+    (hcandidate : UniqueNames candidate)
+    (hrequired : UniqueNames required)
+    (hsatisfies : Satisfies candidate required) :
+    SatisfiesBool candidate required = true := by
+  unfold SatisfiesBool
+  apply all_eq_true_iff.mpr
+  intro field hfield
+  have hcandidateField : field ∈ candidate := hsatisfies field hfield
+  have hlookup := lookup_of_mem_unique candidate hcandidate field hcandidateField
+  simp [hlookup]
+
+/-- The concrete decision procedure and abstract semantic relation coincide on
+    well-formed record shapes. This is the refinement theorem used for Oak's R
+    status on record-shape satisfaction. -/
+theorem satisfiesBool_iff_satisfies
+    (candidate required : ConcreteShape)
+    (hcandidate : UniqueNames candidate)
+    (hrequired : UniqueNames required) :
+    SatisfiesBool candidate required = true ↔ Satisfies candidate required := by
+  constructor
+  · exact satisfiesBool_sound candidate required hcandidate hrequired
+  · exact satisfiesBool_complete candidate required hcandidate hrequired
+
+end Oak.RecordShapeRefinement


### PR DESCRIPTION
## Summary

Add the first explicit implementation-to-model refinement proof for Oak record-shape constraints.

### Concrete checker model
`Oak.RecordShapeRefinement` models the checker-side algorithm as:
- lookup required field by semantic name
- reject missing names
- compare exact semantic type identity
- require unique field names (matching parser/typechecker well-formedness)

### Refinement theorems
Prove:
- lookup success corresponds to membership
- unique-name membership yields lookup success
- executable checker soundness w.r.t. `Oak.RecordShape.Satisfies`
- executable checker completeness w.r.t. `Oak.RecordShape.Satisfies`
- final iff theorem: the concrete decision procedure and abstract semantic relation coincide on well-formed shapes

If the formal gate passes, this is sufficient to mark the record-shape satisfaction relation **R**. It does not yet refine generic inference/substitution or constraint binding as a whole.

## Verification
Require Lean 4.33.1 and normal Go 1.27.1 CI green before merge. Golden corpus debt remains separate.