### PR TITLE
Formalize representation polymorphism and inference contracts

### DIFF
--- a/docs/spec/25-type-inference.md
+++ b/docs/spec/25-type-inference.md
@@ -1,0 +1,235 @@
+# Type Inference and Explicit Contracts
+
+Oak aims for Hindley-Milner-style inference ergonomics without making type
+annotations part of ordinary implementation plumbing.
+
+This document is normative for where Oak infers types, where it generalizes
+polymorphism, and where explicit type contracts are required.
+
+## 1. Design rule
+
+The default rule is:
+
+```text
+inside an implementation:
+    infer as much as is unambiguous and sound
+
+at an exported/module/library boundary:
+    require an explicit contract
+```
+
+This is intentional. Local code should feel lightweight; public APIs should be
+stable, reviewable, documentable, and suitable for separate compilation and
+formal reasoning.
+
+Annotations are therefore primarily **contracts**, not ceremony.
+
+## 2. HM-style local inference
+
+Oak's core inference model is HM-style:
+
+- expressions produce type constraints;
+- fresh type variables stand for unknown types;
+- unification solves compatible constraints;
+- occurs checking rejects infinite types;
+- eligible bindings are generalized to type schemes;
+- each use of a polymorphic binding is instantiated with fresh type variables;
+- qualified constraints are carried as compile-time predicates over quantified
+  type variables.
+
+The implementation target is principal typing whenever the active feature set
+admits a principal type.
+
+For example, ordinary local code should not need repetitive annotations:
+
+```oak
+fn transform(xs: []i32): i32
+  doubled := map(xs, fn x => x * 2)
+  total := fold(doubled, 0, fn acc x => acc + x)
+  total
+```
+
+`doubled`, `total`, the lambda parameter/result relationships, and generic
+instantiations should be inferred when they are unambiguous.
+
+Exact lambda syntax remains governed by the syntax specification; the semantic
+rule here is independent of punctuation.
+
+## 3. Explicit module and library boundaries
+
+Externally visible declarations require explicit contracts.
+
+A public/exported function contract includes at least:
+
+- parameter types;
+- result type;
+- quantified type parameters when they are part of the API;
+- required generic constraints;
+- public effects/capabilities when the effect system makes them observable;
+- ownership/borrowing obligations that callers must satisfy.
+
+A public/exported data contract includes the semantic type identity and any
+representation contract that is intentionally public ABI.
+
+This rule gives separate compilation a stable interface and prevents a private
+implementation change from silently changing a library's public inferred type.
+
+The compiler may verify that an explicit public signature is at least as general
+as, or exactly matches according to the applicable contract rule, the inferred
+implementation. It must not silently widen or weaken the declared API.
+
+## 4. Private functions may infer more
+
+Private/local helpers may omit types when inference has a unique sound result.
+
+Conceptually:
+
+```oak
+fn public_api(x: Request): Response
+  parse := fn bytes => decode(bytes)
+  checked := validate(parse(x.bytes))
+  build_response(checked)
+```
+
+The public boundary is explicit. Local helper values and intermediate types are
+inferred.
+
+Whether a top-level declaration is exported is a module-system concern; this
+document specifies the typing policy rather than freezing export punctuation.
+
+## 5. Generalization is ownership/effect aware
+
+Oak is not a purely functional language. It has mutation, unique authority,
+arenas/regions, raw pointers, effects, and explicit storage.
+
+Therefore Oak must not adopt unrestricted ML let-polymorphism in cases where it
+would make mutable or region-bound state polymorphically aliasable.
+
+The soundness rule is:
+
+> A binding may be generalized only when doing so cannot duplicate or widen
+> authority over mutable, unique, external, or region-bound state.
+
+A conservative implementation may use a traditional value restriction. A more
+precise implementation may generalize a wider class of expressions when the
+ownership/effect checker proves that the binding does not capture unsafe mutable
+or escaping authority.
+
+The long-term preferred rule is proof/effect based rather than syntax based:
+
+```text
+pure/non-escaping value                  -> generalize
+pure computation producing immutable data -> generalize
+unique mutable capability capture       -> do not generalize unsafely
+fresh region-bound allocation           -> preserve region identity
+external/MMIO authority                 -> preserve authority identity
+```
+
+This keeps inference powerful without reproducing the polymorphic-reference
+unsoundness that unrestricted generalization would introduce in an imperative
+systems language.
+
+## 6. Constraints do not imply runtime dictionaries
+
+Qualified inference may infer a concrete type argument and then discharge
+record-shape or method/interface constraints at compile time.
+
+For example:
+
+```oak
+Position: type = { x: f32, y: f32 }
+
+fn length2[T: Position](p: T): f32
+  p.x * p.x + p.y * p.y
+```
+
+A call with a concrete `T` should infer `T`, prove the `Position` obligation,
+and specialize normally. Inference does not imply boxing, a runtime interface
+object, or a dictionary unless a future feature explicitly requests such a
+representation.
+
+## 7. Representation is not inferred from semantic shape
+
+Type inference may determine semantic type identity without choosing a runtime
+representation.
+
+A semantic record shape can remain representation-free. If concrete storage is
+required, representation selection is a separate checked decision.
+
+Inference must never conclude that two semantically compatible records share
+layout merely because they satisfy the same shape constraint.
+
+Likewise, selecting one of several valid representations for a semantic type
+must not change its inferred semantic identity.
+
+## 8. When annotations are required
+
+Oak requires an annotation when inference cannot produce one sound, stable
+contract without guessing.
+
+Important cases include:
+
+- exported/public API boundaries;
+- FFI, ABI, MMIO, wire, or explicit-layout boundaries;
+- ambiguous numeric or overloaded operations after available context is used;
+- recursive definitions when the implementation cannot infer the intended
+  recursive polymorphic contract safely;
+- GADT/refinement cases where local annotations are needed to guide proof or
+  type refinement;
+- existential/dynamic type boundaries if such features are introduced;
+- effect/authority boundaries whose omission would change caller obligations.
+
+The compiler should request the smallest useful annotation rather than forcing a
+fully annotated expression tree.
+
+## 9. Explicit annotations are checked facts
+
+An annotation constrains inference; it does not bypass it.
+
+The checker must verify the implementation against the annotation and report a
+precise mismatch at the source boundary. An annotation must not silently cause:
+
+- a runtime cast;
+- boxing;
+- allocation;
+- narrowing;
+- layout reinterpretation;
+- authority escalation.
+
+Those operations require their own explicit semantics.
+
+## 10. Inference and tooling
+
+Editor tooling should expose inferred facts without requiring the source to spell
+them repeatedly.
+
+Useful projections include:
+
+- hover: inferred semantic type;
+- hover: generalized type scheme;
+- hover: inferred effects/ownership when available;
+- inlay hints for developers who want them;
+- go-to-definition for inferred constraints and type constructors;
+- diagnostics showing the two constraints that failed to unify;
+- an "explain inferred type" view for difficult generic code.
+
+Inlay hints are tooling, not syntax. Source remains lightweight.
+
+## 11. Formal obligations
+
+The inference implementation should be formalized incrementally.
+
+Required proof targets include:
+
+1. substitution application preserves well-formed types;
+2. unification is sound: a returned substitution makes both input types equal;
+3. occurs checking rejects cyclic substitutions;
+4. generalization quantifies only type variables not free in the environment;
+5. instantiation is capture-free and fresh;
+6. qualified constraint discharge agrees with the semantic constraint relation;
+7. ownership/effect-aware generalization cannot duplicate forbidden authority;
+8. inferred local implementation types satisfy explicit exported signatures.
+
+Oak may describe its current compiler as **HM-style** while these pieces are
+implemented incrementally. It should claim full/principal HM inference only for
+the subset for which those properties actually hold.

