### PR TITLE
Prove generic shape-call refinement

### DIFF
--- a/docs/spec/STATUS.md
+++ b/docs/spec/STATUS.md
@@ -18,7 +18,7 @@ Legend:
 | Delimited parser cursor contract | ✓ | ✓ | ✓ | ✓ | ✓ |  | one `parseDelimited[T]` path covers invocations, parameters, type arguments, and array elements; `Oak.Delimited` proves canonical opener/body/close structure, item preservation, unique close suffix, exact close offset, and trailing-separator semantic transparency; refinement pending |
 | Type lattice (`never`, `any`, join/meet) | ✓ | ✓ | ✓ | ✓ | ✓ |  | Go subtype decision procedure is aligned with the proved distributive-lattice laws; explicit implementation refinement is still pending |
 | Semantic records/products | ✓ | ✓ | ✓ |  |  |  | plain `{ ... }` is parsed as a semantic product and projects semantic fields while leaving representation unspecified; source order is preserved as declaration metadata; duplicate fields are rejected |
-| Record shape constraints | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | Semantic IR and the generic checker implement representation-blind required-field satisfaction. `Oak.RecordShapeRefinement` models the concrete name-lookup/exact-type decision procedure and proves soundness, completeness, and equivalence with `Oak.RecordShape.Satisfies` for well-formed unique-name records. **R applies to the shape-satisfaction decision relation only**; generic inference/substitution and whole constraint-discharge refinement remain pending. |
+| Record shape constraints | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | `Oak.RecordShapeRefinement` proves the concrete name-lookup/exact-type decision procedure equivalent to `Oak.RecordShape.Satisfies`. `Oak.GenericConstraintRefinement` additionally proves the implemented direct `T: Shape` call path and one unary-container inference path succeed exactly when the abstract shape obligation holds and return exactly the substituted semantic result. **R is scoped to these modeled record-shape paths**, not arbitrary HM programs or method-interface constraints. |
 | Natural struct representation selection | ✓ | ✓ | ✓ |  |  |  | parser preserves `struct { ... }` distinctly from `{ ... }`; `type = struct { ... }` selects `RepresentationRecord + natural-ordered` while remaining unresolved until target field representations are known |
 | Natural struct layout | ✓ | ✓ | ✓ | ✓ | ✓ |  | `NaturalRecordLayout` computes checked ordered non-packed layout with power-of-two alignment and uint32 overflow rejection; `Oak.RecordLayout` proves identity/order preservation, field alignment, non-overlap, and final-size alignment in the unbounded arithmetic model; implementation refinement pending |
 | Record composition | ✓ | partial | partial |  |  |  | semantic composition is separated from subtyping and from representation composition |
@@ -26,7 +26,7 @@ Legend:
 | Pattern matching | ✓ | ✓ | ✓ |  |  |  | canonical `=>`; legacy aliases remain implementation concern |
 | Exhaustiveness | ✓ | partial | partial | ✓ | ✓ |  | `Oak.Exhaustiveness` proves wildcard coverage, complete finite constructor coverage, missing-constructor rejection, and monotonicity under added arms; implementation refinement pending |
 | GADT-style refinements | direction |  |  |  |  |  | semantic direction specified; surface syntax intentionally not frozen |
-| Generic constraints/interfaces | ✓ | ✓ | ✓ |  |  |  | static predicate semantics; named requirements may be method interfaces or semantic record shapes; no dynamic interface object is introduced by generic constraint checking |
+| Generic constraints/interfaces | ✓ | ✓ | ✓ | partial | partial | partial | static predicate semantics; named requirements may be method interfaces or semantic record shapes; record-shape call inference/discharge/substitution has a scoped refinement proof, but arbitrary multi-variable/multi-parameter unification and method-interface discharge are not yet refined |
 | Phantom types | ✓ | partial | partial | ✓ | ✓ |  | `Oak.PhantomRepresentation` proves phantom rebinding changes static identity while preserving the entire runtime representation record, including size, alignment, and bit width; implementation refinement/inference pending |
 | Views / spans | ✓ | ✓ | ✓ | ✓ | ✓ |  | `Oak.Borrowing` proves the local authority-state laws; compiler correspondence is not yet proved |
 | Borrow-state machine | ✓ | partial | partial | ✓ | ✓ |  | explicit actions; valid transitions preserve state invariant and read/write authority stays exclusive |
