### PR TITLE
Refine recursive pattern analysis against formal semantics

### DIFF
--- a/docs/spec/STATUS.md
+++ b/docs/spec/STATUS.md
@@ -29,7 +29,7 @@ Legend:
 | ADTs | ✓ | ✓ | ✓ |  |  |  | old payload/default/tag meanings need compiler reconciliation |
 | Pattern matching | ✓ | ✓ | ✓ | partial | partial |  | canonical `=>`; constructor/payload narrowing exists; recursive coverage analysis is formalized separately; legacy surface aliases remain implementation concern |
 | Exhaustiveness | ✓ | ✓ | ✓ | ✓ | ✓ |  | recursive coverage tree distinguishes constructor payload cases, finite `Bool`, and open scalar domains; counterexamples are deterministic source-level pattern witnesses; malformed patterns suppress derivative coverage errors. `Oak.Exhaustiveness` proves finite constructor coverage laws and `Oak.PatternAnalysis` proves reachable-case coverage/counterexample laws; implementation refinement pending |
-| Pattern redundancy / reachable-state analysis | ✓ | ✓ | ✓ | ✓ | ✓ |  | source-order usefulness detects subsumed arms; existing narrowed constructor facts restrict the reachable case universe; impossible/redundant arm bodies are treated as `never` and do not widen match results. `OAK-T0202`/`OAK-T0203` are structured unnecessary-code warnings. `Oak.PatternAnalysis` proves redundant-vs-useful exclusion and constructor exclusion under refinements; implementation refinement pending |
+| Pattern redundancy / reachable-state analysis | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | source-order usefulness detects subsumed arms; existing narrowed constructor facts restrict the reachable case universe; impossible/redundant arm bodies are treated as `never` and do not widen match results. `OAK-T0202`/`OAK-T0203` are structured unnecessary-code warnings. `Oak.PatternAnalysisRefinement` proves scoped correspondence for finite recursive semantic case expansion: concrete recursive matching, completion, redundancy, and bounded counterexample witnesses agree with `Oak.PatternAnalysis`. Open scalar domains and representation-level extraction from Go maps remain outside this scoped **R** claim. |
 | GADT-style refinements | direction | partial | partial | ✓ | ✓ |  | the analyzer and formal model operate over a refinement-restricted reachable semantic case set, including empty/vacuously exhaustive states. Concrete support currently consumes existing constructor narrowing only; constructor result-index declaration syntax, equality/proposition generation, and a GADT solver are intentionally not yet frozen or implemented |
 | Generic constraints/interfaces | ✓ | ✓ | ✓ | partial | partial | partial | static predicate semantics; named requirements may be method interfaces or semantic record shapes; record-shape call inference/discharge/substitution has a scoped refinement proof, but arbitrary multi-variable/multi-parameter unification and method-interface discharge are not yet refined |
 | Phantom types | ✓ | partial | partial | ✓ | ✓ |  | `Oak.PhantomRepresentation` proves phantom rebinding changes static identity while preserving the entire runtime representation record, including size, alignment, and bit width; implementation refinement/inference pending |
@@ -64,6 +64,7 @@ The formal gate currently checks:
 - `Oak.Slab`
 - `Oak.Exhaustiveness`
 - `Oak.PatternAnalysis`
+- `Oak.PatternAnalysisRefinement`
 - `Oak.SourcePosition`
 - `Oak.Delimited`
 - `Oak.RegionLifetime`
@@ -82,7 +83,7 @@ A green Lean build means the stated theorems type-check against the pinned proof
 
 ## Immediate formal-verification queue
 
-1. connect concrete recursive coverage-tree operations and generated witnesses to `Oak.PatternAnalysis` with an explicit implementation refinement; then extend the reachable-case provider from constructor narrowing to real GADT result-index equalities/propositions;
+1. extend the reachable-case provider from constructor narrowing to real GADT result-index equalities/propositions, and later connect the Go map representation itself to the now-proved finite recursive decision procedure;
 2. extend general inference refinement from direct/one-level unary `T: Shape` calls to multiple parameters, repeated type-variable occurrences, generic applications, multiple quantified variables and refinement obligations;
 3. connect ownership/effect/region analysis to `GeneralizationFacts`, then prove/refine the concrete generalization decision against `Oak.GeneralizationSafety`;
 4. finish migrating parser/type/effect/representation and remaining borrow/escape/move failures to first-class diagnostic codes and canonical byte locations, then refine the concrete diagnostic identity/primary-cause operations against `Oak.Diagnostics`;