--- a/docs/spec/45-representations.md
+++ b/docs/spec/45-representations.md
@@ -1,0 +1,209 @@
+# Representation Polymorphism
+
+Oak separates **what a value means** from **how one concrete realization stores
+that value**.
+
+This document is normative for representation selection and for allowing one
+semantic type to admit multiple checked runtime representations.
+
+## 1. Semantic type identity is primary
+
+A semantic record such as:
+
+```oak
+Position: type = {
+  x: i32
+  y: i32
+}
+```
+
+states named product semantics. It does not choose offsets, padding, field order
+in memory, size, alignment, packing, ABI classification, or endianness.
+
+Representation is a separate relation over that semantic type.
+
+## 2. A semantic type may have many representations
+
+A semantic type may have:
+
+- no runtime representation, when it is used only as a compile-time shape,
+  proposition, constraint, or other erased concept;
+- one representation;
+- several named representation choices.
+
+Conceptually:
+
+```text
+Position
+  ├─ natural-native
+  ├─ reversed-explicit
+  ├─ packed-wire
+  └─ another proved representation
+```
+
+The representation names above are specification examples, not Oak surface
+syntax.
+
+Two representation choices may have different field order, offsets, padding,
+size, alignment, or encoding while preserving the same semantic type identity.
+
+## 3. Selection is explicit and deterministic
+
+A concrete stored value has one selected representation contract at a time.
+
+For a fixed:
+
+```text
+semantic type
++ representation choice
++ target facts
+```
+
+resolved layout must be deterministic.
+
+The compiler must not arbitrarily choose a different representation because it
+looks smaller or faster unless an explicit optimization/representation policy
+permits that transformation and its semantic preservation is established.
+
+## 4. `struct` selects a representation
+
+The ordinary form:
+
+```oak
+Point: type = struct {
+  x: i32
+  y: i32
+}
+```
+
+has record semantics and selects Oak's natural ordered struct representation.
+
+This is equivalent in architecture to:
+
+```text
+semantic type: { x: i32, y: i32 }
+selected representation policy: natural-ordered
+```
+
+The latter block is specification notation, not Oak syntax.
+
+Selection and resolution remain distinct: target-dependent primitive facts may
+still be required before final offsets and size are known.
+
+## 5. Representation selection cannot change shape satisfaction
+
+If two concrete realizations share the same semantic record, then any
+representation-blind record-shape constraint must give the same result for both.
+
+Formally, if:
+
+```text
+semantic(a) = semantic(b)
+```
+
+then for every semantic record constraint `S`:
+
+```text
+a satisfies S  iff  b satisfies S
+```
+
+regardless of their layouts.
+
+This is a load-bearing rule: representation never participates in generic
+record-shape satisfaction.
+
+## 6. Ordinary record representations must cover semantic fields
+
+For the ordinary resolved `record` representation kind, every semantic field
+must be represented exactly once by semantic name.
+
+A resolved ordinary record representation must not silently:
+
+- omit a semantic field;
+- invent a semantic field;
+- duplicate a semantic field.
+
+Different order and offsets are allowed when the selected representation policy
+allows them.
+
+More exotic encodings may intentionally transform the storage model, but they
+must use an explicit representation kind/policy and establish a semantic mapping
+rather than masquerading as an ordinary record layout.
+
+## 7. Optimized/compressed representations require proof obligations
+
+Representations such as:
+
+- structure-of-arrays;
+- niche/tag elision;
+- bit packing;
+- compressed handles;
+- wire encodings;
+- platform-specific vector layouts;
+- explicit union-like overlap;
+
+may not satisfy the ordinary one-field/one-storage-field rule.
+
+They require a representation-specific abstraction relation explaining how
+concrete bits denote the semantic value. Optimizations are legal only when that
+relation is preserved.
+
+This lets Oak support aggressive systems representations without weakening the
+semantic type system.
+
+## 8. Representation and ABI visibility
+
+A private representation may change without changing the semantic module API,
+provided no exported ABI depends on it.
+
+When representation is part of a public FFI/ABI/wire/MMIO contract, that
+representation choice is itself part of the exported contract and must be
+explicit and stable according to that boundary's rules.
+
+Thus Oak can expose:
+
+```text
+public semantic contract
+```
+
+without necessarily exposing:
+
+```text
+private machine layout
+```
+
+unless callers genuinely need the latter.
+
+## 9. Semantic IR model
+
+Semantic IR represents this separation with named `RepresentationBinding`
+entries in a `RepresentationRegistry`.
+
+A binding contains:
+
+```text
+semantic type name
+representation name
+representation facts/policy
+```
+
+Multiple bindings may name the same semantic type. Selecting a binding copies
+the semantic definition unchanged and rebinds only its representation axis.
+
+This registry is deliberately separate from `Type` so representation alternatives
+cannot accidentally become part of type identity.
+
+## 10. Formal obligations
+
+The representation layer must establish at least:
+
+1. selecting a representation preserves semantic identity;
+2. rebinding representation preserves semantic identity;
+3. record-shape satisfaction is representation-independent;
+4. distinct layouts may realize one semantic type;
+5. ordinary resolved record layouts cover all semantic fields exactly once;
+6. a fixed selected policy plus target facts resolves deterministically;
+7. representation-specific optimizations preserve their abstraction relation.
+
+The initial Lean `Oak.RepresentationPolymorphism` model proves the first four
+abstract laws. Concrete layout/refinement proofs remain separate obligations.

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -48,10 +48,13 @@ Use these terms precisely:
 ## Authoritative documents
 
 - `00-constitution.md` — values, design constraints, semantic axes