@@ -39,7 +39,7 @@ Legend:
 | UTF-16 / UTF-32 encoded views | ✓ | partial | partial |  |  |  | legacy library/spec work exists; no proof yet |
 | Compile-time metadata | ✓ | partial | partial |  |  |  | legacy backtick syntax is not yet normative |
 | C backend | ✓ | ✓ | ✓ |  |  |  | semantic shape constraints erase; concrete struct lowering requires resolved representation; golden corpus currently has known stale/missing debt |
-| Functional generic specialization | ✓ | partial | partial |  |  |  | type-variable inference/substitution now works for direct and nested parameter unification used by record-shape constraints; no-hidden-dispatch/boxing law still needs dedicated tests/proofs |
+| Functional generic specialization | ✓ | partial | partial | ✓ | ✓ | partial | `Oak.GenericConstraintRefinement` proves direct and one-level unary inference, substitution through the result type, constraint discharge, and rejection of unsatisfied record shapes. Full HM/unifier refinement for multiple variables, repeated occurrences, multiple parameters, generic applications, and functions remains pending |
 | Closure capture/storage effects | ✓ |  |  |  |  |  | semantics specified; implementation pending |
 | Protocol/typestate semantic axis | direction |  |  |  |  |  | will receive its own normative spec before implementation |
 
@@ -63,16 +63,18 @@ The formal gate currently checks:
 - `Oak.RecordLayout`
 - `Oak.RecordShape`
 - `Oak.RecordShapeRefinement`
+- `Oak.GenericConstraintRefinement`
 
 A green Lean build means the stated theorems type-check against the pinned proof kernel. It does **not** imply implementation refinement except where an explicit refinement theorem is identified in this matrix.
 
 ## Immediate formal-verification queue
 
-1. formalize generic inference/substitution and whole constraint-discharge preservation around the now-refined record-shape decision relation;
+1. extend generic refinement from direct/one-level unary `T: Shape` calls to multiple parameters, repeated type-variable occurrences, generic applications, and multiple quantified variables;
 2. explicit refinement from selected/resolved struct representation to `Oak.RecordLayout`;
 3. explicit implementation refinements for type lattice, effects, borrowing, exhaustiveness, source positions, delimited parsing, region lifetimes, phantom representation, and layout normalization;
-4. formalize additional resource/boundedness laws as the implementation surfaces stabilize;
-5. add ABI-specific representation profiles only when an actual backend requires semantics beyond the natural ordered profile.
+4. formalize method-interface constraint discharge and its no-runtime-object specialization semantics;
+5. formalize additional resource/boundedness laws as the implementation surfaces stabilize;
+6. add ABI-specific representation profiles only when an actual backend requires semantics beyond the natural ordered profile.
 
 ## Refinement policy
 

--- a/spec/lean/Oak.lean
+++ b/spec/lean/Oak.lean
@@ -12,3 +12,4 @@ import Oak.Layout
 import Oak.RecordLayout
 import Oak.RecordShape
 import Oak.RecordShapeRefinement
+import Oak.GenericConstraintRefinement

--- a/spec/lean/Oak/GenericConstraintRefinement.lean
+++ b/spec/lean/Oak/GenericConstraintRefinement.lean
@@ -87,19 +87,17 @@ theorem invoke_direct_record_iff
     Invoke v (.var v) (.record candidate) result required =
         some (Substitute v (.record candidate) result) ↔
       Satisfies candidate required := by
-  rw [show Invoke v (.var v) (.record candidate) result required =
-      (if SatisfiesBool candidate required then
-        some (Substitute v (.record candidate) result) else none) by
-        simp [Invoke, Infer, Discharge]]
   constructor
   · intro hinvoke
-    by_cases hbool : SatisfiesBool candidate required = true
-    · exact (satisfiesBool_iff_satisfies candidate required hcandidate hrequired).mp hbool
-    · simp [hbool] at hinvoke
+    cases hbool : SatisfiesBool candidate required with
+    | false =>
+        simp [Invoke, Infer, Discharge, hbool] at hinvoke
+    | true =>
+        exact (satisfiesBool_iff_satisfies candidate required hcandidate hrequired).mp hbool
   · intro hsatisfies
     have hbool : SatisfiesBool candidate required = true :=
       (satisfiesBool_iff_satisfies candidate required hcandidate hrequired).mpr hsatisfies
-    simp [hbool]
+    simp [Invoke, Infer, Discharge, hbool]
 
 /-- The same correspondence holds when `T` is inferred through one semantic
     unary constructor (e.g. a modeled view/container position). -/
@@ -115,22 +113,17 @@ theorem invoke_unary_record_iff
         result required =
         some (Substitute v (.record candidate) result) ↔
       Satisfies candidate required := by