--- a/spec/lean/Oak.lean
+++ b/spec/lean/Oak.lean
@@ -7,6 +7,7 @@ import Oak.Handles
 import Oak.Slab
 import Oak.Exhaustiveness
 import Oak.PatternAnalysis
+import Oak.PatternAnalysisRefinement
 import Oak.SourcePosition
 import Oak.Delimited
 import Oak.RegionLifetime

--- a/spec/lean/Oak/PatternAnalysisRefinement.lean
+++ b/spec/lean/Oak/PatternAnalysisRefinement.lean
@@ -4,41 +4,48 @@ namespace Oak.PatternAnalysisRefinement
 
 open Oak.PatternAnalysis
 
-/-- Finite semantic leaves produced by recursively expanding a closed match
-    domain. Constructor payloads remain recursive; booleans are finite leaves,
-    while `scalar` represents a concrete literal in an otherwise open domain. -/
-inductive SemanticCase where
-  | ctor : Nat → Option SemanticCase → SemanticCase
-  | bool : Bool → SemanticCase
-  | scalar : Nat → SemanticCase
-  deriving Repr
+/-- Terminal leaves of the implementation's unary constructor/payload tree. -/
+inductive SemanticLeaf where
+  | unit
+  | bool : Bool → SemanticLeaf
+  | scalar : Nat → SemanticLeaf
+  deriving DecidableEq, Repr
 
-deriving instance DecidableEq for SemanticCase
+/-- A recursively expanded semantic case is a constructor path and its leaf. -/
+structure SemanticCase where
+  constructors : List Nat
+  leaf : SemanticLeaf
+  deriving DecidableEq, Repr
 
 /-- The checker-side pattern fragment handled by the structural coverage tree. -/
-inductive ConcretePattern where
+inductive LeafPattern where
   | any
-  | ctor : Nat → Option ConcretePattern → ConcretePattern
-  | bool : Bool → ConcretePattern
-  | scalar : Nat → ConcretePattern
-  deriving Repr
+  | unit
+  | bool : Bool → LeafPattern
+  | scalar : Nat → LeafPattern
+  deriving DecidableEq, Repr
 
-deriving instance DecidableEq for ConcretePattern
+structure ConcretePattern where
+  constructors : List Nat
+  leaf : LeafPattern
+  deriving DecidableEq, Repr
+
+def PrefixBool : List Nat → List Nat → Bool
+  | [], _ => true
+  | _, [] => false
+  | expected :: expectedRest, actual :: actualRest =>
+      expected == actual && PrefixBool expectedRest actualRest
 
 /-- Executable recursive matching corresponding to `applyCoverage`: a catch-all
     covers the current subtree, and constructor payloads are checked recursively. -/
-def MatchesBool : ConcretePattern → SemanticCase → Bool
-  | .any, _ => true
-  | .ctor expected expectedPayload, .ctor actual actualPayload =>
-      if expected = actual then
-        match expectedPayload, actualPayload with
-        | none, none => true
-        | some pattern, some value => MatchesBool pattern value
-        | _, _ => false
-      else false
-  | .bool expected, .bool actual => expected == actual
-  | .scalar expected, .scalar actual => expected == actual
-  | _, _ => false
+def MatchesBool (pattern : ConcretePattern) (value : SemanticCase) : Bool :=
+  match pattern.leaf with
+  | .any => PrefixBool pattern.constructors value.constructors
+  | .unit => pattern.constructors == value.constructors && value.leaf == .unit
+  | .bool expected =>
+      pattern.constructors == value.constructors && value.leaf == .bool expected
+  | .scalar expected =>
+      pattern.constructors == value.constructors && value.leaf == .scalar expected
 
 def CoveredBool (arms : List ConcretePattern) (value : SemanticCase) : Bool :=
   arms.any fun pattern => MatchesBool pattern value
@@ -108,7 +115,7 @@ theorem witness_is_counterexample
   have hparts :
       value ∈ reachable ∧ value ∈ cases ∧ CoveredBool arms value = false := by
     simpa [MissingCases, Bool.and_eq_true] using hmissing
