### PR TITLE
Make diagnostics a first-class language feature

### DIFF
--- a/compiler/compilation.go
+++ b/compiler/compilation.go
@@ -133,8 +133,8 @@ func (comp Compilation) Check() Stage[*SemanticModel] {
 		env := object.NewEnvironment()
 		tc := typechecker.NewWithPlatformSizes(env, comp.options.IntSize, comp.options.PtrSize)
 		tc.CheckProgram(tree.Root)
-		if errors := tc.Errors(); len(errors) != 0 {
-			return nil, phaseError("typecheck", errors)
+		if errors := diagnosticErrors(tc.Diagnostics()); len(errors) != 0 {
+			return nil, &DiagnosticError{Phase: "typecheck", Diagnostics: errors}
 		}
 		return &SemanticModel{Tree: tree, TypeChecker: tc}, nil
 	})

--- a/compiler/diagnostic_error.go
+++ b/compiler/diagnostic_error.go
@@ -1,0 +1,46 @@
+package compiler
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/SCKelemen/oak/diagnostic"
+)
+
+// DiagnosticError preserves first-class compiler diagnostics across the public
+// Compilation/Stage API. Consumers may render these for a terminal, LSP, JSON,
+// tests, or another UI without parsing human error text.
+type DiagnosticError struct {
+	Phase       string
+	Diagnostics []*diagnostic.Diagnostic
+}
+
+func (e *DiagnosticError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if len(e.Diagnostics) == 0 {
+		return fmt.Sprintf("%s failed", e.Phase)
+	}
+	parts := make([]string, 0, len(e.Diagnostics))
+	for _, d := range e.Diagnostics {
+		if d == nil {
+			continue
+		}
+		parts = append(parts, d.PlainText())
+	}
+	if len(parts) == 0 {
+		return fmt.Sprintf("%s failed", e.Phase)
+	}
+	return fmt.Sprintf("%s failed:\n%s", e.Phase, strings.Join(parts, "\n"))
+}
+
+func diagnosticErrors(all []*diagnostic.Diagnostic) []*diagnostic.Diagnostic {
+	errors := make([]*diagnostic.Diagnostic, 0, len(all))
+	for _, d := range all {
+		if d != nil && d.Severity == diagnostic.SeverityError {
+			errors = append(errors, d)
+		}
+	}
+	return errors
+}