+- `05-ergonomics-and-cost.md` — functional ergonomics and systems cost transparency
 - `10-syntax.md` — lexical/layout/block rules and canonical punctuation
 - `20-types.md` — type universe, subtyping, joins/meets, nominal identity
+- `25-type-inference.md` — HM-style local inference, safe generalization, explicit module/API contracts
 - `30-adts-patterns.md` — ADTs, GADT direction, constructors, matching, exhaustiveness
 - `40-records.md` — products, record identity, composition, order, layout separation
+- `45-representations.md` — multiple checked representations per semantic type and representation selection
 - `50-borrowing.md` — ownership, views, spans, safe/unsafe boundaries
 - `60-effects-allocation.md` — effects, arenas, slabs, handles, realtime prohibitions
 - `70-strings.md` — encoded text, validation, borrowing and representation

--- a/docs/spec/STATUS.md
+++ b/docs/spec/STATUS.md
@@ -17,8 +17,10 @@ Legend:
 | Source spans / UTF-16 editor positions | ✓ | ✓ | ✓ | ✓ | ✓ |  | `Oak.SourcePosition` proves UTF-8/UTF-16 scalar-width rules, additive coordinate accumulation, monotonic offsets, and ASCII width equivalence; Go tests cover emoji, multiline positions, byte-boundary rejection, links, and LSP coordinates; refinement pending |
 | Delimited parser cursor contract | ✓ | ✓ | ✓ | ✓ | ✓ |  | one `parseDelimited[T]` path covers invocations, parameters, type arguments, and array elements; `Oak.Delimited` proves canonical opener/body/close structure, item preservation, unique close suffix, exact close offset, and trailing-separator semantic transparency; refinement pending |
 | Type lattice (`never`, `any`, join/meet) | ✓ | ✓ | ✓ | ✓ | ✓ |  | Go subtype decision procedure is aligned with the proved distributive-lattice laws; explicit implementation refinement is still pending |