-  refine ⟨⟨hparts.2.1, hparts.1⟩, ?_⟩
+  apply missing_reachable_is_counterexample hparts.2.1 hparts.1
   simp [CoveredCases, hparts.2.2]
 
 /-- Completeness refinement for finite recursive domains: the executable check
@@ -152,7 +159,13 @@ theorem redundantBool_iff_redundant
     (arm : ConcretePattern) :
     RedundantBool covered cases arm = true ↔
       Redundant covered (ArmCases cases arm) := by
-  simp only [RedundantBool, all_eq_true_iff]
-  simp [Redundant, ArmCases]
+  constructor
+  · intro h value hvalue
+    have hall := all_eq_true_iff.mp h
+    simpa using hall value hvalue
+  · intro h
+    apply all_eq_true_iff.mpr
+    intro value hvalue
+    simpa using h value hvalue
 
 end Oak.PatternAnalysisRefinement

--- a/spec/lean/Oak/PatternAnalysisRefinement.lean
+++ b/spec/lean/Oak/PatternAnalysisRefinement.lean
@@ -11,7 +11,9 @@ inductive SemanticCase where
   | ctor : Nat → Option SemanticCase → SemanticCase
   | bool : Bool → SemanticCase
   | scalar : Nat → SemanticCase
-  deriving DecidableEq, Repr
+  deriving Repr
+
+deriving instance DecidableEq for SemanticCase
 
 /-- The checker-side pattern fragment handled by the structural coverage tree. -/
 inductive ConcretePattern where
@@ -19,7 +21,9 @@ inductive ConcretePattern where
   | ctor : Nat → Option ConcretePattern → ConcretePattern
   | bool : Bool → ConcretePattern
   | scalar : Nat → ConcretePattern
-  deriving DecidableEq, Repr
+  deriving Repr
+
+deriving instance DecidableEq for ConcretePattern
 
 /-- Executable recursive matching corresponding to `applyCoverage`: a catch-all
     covers the current subtree, and constructor payloads are checked recursively. -/
@@ -116,27 +120,30 @@ theorem completeBool_iff_exhaustive
       Exhaustive cases reachable (CoveredCases cases arms) := by
   constructor
   · intro hcomplete value hreachable
-    by_contra hnotCovered
-    have hmissing : value ∈ MissingCases cases reachable arms := by
-      have hcoveredFalse : CoveredBool arms value = false := by
-        cases hcovered : CoveredBool arms value with
+    by_cases hcovered : value ∈ CoveredCases cases arms
+    · exact hcovered
+    · have hcoveredFalse : CoveredBool arms value = false := by
+        cases hbool : CoveredBool arms value with
         | false => rfl
         | true =>
-            exact False.elim (hnotCovered (by
-              simp [CoveredCases, hreachable.1, hcovered]))
-      simp [MissingCases, hreachable.2, hreachable.1, hcoveredFalse]
-    have hnonempty : MissingCases cases reachable arms ≠ [] := by
-      intro hempty
-      simpa [hempty] using hmissing
-    simpa [CompleteBool, List.isEmpty_iff] using hnonempty
+            exact False.elim (hcovered (by
+              simp [CoveredCases, hreachable.1, hbool]))
+      have hmissing : value ∈ MissingCases cases reachable arms := by
+        simp [MissingCases, hreachable.2, hreachable.1, hcoveredFalse]
+      cases hlist : MissingCases cases reachable arms with
+      | nil => simp [hlist] at hmissing
+      | cons head tail => simp [CompleteBool, hlist] at hcomplete
   · intro hexhaustive
-    apply List.isEmpty_iff.mpr
-    intro value hmissing
-    have hparts :
-        value ∈ reachable ∧ value ∈ cases ∧ CoveredBool arms value = false := by
-      simpa [MissingCases, Bool.and_eq_true] using hmissing
-    have hcovered := hexhaustive value ⟨hparts.2.1, hparts.1⟩
-    simp [CoveredCases, hparts.2.2] at hcovered
+    cases hlist : MissingCases cases reachable arms with
+    | nil => simp [CompleteBool, hlist]
+    | cons value rest =>
+        have hmissing : value ∈ MissingCases cases reachable arms := by
+          simp [hlist]
+        have hparts :
+            value ∈ reachable ∧ value ∈ cases ∧ CoveredBool arms value = false := by
+          simpa [MissingCases, Bool.and_eq_true] using hmissing
+        have hcovered := hexhaustive value ⟨hparts.2.1, hparts.1⟩
+        simp [CoveredCases, hparts.2.2] at hcovered
 
 /-- The checker's no-change decision for an arm coincides with the abstract
     definition of redundancy over the finite semantic case expansion. -/