-  rw [show Invoke v
-        (.unary ctor (.var v))
-        (.unary ctor (.record candidate))
-        result required =
-      (if SatisfiesBool candidate required then
-        some (Substitute v (.record candidate) result) else none) by
-        simp [Invoke, Infer, Discharge]]
   constructor
   · intro hinvoke
-    by_cases hbool : SatisfiesBool candidate required = true
-    · exact (satisfiesBool_iff_satisfies candidate required hcandidate hrequired).mp hbool
-    · simp [hbool] at hinvoke
+    cases hbool : SatisfiesBool candidate required with
+    | false =>
+        simp [Invoke, Infer, Discharge, hbool] at hinvoke
+    | true =>
+        exact (satisfiesBool_iff_satisfies candidate required hcandidate hrequired).mp hbool
   · intro hsatisfies
     have hbool : SatisfiesBool candidate required = true :=
       (satisfiesBool_iff_satisfies candidate required hcandidate hrequired).mpr hsatisfies
-    simp [hbool]
+    simp [Invoke, Infer, Discharge, hbool]
 
 /-- If the abstract shape obligation fails, the direct generic call cannot
     produce a substituted result. -/

--- a/spec/lean/Oak/GenericConstraintRefinement.lean
+++ b/spec/lean/Oak/GenericConstraintRefinement.lean
@@ -17,20 +17,20 @@ inductive Ty where
 
 /-- Substitute one quantified type variable through a semantic type. This
     mirrors `Substitution.Apply` for the constructors modeled here. -/
-def Substitute (variable : Nat) (replacement : Ty) : Ty → Ty
-  | .var name => if name = variable then replacement else .var name
+def Substitute (v : Nat) (replacement : Ty) : Ty → Ty
+  | .var name => if name = v then replacement else .var name
   | .atom name => .atom name
   | .record fields => .record fields
-  | .unary ctor arg => .unary ctor (Substitute variable replacement arg)
+  | .unary ctor arg => .unary ctor (Substitute v replacement arg)
 
 /-- Infer one quantified variable from a parameter pattern and an actual
     argument. Repeated occurrences must infer the same semantic type. -/
-def Infer (variable : Nat) : Ty → Ty → Option Ty
-  | .var name, actual => if name = variable then some actual else none
-  | .atom expected, .atom actual => if expected = actual then none else none
-  | .record expected, .record actual => if expected = actual then none else none
+def Infer (v : Nat) : Ty → Ty → Option Ty
+  | .var name, actual => if name = v then some actual else none
+  | .atom _, .atom _ => none
+  | .record _, .record _ => none
   | .unary expectedCtor expectedArg, .unary actualCtor actualArg =>
-      if expectedCtor = actualCtor then Infer variable expectedArg actualArg else none
+      if expectedCtor = actualCtor then Infer v expectedArg actualArg else none
   | _, _ => none
 
 /-- Record-shape constraint discharge for one inferred semantic type. -/
@@ -42,81 +42,81 @@ def Discharge (inferred : Ty) (required : ConcreteShape) : Bool :=
 /-- Successful direct generic invocation: infer `T`, discharge its record-shape
     requirement, then substitute the inferred semantic type into the result. -/
 def Invoke
-    (variable : Nat)
+    (v : Nat)
     (parameter actual result : Ty)
     (required : ConcreteShape) : Option Ty :=
-  match Infer variable parameter actual with
+  match Infer v parameter actual with
   | none => none
   | some inferred =>
       if Discharge inferred required then
-        some (Substitute variable inferred result)
+        some (Substitute v inferred result)
       else
         none
 
 /-- A direct `T` parameter infers exactly the actual semantic type. -/
-theorem infer_direct (variable : Nat) (actual : Ty) :
-    Infer variable (.var variable) actual = some actual := by
+theorem infer_direct (v : Nat) (actual : Ty) :
+    Infer v (.var v) actual = some actual := by
   simp [Infer]
 
 /-- A nested unary parameter, such as a view/container of `T`, preserves the
     same inferred semantic binding when constructor identity matches. -/
-theorem infer_unary (variable ctor : Nat) (actual : Ty) :
-    Infer variable (.unary ctor (.var variable)) (.unary ctor actual) = some actual := by
+theorem infer_unary (v ctor : Nat) (actual : Ty) :
+    Infer v (.unary ctor (.var v)) (.unary ctor actual) = some actual := by
   simp [Infer]
 
 /-- Substitution of the quantified variable itself yields the inferred type. -/