+| HM-style type inference | ✓ | partial | partial | partial | partial | partial | checker has type schemes, fresh variables, substitution, unification, occurs checks, generalization/instantiation, and qualified constraints. `Oak.GenericConstraintRefinement` proves direct and one-level unary constrained inference/substitution paths. Full principal inference, ownership/effect-aware generalization, multiple-variable inference, and exported-signature checking remain pending |
 | Semantic records/products | ✓ | ✓ | ✓ |  |  |  | plain `{ ... }` is parsed as a semantic product and projects semantic fields while leaving representation unspecified; source order is preserved as declaration metadata; duplicate fields are rejected |
 | Record shape constraints | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | `Oak.RecordShapeRefinement` proves the concrete name-lookup/exact-type decision procedure equivalent to `Oak.RecordShape.Satisfies`. `Oak.GenericConstraintRefinement` additionally proves the implemented direct `T: Shape` call path and one unary-container inference path succeed exactly when the abstract shape obligation holds and return exactly the substituted semantic result. **R is scoped to these modeled record-shape paths**, not arbitrary HM programs or method-interface constraints. |
+| Representation polymorphism | ✓ | ✓ | ✓ | ✓ | ✓ |  | `RepresentationRegistry` permits multiple named representation bindings for one semantic definition; selection rebinds only `Definition.Representation`; ordinary resolved record representations must cover semantic fields exactly once. `Oak.RepresentationPolymorphism` proves semantic identity and shape satisfaction are representation-independent; registry implementation refinement pending |
 | Natural struct representation selection | ✓ | ✓ | ✓ |  |  |  | parser preserves `struct { ... }` distinctly from `{ ... }`; `type = struct { ... }` selects `RepresentationRecord + natural-ordered` while remaining unresolved until target field representations are known |
 | Natural struct layout | ✓ | ✓ | ✓ | ✓ | ✓ |  | `NaturalRecordLayout` computes checked ordered non-packed layout with power-of-two alignment and uint32 overflow rejection; `Oak.RecordLayout` proves identity/order preservation, field alignment, non-overlap, and final-size alignment in the unbounded arithmetic model; implementation refinement pending |
 | Record composition | ✓ | partial | partial |  |  |  | semantic composition is separated from subtyping and from representation composition |
@@ -64,17 +66,19 @@ The formal gate currently checks:
 - `Oak.RecordShape`
 - `Oak.RecordShapeRefinement`
 - `Oak.GenericConstraintRefinement`