@@ -145,7 +152,7 @@ theorem redundantBool_iff_redundant
     (arm : ConcretePattern) :
     RedundantBool covered cases arm = true ↔
       Redundant covered (ArmCases cases arm) := by
-  rw [all_eq_true_iff]
-  simp [RedundantBool, Redundant]
+  simp only [RedundantBool, all_eq_true_iff]
+  simp [Redundant, ArmCases]
 
 end Oak.PatternAnalysisRefinement

--- a/spec/lean/Oak/PatternAnalysisRefinement.lean
+++ b/spec/lean/Oak/PatternAnalysisRefinement.lean
@@ -1,0 +1,151 @@
+import Oak.PatternAnalysis
+
+namespace Oak.PatternAnalysisRefinement
+
+open Oak.PatternAnalysis
+
+/-- Finite semantic leaves produced by recursively expanding a closed match
+    domain. Constructor payloads remain recursive; booleans are finite leaves,
+    while `scalar` represents a concrete literal in an otherwise open domain. -/
+inductive SemanticCase where
+  | ctor : Nat → Option SemanticCase → SemanticCase
+  | bool : Bool → SemanticCase
+  | scalar : Nat → SemanticCase
+  deriving DecidableEq, Repr
+
+/-- The checker-side pattern fragment handled by the structural coverage tree. -/
+inductive ConcretePattern where
+  | any
+  | ctor : Nat → Option ConcretePattern → ConcretePattern
+  | bool : Bool → ConcretePattern
+  | scalar : Nat → ConcretePattern
+  deriving DecidableEq, Repr
+
+/-- Executable recursive matching corresponding to `applyCoverage`: a catch-all
+    covers the current subtree, and constructor payloads are checked recursively. -/
+def MatchesBool : ConcretePattern → SemanticCase → Bool
+  | .any, _ => true
+  | .ctor expected expectedPayload, .ctor actual actualPayload =>
+      if expected = actual then
+        match expectedPayload, actualPayload with
+        | none, none => true
+        | some pattern, some value => MatchesBool pattern value
+        | _, _ => false
+      else false
+  | .bool expected, .bool actual => expected == actual
+  | .scalar expected, .scalar actual => expected == actual
+  | _, _ => false
+
+def CoveredBool (arms : List ConcretePattern) (value : SemanticCase) : Bool :=
+  arms.any fun pattern => MatchesBool pattern value
+
+/-- The abstract covered-case set denoted by the concrete pattern list. -/
+def CoveredCases (cases : List SemanticCase) (arms : List ConcretePattern) :
+    List SemanticCase :=
+  cases.filter fun value => CoveredBool arms value
+
+/-- Concrete missing-case enumeration. Its order is the semantic constructor
+    order, matching the deterministic traversal used by `coverageWitnesses`. -/
+def MissingCases
+    (cases reachable : List SemanticCase)
+    (arms : List ConcretePattern) : List SemanticCase :=
+  reachable.filter fun value =>
+    decide (value ∈ cases) && !CoveredBool arms value
+
+def CompleteBool
+    (cases reachable : List SemanticCase)
+    (arms : List ConcretePattern) : Bool :=
+  (MissingCases cases reachable arms).isEmpty
+
+def Witnesses
+    (cases reachable : List SemanticCase)
+    (arms : List ConcretePattern)
+    (limit : Nat) : List SemanticCase :=
+  (MissingCases cases reachable arms).take limit
+
+/-- Cases denoted by one concrete arm, used to relate the checker's unchanged
+    coverage result to the abstract redundancy definition. -/
+def ArmCases (cases : List SemanticCase) (arm : ConcretePattern) :
+    List SemanticCase :=
+  cases.filter fun value => MatchesBool arm value
+
+def RedundantBool
+    (covered cases : List SemanticCase)
+    (arm : ConcretePattern) : Bool :=
+  (ArmCases cases arm).all fun value => decide (value ∈ covered)
+
+private theorem all_eq_true_iff {xs : List α} {p : α → Bool} :
+    xs.all p = true ↔ ∀ x ∈ xs, p x = true := by
+  induction xs with
+  | nil => simp
+  | cons head tail ih => simp [List.all, ih]
+
+/-- The concrete recursive matcher populates exactly the abstract covered list
+    supplied to the semantic pattern-analysis relation. -/
+theorem mem_coveredCases_iff
+    (cases : List SemanticCase)
+    (arms : List ConcretePattern)
+    (value : SemanticCase) :
+    value ∈ CoveredCases cases arms ↔
+      value ∈ cases ∧ CoveredBool arms value = true := by
+  simp [CoveredCases]
+
+/-- Soundness of every generated source-level witness: each reported leaf is
+    reachable, belongs to the closed case universe, and is not covered. -/
+theorem witness_is_counterexample
+    {cases reachable : List SemanticCase}
+    {arms : List ConcretePattern}
+    {limit : Nat}
+    {value : SemanticCase}
+    (h : value ∈ Witnesses cases reachable arms limit) :
+    Counterexample cases reachable (CoveredCases cases arms) value := by
+  have hmissing : value ∈ MissingCases cases reachable arms :=
+    List.mem_of_mem_take h
+  have hparts :
+      value ∈ reachable ∧ value ∈ cases ∧ CoveredBool arms value = false := by
+    simpa [MissingCases, Bool.and_eq_true] using hmissing
+  refine ⟨⟨hparts.2.1, hparts.1⟩, ?_⟩
+  simp [CoveredCases, hparts.2.2]
+
+/-- Completeness refinement for finite recursive domains: the executable check
+    succeeds exactly when the abstract reachable-case relation is exhaustive. -/
+theorem completeBool_iff_exhaustive
+    (cases reachable : List SemanticCase)
+    (arms : List ConcretePattern) :
+    CompleteBool cases reachable arms = true ↔
+      Exhaustive cases reachable (CoveredCases cases arms) := by
+  constructor
+  · intro hcomplete value hreachable
+    by_contra hnotCovered
+    have hmissing : value ∈ MissingCases cases reachable arms := by
+      have hcoveredFalse : CoveredBool arms value = false := by
+        cases hcovered : CoveredBool arms value with
+        | false => rfl
+        | true =>
+            exact False.elim (hnotCovered (by
+              simp [CoveredCases, hreachable.1, hcovered]))
+      simp [MissingCases, hreachable.2, hreachable.1, hcoveredFalse]
+    have hnonempty : MissingCases cases reachable arms ≠ [] := by
+      intro hempty
+      simpa [hempty] using hmissing
+    simpa [CompleteBool, List.isEmpty_iff] using hnonempty
+  · intro hexhaustive
+    apply List.isEmpty_iff.mpr
+    intro value hmissing
+    have hparts :
+        value ∈ reachable ∧ value ∈ cases ∧ CoveredBool arms value = false := by
+      simpa [MissingCases, Bool.and_eq_true] using hmissing
+    have hcovered := hexhaustive value ⟨hparts.2.1, hparts.1⟩
+    simp [CoveredCases, hparts.2.2] at hcovered
+
+/-- The checker's no-change decision for an arm coincides with the abstract
+    definition of redundancy over the finite semantic case expansion. -/
+theorem redundantBool_iff_redundant
+    (covered cases : List SemanticCase)
+    (arm : ConcretePattern) :
+    RedundantBool covered cases arm = true ↔
+      Redundant covered (ArmCases cases arm) := by
+  rw [all_eq_true_iff]
+  simp [RedundantBool, Redundant]
+
+end Oak.PatternAnalysisRefinement


### PR DESCRIPTION
## Summary
- model the concrete recursive pattern fragment over finite semantic leaves
- prove executable completion agrees with `Oak.PatternAnalysis.Exhaustive`
- prove bounded witnesses are sound counterexamples
- prove the concrete redundancy decision agrees with the abstract relation
- record the deliberately scoped refinement boundary in the status matrix

## Verification
- CI and the pinned Lean 4.33.1 formal build are required before merge

Open scalar domains and representation-level extraction from Go maps remain outside this scoped refinement claim.