-theorem substitute_direct (variable : Nat) (replacement : Ty) :
-    Substitute variable replacement (.var variable) = replacement := by
+theorem substitute_direct (v : Nat) (replacement : Ty) :
+    Substitute v replacement (.var v) = replacement := by
   simp [Substitute]
 
 /-- Substitution is compositional through the modeled unary constructor. -/
-theorem substitute_unary (variable ctor : Nat) (replacement body : Ty) :
-    Substitute variable replacement (.unary ctor body) =
-      .unary ctor (Substitute variable replacement body) := by
+theorem substitute_unary (v ctor : Nat) (replacement body : Ty) :
+    Substitute v replacement (.unary ctor body) =
+      .unary ctor (Substitute v replacement body) := by
   rfl
 
 /-- Whole direct-call refinement. For well-formed record shapes, the executable
     generic pipeline succeeds exactly when the abstract record-shape relation
     holds, and the returned semantic type is exactly the substituted result. -/
 theorem invoke_direct_record_iff
-    (variable : Nat)
+    (v : Nat)
     (candidate required : ConcreteShape)
     (result : Ty)
     (hcandidate : UniqueNames candidate)
     (hrequired : UniqueNames required) :
-    Invoke variable (.var variable) (.record candidate) result required =
-        some (Substitute variable (.record candidate) result) ↔
+    Invoke v (.var v) (.record candidate) result required =
+        some (Substitute v (.record candidate) result) ↔
       Satisfies candidate required := by