+- `Oak.RepresentationPolymorphism`
 
 A green Lean build means the stated theorems type-check against the pinned proof kernel. It does **not** imply implementation refinement except where an explicit refinement theorem is identified in this matrix.
 
 ## Immediate formal-verification queue
 
-1. extend generic refinement from direct/one-level unary `T: Shape` calls to multiple parameters, repeated type-variable occurrences, generic applications, and multiple quantified variables;
-2. explicit refinement from selected/resolved struct representation to `Oak.RecordLayout`;
-3. explicit implementation refinements for type lattice, effects, borrowing, exhaustiveness, source positions, delimited parsing, region lifetimes, phantom representation, and layout normalization;
-4. formalize method-interface constraint discharge and its no-runtime-object specialization semantics;
-5. formalize additional resource/boundedness laws as the implementation surfaces stabilize;
-6. add ABI-specific representation profiles only when an actual backend requires semantics beyond the natural ordered profile.
+1. extend generic/HM refinement from direct/one-level unary `T: Shape` calls to multiple parameters, repeated type-variable occurrences, generic applications, and multiple quantified variables;
+2. formalize ownership/effect-aware generalization and prove that generalized schemes cannot duplicate unique/mutable/region authority;
+3. explicit refinement from selected/resolved struct representation to `Oak.RecordLayout` and from `RepresentationRegistry` selection to `Oak.RepresentationPolymorphism`;
+4. explicit implementation refinements for type lattice, effects, borrowing, exhaustiveness, source positions, delimited parsing, region lifetimes, phantom representation, and layout normalization;
+5. formalize method-interface constraint discharge and its no-runtime-object specialization semantics;
+6. formalize additional resource/boundedness laws as the implementation surfaces stabilize;
+7. add ABI-specific representation profiles only when an actual backend requires semantics beyond the natural ordered profile.
 
 ## Refinement policy
 