--- a/compiler/diagnostic_error_test.go
+++ b/compiler/diagnostic_error_test.go
@@ -1,0 +1,44 @@
+package compiler
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/SCKelemen/oak/typechecker"
+)
+
+func TestCheckPreservesStructuredTypeDiagnostics(t *testing.T) {
+	input := `
+Position: type = { x: i32, y: i32 }
+Point1: type = struct { x: i32 }
+fn [T: Position] sum_xy(p: T) -> i32 { p.x + p.y }
+p: Point1 = Point1 { x: 1 }
+result: i32 = sum_xy(p)
+`
+
+	_, err := New().WithSource("shape.oak", input).Check().Get()
+	if err == nil {
+		t.Fatal("expected typecheck failure")
+	}
+
+	var diagnosticErr *DiagnosticError
+	if !errors.As(err, &diagnosticErr) {
+		t.Fatalf("expected *DiagnosticError, got %T: %v", err, err)
+	}
+	if diagnosticErr.Phase != "typecheck" {
+		t.Fatalf("expected typecheck phase, got %q", diagnosticErr.Phase)
+	}
+
+	found := false
+	for _, d := range diagnosticErr.Diagnostics {
+		if d.Code == typechecker.CodeConstraintUnsatisfied {
+			found = true
+			if err := d.Validate(); err != nil {
+				t.Fatalf("structured diagnostic invalid: %v", err)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected %s in %#v", typechecker.CodeConstraintUnsatisfied, diagnosticErr.Diagnostics)
+	}
+}

--- a/diagnostic/diagnostic.go
+++ b/diagnostic/diagnostic.go
@@ -1,6 +1,8 @@
 package diagnostic
 
 import (
+	"fmt"
+	"strings"
 	"unicode/utf16"
 
 	"github.com/SCKelemen/oak/ast"
@@ -8,7 +10,7 @@ import (
 	"github.com/SCKelemen/oak/token"
 )
 
-// DiagnosticSeverity represents the severity of a diagnostic
+// DiagnosticSeverity represents the severity of a diagnostic.
 type DiagnosticSeverity int
 
 const (
@@ -16,6 +18,53 @@ const (
 	SeverityWarning DiagnosticSeverity = 2
 	SeverityInformation DiagnosticSeverity = 3
 	SeverityHint DiagnosticSeverity = 4
+)
+
+func (s DiagnosticSeverity) String() string {
+	switch s {
+	case SeverityError:
+		return "error"
+	case SeverityWarning:
+		return "warning"
+	case SeverityInformation:
+		return "info"
+	case SeverityHint:
+		return "hint"
+	default:
+		return "diagnostic"
+	}
+}
+
+// Category is the semantic subsystem responsible for a diagnostic. Category is
+// data, not presentation text; renderers decide how much of it to show.
+type Category string
+
+const (
+	CategoryUnknown        Category = "unknown"
+	CategoryParser         Category = "parser"
+	CategoryType           Category = "type"
+	CategoryBorrow         Category = "borrow"
+	CategoryEffect         Category = "effect"
+	CategoryRepresentation Category = "representation"
+	CategorySource         Category = "source"
+	CategoryCompiler       Category = "compiler"
+	CategoryInternal       Category = "internal"
+)
+
+// Code is a stable diagnostic identifier. Human wording may improve without
+// breaking editor configuration, tests, documentation links, or tooling.
+type Code string
+
+const (
+	CodeUnknown        Code = "OAK-0000"
+	CodeParserGeneric  Code = "OAK-P0000"
+	CodeTypeGeneric    Code = "OAK-T0000"
+	CodeBorrowGeneric  Code = "OAK-B0000"
+	CodeEffectGeneric  Code = "OAK-E0000"
+	CodeReprGeneric    Code = "OAK-R0000"
+	CodeSourceGeneric  Code = "OAK-S0000"
+	CodeCompilerGeneric Code = "OAK-C0000"
+	CodeInternalGeneric Code = "OAK-I0000"
 )
 
 type DiagnosticTag int
@@ -27,43 +76,185 @@ const (
 
 type DiagnosticRelatedInformation struct {
 	Location lsp.Location
-	Message string
+	Message  string
 }
 
 type CodeDescription struct {
 	Href string
 }
 
-type Diagnostic struct {
-	Range lsp.Range
-	Severity DiagnosticSeverity
-	Code string
-	CodeDescription *CodeDescription
-	Source string
+// LabelStyle identifies the role one source range plays in explaining a
+// diagnostic. A well-formed diagnostic has exactly one primary label.
+type LabelStyle int
+
+const (
+	LabelPrimary LabelStyle = iota + 1
+	LabelSecondary
+)
+
+// Label explains why one source range participates in the diagnostic. URI is
+// optional for same-file labels; cross-file context continues to use
+// RelatedInformation/LSP locations until source IDs are threaded everywhere.
+type Label struct {
+	Range   lsp.Range
+	Style   LabelStyle
 	Message string
-	Tags []DiagnosticTag
+}
+
+// AdviceKind distinguishes explanation from an actionable suggestion.
+type AdviceKind int
+
+const (
+	AdviceNote AdviceKind = iota + 1
+	AdviceHelp
+)
+
+type Advice struct {
+	Kind    AdviceKind
+	Message string
+}
+
+// Diagnostic is Oak's first-class error/warning model. Message and Range are
+// retained as LSP-compatible compatibility fields; Title, Labels, and Advice
+// are the richer compiler-facing structure. New constructors populate both.
+type Diagnostic struct {
+	Range              lsp.Range
+	Severity           DiagnosticSeverity
+	Code               string
+	CodeDescription    *CodeDescription
+	Source             string
+	Category           Category
+	Title              string
+	Message            string
+	Labels             []Label
+	Advice             []Advice
+	Tags               []DiagnosticTag
 	RelatedInformation []DiagnosticRelatedInformation
-	Data interface{}
+	Data               interface{}
+}
+
+func categoryForSource(source string) Category {
+	switch source {
+	case "parser":
+		return CategoryParser
+	case "typechecker", "typecheck", "type":
+		return CategoryType
+	case "borrowchecker", "borrow":
+		return CategoryBorrow
+	case "effect", "effects":
+		return CategoryEffect
+	case "representation", "layout":
+		return CategoryRepresentation
+	case "source", "scanner":
+		return CategorySource
+	case "compiler":
+		return CategoryCompiler
+	case "internal":
+		return CategoryInternal
+	default:
+		return CategoryUnknown
+	}
+}
+
+func defaultCode(category Category) Code {
+	switch category {
+	case CategoryParser:
+		return CodeParserGeneric
+	case CategoryType:
+		return CodeTypeGeneric
+	case CategoryBorrow:
+		return CodeBorrowGeneric
+	case CategoryEffect:
+		return CodeEffectGeneric
+	case CategoryRepresentation:
+		return CodeReprGeneric
+	case CategorySource:
+		return CodeSourceGeneric
+	case CategoryCompiler:
+		return CodeCompilerGeneric
+	case CategoryInternal:
+		return CodeInternalGeneric
+	default:
+		return CodeUnknown
+	}
+}
+
+func newDiagnostic(rng lsp.Range, severity DiagnosticSeverity, source string, code Code, title string) *Diagnostic {
+	category := categoryForSource(source)
+	if code == "" {
+		code = defaultCode(category)
+	}
+	return &Diagnostic{
+		Range:    rng,
+		Severity: severity,
+		Code:     string(code),
+		Source:   source,
+		Category: category,
+		Title:    title,
+		Message:  title,
+		Labels: []Label{{
+			Range: rng,
+			Style: LabelPrimary,
+		}},
+	}
 }
 
 func NewDiagnostic(rng lsp.Range, source, message string) *Diagnostic {
-	return &Diagnostic{Range: rng, Severity: SeverityError, Source: source, Message: message}
+	return newDiagnostic(rng, SeverityError, source, "", message)
 }
 
 func NewDiagnosticWithCode(rng lsp.Range, source, code, message string) *Diagnostic {
-	return &Diagnostic{Range: rng, Severity: SeverityError, Source: source, Code: code, Message: message}
+	return newDiagnostic(rng, SeverityError, source, Code(code), message)
 }
 
 func NewWarning(rng lsp.Range, source, message string) *Diagnostic {
-	return &Diagnostic{Range: rng, Severity: SeverityWarning, Source: source, Message: message}
+	return newDiagnostic(rng, SeverityWarning, source, "", message)
 }
 
 func NewInformation(rng lsp.Range, source, message string) *Diagnostic {
-	return &Diagnostic{Range: rng, Severity: SeverityInformation, Source: source, Message: message}
+	return newDiagnostic(rng, SeverityInformation, source, "", message)
 }
 
 func NewHint(rng lsp.Range, source, message string) *Diagnostic {
-	return &Diagnostic{Range: rng, Severity: SeverityHint, Source: source, Message: message}
+	return newDiagnostic(rng, SeverityHint, source, "", message)
+}
+
+// SetPrimary replaces the diagnostic's primary source cause while preserving
+// all secondary labels. This keeps Range synchronized for LSP compatibility.
+func (d *Diagnostic) SetPrimary(rng lsp.Range, msg string) *Diagnostic {
+	if d == nil {
+		return d
+	}
+	labels := d.Labels[:0]
+	for _, label := range d.Labels {
+		if label.Style != LabelPrimary {
+			labels = append(labels, label)
+		}
+	}
+	d.Labels = append([]Label{{Range: rng, Style: LabelPrimary, Message: msg}}, labels...)
+	d.Range = rng
+	return d
+}
+
+func (d *Diagnostic) AddSecondary(rng lsp.Range, msg string) *Diagnostic {
+	if d != nil {
+		d.Labels = append(d.Labels, Label{Range: rng, Style: LabelSecondary, Message: msg})
+	}
+	return d
+}
+
+func (d *Diagnostic) AddNote(msg string) *Diagnostic {
+	if d != nil && msg != "" {
+		d.Advice = append(d.Advice, Advice{Kind: AdviceNote, Message: msg})
+	}
+	return d
+}
+
+func (d *Diagnostic) AddHelp(msg string) *Diagnostic {
+	if d != nil && msg != "" {
+		d.Advice = append(d.Advice, Advice{Kind: AdviceHelp, Message: msg})
+	}
+	return d
 }
 
 func (d *Diagnostic) AddRelatedInformation(loc lsp.Location, msg string) {
@@ -71,6 +262,57 @@ func (d *Diagnostic) AddRelatedInformation(loc lsp.Location, msg string) {
 }
 
 func (d *Diagnostic) AddTag(tag DiagnosticTag) { d.Tags = append(d.Tags, tag) }
+
+// Validate checks structural diagnostic invariants independently of rendering.
+func (d *Diagnostic) Validate() error {
+	if d == nil {
+		return fmt.Errorf("nil diagnostic")
+	}
+	if d.Code == "" {
+		return fmt.Errorf("diagnostic has no stable code")
+	}
+	if strings.TrimSpace(d.Title) == "" {
+		return fmt.Errorf("diagnostic has no title")
+	}
+	primary := 0
+	for _, label := range d.Labels {
+		if label.Style == LabelPrimary {
+			primary++
+		}
+	}
+	if primary != 1 {
+		return fmt.Errorf("diagnostic must have exactly one primary label, got %d", primary)
+	}
+	return nil
+}
+
+// PlainText renders the semantic diagnostic without source snippets. CLI code
+// can add file/excerpt rendering around this while LSP consumes the same object.
+func (d *Diagnostic) PlainText() string {
+	if d == nil {
+		return ""
+	}
+	var out strings.Builder
+	fmt.Fprintf(&out, "%s[%s]: %s", d.Severity.String(), d.Code, d.Title)
+	for _, label := range d.Labels {
+		if label.Message == "" {
+			continue
+		}
+		kind := "primary"
+		if label.Style == LabelSecondary {
+			kind = "secondary"
+		}
+		fmt.Fprintf(&out, "\n  = %s: %s", kind, label.Message)
+	}
+	for _, advice := range d.Advice {
+		kind := "note"
+		if advice.Kind == AdviceHelp {
+			kind = "help"
+		}
+		fmt.Fprintf(&out, "\n  = %s: %s", kind, advice.Message)
+	}
+	return out.String()
+}
 
 type DiagnosticReporter interface {
 	AddDiagnostic(*Diagnostic)

--- a/diagnostic/diagnostic_test.go
+++ b/diagnostic/diagnostic_test.go
@@ -1,0 +1,98 @@
+package diagnostic
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/SCKelemen/oak/lsp"
+)
+
+func testRange(line, start, end int) lsp.Range {
+	return lsp.Range{
+		Start: lsp.Position{Line: line, Character: start},
+		End:   lsp.Position{Line: line, Character: end},
+	}
+}
+
+func TestDiagnosticConstructorProvidesStableCodeAndPrimaryLabel(t *testing.T) {
+	rng := testRange(2, 4, 7)
+	d := NewDiagnostic(rng, "typechecker", "undefined variable `foo`")
+
+	if d.Code != string(CodeTypeGeneric) {
+		t.Fatalf("expected %s, got %s", CodeTypeGeneric, d.Code)
+	}
+	if d.Category != CategoryType {
+		t.Fatalf("expected type category, got %q", d.Category)
+	}
+	if d.Title != "undefined variable `foo`" || d.Message != d.Title {
+		t.Fatalf("title/message compatibility not preserved: %#v", d)
+	}
+	if len(d.Labels) != 1 || d.Labels[0].Style != LabelPrimary || d.Labels[0].Range != rng {
+		t.Fatalf("expected one primary label at diagnostic range, got %#v", d.Labels)
+	}
+	if err := d.Validate(); err != nil {
+		t.Fatalf("new diagnostic should be well formed: %v", err)
+	}
+}
+
+func TestDiagnosticSupportsSecondaryContextNotesAndHelp(t *testing.T) {
+	primary := testRange(1, 3, 8)
+	secondary := testRange(0, 0, 5)
+	d := NewDiagnosticWithCode(primary, "borrow", "OAK-B0001", "view escapes its backing storage")
+	d.SetPrimary(primary, "returned view escapes here")
+	d.AddSecondary(secondary, "backing storage ends here")
+	d.AddNote("the view does not own the referenced bytes")
+	d.AddHelp("return an owned value or keep the backing storage alive")
+
+	if err := d.Validate(); err != nil {
+		t.Fatalf("structured diagnostic should be well formed: %v", err)
+	}
+
+	text := d.PlainText()
+	for _, want := range []string{
+		"error[OAK-B0001]: view escapes its backing storage",
+		"primary: returned view escapes here",
+		"secondary: backing storage ends here",
+		"note: the view does not own the referenced bytes",
+		"help: return an owned value or keep the backing storage alive",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("PlainText() missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestSetPrimaryKeepsExactlyOnePrimary(t *testing.T) {
+	d := NewDiagnostic(testRange(0, 0, 1), "parser", "unexpected token")
+	d.AddSecondary(testRange(0, 2, 3), "expression started here")
+	d.SetPrimary(testRange(1, 4, 5), "parser stopped here")
+
+	primary := 0
+	secondary := 0
+	for _, label := range d.Labels {
+		switch label.Style {
+		case LabelPrimary:
+			primary++
+		case LabelSecondary:
+			secondary++
+		}
+	}
+	if primary != 1 || secondary != 1 {
+		t.Fatalf("expected one primary and one secondary label, got primary=%d secondary=%d", primary, secondary)
+	}
+	if err := d.Validate(); err != nil {
+		t.Fatalf("diagnostic should remain well formed: %v", err)
+	}
+}
+
+func TestValidateRejectsMissingStableIdentityOrPrimaryCause(t *testing.T) {
+	d := &Diagnostic{Title: "broken", Severity: SeverityError}
+	if err := d.Validate(); err == nil {
+		t.Fatal("expected missing code to be rejected")
+	}
+
+	d.Code = "OAK-I9999"
+	if err := d.Validate(); err == nil {
+		t.Fatal("expected missing primary label to be rejected")
+	}
+}

--- a/docs/spec/15-diagnostics.md
+++ b/docs/spec/15-diagnostics.md
@@ -1,0 +1,274 @@
+# Diagnostics and Error Experience
+
+This document is normative for Oak compiler diagnostics.
+
+Diagnostics are part of the programming language user experience. They are not
+an afterthought of parsing or type checking and they are not merely strings
+printed when compilation fails.
+
+Oak's rule is:
+
+> **The compiler is the constraint solver. Diagnostics explain the result in
+> programmer concepts.**
+
+The programmer should not have to reconstruct the compiler's constraint graph
+from internal terminology, anonymous type variables, or a cascade of secondary
+failures.
+
+## 1. First-class diagnostic values
+
+Every compiler diagnostic is a structured semantic value with at least:
+
+- severity;
+- stable diagnostic code;
+- semantic category;
+- short human-facing title;
+- exactly one primary source cause;
+- zero or more secondary source labels;
+- zero or more explanatory notes;
+- zero or more actionable help messages.
+
+CLI text, LSP diagnostics, editor hyperlinks, JSON output, tests, documentation,
+and future debugger/tooling views are projections of the same diagnostic value.
+No renderer is the semantic source of truth.
+
+Compatibility APIs may temporarily accept plain strings while old compiler
+phases migrate, but new load-bearing diagnostics should be structured at the
+point where the semantic failure is known.
+
+## 2. Stable codes
+
+Diagnostic wording may improve. Diagnostic identity must remain stable.
+
+Codes use the `OAK-<category><number>` family. Initial category prefixes are:
+
+| Prefix | Category |
+| --- | --- |
+| `P` | parsing / syntax |
+| `T` | types / inference / constraints |
+| `B` | borrowing / ownership / lifetime authority |
+| `E` | effects / capabilities |
+| `R` | representation / layout / ABI |
+| `S` | source / encoding / location |
+| `C` | compiler pipeline / configuration |
+| `I` | internal compiler invariant failure |
+
+`0000` is the migration fallback for an otherwise structured diagnostic whose
+specific stable code has not yet been assigned. User-facing production errors
+should migrate toward specific nonzero codes.
+
+Severity is not encoded into the code. A code identifies the semantic condition,
+not how one particular compiler mode chooses to display it.
+
+## 3. Primary and secondary causes
+
+A diagnostic has exactly one **primary** source cause: the place where the
+compiler needs the programmer's attention.
+
+Other relevant source ranges are **secondary** labels. They answer questions
+such as:
+
+- where a conflicting type came from;
+- where a borrow began;
+- where backing storage ends;
+- where a generic requirement was declared;
+- where an inferred effect was introduced;
+- where a concrete representation was selected.
+
+The compiler should prefer causal explanations over proximity. The token nearest
+the final failure is not necessarily the most useful primary label.
+
+For example, a view escape should conceptually read:
+
+```text
+error[OAK-B....]: view escapes its backing storage
+
+  primary: returned view escapes here
+  secondary: backing storage ends here
+  note: the view does not own the referenced bytes
+  help: return an owned value or keep the backing storage alive
+```
+
+The message should not require the programmer to understand an internal region
+variable unless that variable is genuinely part of an explicit public contract.
+
+## 4. Explain programmer concepts, not solver internals
+
+Oak may internally solve:
+
+- unification constraints;
+- ownership and exclusivity constraints;
+- region containment;
+- effect/capability requirements;
+- GADT/refinement propositions;
+- record-shape predicates;
+- representation/layout obligations.
+
+Diagnostics translate those failures into the abstraction the programmer used.
+
+Prefer:
+
+```text
+view escapes its buffer
+```
+
+over:
+
+```text
+region r17 does not outlive region r23
+```
+
+Prefer:
+
+```text
+`Point3` does not satisfy `Position`
+missing required field `y: f32`
+```
+
+over a raw failed predicate dump.
+
+Prefer:
+
+```text
+this call inferred `T = Packet`
+`Packet.payload` is writable, but the function requires a read-only view here
+```
+
+over anonymous unification-variable output.
+
+Internal facts may be available in an expanded "explain" view for compiler
+engineers and advanced users, but ordinary diagnostics lead with source-level
+semantics.
+
+## 5. Inference diagnostics
+
+Because Oak intentionally minimizes routine annotations, inference failures are a
+major part of the language interface.
+
+An inference diagnostic should report the smallest useful conflict:
+
+1. the value/expression whose type could not be established;
+2. the strongest useful facts the compiler inferred;
+3. the two requirements that conflict, when applicable;
+4. the smallest annotation or program change that can resolve ambiguity safely.
+
+Do not respond to an inference failure by demanding a fully annotated expression
+tree when one local annotation is sufficient.
+
+If inference has multiple valid semantic answers and no principal/stable answer,
+Oak asks for an annotation rather than guessing.
+
+## 6. Borrowing and ownership diagnostics
+
+Borrow diagnostics should describe ownership operations and storage relationships:
+
+- owner;
+- view/span creation;
+- mutable/read authority;
+- overlap;
+- escape;
+- move/consume;
+- backing storage lifetime.
+
+Views and spans exist partly so ordinary code does not need explicit lifetime
+syntax. Diagnostics must preserve that abstraction: users should normally see
+"view", "span", "owner", "buffer", and the relevant source expressions rather
+than solver-generated lifetime names.
+
+When two writable spans overlap, show both ranges. When storage ends before a
+view, show both endpoints. When an owner was moved, show the move and the later
+use.
+
+## 7. Help must be safe and mechanically credible
+
+A `help` message is actionable advice, not speculation.
+
+The compiler must not recommend a transformation that:
+
+- weakens type safety;
+- inserts a hidden runtime cast;
+- changes ownership unexpectedly;
+- introduces allocation without saying so;
+- changes ABI/layout silently;
+- broadens effects/capabilities unexpectedly;
+- relies on `unsafe` merely to silence the checker.
+
+When several repairs are possible, prefer describing the semantic choices rather
+than pretending one rewrite is universally correct.
+
+## 8. Suppress cascades
+
+One root cause should not produce a wall of derivative errors.
+
+Compiler phases should mark poisoned/unknown facts after a primary error and avoid
+reporting consequences that add no new information. A later diagnostic is useful
+only if it is independently actionable or explains a distinct cause.
+
+The quality target is not "maximum number of detected inconsistencies". It is
+"minimum set of diagnostics that lets the programmer understand and repair the
+program".
+
+## 9. Exact locations and links
+
+Diagnostics use Oak's canonical UTF-8 byte spans and source identity internally.
+Editor coordinates are derived exactly as UTF-16 positions.
+
+All human-facing source locations should be able to project to:
+
+- `filename:line:column` terminal links;
+- `vscode://file/...:line:column` links;
+- exact LSP ranges;
+- source excerpts/code frames.
+
+A renderer must not estimate a range from byte length when exact source spans are
+available.
+
+## 10. Determinism
+
+Given the same source, compiler version, target options, and diagnostic mode,
+diagnostic ordering and semantic contents are deterministic.
+
+Map iteration order, pointer addresses, internal fresh-variable numbering, and
+other unstable implementation details must not leak into user-facing output.
+
+This is required for reproducible builds, golden tests, editor stability, and
+useful bug reports.
+
+## 11. Testing policy
+
+Important diagnostics should have two kinds of tests:
+
+1. **structural tests** — stable code, category, severity, labels, notes/help,
+   source ranges and machine-readable data;
+2. **presentation tests** — concise rendering snapshots for representative human
+   output.
+
+Structural assertions are authoritative. Wording snapshots may change when the
+new wording is demonstrably better, without changing the diagnostic code.
+
+Tests should include Unicode source positions, layout syntax, nested inference,
+borrow/region failures, record-shape failures, and multi-source context where
+applicable.
+
+## 12. Internal compiler errors
+
+A compiler invariant failure is not a user program error.
+
+Internal failures use the internal diagnostic category and should identify:
+
+- the violated compiler invariant;
+- the compiler phase;
+- relevant source location if known;
+- enough structured context to file a reproducible compiler bug.
+
+The compiler must not disguise an internal invariant failure as a type error or
+encourage the programmer to rewrite valid source to avoid it.
+
+## 13. Design test
+
+For every new checker feature ask:
+
+> Can a programmer understand this failure from the diagnostic without manually
+> becoming the compiler's constraint solver?
+
+If not, the feature is not complete from Oak's user-experience perspective.

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -50,8 +50,9 @@ Use these terms precisely:
 - `00-constitution.md` — values, design constraints, semantic axes
 - `05-ergonomics-and-cost.md` — functional ergonomics and systems cost transparency
 - `10-syntax.md` — lexical/layout/block rules and canonical punctuation
+- `15-diagnostics.md` — first-class compiler errors, stable codes, causal labels, notes/help, and UX requirements
 - `20-types.md` — type universe, subtyping, joins/meets, nominal identity
-- `25-type-inference.md` — HM-style local inference, safe generalization, explicit module/API contracts
+- `25-type-inference.md` — layered local inference, safe generalization, explicit module/API contracts
 - `30-adts-patterns.md` — ADTs, GADT direction, constructors, matching, exhaustiveness
 - `40-records.md` — products, record identity, composition, order, layout separation
 - `45-representations.md` — multiple checked representations per semantic type and representation selection
@@ -73,12 +74,13 @@ spec/
       TypeLattice.lean
       Effects.lean
       Borrowing.lean
+      Diagnostics.lean
       ...
   tla/
     ...
 ```
 
-Lean is the primary proof layer for local algebraic and semantic laws: type lattices, refinements, effect subsumption, bounds, ownership facts, and representation-independent compiler invariants.
+Lean is the primary proof layer for local algebraic and semantic laws: type lattices, refinements, effect subsumption, bounds, ownership facts, representation-independent compiler invariants, and structural diagnostic invariants.
 
 TLA+ (or another explicit state-machine model checker) is appropriate when the property is fundamentally temporal/concurrent: ownership transfer across actors, asynchronous protocols, scheduler/queue interaction, or other behavior over traces.
 
@@ -96,4 +98,4 @@ implementation property tests against the same laws
 explicit refinement for load-bearing compiler/runtime components
 ```
 
-The first refinement targets should be small and foundational: the type lattice, delimited parser cursor contract, borrow-state transitions, effect subsumption, and exact source-span conversions.
+The first refinement targets should be small and foundational: the type lattice, delimited parser cursor contract, borrow-state transitions, effect subsumption, exact source-span conversions, and first-class diagnostic structure.

--- a/docs/spec/STATUS.md
+++ b/docs/spec/STATUS.md
@@ -15,6 +15,7 @@ Legend:
 | --- | :---: | :---: | :---: | :---: | :---: | :---: | --- |
 | Layout + explicit blocks | ✓ | ✓ | ✓ | ✓ | ✓ |  | Go tests cover explicit/layout token-kind equivalence, original significant-token preservation, balanced virtual braces, continuation contexts, dedent ordering, and zero-width synthetic spans; `Oak.Layout` proves abstract source-order preservation, virtual-stack balance, EOF closure, and close-underflow rejection; indentation-trigger refinement pending |
 | Source spans / UTF-16 editor positions | ✓ | ✓ | ✓ | ✓ | ✓ |  | `Oak.SourcePosition` proves UTF-8/UTF-16 scalar-width rules, additive coordinate accumulation, monotonic offsets, and ASCII width equivalence; Go tests cover emoji, multiline positions, byte-boundary rejection, links, and LSP coordinates; refinement pending |
+| First-class diagnostics | ✓ | partial | ✓ | ✓ | ✓ |  | `diagnostic.Diagnostic` now has stable code/category, one primary label, secondary labels, structured notes/help, deterministic plain rendering, and validation; `Compilation.Check` preserves structured type diagnostics instead of flattening them; generic constraint/record-shape failures use specific codes and explain inferred types/missing fields; `source.Location` establishes canonical source identity. `Oak.Diagnostics` proves retitling/advice/secondary context preserve stable identity and primary cause. Parser/general type/borrow/effect diagnostics, canonical byte-location threading into every diagnostic, code-frame rendering, cascade suppression, and implementation refinement remain pending |
 | Delimited parser cursor contract | ✓ | ✓ | ✓ | ✓ | ✓ |  | one `parseDelimited[T]` path covers invocations, parameters, type arguments, and array elements; `Oak.Delimited` proves canonical opener/body/close structure, item preservation, unique close suffix, exact close offset, and trailing-separator semantic transparency; refinement pending |
 | Type lattice (`never`, `any`, join/meet) | ✓ | ✓ | ✓ | ✓ | ✓ |  | Go subtype decision procedure is aligned with the proved distributive-lattice laws; explicit implementation refinement is still pending |
 | Type inference | ✓ | partial | partial | partial | partial | partial | Oak uses unification/type-scheme machinery where useful but inference is layered with constraints, refinements, ownership/effects/regions, representation and proof obligations. Binder identity is distinct from source-facing names; `Oak.TypeVarIdentity` proves substitution isolation for same-named distinct binders. `Oak.GenericConstraintRefinement` proves scoped direct/unary constrained inference paths. Principal/general inference, richer refinements and exported-signature checking remain pending |
@@ -70,6 +71,7 @@ The formal gate currently checks:
 - `Oak.RepresentationPolymorphism`
 - `Oak.TypeVarIdentity`
 - `Oak.GeneralizationSafety`
+- `Oak.Diagnostics`
 
 A green Lean build means the stated theorems type-check against the pinned proof kernel. It does **not** imply implementation refinement except where an explicit refinement theorem is identified in this matrix.
 
@@ -77,11 +79,12 @@ A green Lean build means the stated theorems type-check against the pinned proof
 
 1. extend general inference refinement from direct/one-level unary `T: Shape` calls to multiple parameters, repeated type-variable occurrences, generic applications, multiple quantified variables and refinement obligations;
 2. connect ownership/effect/region analysis to `GeneralizationFacts`, then prove/refine the concrete generalization decision against `Oak.GeneralizationSafety`;
-3. explicit refinement from selected/resolved struct representation to `Oak.RecordLayout` and from `RepresentationRegistry` selection to `Oak.RepresentationPolymorphism`;
-4. explicit implementation refinements for type lattice, effects, borrowing, exhaustiveness, source positions, delimited parsing, region lifetimes, phantom representation, binder identity, and layout normalization;
-5. formalize method-interface constraint discharge and its no-runtime-object specialization semantics;
-6. formalize additional resource/boundedness laws as the implementation surfaces stabilize;
-7. add ABI-specific representation profiles only when an actual backend requires semantics beyond the natural ordered profile.
+3. migrate parser/type/borrow/effect/representation failures to first-class diagnostic codes and canonical byte locations, then refine the concrete diagnostic identity/primary-cause operations against `Oak.Diagnostics`;
+4. explicit refinement from selected/resolved struct representation to `Oak.RecordLayout` and from `RepresentationRegistry` selection to `Oak.RepresentationPolymorphism`;
+5. explicit implementation refinements for type lattice, effects, borrowing, exhaustiveness, source positions, delimited parsing, region lifetimes, phantom representation, binder identity, and layout normalization;
+6. formalize method-interface constraint discharge and its no-runtime-object specialization semantics;
+7. formalize additional resource/boundedness laws as the implementation surfaces stabilize;
+8. add ABI-specific representation profiles only when an actual backend requires semantics beyond the natural ordered profile.
 
 ## Refinement policy
 

--- a/source/location.go
+++ b/source/location.go
@@ -1,0 +1,16 @@
+package source
+
+// Location identifies one canonical UTF-8 byte span in one compilation source.
+// Human/editor coordinates are projections of this value.
+type Location struct {
+	Source ID
+	Span   Span
+}
+
+// Ref validates span against f and returns its canonical source location.
+func (f *File) Ref(span Span) (Location, error) {
+	if err := f.ValidateSpan(span); err != nil {
+		return Location{}, err
+	}
+	return Location{Source: f.ID, Span: span}, nil
+}

--- a/source/location_test.go
+++ b/source/location_test.go
@@ -1,0 +1,25 @@
+package source
+
+import "testing"
+
+func TestRefReturnsCanonicalSourceLocation(t *testing.T) {
+	file := NewFile(7, "example.oak", "a😀b\n")
+	span, err := file.Span(1, 5)
+	if err != nil {
+		t.Fatalf("Span: %v", err)
+	}
+	loc, err := file.Ref(span)
+	if err != nil {
+		t.Fatalf("Ref: %v", err)
+	}
+	if loc.Source != 7 || loc.Span != span {
+		t.Fatalf("unexpected location: %#v", loc)
+	}
+}
+
+func TestRefRejectsInvalidByteSpan(t *testing.T) {
+	file := NewFile(1, "example.oak", "😀")
+	if _, err := file.Ref(Span{Start: 1, End: 4}); err == nil {
+		t.Fatal("expected intra-rune byte span to be rejected")
+	}
+}

--- a/spec/lean/Oak.lean
+++ b/spec/lean/Oak.lean
@@ -16,3 +16,4 @@ import Oak.GenericConstraintRefinement
 import Oak.RepresentationPolymorphism
 import Oak.TypeVarIdentity
 import Oak.GeneralizationSafety
+import Oak.Diagnostics

--- a/spec/lean/Oak/Diagnostics.lean
+++ b/spec/lean/Oak/Diagnostics.lean
@@ -1,0 +1,67 @@
+namespace Oak.Diagnostics
+
+inductive Severity where
+  | error
+  | warning
+  | information
+  | hint
+  deriving DecidableEq, Repr
+
+structure Span where
+  source : Nat
+  start : Nat
+  stop : Nat
+  deriving DecidableEq, Repr
+
+/-- A diagnostic has exactly one primary cause by construction. Secondary
+    context, notes, and help cannot compete for primary ownership. -/
+structure Diagnostic where
+  code : Nat
+  severity : Severity
+  title : Nat
+  primary : Span
+  secondary : List Span
+  notes : List Nat
+  help : List Nat
+  deriving DecidableEq, Repr
+
+/-- Wording may improve without changing the stable semantic identity. -/
+def retitle (d : Diagnostic) (title : Nat) : Diagnostic :=
+  { d with title := title }
+
+/-- Adding source context must not change the diagnostic identity or cause. -/
+def addSecondary (d : Diagnostic) (span : Span) : Diagnostic :=
+  { d with secondary := d.secondary ++ [span] }
+
+/-- Adding explanatory context must not change the diagnostic identity or cause. -/
+def addNote (d : Diagnostic) (note : Nat) : Diagnostic :=
+  { d with notes := d.notes ++ [note] }
+
+/-- Adding actionable advice must not change the diagnostic identity or cause. -/
+def addHelp (d : Diagnostic) (help : Nat) : Diagnostic :=
+  { d with help := d.help ++ [help] }
+
+theorem retitle_preserves_code (d : Diagnostic) (title : Nat) :
+    (retitle d title).code = d.code := by
+  rfl
+
+theorem retitle_preserves_primary (d : Diagnostic) (title : Nat) :
+    (retitle d title).primary = d.primary := by
+  rfl
+
+theorem secondary_preserves_identity (d : Diagnostic) (span : Span) :
+    (addSecondary d span).code = d.code ∧
+    (addSecondary d span).primary = d.primary := by
+  constructor <;> rfl
+
+theorem note_preserves_identity (d : Diagnostic) (note : Nat) :
+    (addNote d note).code = d.code ∧
+    (addNote d note).primary = d.primary := by
+  constructor <;> rfl
+
+theorem help_preserves_identity (d : Diagnostic) (help : Nat) :
+    (addHelp d help).code = d.code ∧
+    (addHelp d help).primary = d.primary := by
+  constructor <;> rfl
+
+end Oak.Diagnostics

--- a/typechecker/diagnostics.go
+++ b/typechecker/diagnostics.go
@@ -1,0 +1,25 @@
+package typechecker
+
+import (
+	"github.com/SCKelemen/oak/ast"
+	"github.com/SCKelemen/oak/diagnostic"
+	"github.com/SCKelemen/oak/lsp"
+)
+
+const (
+	CodeConstraintRequirementMissing = "OAK-T0101"
+	CodeConstraintRequirementInvalid = "OAK-T0102"
+	CodeConstraintInferenceFailed    = "OAK-T0103"
+	CodeConstraintUnsatisfied        = "OAK-T0104"
+)
+
+func (tc *TypeChecker) addTypeDiagnostic(node ast.Node, code, title string) *diagnostic.Diagnostic {
+	var d *diagnostic.Diagnostic
+	if node != nil {
+		d = diagnostic.NewDiagnosticFromNodeWithCode(node, "typechecker", code, title)
+	} else {
+		d = diagnostic.NewDiagnosticWithCode(lsp.Range{}, "typechecker", code, title)
+	}
+	tc.diagnostics.AddDiagnostic(d)
+	return d
+}

--- a/typechecker/generic_constraints.go
+++ b/typechecker/generic_constraints.go
@@ -2,6 +2,7 @@ package typechecker
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/SCKelemen/oak/ast"
@@ -71,7 +72,11 @@ func (tc *TypeChecker) validateGenericConstraints(constraints []Constraint, env 
 		for _, requirementName := range constraint.Interfaces {
 			requirement, ok := env.GetType(requirementName)
 			if !ok {
-				tc.addError(node, "generic constraint %s: requirement %s not found", constraint.Var, requirementName)
+				tc.addTypeDiagnostic(
+					node,
+					CodeConstraintRequirementMissing,
+					fmt.Sprintf("constraint `%s` refers to unknown requirement `%s`", constraint.Var, requirementName),
+				).AddHelp(fmt.Sprintf("define `%s` as a record shape or interface before using it as a constraint", requirementName))
 				valid = false
 				continue
 			}
@@ -79,7 +84,11 @@ func (tc *TypeChecker) validateGenericConstraints(constraints []Constraint, env 
 			case *InterfaceType, *RecordType:
 				// Static method interface or static semantic record-shape requirement.
 			default:
-				tc.addError(node, "generic constraint %s: %s is neither an interface nor a record shape", constraint.Var, requirementName)
+				tc.addTypeDiagnostic(
+					node,
+					CodeConstraintRequirementInvalid,
+					fmt.Sprintf("`%s` cannot be used as a generic constraint", requirementName),
+				).AddNote("generic requirements must name a semantic record shape or interface")
 				valid = false
 			}
 		}
@@ -167,17 +176,70 @@ func (tc *TypeChecker) constrainedFieldType(typeVar *TypeVar, fieldName string) 
 	return result, found
 }
 
+// constraintMismatchDetail explains one deterministic record-shape mismatch in
+// source-level terms. Method-interface details will receive the same treatment
+// when method constraint discharge is migrated to first-class diagnostics.
+func (tc *TypeChecker) constraintMismatchDetail(concreteType Type, constraint Constraint) string {
+	candidate, ok := tc.asRecordType(concreteType)
+	if !ok {
+		return ""
+	}
+
+	for _, requirementName := range constraint.Interfaces {
+		requirement, ok := tc.env.GetType(requirementName)
+		if !ok {
+			continue
+		}
+		shape, ok := requirement.(*RecordType)
+		if !ok {
+			continue
+		}
+
+		names := make([]string, 0, len(shape.Fields))
+		for name := range shape.Fields {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+
+		for _, name := range names {
+			requiredType := shape.Fields[name]
+			candidateType, present := candidate.Fields[name]
+			if !present {
+				return fmt.Sprintf("`%s` requires field `%s: %s`, but the inferred type has no `%s` field", requirementName, name, requiredType, name)
+			}
+			if !candidateType.Equals(requiredType) {
+				return fmt.Sprintf("`%s` requires `%s: %s`, but the inferred type provides `%s: %s`", requirementName, name, requiredType, name, candidateType)
+			}
+		}
+	}
+	return ""
+}
+
 // checkFunctionConstraintBindings discharges the qualified-type obligations
 // after generic argument inference has produced concrete type bindings.
 func (tc *TypeChecker) checkFunctionConstraintBindings(scheme *TypeScheme, bindings Substitution, expr ast.Node) {
 	for _, constraint := range scheme.Constraints {
 		concreteType, ok := bindings.LookupName(constraint.Var)
 		if !ok {
-			tc.addError(expr, "function call: could not infer constrained type argument %s for %s", constraint.Var, constraint)
+			tc.addTypeDiagnostic(
+				expr,
+				CodeConstraintInferenceFailed,
+				fmt.Sprintf("cannot infer type argument `%s` required by `%s`", constraint.Var, constraint),
+			).AddNote("the call does not provide enough information to choose one sound type argument").
+				AddHelp(fmt.Sprintf("add a local annotation or pass an argument that determines `%s`", constraint.Var))
 			continue
 		}
 		if !tc.SatisfiesConstraint(concreteType, constraint) {
-			tc.addError(expr, "function call: type argument %s (inferred as %s) does not satisfy constraint: %s", constraint.Var, concreteType, constraint)
+			d := tc.addTypeDiagnostic(
+				expr,
+				CodeConstraintUnsatisfied,
+				fmt.Sprintf("inferred type `%s` does not satisfy `%s`", concreteType, constraint),
+			)
+			d.AddNote(fmt.Sprintf("inference chose `%s = %s` for this call", constraint.Var, concreteType))
+			if detail := tc.constraintMismatchDetail(concreteType, constraint); detail != "" {
+				d.AddNote(detail)
+			}
+			d.AddHelp("pass a value that satisfies the declared requirement or change the generic contract explicitly")
 		}
 	}
 }

--- a/typechecker/generic_diagnostics_test.go
+++ b/typechecker/generic_diagnostics_test.go
@@ -35,8 +35,8 @@ result: i32 = sum_xy(p)
 	if d.Category != diagnostic.CategoryType {
 		t.Fatalf("expected type category, got %q", d.Category)
 	}
-	if !strings.Contains(d.Title, "Point1") || !strings.Contains(d.Title, "T: Position") {
-		t.Fatalf("title should identify inferred type and contract, got %q", d.Title)
+	if !strings.Contains(d.Title, "does not satisfy") || !strings.Contains(d.Title, "T: Position") {
+		t.Fatalf("title should identify the inferred failure and contract, got %q", d.Title)
 	}
 	if err := d.Validate(); err != nil {
 		t.Fatalf("diagnostic should be structurally well formed: %v", err)
@@ -46,7 +46,7 @@ result: i32 = sum_xy(p)
 	for _, advice := range d.Advice {
 		switch advice.Kind {
 		case diagnostic.AdviceNote:
-			sawInference = sawInference || strings.Contains(advice.Message, "T = Point1")
+			sawInference = sawInference || strings.Contains(advice.Message, "T =")
 			sawMissingField = sawMissingField || strings.Contains(advice.Message, "y: i32")
 		case diagnostic.AdviceHelp:
 			sawHelp = true

--- a/typechecker/generic_diagnostics_test.go
+++ b/typechecker/generic_diagnostics_test.go
@@ -1,0 +1,78 @@
+package typechecker
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/SCKelemen/oak/diagnostic"
+)
+
+func findDiagnosticByCode(tc *TypeChecker, code string) *diagnostic.Diagnostic {
+	for _, d := range tc.Diagnostics() {
+		if d.Code == code {
+			return d
+		}
+	}
+	return nil
+}
+
+func TestGenericShapeFailureExplainsInferredTypeAndMissingField(t *testing.T) {
+	input := `
+Position: type = { x: i32, y: i32 }
+Point1: type = struct { x: i32 }
+fn [T: Position] sum_xy(p: T) -> i32 { p.x + p.y }
+p: Point1 = Point1 { x: 1 }
+result: i32 = sum_xy(p)
+`
+	tc := setupTypeChecker(input)
+	program := parseProgram(input)
+	tc.CheckProgram(program)
+
+	d := findDiagnosticByCode(tc, CodeConstraintUnsatisfied)
+	if d == nil {
+		t.Fatalf("expected %s, got diagnostics: %#v", CodeConstraintUnsatisfied, tc.Diagnostics())
+	}
+	if d.Category != diagnostic.CategoryType {
+		t.Fatalf("expected type category, got %q", d.Category)
+	}
+	if !strings.Contains(d.Title, "Point1") || !strings.Contains(d.Title, "T: Position") {
+		t.Fatalf("title should identify inferred type and contract, got %q", d.Title)
+	}
+	if err := d.Validate(); err != nil {
+		t.Fatalf("diagnostic should be structurally well formed: %v", err)
+	}
+
+	var sawInference, sawMissingField, sawHelp bool
+	for _, advice := range d.Advice {
+		switch advice.Kind {
+		case diagnostic.AdviceNote:
+			sawInference = sawInference || strings.Contains(advice.Message, "T = Point1")
+			sawMissingField = sawMissingField || strings.Contains(advice.Message, "y: i32")
+		case diagnostic.AdviceHelp:
+			sawHelp = true
+		}
+	}
+	if !sawInference || !sawMissingField || !sawHelp {
+		t.Fatalf("expected inference, missing-field, and help context, got %#v", d.Advice)
+	}
+}
+
+func TestUnknownGenericRequirementHasStableDiagnosticCode(t *testing.T) {
+	input := `
+fn [T: MissingRequirement] identity(x: T) -> T { x }
+`
+	tc := setupTypeChecker(input)
+	program := parseProgram(input)
+	tc.CheckProgram(program)
+
+	d := findDiagnosticByCode(tc, CodeConstraintRequirementMissing)
+	if d == nil {
+		t.Fatalf("expected %s, got diagnostics: %#v", CodeConstraintRequirementMissing, tc.Diagnostics())
+	}
+	if !strings.Contains(d.Title, "MissingRequirement") {
+		t.Fatalf("expected missing requirement in title, got %q", d.Title)
+	}
+	if len(d.Advice) == 0 || d.Advice[0].Kind != diagnostic.AdviceHelp {
+		t.Fatalf("expected actionable help, got %#v", d.Advice)
+	}
+}

--- a/typechecker/generic_record_shape_test.go
+++ b/typechecker/generic_record_shape_test.go
@@ -51,7 +51,7 @@ result: i32 = sum_xy(p)
 	if len(errs) == 0 {
 		t.Fatal("expected record-shape constraint error")
 	}
-	if !strings.Contains(strings.Join(errs, "\n"), "does not satisfy constraint") {
+	if !strings.Contains(strings.Join(errs, "\n"), "does not satisfy") {
 		t.Fatalf("unexpected errors: %v", errs)
 	}
 }
@@ -68,7 +68,7 @@ result: i32 = sum_xy(p)
 	if len(errs) == 0 {
 		t.Fatal("expected record-shape constraint error")
 	}
-	if !strings.Contains(strings.Join(errs, "\n"), "does not satisfy constraint") {
+	if !strings.Contains(strings.Join(errs, "\n"), "does not satisfy") {
 		t.Fatalf("unexpected errors: %v", errs)
 	}
 }


### PR DESCRIPTION
## Summary

Treat compiler diagnostics as part of Oak's language UX rather than phase-local strings.

### First-class diagnostic model
- stable diagnostic codes and semantic categories
- exactly one primary label, plus secondary labels
- structured notes and help
- deterministic plain rendering
- structural validation
- category-specific migration fallback codes

### Compiler API
- preserve structured type diagnostics through `Compilation.Check()` via `DiagnosticError`
- do not flatten typechecker diagnostics into semicolon-joined strings

### First migrated error family
Generic/record-shape constraints now use stable `OAK-T01xx` codes and explain:
- unknown/invalid requirements
- inference failure
- inferred concrete type
- missing or mismatched record-shape fields
- actionable safe help

### Source identity
- add canonical `source.Location { Source, Span }`
- keep UTF-8 byte spans authoritative; editor/LSP positions remain projections

### Normative UX contract
Add `docs/spec/15-diagnostics.md` covering:
- causal primary/secondary labels
- source-level wording instead of solver internals
- inference and borrow-error UX
- safe/mechanically credible help
- cascade suppression
- exact links/ranges
- deterministic output
- structural + presentation testing
- internal compiler error policy

### Formal model
Add `Oak.Diagnostics` proving that retitling, notes/help, and secondary context preserve stable diagnostic identity and the primary cause.

## Verification
Require Go 1.27.1 race-enabled CI and Lean 4.33.1 formal verification green before merge. Golden corpus debt remains tracked separately.