-  simp [Invoke, infer_direct, Discharge,
+  simp [Invoke, Infer, Discharge,
     satisfiesBool_iff_satisfies candidate required hcandidate hrequired]
 
 /-- The same correspondence holds when `T` is inferred through one semantic
     unary constructor (e.g. a modeled view/container position). -/
 theorem invoke_unary_record_iff
-    (variable ctor : Nat)
+    (v ctor : Nat)
     (candidate required : ConcreteShape)
     (result : Ty)
     (hcandidate : UniqueNames candidate)
     (hrequired : UniqueNames required) :
-    Invoke variable
-        (.unary ctor (.var variable))
+    Invoke v
+        (.unary ctor (.var v))
         (.unary ctor (.record candidate))
         result required =
-        some (Substitute variable (.record candidate) result) ↔
+        some (Substitute v (.record candidate) result) ↔
       Satisfies candidate required := by
-  simp [Invoke, infer_unary, Discharge,
+  simp [Invoke, Infer, Discharge,
     satisfiesBool_iff_satisfies candidate required hcandidate hrequired]
 
 /-- If the abstract shape obligation fails, the direct generic call cannot
     produce a substituted result. -/
 theorem invoke_direct_rejects_unsatisfied
-    (variable : Nat)
+    (v : Nat)
     (candidate required : ConcreteShape)
     (result : Ty)
     (hcandidate : UniqueNames candidate)
     (hrequired : UniqueNames required)
     (hnot : ¬ Satisfies candidate required) :
-    Invoke variable (.var variable) (.record candidate) result required = none := by
+    Invoke v (.var v) (.record candidate) result required = none := by
   have hbool : SatisfiesBool candidate required = false := by
     cases h : SatisfiesBool candidate required with
     | false => rfl

--- a/spec/lean/Oak/GenericConstraintRefinement.lean
+++ b/spec/lean/Oak/GenericConstraintRefinement.lean
@@ -1,0 +1,128 @@
+import Oak.RecordShapeRefinement
+
+namespace Oak.GenericConstraintRefinement
+
+open Oak.RecordShape
+open Oak.RecordShapeRefinement
+
+/-- Small semantic type language for the concrete generic-call path. Runtime
+    representation is deliberately absent: inference and qualified constraints
+    operate only on semantic types. -/
+inductive Ty where
+  | var : Nat → Ty
+  | atom : Nat → Ty
+  | record : ConcreteShape → Ty
+  | unary : Nat → Ty → Ty
+  deriving DecidableEq, Repr
+
+/-- Substitute one quantified type variable through a semantic type. This
+    mirrors `Substitution.Apply` for the constructors modeled here. -/
+def Substitute (variable : Nat) (replacement : Ty) : Ty → Ty
+  | .var name => if name = variable then replacement else .var name
+  | .atom name => .atom name
+  | .record fields => .record fields
+  | .unary ctor arg => .unary ctor (Substitute variable replacement arg)
+
+/-- Infer one quantified variable from a parameter pattern and an actual
+    argument. Repeated occurrences must infer the same semantic type. -/
+def Infer (variable : Nat) : Ty → Ty → Option Ty
+  | .var name, actual => if name = variable then some actual else none
+  | .atom expected, .atom actual => if expected = actual then none else none
+  | .record expected, .record actual => if expected = actual then none else none
+  | .unary expectedCtor expectedArg, .unary actualCtor actualArg =>
+      if expectedCtor = actualCtor then Infer variable expectedArg actualArg else none
+  | _, _ => none
+
+/-- Record-shape constraint discharge for one inferred semantic type. -/
+def Discharge (inferred : Ty) (required : ConcreteShape) : Bool :=
+  match inferred with
+  | .record candidate => SatisfiesBool candidate required
+  | _ => false
+
+/-- Successful direct generic invocation: infer `T`, discharge its record-shape
+    requirement, then substitute the inferred semantic type into the result. -/
+def Invoke
+    (variable : Nat)
+    (parameter actual result : Ty)
+    (required : ConcreteShape) : Option Ty :=
+  match Infer variable parameter actual with
+  | none => none
+  | some inferred =>
+      if Discharge inferred required then
+        some (Substitute variable inferred result)
+      else
+        none
+
+/-- A direct `T` parameter infers exactly the actual semantic type. -/
+theorem infer_direct (variable : Nat) (actual : Ty) :
+    Infer variable (.var variable) actual = some actual := by
+  simp [Infer]
+
+/-- A nested unary parameter, such as a view/container of `T`, preserves the
+    same inferred semantic binding when constructor identity matches. -/
+theorem infer_unary (variable ctor : Nat) (actual : Ty) :
+    Infer variable (.unary ctor (.var variable)) (.unary ctor actual) = some actual := by
+  simp [Infer]
+
+/-- Substitution of the quantified variable itself yields the inferred type. -/
+theorem substitute_direct (variable : Nat) (replacement : Ty) :
+    Substitute variable replacement (.var variable) = replacement := by
+  simp [Substitute]
+
+/-- Substitution is compositional through the modeled unary constructor. -/
+theorem substitute_unary (variable ctor : Nat) (replacement body : Ty) :
+    Substitute variable replacement (.unary ctor body) =
+      .unary ctor (Substitute variable replacement body) := by
+  rfl
+
+/-- Whole direct-call refinement. For well-formed record shapes, the executable
+    generic pipeline succeeds exactly when the abstract record-shape relation
+    holds, and the returned semantic type is exactly the substituted result. -/
+theorem invoke_direct_record_iff
+    (variable : Nat)
+    (candidate required : ConcreteShape)
+    (result : Ty)
+    (hcandidate : UniqueNames candidate)
+    (hrequired : UniqueNames required) :
+    Invoke variable (.var variable) (.record candidate) result required =
+        some (Substitute variable (.record candidate) result) ↔
+      Satisfies candidate required := by
+  simp [Invoke, infer_direct, Discharge,
+    satisfiesBool_iff_satisfies candidate required hcandidate hrequired]
+
+/-- The same correspondence holds when `T` is inferred through one semantic
+    unary constructor (e.g. a modeled view/container position). -/
+theorem invoke_unary_record_iff
+    (variable ctor : Nat)
+    (candidate required : ConcreteShape)
+    (result : Ty)
+    (hcandidate : UniqueNames candidate)
+    (hrequired : UniqueNames required) :
+    Invoke variable
+        (.unary ctor (.var variable))
+        (.unary ctor (.record candidate))
+        result required =
+        some (Substitute variable (.record candidate) result) ↔
+      Satisfies candidate required := by
+  simp [Invoke, infer_unary, Discharge,
+    satisfiesBool_iff_satisfies candidate required hcandidate hrequired]
+
+/-- If the abstract shape obligation fails, the direct generic call cannot
+    produce a substituted result. -/
+theorem invoke_direct_rejects_unsatisfied
+    (variable : Nat)
+    (candidate required : ConcreteShape)
+    (result : Ty)
+    (hcandidate : UniqueNames candidate)
+    (hrequired : UniqueNames required)
+    (hnot : ¬ Satisfies candidate required) :
+    Invoke variable (.var variable) (.record candidate) result required = none := by
+  have hbool : SatisfiesBool candidate required = false := by
+    cases h : SatisfiesBool candidate required with
+    | false => rfl
+    | true =>
+        exfalso
+        exact hnot ((satisfiesBool_iff_satisfies candidate required hcandidate hrequired).mp h)
+  simp [Invoke, Infer, Discharge, hbool]
+
+end Oak.GenericConstraintRefinement

--- a/spec/lean/Oak/GenericConstraintRefinement.lean
+++ b/spec/lean/Oak/GenericConstraintRefinement.lean
@@ -24,7 +24,7 @@ def Substitute (v : Nat) (replacement : Ty) : Ty → Ty
   | .unary ctor arg => .unary ctor (Substitute v replacement arg)
 
 /-- Infer one quantified variable from a parameter pattern and an actual
-    argument. Repeated occurrences must infer the same semantic type. -/
+    argument. -/
 def Infer (v : Nat) : Ty → Ty → Option Ty
   | .var name, actual => if name = v then some actual else none
   | .atom _, .atom _ => none
@@ -39,7 +39,7 @@ def Discharge (inferred : Ty) (required : ConcreteShape) : Bool :=
   | .record candidate => SatisfiesBool candidate required
   | _ => false
 
-/-- Successful direct generic invocation: infer `T`, discharge its record-shape
+/-- Successful generic invocation: infer `T`, discharge its record-shape
     requirement, then substitute the inferred semantic type into the result. -/
 def Invoke
     (v : Nat)
@@ -87,8 +87,19 @@ theorem invoke_direct_record_iff
     Invoke v (.var v) (.record candidate) result required =
         some (Substitute v (.record candidate) result) ↔
       Satisfies candidate required := by
-  simp [Invoke, Infer, Discharge,
-    satisfiesBool_iff_satisfies candidate required hcandidate hrequired]
+  rw [show Invoke v (.var v) (.record candidate) result required =
+      (if SatisfiesBool candidate required then
+        some (Substitute v (.record candidate) result) else none) by
+        simp [Invoke, Infer, Discharge]]
+  constructor
+  · intro hinvoke
+    by_cases hbool : SatisfiesBool candidate required = true
+    · exact (satisfiesBool_iff_satisfies candidate required hcandidate hrequired).mp hbool
+    · simp [hbool] at hinvoke
+  · intro hsatisfies
+    have hbool : SatisfiesBool candidate required = true :=
+      (satisfiesBool_iff_satisfies candidate required hcandidate hrequired).mpr hsatisfies
+    simp [hbool]
 
 /-- The same correspondence holds when `T` is inferred through one semantic
     unary constructor (e.g. a modeled view/container position). -/
@@ -104,8 +115,22 @@ theorem invoke_unary_record_iff
         result required =
         some (Substitute v (.record candidate) result) ↔
       Satisfies candidate required := by
-  simp [Invoke, Infer, Discharge,
-    satisfiesBool_iff_satisfies candidate required hcandidate hrequired]
+  rw [show Invoke v
+        (.unary ctor (.var v))
+        (.unary ctor (.record candidate))
+        result required =
+      (if SatisfiesBool candidate required then
+        some (Substitute v (.record candidate) result) else none) by
+        simp [Invoke, Infer, Discharge]]
+  constructor
+  · intro hinvoke
+    by_cases hbool : SatisfiesBool candidate required = true
+    · exact (satisfiesBool_iff_satisfies candidate required hcandidate hrequired).mp hbool
+    · simp [hbool] at hinvoke
+  · intro hsatisfies
+    have hbool : SatisfiesBool candidate required = true :=
+      (satisfiesBool_iff_satisfies candidate required hcandidate hrequired).mpr hsatisfies
+    simp [hbool]
 
 /-- If the abstract shape obligation fails, the direct generic call cannot
     produce a substituted result. -/


### PR DESCRIPTION
## Summary

Refine the generic `T: Shape` invocation path around the already-implemented checker semantics.

### Model
`Oak.GenericConstraintRefinement` models:
- inference of one quantified semantic type variable from a direct parameter position
- inference through one unary semantic constructor
- substitution through return types
- record-shape constraint discharge using the already-refined `Oak.RecordShapeRefinement.SatisfiesBool`
- invocation success/failure

### Proofs
Prove:
- direct and unary inference bind the actual semantic type
- substitution replaces the quantified variable compositionally
- direct generic invocation succeeds with exactly the substituted result iff the abstract record-shape constraint holds
- the same correspondence holds through one unary parameter constructor
- an unsatisfied shape constraint cannot produce a result

This intentionally does not claim full HM/unifier refinement for arbitrary multi-variable/multi-parameter programs yet.

## Verification
Require Lean 4.33.1 and Go 1.27.1 CI green before merge. Golden corpus debt remains separate.