--- a/semir/representations.go
+++ b/semir/representations.go
@@ -1,0 +1,150 @@
+package semir
+
+import "fmt"
+
+// RepresentationPolicyExplicitOffsets selects a representation whose concrete
+// field offsets are part of the representation contract rather than derived
+// from Oak's natural ordered layout algorithm.
+const RepresentationPolicyExplicitOffsets RepresentationPolicy = "explicit-offsets"
+
+// RepresentationBinding associates one named runtime representation with one
+// semantic type definition. Multiple bindings may reference the same TypeName:
+// semantic identity is authoritative and representation is a separately chosen
+// realization of that meaning.
+type RepresentationBinding struct {
+	TypeName       string
+	Name           string
+	Representation Representation
+}
+
+// RepresentationRegistry is the representation axis for semantic definitions.
+// It deliberately lives beside Module rather than inside Type: adding, removing,
+// or selecting a runtime representation must not mutate semantic type identity.
+type RepresentationRegistry struct {
+	Bindings []RepresentationBinding
+}
+
+// Validate checks that every representation binding names an existing semantic
+// definition, has a unique name within that semantic type, and is itself a valid
+// representation for the already-validated definition.
+func (registry RepresentationRegistry) Validate(module Module) error {
+	if err := module.Validate(); err != nil {
+		return fmt.Errorf("semantic module: %w", err)
+	}
+
+	definitions := make(map[string]Definition, len(module.Definitions))
+	for _, definition := range module.Definitions {
+		definitions[definition.Name] = definition
+	}
+
+	seen := make(map[string]struct{}, len(registry.Bindings))
+	for _, binding := range registry.Bindings {
+		if binding.TypeName == "" {
+			return fmt.Errorf("representation binding has empty semantic type name")
+		}
+		if binding.Name == "" {
+			return fmt.Errorf("representation binding for %q has empty name", binding.TypeName)
+		}
+		definition, ok := definitions[binding.TypeName]
+		if !ok {
+			return fmt.Errorf("representation %q references unknown semantic type %q", binding.Name, binding.TypeName)
+		}
+		key := binding.TypeName + "\x00" + binding.Name
+		if _, exists := seen[key]; exists {
+			return fmt.Errorf("duplicate representation %q for semantic type %q", binding.Name, binding.TypeName)
+		}
+		seen[key] = struct{}{}
+
+		if binding.Representation.Kind == RepresentationUnspecified {
+			return fmt.Errorf("representation %q for %q has unspecified kind", binding.Name, binding.TypeName)
+		}
+
+		// Reuse Definition.Validate so representation facts obey the same checked
+		// invariants whether selected inline by `struct` or named in a registry.
+		candidate := definition
+		candidate.Representation = binding.Representation
+		if err := candidate.Validate(); err != nil {
+			return fmt.Errorf("representation %q for %q: %w", binding.Name, binding.TypeName, err)
+		}
+
+		if err := validateSemanticRecordCoverage(definition.Type, binding.Representation); err != nil {
+			return fmt.Errorf("representation %q for %q: %w", binding.Name, binding.TypeName, err)
+		}
+	}
+	return nil
+}
+
+// BindingsFor returns the named representation choices for one semantic type in
+// declaration order. The returned slice is independent of registry storage.
+func (registry RepresentationRegistry) BindingsFor(typeName string) []RepresentationBinding {
+	bindings := make([]RepresentationBinding, 0)
+	for _, binding := range registry.Bindings {
+		if binding.TypeName == typeName {
+			bindings = append(bindings, binding)
+		}
+	}
+	return bindings
+}
+
+// Select returns a concrete view of a semantic definition using one named
+// representation. The semantic Type is copied unchanged; only the orthogonal
+// Representation axis is rebound.
+func (registry RepresentationRegistry) Select(module Module, typeName, representationName string) (Definition, error) {
+	if err := registry.Validate(module); err != nil {
+		return Definition{}, err
+	}
+
+	var definition *Definition
+	for i := range module.Definitions {
+		if module.Definitions[i].Name == typeName {
+			candidate := module.Definitions[i]
+			definition = &candidate
+			break
+		}
+	}
+	if definition == nil {
+		return Definition{}, fmt.Errorf("unknown semantic type %q", typeName)
+	}
+
+	for _, binding := range registry.Bindings {
+		if binding.TypeName == typeName && binding.Name == representationName {
+			selected := *definition
+			selected.Representation = binding.Representation
+			return selected, nil
+		}
+	}
+	return Definition{}, fmt.Errorf("semantic type %q has no representation %q", typeName, representationName)
+}
+
+// validateSemanticRecordCoverage ensures that an ordinary resolved record
+// representation still realizes every semantic field exactly once. More exotic
+// encodings (SoA, compressed/wire transforms, etc.) will require their own
+// explicit representation kind plus a proof that establishes the semantic map;
+// they must not silently masquerade as an ordinary record layout.
+func validateSemanticRecordCoverage(semantic Type, representation Representation) error {
+	if semantic.Kind != TypeRecord || representation.Kind != RepresentationRecord || !representation.Resolved {
+		return nil
+	}
+
+	required := make(map[string]struct{}, len(semantic.Fields))
+	for _, field := range semantic.Fields {
+		required[field.Name] = struct{}{}
+	}
+
+	seen := make(map[string]struct{}, len(representation.Fields))
+	for _, field := range representation.Fields {
+		if _, duplicate := seen[field.Name]; duplicate {
+			return fmt.Errorf("resolved record representation has duplicate field %q", field.Name)
+		}
+		seen[field.Name] = struct{}{}
+		if _, exists := required[field.Name]; !exists {
+			return fmt.Errorf("resolved record representation contains non-semantic field %q", field.Name)
+		}
+	}
+	for name := range required {
+		if _, exists := seen[name]; !exists {
+			return fmt.Errorf("resolved record representation omits semantic field %q", name)
+		}
+	}
+	return nil
+}

--- a/semir/representations_test.go
+++ b/semir/representations_test.go
@@ -1,0 +1,159 @@
+package semir
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func representationTestModule() Module {
+	return Module{Definitions: []Definition{{
+		Name: "Position",
+		Type: Type{
+			Kind: TypeRecord,
+			Fields: []Field{
+				{Name: "x", Type: "i32"},
+				{Name: "y", Type: "i32"},
+			},
+		},
+	}}}
+}
+
+func representationTestRegistry() RepresentationRegistry {
+	return RepresentationRegistry{Bindings: []RepresentationBinding{
+		{
+			TypeName: "Position",
+			Name:     "natural",
+			Representation: Representation{
+				Kind:      RepresentationRecord,
+				Policy:    RepresentationPolicyNaturalOrdered,
+				Resolved:  true,
+				Size:      8,
+				Alignment: 4,
+				Fields: []FieldLayout{
+					{Name: "x", Offset: 0, Size: 4},
+					{Name: "y", Offset: 4, Size: 4},
+				},
+			},
+		},
+		{
+			TypeName: "Position",
+			Name:     "reversed",
+			Representation: Representation{
+				Kind:      RepresentationRecord,
+				Policy:    RepresentationPolicyExplicitOffsets,
+				Resolved:  true,
+				Size:      8,
+				Alignment: 4,
+				Fields: []FieldLayout{
+					{Name: "y", Offset: 0, Size: 4},
+					{Name: "x", Offset: 4, Size: 4},
+				},
+			},
+		},
+	}}
+}
+
+func TestRepresentationRegistryAllowsManyLayoutsForOneSemanticRecord(t *testing.T) {
+	module := representationTestModule()
+	registry := representationTestRegistry()
+
+	if err := registry.Validate(module); err != nil {
+		t.Fatalf("valid representation registry rejected: %v", err)
+	}
+
+	choices := registry.BindingsFor("Position")
+	if len(choices) != 2 {
+		t.Fatalf("expected two representation choices, got %d", len(choices))
+	}
+	if reflect.DeepEqual(choices[0].Representation.Fields, choices[1].Representation.Fields) {
+		t.Fatal("test requires physically distinct layouts")
+	}
+}
+
+func TestSelectingRepresentationDoesNotChangeSemanticType(t *testing.T) {
+	module := representationTestModule()
+	registry := representationTestRegistry()
+
+	natural, err := registry.Select(module, "Position", "natural")
+	if err != nil {
+		t.Fatal(err)
+	}
+	reversed, err := registry.Select(module, "Position", "reversed")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(natural.Type, reversed.Type) {
+		t.Fatalf("representation selection changed semantic type:\n%#v\n%#v", natural.Type, reversed.Type)
+	}
+	if reflect.DeepEqual(natural.Representation.Fields, reversed.Representation.Fields) {
+		t.Fatal("expected selected representations to remain physically distinct")
+	}
+}
+
+func TestRecordShapeSatisfactionIgnoresSelectedRepresentation(t *testing.T) {
+	module := representationTestModule()
+	registry := representationTestRegistry()
+	shape := Definition{
+		Name: "HasX",
+		Type: Type{Kind: TypeRecord, Fields: []Field{{Name: "x", Type: "i32"}}},
+	}
+
+	for _, name := range []string{"natural", "reversed"} {
+		selected, err := registry.Select(module, "Position", name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ok, err := DefinitionSatisfiesRecordShape(selected, shape)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !ok {
+			t.Fatalf("representation %q changed record-shape satisfaction", name)
+		}
+	}
+}
+
+func TestRepresentationRegistryRejectsUnknownTypeAndDuplicateName(t *testing.T) {
+	module := representationTestModule()
+
+	unknown := RepresentationRegistry{Bindings: []RepresentationBinding{{
+		TypeName: "Missing",
+		Name:     "natural",
+		Representation: Representation{
+			Kind: RepresentationRecord,
+		},
+	}}}
+	if err := unknown.Validate(module); err == nil || !strings.Contains(err.Error(), "unknown semantic type") {
+		t.Fatalf("expected unknown-type error, got %v", err)
+	}
+
+	duplicate := representationTestRegistry()
+	duplicate.Bindings = append(duplicate.Bindings, duplicate.Bindings[0])
+	if err := duplicate.Validate(module); err == nil || !strings.Contains(err.Error(), "duplicate representation") {
+		t.Fatalf("expected duplicate-representation error, got %v", err)
+	}
+}
+
+func TestResolvedRecordRepresentationMustCoverSemanticFieldsExactlyOnce(t *testing.T) {
+	module := representationTestModule()
+	registry := RepresentationRegistry{Bindings: []RepresentationBinding{{
+		TypeName: "Position",
+		Name:     "broken",
+		Representation: Representation{
+			Kind:      RepresentationRecord,
+			Policy:    RepresentationPolicyExplicitOffsets,
+			Resolved:  true,
+			Size:      4,
+			Alignment: 4,
+			Fields: []FieldLayout{
+				{Name: "x", Offset: 0, Size: 4},
+			},
+		},
+	}}}
+
+	if err := registry.Validate(module); err == nil || !strings.Contains(err.Error(), "omits semantic field") {
+		t.Fatalf("expected missing-semantic-field error, got %v", err)
+	}
+}

--- a/spec/lean/Oak.lean
+++ b/spec/lean/Oak.lean
@@ -13,3 +13,4 @@ import Oak.RecordLayout
 import Oak.RecordShape
 import Oak.RecordShapeRefinement
 import Oak.GenericConstraintRefinement
+import Oak.RepresentationPolymorphism

--- a/spec/lean/Oak/RepresentationPolymorphism.lean
+++ b/spec/lean/Oak/RepresentationPolymorphism.lean
@@ -1,0 +1,72 @@
+namespace Oak.RepresentationPolymorphism
+
+/-- A semantic record is only its named-field meaning. Runtime placement is not
+    part of this object. Names/types are represented abstractly as naturals so
+    the proof is independent of Oak surface syntax. -/
+structure SemanticRecord where
+  fields : List (Nat × Nat)
+  deriving DecidableEq, Repr
+
+/-- One concrete runtime layout. Field offsets/order may differ between layouts
+    that realize the same semantic record. -/
+structure Layout where
+  name : Nat
+  fields : List (Nat × Nat)
+  size : Nat
+  alignment : Nat
+  deriving DecidableEq, Repr
+
+/-- A realization pairs one semantic record with one selected runtime layout. -/
+structure Realization where
+  semantic : SemanticRecord
+  representation : Layout
+  deriving DecidableEq, Repr
+
+/-- Selecting representation is intentionally an operation on the representation
+    axis only. -/
+def select (semantic : SemanticRecord) (representation : Layout) : Realization :=
+  { semantic := semantic, representation := representation }
+
+/-- Record-shape satisfaction depends only on semantic fields. -/
+def Satisfies (candidate : Realization) (required : SemanticRecord) : Prop :=
+  ∀ field, field ∈ required.fields → field ∈ candidate.semantic.fields
+
+/-- Selecting any representation preserves semantic identity exactly. -/
+theorem select_preserves_semantics (semantic : SemanticRecord) (representation : Layout) :
+    (select semantic representation).semantic = semantic := by
+  rfl
+
+/-- Rebinding a realization to a different representation preserves semantics. -/
+def rebind (value : Realization) (representation : Layout) : Realization :=
+  { semantic := value.semantic, representation := representation }
+
+/-- Rebinding cannot change the semantic record. -/
+theorem rebind_preserves_semantics (value : Realization) (representation : Layout) :
+    (rebind value representation).semantic = value.semantic := by
+  rfl
+
+/-- Shape satisfaction is representation-independent by construction. -/
+theorem satisfaction_representation_irrelevant (semantic required : SemanticRecord)
+    (left right : Layout) :
+    Satisfies (select semantic left) required ↔
+      Satisfies (select semantic right) required := by
+  rfl
+
+/-- Two physically distinct layouts may realize exactly the same semantic type. -/
+theorem distinct_layouts_can_share_semantics (semantic : SemanticRecord)
+    (left right : Layout) (hne : left ≠ right) :
+    select semantic left ≠ select semantic right ∧
+      (select semantic left).semantic = (select semantic right).semantic := by
+  constructor
+  · intro heq
+    apply hne
+    exact congrArg Realization.representation heq
+  · rfl
+
+/-- Rebinding twice keeps only the final representation while semantic identity
+    remains unchanged. -/
+theorem rebind_last_wins (value : Realization) (first second : Layout) :
+    rebind (rebind value first) second = rebind value second := by
+  rfl
+
+end Oak.RepresentationPolymorphism


### PR DESCRIPTION
## Summary

Make two related type-system contracts explicit without expanding Oak's surface language.

### Representation polymorphism
- add `semir.RepresentationRegistry` and named `RepresentationBinding`s
- allow multiple checked runtime representations for one semantic type
- selecting a representation rebinds only the representation axis and leaves semantic `Type` unchanged
- ordinary resolved record representations must cover semantic fields exactly once
- add explicit-offset representation policy support
- add Go tests for distinct layouts sharing one semantic record, selection invariance, representation-blind shape satisfaction, duplicate/unknown bindings, and semantic-field coverage
- add normative `docs/spec/45-representations.md`
- add Lean `Oak.RepresentationPolymorphism` proving selection/rebinding preserve semantics, shape satisfaction is representation-independent, and distinct layouts may share one semantic type

### HM-style inference contract
- add normative `docs/spec/25-type-inference.md`
- specify inference-heavy local implementations and explicit public/module/library contracts
- keep qualified constraints compile-time only
- require ownership/effect-aware generalization so mutable/unique/region authority cannot become unsafely polymorphic
- document when annotations are required and the formal obligations for inference

### Status discipline
- mark representation polymorphism S/I/T/M/P, not R
- mark HM-style inference partial I/T/M/P/R only where existing scoped generic refinement proofs apply

## Verification
Require Go 1.27.1 race-enabled CI and Lean 4.33.1 formal verification green before merge. Golden corpus debt remains separate.