### PR TITLE
Derive conservative generalization safety facts

### DIFF
--- a/.github/workflows/generalization.yml
+++ b/.github/workflows/generalization.yml
@@ -12,6 +12,13 @@ jobs:
           go-version: '1.27.1'
       - name: Test typechecker
         run: go test -race ./typechecker
+      - name: Test generic ring integration
+        run: go test ./compiler -run '^TestE2EStdlibRing
+        if: always()
+        run: |
+          gofmt -d typechecker/typechecker.go typechecker/hm.go typechecker/generalization.go typechecker/generalization_test.go typechecker/pattern_generalization_test.go typechecker/genericfn.go typechecker/generic_constraints.go typechecker/gadt.go
+          test -z "$(gofmt -l typechecker/typechecker.go typechecker/hm.go typechecker/generalization.go typechecker/generalization_test.go typechecker/pattern_generalization_test.go typechecker/genericfn.go typechecker/generic_constraints.go typechecker/gadt.go)"
+ -count=1
       - name: Check formatting
         if: always()
         run: |

--- a/.github/workflows/generalization.yml
+++ b/.github/workflows/generalization.yml
@@ -1,0 +1,19 @@
+name: Generalization safety
+on:
+  pull_request:
+    branches: [specification]
+jobs:
+  generalization:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.27.1'
+      - name: Test typechecker
+        run: go test -race ./typechecker
+      - name: Check formatting
+        if: always()
+        run: |
+          gofmt -d typechecker/typechecker.go typechecker/hm.go typechecker/generalization.go typechecker/generalization_test.go typechecker/pattern_generalization_test.go typechecker/genericfn.go typechecker/generic_constraints.go typechecker/gadt.go
+          test -z "$(gofmt -l typechecker/typechecker.go typechecker/hm.go typechecker/generalization.go typechecker/generalization_test.go typechecker/pattern_generalization_test.go typechecker/genericfn.go typechecker/generic_constraints.go typechecker/gadt.go)"

--- a/.github/workflows/generalization.yml
+++ b/.github/workflows/generalization.yml
@@ -13,12 +13,7 @@ jobs:
       - name: Test typechecker
         run: go test -race ./typechecker
       - name: Test generic ring integration
-        run: go test ./compiler -run '^TestE2EStdlibRing
-        if: always()
-        run: |
-          gofmt -d typechecker/typechecker.go typechecker/hm.go typechecker/generalization.go typechecker/generalization_test.go typechecker/pattern_generalization_test.go typechecker/genericfn.go typechecker/generic_constraints.go typechecker/gadt.go
-          test -z "$(gofmt -l typechecker/typechecker.go typechecker/hm.go typechecker/generalization.go typechecker/generalization_test.go typechecker/pattern_generalization_test.go typechecker/genericfn.go typechecker/generic_constraints.go typechecker/gadt.go)"
- -count=1
+        run: go test ./compiler -run '^TestE2EStdlibRing$' -count=1
       - name: Check formatting
         if: always()
         run: |

--- a/docs/spec/25-type-inference.md
+++ b/docs/spec/25-type-inference.md
@@ -228,6 +228,12 @@ not count as captured authority; only the function value's environment does.
 This rule is deliberately fail-closed while effect summaries and compiler-wide
 region identities are being threaded through type schemes.
 
+Writes through a function's parameters or fresh local storage do not by themselves
+capture authority at the function binding. Such helpers may specialize for
+multiple concrete input types; each caller still supplies separately checked
+storage and borrowing obligations. Writes rooted in outer bindings retain the
+corresponding captured-authority barriers.
+
 ## 8. Constraints and refinements extend inference
 
 Inference may produce obligations in addition to equalities.

--- a/docs/spec/25-type-inference.md
+++ b/docs/spec/25-type-inference.md
@@ -208,6 +208,26 @@ external/MMIO authority                   -> preserve authority identity
 This keeps inference powerful without reproducing polymorphic-reference or
 capability-duplication unsoundness in an imperative systems language.
 
+The initial implementation derives conservative evidence at each local variable or named-function binding:
+
+- owned arrays contribute mutable and unique authority;
+- views contribute a region-bound barrier;
+- spans contribute mutable, unique, and region-bound barriers;
+- raw pointer-sized values contribute external and unresolved authority;
+- closures contribute the authority of referenced outer bindings and any
+  lexically contained unsafe assumption;
+- invocation initializers contribute effectful and unresolved evidence until
+  their callee carries a checked effect summary.
+
+Evidence is joined monotonically: later analysis may add barriers but must never
+erase an already established one. A blocked scheme retains a shared monomorphic
+substitution: the first successful use that solves a remaining free variable
+fixes that variable for every later use; independent call-site unifiers must not
+reopen it. Function parameter and result types alone do
+not count as captured authority; only the function value's environment does.
+This rule is deliberately fail-closed while effect summaries and compiler-wide
+region identities are being threaded through type schemes.
+
 ## 8. Constraints and refinements extend inference
 
 Inference may produce obligations in addition to equalities.

--- a/spec/lean/Oak/GeneralizationSafety.lean
+++ b/spec/lean/Oak/GeneralizationSafety.lean
@@ -77,4 +77,16 @@ theorem unknown_authority_blocks (inferredType : Nat) (facts : Facts)
     (decideGeneralization inferredType facts).generalized = false := by
   simp [decideGeneralization, h]
 
+/-- Capturing effect authority forbids generalization. -/
+theorem effectful_capture_blocks (inferredType : Nat) (facts : Facts)
+    (h : facts.effectfulCapture = true) :
+    (decideGeneralization inferredType facts).generalized = false := by
+  simp [decideGeneralization, h]
+
+/-- A lexically admitted unsafe assumption cannot be generalized away. -/
+theorem unsafe_assumption_blocks (inferredType : Nat) (facts : Facts)
+    (h : facts.unsafeAssumption = true) :
+    (decideGeneralization inferredType facts).generalized = false := by
+  simp [decideGeneralization, h]
+
 end Oak.GeneralizationSafety

--- a/typechecker/gadt.go
+++ b/typechecker/gadt.go
@@ -111,6 +111,56 @@ func (tc *TypeChecker) instantiateStoredType(spelling string, bindings map[strin
 	return tc.storedIndexType(spelling)
 }
 
+func substituteNamedADTParameters(typ Type, bindings map[string]Type) Type {
+	if typ == nil { return nil }
+	switch t := typ.(type) {
+	case *ADTType:
+		if bound, ok := bindings[t.Name]; ok { return bound }
+		return t
+	case *ArrayType:
+		return &ArrayType{
+			Length: t.Length, IsSlice: t.IsSlice, IsSpan: t.IsSpan,
+			ElementType: substituteNamedADTParameters(t.ElementType, bindings),
+		}
+	case *GenericType:
+		arguments := make([]Type, len(t.TypeArgs))
+		for i, argument := range t.TypeArgs {
+			arguments[i] = substituteNamedADTParameters(argument, bindings)
+		}
+		return &GenericType{Name: t.Name, TypeArgs: arguments}
+	case *RecordType:
+		fields := make(map[string]Type, len(t.Fields))
+		for name, field := range t.Fields {
+			fields[name] = substituteNamedADTParameters(field, bindings)
+		}
+		result := *t
+		result.Fields = fields
+		return &result
+	case *FunctionType:
+		parameters := make([]Type, len(t.Parameters))
+		for i, parameter := range t.Parameters {
+			parameters[i] = substituteNamedADTParameters(parameter, bindings)
+		}
+		return &FunctionType{
+			Parameters: parameters,
+			ReturnType: substituteNamedADTParameters(t.ReturnType, bindings),
+			Variadic: t.Variadic,
+		}
+	default:
+		return typ
+	}
+}
+
+func (tc *TypeChecker) instantiatedVariantPayload(adtName string, variant *object.ADTVariantDef, bindings map[string]Type) Type {
+	if variant == nil || variant.Payload == "" { return nil }
+	if variants := tc.adtPayloadTypes[adtName]; variants != nil {
+		if checked := variants[variant.Name]; checked != nil {
+			return substituteNamedADTParameters(checked, bindings)
+		}
+	}
+	return tc.instantiateStoredType(variant.Payload, bindings)
+}
+
 // variantIndexBindings is the first concrete GADT solver. Constructor-result
 // equations are solved under one accumulated substitution. Named result
 // parameters and fixed positional indices must agree with every prior equation.
@@ -229,6 +279,7 @@ func (tc *TypeChecker) variantResultType(
 	}
 	return &GenericType{Name: adt.Name, TypeArgs: args}
 }
+
 
 func variantResultString(adt *object.ADTType, variant *object.ADTVariantDef) string {
 	name := variant.ResultName

--- a/typechecker/gadt.go
+++ b/typechecker/gadt.go
@@ -112,10 +112,14 @@ func (tc *TypeChecker) instantiateStoredType(spelling string, bindings map[strin
 }
 
 func substituteNamedADTParameters(typ Type, bindings map[string]Type) Type {
-	if typ == nil { return nil }
+	if typ == nil {
+		return nil
+	}
 	switch t := typ.(type) {
 	case *ADTType:
-		if bound, ok := bindings[t.Name]; ok { return bound }
+		if bound, ok := bindings[t.Name]; ok {
+			return bound
+		}
 		return t
 	case *ArrayType:
 		return &ArrayType{
@@ -144,7 +148,7 @@ func substituteNamedADTParameters(typ Type, bindings map[string]Type) Type {
 		return &FunctionType{
 			Parameters: parameters,
 			ReturnType: substituteNamedADTParameters(t.ReturnType, bindings),
-			Variadic: t.Variadic,
+			Variadic:   t.Variadic,
 		}
 	default:
 		return typ
@@ -152,7 +156,9 @@ func substituteNamedADTParameters(typ Type, bindings map[string]Type) Type {
 }
 
 func (tc *TypeChecker) instantiatedVariantPayload(adtName string, variant *object.ADTVariantDef, bindings map[string]Type) Type {
-	if variant == nil || variant.Payload == "" { return nil }
+	if variant == nil || variant.Payload == "" {
+		return nil
+	}
 	if variants := tc.adtPayloadTypes[adtName]; variants != nil {
 		if checked := variants[variant.Name]; checked != nil {
 			return substituteNamedADTParameters(checked, bindings)
@@ -279,7 +285,6 @@ func (tc *TypeChecker) variantResultType(
 	}
 	return &GenericType{Name: adt.Name, TypeArgs: args}
 }
-
 
 func variantResultString(adt *object.ADTType, variant *object.ADTVariantDef) string {
 	name := variant.ResultName

--- a/typechecker/generalization.go
+++ b/typechecker/generalization.go
@@ -161,7 +161,7 @@ func functionCaptureFacts(fn *ast.FunctionLiteral, env *TypeEnvironment) General
 // methodSelectorFacts propagates authority carried by the method implementation
 // while keeping ordinary field selector names out of lexical binding lookup.
 func methodSelectorFacts(selector *ast.IndexExpression, env *TypeEnvironment) GeneralizationFacts {
-	if selector == nil || selector.Token.Literal != "." {
+	if selector == nil || (!selector.Dot && selector.Token.Literal != ".") {
 		return GeneralizationFacts{}
 	}
 	method, ok := selector.Index.(*ast.Identifier)
@@ -247,7 +247,7 @@ func functionCaptureFactsWithBound(fn *ast.FunctionLiteral, env *TypeEnvironment
 			walkExpr(e.Left)
 			// The identifier after '.' is a selector name, not a lexical
 			// variable. Computed array indices still participate in capture.
-			if e.Token.Literal != "." {
+			if !e.Dot && e.Token.Literal != "." {
 				walkExpr(e.Index)
 			}
 		case *ast.SliceExpression:
@@ -264,7 +264,7 @@ func functionCaptureFactsWithBound(fn *ast.FunctionLiteral, env *TypeEnvironment
 			}
 		case *ast.InvocationExpression:
 			if selector, ok := e.Function.(*ast.IndexExpression); ok &&
-				selector.Token.Literal == "." {
+				(selector.Dot || selector.Token.Literal == ".") {
 				if library, ok := selector.Left.(*ast.Identifier); ok && CompilerKnownLibrary(library.Value) {
 					// Compiler libraries are namespaces, not captured values or
 					// authority-bearing method receivers. Their arguments still
@@ -334,8 +334,7 @@ func functionCaptureFactsWithBound(fn *ast.FunctionLiteral, env *TypeEnvironment
 				facts = facts.With(GeneralizationMutableAuthority).With(GeneralizationEffectfulCapture)
 			}
 			if s.Target != nil {
-				walkExpr(s.Target.Left)
-				walkExpr(s.Target.Index)
+				walkExpr(s.Target)
 			}
 			walkExpr(s.Value)
 		case *ast.IfStatement:
@@ -720,7 +719,7 @@ func deriveGeneralizationFacts(typ Type, initializer ast.Expression, env *TypeEn
 			return bindingFacts(e.Payload)
 		case *ast.IndexExpression:
 			result := bindingFacts(e.Left)
-			if e.Token.Literal != "." {
+			if !e.Dot && e.Token.Literal != "." {
 				result.Barriers |= bindingFacts(e.Index).Barriers
 			}
 			return result
@@ -762,8 +761,7 @@ func deriveGeneralizationFacts(typ Type, initializer ast.Expression, env *TypeEn
 				Barriers: GeneralizationMutableAuthority | GeneralizationEffectfulCapture,
 			}
 			if s.Target != nil {
-				result.Barriers |= bindingFacts(s.Target.Left).Barriers
-				result.Barriers |= bindingFacts(s.Target.Index).Barriers
+				result.Barriers |= bindingFacts(s.Target).Barriers
 			}
 			result.Barriers |= bindingFacts(s.Value).Barriers
 			return result
@@ -837,7 +835,7 @@ func deriveGeneralizationFacts(typ Type, initializer ast.Expression, env *TypeEn
 			visitExpr(e.Left)
 			// A dotted identifier is a selector name, not a lexical binding.
 			// Computed indices remain ordinary expressions and propagate metadata.
-			if e.Token.Literal != "." {
+			if !e.Dot && e.Token.Literal != "." {
 				visitExpr(e.Index)
 			}
 		case *ast.SliceExpression:
@@ -925,9 +923,8 @@ func deriveGeneralizationFacts(typ Type, initializer ast.Expression, env *TypeEn
 		case *ast.IndexAssignmentStatement:
 			facts = facts.With(GeneralizationMutableAuthority).With(GeneralizationEffectfulCapture)
 			if s.Target != nil {
-				visitExpr(s.Target.Left)
-				visitExpr(s.Target.Index)
-				facts.Barriers |= bindingFacts(s.Target.Left).Barriers
+				visitExpr(s.Target)
+				facts.Barriers |= bindingFacts(s.Target).Barriers
 			}
 			visitExpr(s.Value)
 			facts.Barriers |= bindingFacts(s.Value).Barriers

--- a/typechecker/generalization.go
+++ b/typechecker/generalization.go
@@ -328,9 +328,11 @@ func functionCaptureFactsWithBound(fn *ast.FunctionLiteral, env *TypeEnvironment
 			}
 			walkExpr(s.Value)
 		case *ast.IndexAssignmentStatement:
-			// An indexed store exercises mutation authority even when the owner is
-			// otherwise mentioned nowhere in the function body.
-			facts = facts.With(GeneralizationMutableAuthority).With(GeneralizationEffectfulCapture)
+			// Writes through parameters or fresh locals do not capture storage.
+			// Writes rooted outside this function retain the outer authority.
+			if s.Target == nil || !locallyBoundStorage(s.Target.Left, bound) {
+				facts = facts.With(GeneralizationMutableAuthority).With(GeneralizationEffectfulCapture)
+			}
 			if s.Target != nil {
 				walkExpr(s.Target.Left)
 				walkExpr(s.Target.Index)
@@ -982,4 +984,17 @@ func deriveGeneralizationFacts(typ Type, initializer ast.Expression, env *TypeEn
 	}
 	visitExpr(initializer)
 	return facts
+}
+
+func locallyBoundStorage(expr ast.Expression, bound map[string]bool) bool {
+	switch e := expr.(type) {
+	case *ast.Identifier:
+		return bound[e.Value]
+	case *ast.IndexExpression:
+		return locallyBoundStorage(e.Left, bound)
+	case *ast.SliceExpression:
+		return locallyBoundStorage(e.Seq, bound)
+	default:
+		return false
+	}
 }

--- a/typechecker/generalization.go
+++ b/typechecker/generalization.go
@@ -83,7 +83,6 @@ func GeneralizeWithFacts(typ Type, env *TypeEnvironment, facts GeneralizationFac
 	return scheme
 }
 
-
 // factsFromType conservatively extracts authority and region evidence already
 // represented by the checker type. It recurses through data containers, but not
 // through function parameters/results: accepting a function value does not
@@ -340,7 +339,9 @@ func functionCaptureFactsWithBound(fn *ast.FunctionLiteral, env *TypeEnvironment
 		case *ast.IfStatement:
 			walkExpr(s.Condition)
 			walkBlock(s.Consequence)
-			if s.Alternative != nil { walkStmt(s.Alternative) }
+			if s.Alternative != nil {
+				walkStmt(s.Alternative)
+			}
 		case *ast.WhileStatement:
 			walkExpr(s.Condition)
 			walkBlock(s.Body)
@@ -399,7 +400,6 @@ func functionCaptureFactsWithBound(fn *ast.FunctionLiteral, env *TypeEnvironment
 	}
 	return facts
 }
-
 
 func generalizationDeclaredType(expr ast.Expression, env *TypeEnvironment) Type {
 	switch e := expr.(type) {
@@ -515,10 +515,14 @@ func conservativePatternBindingFacts(pattern ast.Pattern) map[string]Generalizat
 func (tc *TypeChecker) valueAuthorityFacts(typ Type, visiting map[string]bool) GeneralizationFacts {
 	facts := factsFromType(typ)
 	adtName, _, arguments, ok := adtInstantiation(typ)
-	if !ok { return facts }
+	if !ok {
+		return facts
+	}
 	// Recursive definitions can change their type arguments on every step
 	// (for example Nest[T] -> Nest[[]T]); bound traversal by definition.
-	if visiting[adtName] { return facts }
+	if visiting[adtName] {
+		return facts
+	}
 	visiting[adtName] = true
 	defer delete(visiting, adtName)
 	adt := tc.adtTypes[adtName]
@@ -527,7 +531,9 @@ func (tc *TypeChecker) valueAuthorityFacts(typ Type, visiting map[string]bool) G
 	}
 	for _, variant := range adt.Variants {
 		bindings, _, reachable := tc.variantIndexBindings(adt, variant, arguments)
-		if !reachable { continue }
+		if !reachable {
+			continue
+		}
 		if payload := tc.instantiatedVariantPayload(adtName, variant, bindings); payload != nil {
 			facts.Barriers |= tc.valueAuthorityFacts(payload, visiting).Barriers
 		}
@@ -549,12 +555,18 @@ func (tc *TypeChecker) generalizationPatternBindingFacts(pattern ast.Pattern, ex
 			}
 		case *ast.VariantPattern:
 			adtName, _, arguments, ok := adtInstantiation(currentType)
-			if !ok || p.Variant == nil { return }
+			if !ok || p.Variant == nil {
+				return
+			}
 			adt := tc.adtTypes[adtName]
 			variant, found := tc.findADTVariant(adtName, p.Variant.Value)
-			if adt == nil || !found { return }
+			if adt == nil || !found {
+				return
+			}
 			bindings, _, reachable := tc.variantIndexBindings(adt, variant, arguments)
-			if !reachable { return }
+			if !reachable {
+				return
+			}
 			if p.Payload != nil {
 				visit(p.Payload, tc.instantiatedVariantPayload(adtName, variant, bindings))
 			}
@@ -755,8 +767,12 @@ func deriveGeneralizationFacts(typ Type, initializer ast.Expression, env *TypeEn
 			return result
 		case *ast.IfStatement:
 			result := bindingFacts(s.Condition)
-			if s.Consequence != nil { result.Barriers |= statementBindingFacts(s.Consequence).Barriers }
-			if s.Alternative != nil { result.Barriers |= statementBindingFacts(s.Alternative).Barriers }
+			if s.Consequence != nil {
+				result.Barriers |= statementBindingFacts(s.Consequence).Barriers
+			}
+			if s.Alternative != nil {
+				result.Barriers |= statementBindingFacts(s.Alternative).Barriers
+			}
 			return result
 		case *ast.WhileStatement:
 			result := bindingFacts(s.Condition)
@@ -916,7 +932,9 @@ func deriveGeneralizationFacts(typ Type, initializer ast.Expression, env *TypeEn
 		case *ast.IfStatement:
 			visitExpr(s.Condition)
 			visitBlock(s.Consequence)
-			if s.Alternative != nil { visitStmt(s.Alternative) }
+			if s.Alternative != nil {
+				visitStmt(s.Alternative)
+			}
 		case *ast.WhileStatement:
 			visitExpr(s.Condition)
 			visitBlock(s.Body)

--- a/typechecker/generalization.go
+++ b/typechecker/generalization.go
@@ -1,6 +1,10 @@
 package typechecker
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/SCKelemen/oak/ast"
+)
 
 // GeneralizationBarrier records one reason a locally inferred type must remain
 // monomorphic. Inference may still determine a precise type; this gate controls
@@ -74,9 +78,890 @@ func GeneralizeWithFacts(typ Type, env *TypeEnvironment, facts GeneralizationFac
 	if facts.Safe() {
 		return Generalize(typ, env)
 	}
-	return &TypeScheme{
-		TypeVars:    []string{},
-		Constraints: []Constraint{},
-		Type:        typ,
+	scheme := makeMonomorphicSchemeInEnv(typ, nil, env)
+	scheme.GeneralizationBarriers = facts.Barriers
+	return scheme
+}
+
+
+// factsFromType conservatively extracts authority and region evidence already
+// represented by the checker type. It recurses through data containers, but not
+// through function parameters/results: accepting a function value does not
+// acquire the authority that a future caller may pass to it.
+func factsFromType(typ Type) GeneralizationFacts {
+	facts := GeneralizationFacts{}
+	var visit func(Type)
+	visit = func(current Type) {
+		switch t := current.(type) {
+		case *AtomicType:
+			facts = facts.With(GeneralizationMutableAuthority).With(GeneralizationUniqueAuthority)
+		case *PrimitiveType:
+			if t.Name == "ptr" || t.Name == "uptr" {
+				facts = facts.With(GeneralizationExternalAuthority).With(GeneralizationUnknownAuthority)
+			}
+		case *ArrayType:
+			visit(t.ElementType)
+			if t.IsSpan {
+				facts = facts.With(GeneralizationMutableAuthority).
+					With(GeneralizationUniqueAuthority).
+					With(GeneralizationRegionBound)
+			} else if t.IsSlice {
+				facts = facts.With(GeneralizationRegionBound)
+			} else {
+				facts = facts.With(GeneralizationMutableAuthority).
+					With(GeneralizationUniqueAuthority)
+			}
+		case *RecordType:
+			for _, field := range t.Fields {
+				visit(field)
+			}
+		case *GenericType:
+			for _, arg := range t.TypeArgs {
+				visit(arg)
+			}
+			switch t.Name {
+			case "Arena":
+				facts = facts.With(GeneralizationUniqueAuthority).With(GeneralizationRegionBound)
+			case "View":
+				facts = facts.With(GeneralizationRegionBound)
+			case "Span":
+				facts = facts.With(GeneralizationMutableAuthority).
+					With(GeneralizationUniqueAuthority).
+					With(GeneralizationRegionBound)
+			case "Mmio", "MMIO":
+				facts = facts.With(GeneralizationExternalAuthority)
+			}
+		case *NarrowedADTVariantType:
+			for _, arg := range t.TypeArgs {
+				visit(arg)
+			}
+		case *UnionType:
+			for _, member := range t.Types {
+				visit(member)
+			}
+		case *IntersectionType:
+			for _, member := range t.Types {
+				visit(member)
+			}
+		}
 	}
+	if typ != nil {
+		visit(typ)
+	}
+	return facts
+}
+
+// functionCaptureFacts identifies outer bindings referenced by a closure.
+// Oak bindings are assignable, so capturing one preserves mutable authority;
+// contained view/span/raw-pointer types add their more specific evidence.
+// Unsafe assumptions are lexically visible in the captured function body.
+func functionCaptureFacts(fn *ast.FunctionLiteral, env *TypeEnvironment) GeneralizationFacts {
+	return functionCaptureFactsWithBound(fn, env, nil)
+}
+
+// methodSelectorFacts propagates authority carried by the method implementation
+// while keeping ordinary field selector names out of lexical binding lookup.
+func methodSelectorFacts(selector *ast.IndexExpression, env *TypeEnvironment) GeneralizationFacts {
+	if selector == nil || selector.Token.Literal != "." {
+		return GeneralizationFacts{}
+	}
+	method, ok := selector.Index.(*ast.Identifier)
+	if !ok {
+		return GeneralizationFacts{Barriers: GeneralizationUnknownAuthority}
+	}
+	receiverType := generalizationExpressionType(selector.Left, env)
+	adt, ok := receiverType.(*ADTType)
+	if !ok {
+		return GeneralizationFacts{Barriers: GeneralizationUnknownAuthority}
+	}
+	scheme, found := env.Get(adt.Name + "::" + method.Value)
+	if !found || scheme == nil {
+		return GeneralizationFacts{Barriers: GeneralizationUnknownAuthority}
+	}
+	return GeneralizationFacts{Barriers: scheme.GeneralizationBarriers}
+}
+
+func generalizationExpressionType(expr ast.Expression, env *TypeEnvironment) Type {
+	switch e := expr.(type) {
+	case *ast.Identifier:
+		if scheme, found := env.Get(e.Value); found && scheme != nil {
+			return scheme.Monomorphic.Apply(scheme.Type)
+		}
+		if typ, found := env.GetType(e.Value); found {
+			return typ
+		}
+	case *ast.InvocationExpression:
+		if ident, ok := e.Function.(*ast.Identifier); ok {
+			if scheme, found := env.Get(ident.Value); found && scheme != nil {
+				if fn, ok := scheme.Monomorphic.Apply(scheme.Type).(*FunctionType); ok {
+					return fn.ReturnType
+				}
+			}
+		}
+		if selector, ok := e.Function.(*ast.IndexExpression); ok {
+			if receiver, ok := generalizationExpressionType(selector.Left, env).(*ADTType); ok {
+				if method, ok := selector.Index.(*ast.Identifier); ok {
+					if scheme, found := env.Get(receiver.Name + "::" + method.Value); found && scheme != nil {
+						if fn, ok := scheme.Monomorphic.Apply(scheme.Type).(*FunctionType); ok {
+							return fn.ReturnType
+						}
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func functionCaptureFactsWithBound(fn *ast.FunctionLiteral, env *TypeEnvironment, outerBound map[string]bool) GeneralizationFacts {
+	facts := GeneralizationFacts{}
+	if fn == nil || fn.Body == nil {
+		return facts
+	}
+	bound := make(map[string]bool, len(outerBound)+len(fn.Arguments))
+	for name, isBound := range outerBound {
+		if isBound {
+			bound[name] = true
+		}
+	}
+	for _, arg := range fn.Arguments {
+		if arg != nil {
+			bound[arg.Value] = true
+		}
+	}
+	referenced := make(map[string]bool)
+	var walkExpr func(ast.Expression)
+	var walkStmt func(ast.Statement)
+	var walkBlock func(*ast.BlockStatement)
+	walkExpr = func(expr ast.Expression) {
+		switch e := expr.(type) {
+		case *ast.Identifier:
+			if !bound[e.Value] {
+				referenced[e.Value] = true
+			}
+		case *ast.PrefixExpression:
+			walkExpr(e.Right)
+		case *ast.InfixExpression:
+			walkExpr(e.Left)
+			walkExpr(e.Right)
+		case *ast.IndexExpression:
+			walkExpr(e.Left)
+			// The identifier after '.' is a selector name, not a lexical
+			// variable. Computed array indices still participate in capture.
+			if e.Token.Literal != "." {
+				walkExpr(e.Index)
+			}
+		case *ast.SliceExpression:
+			walkExpr(e.Seq)
+			walkExpr(e.Low)
+			walkExpr(e.High)
+		case *ast.ArrayLiteral:
+			for _, element := range e.Elements {
+				walkExpr(element)
+			}
+		case *ast.RecordLiteral:
+			for _, field := range e.OrderedFields() {
+				walkExpr(field.Value)
+			}
+		case *ast.InvocationExpression:
+			if selector, ok := e.Function.(*ast.IndexExpression); ok &&
+				selector.Token.Literal == "." {
+				if library, ok := selector.Left.(*ast.Identifier); ok && CompilerKnownLibrary(library.Value) {
+					// Compiler libraries are namespaces, not captured values or
+					// authority-bearing method receivers. Their arguments still
+					// participate in ordinary capture analysis.
+					for _, argument := range e.Arguments {
+						walkExpr(argument)
+					}
+					return
+				}
+				facts.Barriers |= methodSelectorFacts(selector, env).Barriers
+			}
+			walkExpr(e.Function)
+			for _, argument := range e.Arguments {
+				walkExpr(argument)
+			}
+		case *ast.BlockExpression:
+			walkBlock(e.Block)
+		case *ast.MatchExpression:
+			walkExpr(e.Scrutinee)
+			for _, arm := range e.Arms {
+				if arm == nil {
+					continue
+				}
+				names := patternBindingNames(arm.Pattern)
+				previous := make(map[string]bool, len(names))
+				for _, name := range names {
+					previous[name] = bound[name]
+					bound[name] = true
+				}
+				walkExpr(arm.Body)
+				for _, name := range names {
+					if previous[name] {
+						bound[name] = true
+					} else {
+						delete(bound, name)
+					}
+				}
+			}
+		case *ast.VariantExpression:
+			walkExpr(e.Payload)
+		case *ast.FunctionLiteral:
+			nested := functionCaptureFactsWithBound(e, env, bound)
+			facts.Barriers |= nested.Barriers
+		}
+	}
+	walkStmt = func(stmt ast.Statement) {
+		switch s := stmt.(type) {
+		case *ast.ExpressionStatement:
+			walkExpr(s.Expression)
+		case *ast.VariableDeclaration:
+			walkExpr(s.Value)
+			if s.Name != nil {
+				bound[s.Name.Value] = true
+				if typ := generalizationDeclaredType(s.Type, env); typ != nil {
+					env.SetType(s.Name.Value, typ)
+				}
+			}
+		case *ast.AssignmentStatement:
+			if s.Name != nil && !bound[s.Name.Value] {
+				referenced[s.Name.Value] = true
+			}
+			walkExpr(s.Value)
+		case *ast.IndexAssignmentStatement:
+			// An indexed store exercises mutation authority even when the owner is
+			// otherwise mentioned nowhere in the function body.
+			facts = facts.With(GeneralizationMutableAuthority).With(GeneralizationEffectfulCapture)
+			if s.Target != nil {
+				walkExpr(s.Target.Left)
+				walkExpr(s.Target.Index)
+			}
+			walkExpr(s.Value)
+		case *ast.IfStatement:
+			walkExpr(s.Condition)
+			walkBlock(s.Consequence)
+			if s.Alternative != nil { walkStmt(s.Alternative) }
+		case *ast.WhileStatement:
+			walkExpr(s.Condition)
+			walkBlock(s.Body)
+		case *ast.BlockStatement:
+			walkBlock(s)
+		case *ast.FunctionStatement:
+			if s.Name != nil {
+				bound[s.Name.Value] = true
+			}
+			nested := functionStatementCaptureFactsWithBound(s, env, bound)
+			facts.Barriers |= nested.Barriers
+		case *ast.UnsafeBlock:
+			facts = facts.With(GeneralizationUnsafeAssumption)
+			walkBlock(s.Body)
+		}
+	}
+	walkBlock = func(block *ast.BlockStatement) {
+		if block == nil {
+			return
+		}
+		outer := bound
+		outerEnv := env
+		bound = make(map[string]bool, len(outer))
+		for name, isBound := range outer {
+			bound[name] = isBound
+		}
+		env = NewEnclosedTypeEnvironment(outerEnv)
+		for _, statement := range block.Statements {
+			walkStmt(statement)
+		}
+		env = outerEnv
+		bound = outer
+	}
+	walkBlock(fn.Body)
+	for name := range referenced {
+		scheme, ok := env.Get(name)
+		if !ok || scheme == nil {
+			// Type constructors and compiler intrinsics are stateless language
+			// operations, not captured values. Other missing capture metadata
+			// cannot prove safety during forward summary construction.
+			if _, isType := env.GetType(name); isType || isNonCapturingBuiltin(name) {
+				continue
+			}
+			facts = facts.With(GeneralizationUnknownAuthority)
+			continue
+		}
+		// An ordinary named function is a direct code pointer, not an
+		// environment capture. A blocked function scheme remains
+		// conservative because it may carry captured authority.
+		if _, isFunction := scheme.Type.(*FunctionType); isFunction && scheme.GeneralizationBarriers == 0 {
+			continue
+		}
+		facts = facts.With(GeneralizationMutableAuthority)
+		facts.Barriers |= scheme.GeneralizationBarriers
+		facts.Barriers |= factsFromType(scheme.Type).Barriers
+	}
+	return facts
+}
+
+
+func generalizationDeclaredType(expr ast.Expression, env *TypeEnvironment) Type {
+	switch e := expr.(type) {
+	case *ast.Identifier:
+		if typ, ok := env.GetType(e.Value); ok {
+			return typ
+		}
+		switch e.Value {
+		case "string":
+			return &StringType{}
+		case "Bool":
+			return &BoolType{}
+		case "i8", "i16", "i32", "i64", "u8", "u16", "u32", "u64",
+			"int", "uint", "ptr", "uptr", "byte", "rune":
+			return &PrimitiveType{Name: e.Value}
+		default:
+			if e.Value != "" {
+				return &ADTType{Name: e.Value}
+			}
+		}
+	case *ast.IndexExpression:
+		element := generalizationDeclaredType(e.Left, env)
+		if element == nil {
+			return nil
+		}
+		switch marker := e.Index.(type) {
+		case *ast.IntegerLiteral:
+			return &ArrayType{Length: marker.Value, ElementType: element}
+		case *ast.Identifier:
+			if marker.Value == "" {
+				return &ArrayType{Length: -1, IsSlice: true, ElementType: element}
+			}
+			if marker.Value == "*" {
+				return &ArrayType{Length: -1, IsSpan: true, ElementType: element}
+			}
+		}
+	}
+	return nil
+}
+
+func isNonCapturingBuiltin(name string) bool {
+	switch name {
+	case "u8", "u16", "u32", "u64",
+		"i8", "i16", "i32", "i64",
+		"int", "uint", "ptr", "uptr", "byte", "rune", "string",
+		"view_as", "span_as", "view", "span", "subslice",
+		"len", "is_valid_utf8", "assert":
+		return true
+	}
+	return splitNarrowingFunctionName(name) != nil
+}
+
+func patternBindingNames(pattern ast.Pattern) []string {
+	var names []string
+	var visit func(ast.Pattern)
+	visit = func(current ast.Pattern) {
+		switch p := current.(type) {
+		case *ast.BindingPattern:
+			if p.Name != nil {
+				names = append(names, p.Name.Value)
+			}
+		case *ast.VariantPattern:
+			visit(p.Payload)
+		}
+	}
+	visit(pattern)
+	return names
+}
+
+// functionStatementCaptureFacts treats a named function declaration as the
+// closure value it creates. Its name, receiver, and parameters are local binders;
+// references outside that set are captures from the surrounding environment.
+func functionStatementCaptureFacts(fn *ast.FunctionStatement, env *TypeEnvironment) GeneralizationFacts {
+	return functionStatementCaptureFactsWithBound(fn, env, nil)
+}
+
+func functionStatementCaptureFactsWithBound(fn *ast.FunctionStatement, env *TypeEnvironment, outerBound map[string]bool) GeneralizationFacts {
+	if fn == nil {
+		return GeneralizationFacts{}
+	}
+	arguments := make([]*ast.Identifier, 0, len(fn.Parameters)+2)
+	if fn.Name != nil {
+		arguments = append(arguments, fn.Name)
+	}
+	if fn.Receiver != nil && fn.Receiver.Name != nil {
+		arguments = append(arguments, fn.Receiver.Name)
+	}
+	for _, parameter := range fn.Parameters {
+		if parameter != nil && parameter.Name != nil {
+			arguments = append(arguments, parameter.Name)
+		}
+	}
+	var body *ast.BlockStatement
+	if block, ok := fn.Body.(*ast.BlockExpression); ok {
+		body = block.Block
+	} else if fn.Body != nil {
+		body = &ast.BlockStatement{Statements: []ast.Statement{
+			&ast.ExpressionStatement{Expression: fn.Body},
+		}}
+	}
+	return functionCaptureFactsWithBound(&ast.FunctionLiteral{Arguments: arguments, Body: body}, env, outerBound)
+}
+
+func conservativePatternBindingFacts(pattern ast.Pattern) map[string]GeneralizationFacts {
+	result := make(map[string]GeneralizationFacts)
+	unknown := GeneralizationFacts{Barriers: GeneralizationUnknownAuthority}
+	for _, name := range patternBindingNames(pattern) {
+		result[name] = unknown
+	}
+	return result
+}
+
+func (tc *TypeChecker) valueAuthorityFacts(typ Type, visiting map[string]bool) GeneralizationFacts {
+	facts := factsFromType(typ)
+	adtName, _, arguments, ok := adtInstantiation(typ)
+	if !ok { return facts }
+	// Recursive definitions can change their type arguments on every step
+	// (for example Nest[T] -> Nest[[]T]); bound traversal by definition.
+	if visiting[adtName] { return facts }
+	visiting[adtName] = true
+	defer delete(visiting, adtName)
+	adt := tc.adtTypes[adtName]
+	if adt == nil {
+		return facts.With(GeneralizationUnknownAuthority)
+	}
+	for _, variant := range adt.Variants {
+		bindings, _, reachable := tc.variantIndexBindings(adt, variant, arguments)
+		if !reachable { continue }
+		if payload := tc.instantiatedVariantPayload(adtName, variant, bindings); payload != nil {
+			facts.Barriers |= tc.valueAuthorityFacts(payload, visiting).Barriers
+		}
+	}
+	return facts
+}
+
+func (tc *TypeChecker) generalizationPatternBindingFacts(pattern ast.Pattern, expected Type) map[string]GeneralizationFacts {
+	if expected == nil {
+		return conservativePatternBindingFacts(pattern)
+	}
+	result := make(map[string]GeneralizationFacts)
+	var visit func(ast.Pattern, Type)
+	visit = func(current ast.Pattern, currentType Type) {
+		switch p := current.(type) {
+		case *ast.BindingPattern:
+			if p.Name != nil {
+				result[p.Name.Value] = tc.valueAuthorityFacts(currentType, make(map[string]bool))
+			}
+		case *ast.VariantPattern:
+			adtName, _, arguments, ok := adtInstantiation(currentType)
+			if !ok || p.Variant == nil { return }
+			adt := tc.adtTypes[adtName]
+			variant, found := tc.findADTVariant(adtName, p.Variant.Value)
+			if adt == nil || !found { return }
+			bindings, _, reachable := tc.variantIndexBindings(adt, variant, arguments)
+			if !reachable { return }
+			if p.Payload != nil {
+				visit(p.Payload, tc.instantiatedVariantPayload(adtName, variant, bindings))
+			}
+		}
+	}
+	visit(pattern, expected)
+	return result
+}
+
+// deriveGeneralizationFacts joins evidence from the inferred value shape and
+// initializer evaluation. Unknown calls fail closed until effect summaries are
+// carried in TypeScheme; closure bodies contribute captured authority rather
+// than being treated as immediately executed effects.
+func deriveGeneralizationFacts(typ Type, initializer ast.Expression, env *TypeEnvironment, checkers ...*TypeChecker) GeneralizationFacts {
+	facts := factsFromType(typ)
+	var checker *TypeChecker
+	if len(checkers) > 0 {
+		checker = checkers[0]
+	}
+	metadataBound := make(map[string]bool)
+	localFacts := make(map[string]GeneralizationFacts)
+	var captureScope func() (*TypeEnvironment, map[string]bool)
+	var matchPatternFacts func(*ast.MatchExpression, ast.Pattern) map[string]GeneralizationFacts
+	var bindingFacts func(ast.Expression) GeneralizationFacts
+	var statementBindingFacts func(ast.Statement) GeneralizationFacts
+	var visitExpr func(ast.Expression)
+	var visitStmt func(ast.Statement)
+	var visitBlock func(*ast.BlockStatement)
+
+	captureScope = func() (*TypeEnvironment, map[string]bool) {
+		scopedEnv := NewEnclosedTypeEnvironment(env)
+		bound := make(map[string]bool, len(metadataBound))
+		for name, isBound := range metadataBound {
+			bound[name] = isBound
+		}
+		for name, local := range localFacts {
+			if local.Safe() {
+				continue
+			}
+			// Authority-bearing locals are genuine captures. Expose their
+			// facts through a scoped synthetic scheme and stop suppressing
+			// their names as mere lexical shadows.
+			scopedEnv.Set(name, &TypeScheme{
+				Type:                   &UnitType{},
+				GeneralizationBarriers: local.Barriers,
+			})
+			delete(bound, name)
+		}
+		return scopedEnv, bound
+	}
+
+	matchPatternFacts = func(match *ast.MatchExpression, pattern ast.Pattern) map[string]GeneralizationFacts {
+		// The compatibility entry point without a checker preserves the original
+		// lexical-shadow behavior used by isolated fact-analysis callers.
+		if checker == nil {
+			return map[string]GeneralizationFacts{}
+		}
+		if match == nil {
+			return conservativePatternBindingFacts(pattern)
+		}
+		identifier, ok := match.Scrutinee.(*ast.Identifier)
+		if !ok {
+			return conservativePatternBindingFacts(pattern)
+		}
+		if metadataBound[identifier.Value] {
+			// A current lexical binder shadows any homonymous outer scheme. Until
+			// local semantic types are retained here, fail closed on its payload.
+			return conservativePatternBindingFacts(pattern)
+		}
+		scheme, ok := env.Get(identifier.Value)
+		if !ok || scheme == nil {
+			return conservativePatternBindingFacts(pattern)
+		}
+		return checker.generalizationPatternBindingFacts(pattern, scheme.Type)
+	}
+
+	bindingFacts = func(expr ast.Expression) GeneralizationFacts {
+		switch e := expr.(type) {
+		case *ast.Identifier:
+			if local, ok := localFacts[e.Value]; ok {
+				return local
+			}
+			if metadataBound[e.Value] {
+				return GeneralizationFacts{}
+			}
+			if scheme, ok := env.Get(e.Value); ok && scheme != nil {
+				result := factsFromType(scheme.Type)
+				result.Barriers |= scheme.GeneralizationBarriers
+				return result
+			}
+		case *ast.ArrayLiteral:
+			result := GeneralizationFacts{Barriers: GeneralizationMutableAuthority}
+			for _, element := range e.Elements {
+				result.Barriers |= bindingFacts(element).Barriers
+			}
+			return result
+		case *ast.RecordLiteral:
+			result := GeneralizationFacts{}
+			for _, field := range e.OrderedFields() {
+				result.Barriers |= bindingFacts(field.Value).Barriers
+			}
+			return result
+		case *ast.BlockExpression:
+			result := GeneralizationFacts{}
+			if e.Block != nil {
+				for _, statement := range e.Block.Statements {
+					result.Barriers |= statementBindingFacts(statement).Barriers
+				}
+			}
+			return result
+		case *ast.MatchExpression:
+			result := bindingFacts(e.Scrutinee)
+			namesByArm := make([][]string, len(e.Arms))
+			for i, arm := range e.Arms {
+				if arm == nil {
+					continue
+				}
+				namesByArm[i] = patternBindingNames(arm.Pattern)
+				armFacts := matchPatternFacts(e, arm.Pattern)
+				previous := make(map[string]bool, len(namesByArm[i]))
+				previousFacts := make(map[string]GeneralizationFacts, len(namesByArm[i]))
+				hadFacts := make(map[string]bool, len(namesByArm[i]))
+				for _, name := range namesByArm[i] {
+					previous[name] = metadataBound[name]
+					previousFacts[name], hadFacts[name] = localFacts[name]
+					metadataBound[name] = true
+					if payloadFacts, ok := armFacts[name]; ok {
+						localFacts[name] = payloadFacts
+					} else {
+						delete(localFacts, name)
+					}
+				}
+				result.Barriers |= bindingFacts(arm.Body).Barriers
+				for _, name := range namesByArm[i] {
+					if previous[name] {
+						metadataBound[name] = true
+					} else {
+						delete(metadataBound, name)
+					}
+					if hadFacts[name] {
+						localFacts[name] = previousFacts[name]
+					} else {
+						delete(localFacts, name)
+					}
+				}
+			}
+			return result
+		case *ast.VariantExpression:
+			return bindingFacts(e.Payload)
+		case *ast.IndexExpression:
+			result := bindingFacts(e.Left)
+			if e.Token.Literal != "." {
+				result.Barriers |= bindingFacts(e.Index).Barriers
+			}
+			return result
+		case *ast.InfixExpression:
+			result := bindingFacts(e.Left)
+			result.Barriers |= bindingFacts(e.Right).Barriers
+			return result
+		case *ast.SliceExpression:
+			result := bindingFacts(e.Seq)
+			result.Barriers |= GeneralizationRegionBound
+			return result
+		case *ast.PrefixExpression:
+			result := bindingFacts(e.Right)
+			if e.Operator == "&" {
+				result.Barriers |= GeneralizationExternalAuthority
+			}
+			return result
+		case *ast.FunctionLiteral:
+			scopedEnv, bound := captureScope()
+			return functionCaptureFactsWithBound(e, scopedEnv, bound)
+		case *ast.InvocationExpression:
+			return GeneralizationFacts{
+				Barriers: GeneralizationEffectfulCapture | GeneralizationUnknownAuthority,
+			}
+		}
+		return GeneralizationFacts{}
+	}
+
+	statementBindingFacts = func(stmt ast.Statement) GeneralizationFacts {
+		switch s := stmt.(type) {
+		case *ast.ExpressionStatement:
+			return bindingFacts(s.Expression)
+		case *ast.VariableDeclaration:
+			return bindingFacts(s.Value)
+		case *ast.AssignmentStatement:
+			return bindingFacts(s.Value)
+		case *ast.IndexAssignmentStatement:
+			result := GeneralizationFacts{
+				Barriers: GeneralizationMutableAuthority | GeneralizationEffectfulCapture,
+			}
+			if s.Target != nil {
+				result.Barriers |= bindingFacts(s.Target.Left).Barriers
+				result.Barriers |= bindingFacts(s.Target.Index).Barriers
+			}
+			result.Barriers |= bindingFacts(s.Value).Barriers
+			return result
+		case *ast.IfStatement:
+			result := bindingFacts(s.Condition)
+			if s.Consequence != nil { result.Barriers |= statementBindingFacts(s.Consequence).Barriers }
+			if s.Alternative != nil { result.Barriers |= statementBindingFacts(s.Alternative).Barriers }
+			return result
+		case *ast.WhileStatement:
+			result := bindingFacts(s.Condition)
+			if s.Body != nil {
+				for _, inner := range s.Body.Statements {
+					result.Barriers |= statementBindingFacts(inner).Barriers
+				}
+			}
+			return result
+		case *ast.BlockStatement:
+			result := GeneralizationFacts{}
+			for _, inner := range s.Statements {
+				result.Barriers |= statementBindingFacts(inner).Barriers
+			}
+			return result
+		case *ast.UnsafeBlock:
+			result := GeneralizationFacts{Barriers: GeneralizationUnsafeAssumption}
+			if s.Body != nil {
+				for _, inner := range s.Body.Statements {
+					result.Barriers |= statementBindingFacts(inner).Barriers
+				}
+			}
+			return result
+		case *ast.FunctionStatement:
+			scopedEnv, bound := captureScope()
+			return functionStatementCaptureFactsWithBound(s, scopedEnv, bound)
+		}
+		return GeneralizationFacts{}
+	}
+
+	visitExpr = func(expr ast.Expression) {
+		switch e := expr.(type) {
+		case nil:
+			return
+		case *ast.Identifier:
+			if metadataBound[e.Value] {
+				if local, ok := localFacts[e.Value]; ok {
+					facts.Barriers |= local.Barriers
+				}
+				return
+			}
+			if scheme, ok := env.Get(e.Value); ok && scheme != nil {
+				facts.Barriers |= scheme.GeneralizationBarriers
+			}
+		case *ast.FunctionLiteral:
+			scopedEnv, bound := captureScope()
+			facts.Barriers |= functionCaptureFactsWithBound(e, scopedEnv, bound).Barriers
+		case *ast.InvocationExpression:
+			facts = facts.With(GeneralizationEffectfulCapture).With(GeneralizationUnknownAuthority)
+			visitExpr(e.Function)
+			for _, argument := range e.Arguments {
+				visitExpr(argument)
+			}
+		case *ast.PrefixExpression:
+			visitExpr(e.Right)
+		case *ast.InfixExpression:
+			visitExpr(e.Left)
+			visitExpr(e.Right)
+		case *ast.IndexExpression:
+			visitExpr(e.Left)
+			// A dotted identifier is a selector name, not a lexical binding.
+			// Computed indices remain ordinary expressions and propagate metadata.
+			if e.Token.Literal != "." {
+				visitExpr(e.Index)
+			}
+		case *ast.SliceExpression:
+			visitExpr(e.Seq)
+			visitExpr(e.Low)
+			visitExpr(e.High)
+		case *ast.ArrayLiteral:
+			for _, element := range e.Elements {
+				visitExpr(element)
+			}
+		case *ast.RecordLiteral:
+			for _, field := range e.OrderedFields() {
+				visitExpr(field.Value)
+			}
+		case *ast.BlockExpression:
+			visitBlock(e.Block)
+		case *ast.MatchExpression:
+			visitExpr(e.Scrutinee)
+			for _, arm := range e.Arms {
+				if arm == nil {
+					continue
+				}
+				names := patternBindingNames(arm.Pattern)
+				armFacts := matchPatternFacts(e, arm.Pattern)
+				previousBound := make(map[string]bool, len(names))
+				previousFacts := make(map[string]GeneralizationFacts, len(names))
+				hadFacts := make(map[string]bool, len(names))
+				for _, name := range names {
+					previousBound[name] = metadataBound[name]
+					previousFacts[name], hadFacts[name] = localFacts[name]
+					metadataBound[name] = true
+					if payloadFacts, ok := armFacts[name]; ok {
+						localFacts[name] = payloadFacts
+					} else {
+						delete(localFacts, name)
+					}
+				}
+				visitExpr(arm.Body)
+				for _, name := range names {
+					if previousBound[name] {
+						metadataBound[name] = true
+					} else {
+						delete(metadataBound, name)
+					}
+					if hadFacts[name] {
+						localFacts[name] = previousFacts[name]
+					} else {
+						delete(localFacts, name)
+					}
+				}
+			}
+		case *ast.VariantExpression:
+			visitExpr(e.Payload)
+		}
+	}
+	visitStmt = func(stmt ast.Statement) {
+		switch s := stmt.(type) {
+		case *ast.ExpressionStatement:
+			visitExpr(s.Expression)
+		case *ast.VariableDeclaration:
+			visitExpr(s.Value)
+			if s.Name != nil {
+				metadataBound[s.Name.Value] = true
+				localFacts[s.Name.Value] = bindingFacts(s.Value)
+			}
+		case *ast.AssignmentStatement:
+			visitExpr(s.Value)
+			assigned := bindingFacts(s.Value)
+			if s.Name != nil && metadataBound[s.Name.Value] {
+				local := localFacts[s.Name.Value]
+				local.Barriers |= assigned.Barriers
+				localFacts[s.Name.Value] = local
+				break
+			}
+			if s.Name != nil {
+				// Updating an outer binding is itself an effectful mutable
+				// capture, independently of the authority carried by the RHS.
+				facts = facts.With(GeneralizationMutableAuthority).With(GeneralizationEffectfulCapture)
+				facts.Barriers |= assigned.Barriers
+				if scheme, ok := env.Get(s.Name.Value); ok && scheme != nil {
+					facts.Barriers |= scheme.GeneralizationBarriers
+					facts.Barriers |= factsFromType(scheme.Type).Barriers
+				}
+			}
+		case *ast.IndexAssignmentStatement:
+			facts = facts.With(GeneralizationMutableAuthority).With(GeneralizationEffectfulCapture)
+			if s.Target != nil {
+				visitExpr(s.Target.Left)
+				visitExpr(s.Target.Index)
+				facts.Barriers |= bindingFacts(s.Target.Left).Barriers
+			}
+			visitExpr(s.Value)
+			facts.Barriers |= bindingFacts(s.Value).Barriers
+		case *ast.IfStatement:
+			visitExpr(s.Condition)
+			visitBlock(s.Consequence)
+			if s.Alternative != nil { visitStmt(s.Alternative) }
+		case *ast.WhileStatement:
+			visitExpr(s.Condition)
+			visitBlock(s.Body)
+		case *ast.BlockStatement:
+			visitBlock(s)
+		case *ast.UnsafeBlock:
+			facts = facts.With(GeneralizationUnsafeAssumption)
+			visitBlock(s.Body)
+		case *ast.FunctionStatement:
+			scopedEnv, bound := captureScope()
+			functionFacts := functionStatementCaptureFactsWithBound(s, scopedEnv, bound)
+			facts.Barriers |= functionFacts.Barriers
+			if s.Name != nil {
+				metadataBound[s.Name.Value] = true
+				localFacts[s.Name.Value] = functionFacts
+			}
+		}
+	}
+	visitBlock = func(block *ast.BlockStatement) {
+		if block == nil {
+			return
+		}
+		outerBound := metadataBound
+		outerFacts := localFacts
+		metadataBound = make(map[string]bool, len(outerBound))
+		localFacts = make(map[string]GeneralizationFacts, len(outerFacts))
+		for name, isBound := range outerBound {
+			metadataBound[name] = isBound
+		}
+		for name, local := range outerFacts {
+			localFacts[name] = local
+		}
+		for _, statement := range block.Statements {
+			visitStmt(statement)
+		}
+		// New nested declarations leave with the block, but authority updates
+		// to inherited locals are monotone dataflow facts and survive scope exit.
+		for name := range outerBound {
+			if updated, ok := localFacts[name]; ok {
+				outerFacts[name] = updated
+			}
+		}
+		metadataBound = outerBound
+		localFacts = outerFacts
+	}
+	visitExpr(initializer)
+	return facts
 }

--- a/typechecker/generalization_test.go
+++ b/typechecker/generalization_test.go
@@ -150,7 +150,6 @@ func TestClosedFunctionLiteralAddsNoAuthorityBarrier(t *testing.T) {
 	}
 }
 
-
 func TestNestedNamedClosureContributesOuterCaptureFacts(t *testing.T) {
 	tc := New(nilObjectEnvironment())
 	element := NewUnifier().FreshTypeVar("T")
@@ -173,7 +172,7 @@ func TestBlockInitializerVisitsAllExecutedStatements(t *testing.T) {
 	tc := New(nilObjectEnvironment())
 	block := &ast.BlockExpression{Block: &ast.BlockStatement{Statements: []ast.Statement{
 		&ast.VariableDeclaration{
-			Name: &ast.Identifier{Value: "value"},
+			Name:  &ast.Identifier{Value: "value"},
 			Value: &ast.InvocationExpression{Function: &ast.Identifier{Value: "unknown"}},
 		},
 		&ast.WhileStatement{
@@ -218,8 +217,6 @@ func TestNamedGenericFunctionUnsafeBodyRemainsMonomorphic(t *testing.T) {
 		t.Fatalf("unsafe named closure generalized to %#v", scheme.TypeVars)
 	}
 }
-
-
 
 func TestStatelessBuiltinDoesNotBecomeForwardCapture(t *testing.T) {
 	tc := New(nilObjectEnvironment())
@@ -330,7 +327,6 @@ func TestSafeForwardCalleePreservesEarlierGenericCaller(t *testing.T) {
 	}
 }
 
-
 func TestGenericCalleeParticipatesInForwardBarrierFixedPoint(t *testing.T) {
 	tc := New(nilObjectEnvironment())
 	helper := &ast.FunctionStatement{
@@ -397,7 +393,6 @@ func TestGenericCalleeParticipatesInForwardBarrierFixedPoint(t *testing.T) {
 	}
 }
 
-
 func TestBlockedSchemePersistsFirstCallSubstitution(t *testing.T) {
 	tc := New(nilObjectEnvironment())
 	v := NewUnifier().FreshTypeVar("T")
@@ -455,7 +450,7 @@ func TestBlockedSchemePersistsThroughHigherOrderArguments(t *testing.T) {
 	})
 
 	first := &ast.InvocationExpression{
-		Function: &ast.Identifier{Value: "takesInt"},
+		Function:  &ast.Identifier{Value: "takesInt"},
 		Arguments: []ast.Expression{&ast.Identifier{Value: "blocked"}},
 	}
 	tc.checkInvocationExpression(first)
@@ -465,7 +460,7 @@ func TestBlockedSchemePersistsThroughHigherOrderArguments(t *testing.T) {
 
 	before := len(tc.Errors())
 	second := &ast.InvocationExpression{
-		Function: &ast.Identifier{Value: "takesString"},
+		Function:  &ast.Identifier{Value: "takesString"},
 		Arguments: []ast.Expression{&ast.Identifier{Value: "blocked"}},
 	}
 	tc.checkInvocationExpression(second)
@@ -484,7 +479,7 @@ func TestBlockedSchemeCannotBeRegeneralizedByAlias(t *testing.T) {
 	)
 	tc.env.Set("blocked", blocked)
 	tc.checkVariableDeclaration(&ast.VariableDeclaration{
-		Name: &ast.Identifier{Value: "alias"},
+		Name:  &ast.Identifier{Value: "alias"},
 		Value: &ast.Identifier{Value: "blocked"},
 	})
 	alias, ok := tc.env.Get("alias")
@@ -493,12 +488,12 @@ func TestBlockedSchemeCannotBeRegeneralizedByAlias(t *testing.T) {
 	}
 
 	tc.checkInvocationExpression(&ast.InvocationExpression{
-		Function: &ast.Identifier{Value: "alias"},
+		Function:  &ast.Identifier{Value: "alias"},
 		Arguments: []ast.Expression{&ast.IntegerLiteral{Value: 1}},
 	})
 	before := len(tc.Errors())
 	tc.checkInvocationExpression(&ast.InvocationExpression{
-		Function: &ast.Identifier{Value: "blocked"},
+		Function:  &ast.Identifier{Value: "blocked"},
 		Arguments: []ast.Expression{&ast.StringLiteral{Value: "different"}},
 	})
 	if len(tc.Errors()) == before {
@@ -516,7 +511,7 @@ func TestBlockedConstrainedSchemeReusesPersistentBinding(t *testing.T) {
 	tc.env.Set("blockedConstrained", scheme)
 	call := func() {
 		tc.checkInvocationExpression(&ast.InvocationExpression{
-			Function: &ast.Identifier{Value: "blockedConstrained"},
+			Function:  &ast.Identifier{Value: "blockedConstrained"},
 			Arguments: []ast.Expression{&ast.IntegerLiteral{Value: 1}},
 		})
 	}
@@ -546,8 +541,8 @@ func TestMatchArmBindingIsNotAnOuterCapture(t *testing.T) {
 	tc := New(nilObjectEnvironment())
 	tc.env.SetType("item", &ArrayType{
 		ElementType: &PrimitiveType{Name: "u8"},
-		Length: -1,
-		IsSpan: true,
+		Length:      -1,
+		IsSpan:      true,
 	})
 	fn := &ast.FunctionLiteral{
 		Arguments: []*ast.Identifier{{Value: "value"}},
@@ -556,7 +551,7 @@ func TestMatchArmBindingIsNotAnOuterCapture(t *testing.T) {
 				Scrutinee: &ast.Identifier{Value: "value"},
 				Arms: []*ast.MatchArm{{
 					Pattern: &ast.BindingPattern{Name: &ast.Identifier{Value: "item"}},
-					Body: &ast.Identifier{Value: "item"},
+					Body:    &ast.Identifier{Value: "item"},
 				}},
 			}},
 		}},
@@ -570,15 +565,15 @@ func TestSelectorNameIsNotAnOuterCapture(t *testing.T) {
 	tc := New(nilObjectEnvironment())
 	tc.env.SetType("field", &ArrayType{
 		ElementType: &PrimitiveType{Name: "u8"},
-		Length: -1,
-		IsSpan: true,
+		Length:      -1,
+		IsSpan:      true,
 	})
 	fn := &ast.FunctionLiteral{
 		Arguments: []*ast.Identifier{{Value: "record"}},
 		Body: &ast.BlockStatement{Statements: []ast.Statement{
 			&ast.ExpressionStatement{Expression: &ast.IndexExpression{
 				Token: token.Token{Literal: "."},
-				Left: &ast.Identifier{Value: "record"},
+				Left:  &ast.Identifier{Value: "record"},
 				Index: &ast.Identifier{Value: "field"},
 			}},
 		}},
@@ -598,7 +593,7 @@ func TestSelectorNameDoesNotPropagateInitializerBarrier(t *testing.T) {
 	tc.env.Set("field", selectorBinding)
 	projection := &ast.IndexExpression{
 		Token: token.Token{Literal: "."},
-		Left: &ast.Identifier{Value: "record"},
+		Left:  &ast.Identifier{Value: "record"},
 		Index: &ast.Identifier{Value: "field"},
 	}
 	if facts := deriveGeneralizationFacts(polymorphicIdentityType(), projection, tc.env); !facts.Safe() {
@@ -821,7 +816,7 @@ func TestMethodSelectorPropagatesResolvedSchemeBarriers(t *testing.T) {
 	tc := New(nilObjectEnvironment())
 	tc.env.SetType("receiver", &ADTType{Name: "Box"})
 	tc.env.Set("Box::touch", &TypeScheme{
-		Type: &FunctionType{ReturnType: &UnitType{}},
+		Type:                   &FunctionType{ReturnType: &UnitType{}},
 		GeneralizationBarriers: GeneralizationUnsafeAssumption,
 	})
 	call := &ast.InvocationExpression{
@@ -873,8 +868,8 @@ func TestNestedClosureInheritsMatchArmBindingScope(t *testing.T) {
 	tc := New(nilObjectEnvironment())
 	tc.env.SetType("item", &ArrayType{
 		ElementType: &PrimitiveType{Name: "u8"},
-		Length: -1,
-		IsSpan: true,
+		Length:      -1,
+		IsSpan:      true,
 	})
 	nested := &ast.FunctionLiteral{Body: &ast.BlockStatement{Statements: []ast.Statement{
 		&ast.ExpressionStatement{Expression: &ast.Identifier{Value: "item"}},
@@ -886,7 +881,7 @@ func TestNestedClosureInheritsMatchArmBindingScope(t *testing.T) {
 				Scrutinee: &ast.Identifier{Value: "value"},
 				Arms: []*ast.MatchArm{{
 					Pattern: &ast.BindingPattern{Name: &ast.Identifier{Value: "item"}},
-					Body: nested,
+					Body:    nested,
 				}},
 			}},
 		}},
@@ -944,7 +939,7 @@ func TestDirectFunctionReferenceAddsNoCaptureBarrier(t *testing.T) {
 	})
 	fn := &ast.FunctionLiteral{Body: &ast.BlockStatement{Statements: []ast.Statement{
 		&ast.ExpressionStatement{Expression: &ast.InvocationExpression{
-			Function: &ast.Identifier{Value: "helper"},
+			Function:  &ast.Identifier{Value: "helper"},
 			Arguments: []ast.Expression{&ast.IntegerLiteral{Value: 1}},
 		}},
 	}}}
@@ -964,13 +959,13 @@ func TestArgumentDiagnosticPreventsMonomorphicCommit(t *testing.T) {
 	tc.env.Set("blocked", scheme)
 	badArray := &ast.ArrayLiteral{
 		Type: &ast.IndexExpression{
-			Left: &ast.Identifier{Value: "int"},
+			Left:  &ast.Identifier{Value: "int"},
 			Index: &ast.IntegerLiteral{Value: 1},
 		},
 		Elements: []ast.Expression{&ast.StringLiteral{Value: "bad element"}},
 	}
 	tc.checkInvocationExpression(&ast.InvocationExpression{
-		Function: &ast.Identifier{Value: "blocked"},
+		Function:  &ast.Identifier{Value: "blocked"},
 		Arguments: []ast.Expression{badArray},
 	})
 	if _, fixed := scheme.Monomorphic[v]; fixed {
@@ -979,7 +974,7 @@ func TestArgumentDiagnosticPreventsMonomorphicCommit(t *testing.T) {
 
 	before := len(tc.Errors())
 	result := tc.checkInvocationExpression(&ast.InvocationExpression{
-		Function: &ast.Identifier{Value: "blocked"},
+		Function:  &ast.Identifier{Value: "blocked"},
 		Arguments: []ast.Expression{&ast.StringLiteral{Value: "valid"}},
 	})
 	if result == nil || !result.Equals(&StringType{}) {
@@ -994,8 +989,8 @@ func TestNestedNamedFunctionInheritsMatchArmBindingScope(t *testing.T) {
 	tc := New(nilObjectEnvironment())
 	tc.env.SetType("item", &ArrayType{
 		ElementType: &PrimitiveType{Name: "u8"},
-		Length: -1,
-		IsSpan: true,
+		Length:      -1,
+		IsSpan:      true,
 	})
 	inner := &ast.FunctionStatement{
 		Name: &ast.Identifier{Value: "inner"},
@@ -1012,7 +1007,7 @@ func TestNestedNamedFunctionInheritsMatchArmBindingScope(t *testing.T) {
 				Scrutinee: &ast.Identifier{Value: "value"},
 				Arms: []*ast.MatchArm{{
 					Pattern: &ast.BindingPattern{Name: &ast.Identifier{Value: "item"}},
-					Body: armBody,
+					Body:    armBody,
 				}},
 			}},
 		}},
@@ -1041,8 +1036,8 @@ func TestAnnotatedAliasCommitsBlockedSpecialization(t *testing.T) {
 	})
 
 	tc.checkVariableDeclaration(&ast.VariableDeclaration{
-		Name: &ast.Identifier{Value: "intAlias"},
-		Type: &ast.Identifier{Value: "IntFn"},
+		Name:  &ast.Identifier{Value: "intAlias"},
+		Type:  &ast.Identifier{Value: "IntFn"},
 		Value: &ast.Identifier{Value: "blocked"},
 	})
 	if got := blocked.Monomorphic.Apply(v); !got.Equals(&PrimitiveType{Name: "int"}) {
@@ -1050,8 +1045,8 @@ func TestAnnotatedAliasCommitsBlockedSpecialization(t *testing.T) {
 	}
 	before := len(tc.Errors())
 	tc.checkVariableDeclaration(&ast.VariableDeclaration{
-		Name: &ast.Identifier{Value: "stringAlias"},
-		Type: &ast.Identifier{Value: "StringFn"},
+		Name:  &ast.Identifier{Value: "stringAlias"},
+		Type:  &ast.Identifier{Value: "StringFn"},
 		Value: &ast.Identifier{Value: "blocked"},
 	})
 	if len(tc.Errors()) == before {
@@ -1091,7 +1086,7 @@ func TestIndependentBlockedSchemesDoNotPolluteConstraints(t *testing.T) {
 	before := len(tc.Errors())
 	for _, name := range []string{"first", "second"} {
 		tc.checkInvocationExpression(&ast.InvocationExpression{
-			Function: &ast.Identifier{Value: name},
+			Function:  &ast.Identifier{Value: name},
 			Arguments: []ast.Expression{&ast.IntegerLiteral{Value: 1}},
 		})
 	}
@@ -1106,7 +1101,7 @@ func TestBlockedLocalDoesNotCaptureEnclosingTypeBinder(t *testing.T) {
 	env.SetType("T", enclosing)
 	localType := &ArrayType{
 		ElementType: enclosing,
-		Length: 1,
+		Length:      1,
 	}
 	scheme := GeneralizeWithFacts(
 		localType,
@@ -1168,7 +1163,7 @@ func TestMatchInitializerDoesNotPropagateShadowedBarrierMetadata(t *testing.T) {
 		Scrutinee: &ast.Boolean{Value: true},
 		Arms: []*ast.MatchArm{{
 			Pattern: &ast.BindingPattern{Name: &ast.Identifier{Value: "item"}},
-			Body: &ast.Identifier{Value: "item"},
+			Body:    &ast.Identifier{Value: "item"},
 		}},
 	}
 	if facts := deriveGeneralizationFacts(polymorphicIdentityType(), match, tc.env); !facts.Safe() {
@@ -1228,7 +1223,7 @@ func TestFailedAnnotatedDeclarationRollsBackNestedCall(t *testing.T) {
 		Name: &ast.Identifier{Value: "bad"},
 		Type: &ast.Identifier{Value: "string"},
 		Value: &ast.InvocationExpression{
-			Function: &ast.Identifier{Value: "blocked"},
+			Function:  &ast.Identifier{Value: "blocked"},
 			Arguments: []ast.Expression{&ast.IntegerLiteral{Value: 1}},
 		},
 	})
@@ -1237,7 +1232,7 @@ func TestFailedAnnotatedDeclarationRollsBackNestedCall(t *testing.T) {
 	}
 	before := len(tc.Errors())
 	result := tc.checkInvocationExpression(&ast.InvocationExpression{
-		Function: &ast.Identifier{Value: "blocked"},
+		Function:  &ast.Identifier{Value: "blocked"},
 		Arguments: []ast.Expression{&ast.StringLiteral{Value: "valid"}},
 	})
 	if result == nil || !result.Equals(&StringType{}) {
@@ -1266,7 +1261,7 @@ func TestSiblingUsesSharePendingMonomorphicSpecialization(t *testing.T) {
 	})
 	callBlocked := func(argument ast.Expression) ast.Expression {
 		return &ast.InvocationExpression{
-			Function: &ast.Identifier{Value: "blocked"},
+			Function:  &ast.Identifier{Value: "blocked"},
 			Arguments: []ast.Expression{argument},
 		}
 	}
@@ -1299,7 +1294,7 @@ func TestAssertFailureRollsBackNestedSpecialization(t *testing.T) {
 		Function: &ast.Identifier{Value: "assert"},
 		Arguments: []ast.Expression{
 			&ast.InvocationExpression{
-				Function: &ast.Identifier{Value: "blocked"},
+				Function:  &ast.Identifier{Value: "blocked"},
 				Arguments: []ast.Expression{&ast.IntegerLiteral{Value: 1}},
 			},
 		},
@@ -1309,7 +1304,7 @@ func TestAssertFailureRollsBackNestedSpecialization(t *testing.T) {
 	}
 	before := len(tc.Errors())
 	result := tc.checkInvocationExpression(&ast.InvocationExpression{
-		Function: &ast.Identifier{Value: "blocked"},
+		Function:  &ast.Identifier{Value: "blocked"},
 		Arguments: []ast.Expression{&ast.StringLiteral{Value: "valid"}},
 	})
 	if result == nil || !result.Equals(&StringType{}) {
@@ -1371,7 +1366,7 @@ func TestFailedAssignmentRollsBackNestedSpecialization(t *testing.T) {
 	tc.checkAssignmentStatement(&ast.AssignmentStatement{
 		Name: &ast.Identifier{Value: "target"},
 		Value: &ast.InvocationExpression{
-			Function: &ast.Identifier{Value: "blocked"},
+			Function:  &ast.Identifier{Value: "blocked"},
 			Arguments: []ast.Expression{&ast.IntegerLiteral{Value: 1}},
 		},
 	})
@@ -1380,7 +1375,7 @@ func TestFailedAssignmentRollsBackNestedSpecialization(t *testing.T) {
 	}
 	before := len(tc.Errors())
 	result := tc.checkInvocationExpression(&ast.InvocationExpression{
-		Function: &ast.Identifier{Value: "blocked"},
+		Function:  &ast.Identifier{Value: "blocked"},
 		Arguments: []ast.Expression{&ast.StringLiteral{Value: "valid"}},
 	})
 	if result == nil || !result.Equals(&StringType{}) {
@@ -1390,7 +1385,6 @@ func TestFailedAssignmentRollsBackNestedSpecialization(t *testing.T) {
 		t.Fatalf("later valid call cascaded: %v", tc.Errors()[before:])
 	}
 }
-
 
 func TestSiblingConstrainedUsesSeePendingMonomorphicSpecialization(t *testing.T) {
 	tc := New(nilObjectEnvironment())
@@ -1409,7 +1403,7 @@ func TestSiblingConstrainedUsesSeePendingMonomorphicSpecialization(t *testing.T)
 	})
 	callBlocked := func(value int64) ast.Expression {
 		return &ast.InvocationExpression{
-			Function: &ast.Identifier{Value: "blocked"},
+			Function:  &ast.Identifier{Value: "blocked"},
 			Arguments: []ast.Expression{&ast.IntegerLiteral{Value: value}},
 		}
 	}
@@ -1432,7 +1426,6 @@ func TestSiblingConstrainedUsesSeePendingMonomorphicSpecialization(t *testing.T)
 		t.Fatalf("committed constrained specialization = %v, want int", got)
 	}
 }
-
 
 func TestEscapedTypeVariableJoinsBlockedMonomorphicGroup(t *testing.T) {
 	tc := New(nilObjectEnvironment())
@@ -1460,7 +1453,7 @@ func TestEscapedTypeVariableJoinsBlockedMonomorphicGroup(t *testing.T) {
 	tc.env.Set("stringIdentity", &TypeScheme{Type: stringFn})
 	callBlocked := func(name string) Type {
 		return tc.checkInvocationExpression(&ast.InvocationExpression{
-			Function: &ast.Identifier{Value: "blocked"},
+			Function:  &ast.Identifier{Value: "blocked"},
 			Arguments: []ast.Expression{&ast.Identifier{Value: name}},
 		})
 	}
@@ -1485,7 +1478,6 @@ func TestEscapedTypeVariableJoinsBlockedMonomorphicGroup(t *testing.T) {
 		t.Fatal("escaped variable reopened blocked binding at string identity")
 	}
 }
-
 
 func TestBarredPredeclaredGenericIsPersistent(t *testing.T) {
 	tc := New(object.NewEnvironment())
@@ -1537,7 +1529,6 @@ func TestBarredPredeclaredGenericIsPersistent(t *testing.T) {
 	}
 }
 
-
 func TestPredeclaredMethodCallDoesNotMonomorphizeSafeGeneric(t *testing.T) {
 	box := &ast.ADTType{
 		Name: &ast.Identifier{Value: "Box"},
@@ -1586,7 +1577,6 @@ func TestPredeclaredMethodCallDoesNotMonomorphizeSafeGeneric(t *testing.T) {
 	}
 }
 
-
 func TestCompilerLibraryCallDoesNotCreateCaptureBarrier(t *testing.T) {
 	tc := New(nilObjectEnvironment())
 	fn := &ast.FunctionLiteral{
@@ -1609,16 +1599,16 @@ func TestCompilerLibraryCallDoesNotCreateCaptureBarrier(t *testing.T) {
 
 func TestPredeclaredMethodParametersResolveMethodAuthority(t *testing.T) {
 	box := &ast.ADTType{
-		Name: &ast.Identifier{Value: "Box"},
+		Name:     &ast.Identifier{Value: "Box"},
 		Variants: []*ast.ADTVariant{{Name: &ast.Identifier{Value: "Box"}}},
 	}
 	read := &ast.FunctionStatement{
 		Receiver: &ast.FunctionParameter{
 			Name: &ast.Identifier{Value: "self"}, Type: &ast.Identifier{Value: "Box"},
 		},
-		Name: &ast.Identifier{Value: "read"},
+		Name:       &ast.Identifier{Value: "read"},
 		ReturnType: &ast.Identifier{Value: "i32"},
-		Body: &ast.IntegerLiteral{Value: 0},
+		Body:       &ast.IntegerLiteral{Value: 0},
 	}
 	forward := &ast.FunctionStatement{
 		Receiver: &ast.FunctionParameter{
@@ -1632,7 +1622,7 @@ func TestPredeclaredMethodParametersResolveMethodAuthority(t *testing.T) {
 		Body: &ast.InvocationExpression{
 			Function: &ast.IndexExpression{
 				Token: token.Token{Literal: "."},
-				Left: &ast.Identifier{Value: "other"},
+				Left:  &ast.Identifier{Value: "other"},
 				Index: &ast.Identifier{Value: "read"},
 			},
 		},
@@ -1649,7 +1639,6 @@ func TestPredeclaredMethodParametersResolveMethodAuthority(t *testing.T) {
 	}
 }
 
-
 func TestDeclaredLocalTypeResolvesMethodAuthority(t *testing.T) {
 	tc := New(nilObjectEnvironment())
 	tc.env.Set("Box::read", &TypeScheme{
@@ -1662,13 +1651,13 @@ func TestDeclaredLocalTypeResolvesMethodAuthority(t *testing.T) {
 				Type: &ast.Identifier{Value: "Box"},
 				Value: &ast.VariantExpression{
 					TypeName: &ast.Identifier{Value: "Box"},
-					Variant: &ast.Identifier{Value: "Box"},
+					Variant:  &ast.Identifier{Value: "Box"},
 				},
 			},
 			&ast.ExpressionStatement{Expression: &ast.InvocationExpression{
 				Function: &ast.IndexExpression{
 					Token: token.Token{Literal: "."},
-					Left: &ast.Identifier{Value: "box"},
+					Left:  &ast.Identifier{Value: "box"},
 					Index: &ast.Identifier{Value: "read"},
 				},
 			}},
@@ -1679,7 +1668,6 @@ func TestDeclaredLocalTypeResolvesMethodAuthority(t *testing.T) {
 	}
 }
 
-
 func TestExpressionReceiverResolvesMethodAuthority(t *testing.T) {
 	tc := New(nilObjectEnvironment())
 	tc.env.Set("makeBox", &TypeScheme{Type: &FunctionType{ReturnType: &ADTType{Name: "Box"}}})
@@ -1688,12 +1676,62 @@ func TestExpressionReceiverResolvesMethodAuthority(t *testing.T) {
 		&ast.ExpressionStatement{Expression: &ast.InvocationExpression{
 			Function: &ast.IndexExpression{
 				Token: token.Token{Literal: "."},
-				Left: &ast.InvocationExpression{Function: &ast.Identifier{Value: "makeBox"}},
+				Left:  &ast.InvocationExpression{Function: &ast.Identifier{Value: "makeBox"}},
 				Index: &ast.Identifier{Value: "read"},
 			},
 		}},
 	}}}
 	if facts := functionCaptureFacts(fn, tc.env); !facts.Safe() {
 		t.Fatalf("expression receiver blocked generalization: %v", facts)
+	}
+}
+
+func TestTemplateAuthorityCannotBeReopenedBySpecialization(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	fn := &ast.FunctionStatement{
+		Name:       &ast.Identifier{Value: "restricted"},
+		TypeParams: []*ast.TypeParameter{{Name: &ast.Identifier{Value: "T"}}},
+		Parameters: []*ast.FunctionParameter{{
+			Name: &ast.Identifier{Value: "value"},
+			Type: &ast.Identifier{Value: "T"},
+		}},
+		ReturnType: &ast.Identifier{Value: "T"},
+		Body: &ast.BlockExpression{Block: &ast.BlockStatement{Statements: []ast.Statement{
+			&ast.UnsafeBlock{Body: &ast.BlockStatement{}},
+			&ast.ExpressionStatement{Expression: &ast.Identifier{Value: "value"}},
+		}}},
+	}
+	tc.CheckProgram(&ast.Program{Statements: []ast.Statement{fn}})
+	first := tc.CheckExpression(&ast.InvocationExpression{
+		Function:  &ast.Identifier{Value: "restricted"},
+		Arguments: []ast.Expression{&ast.IntegerLiteral{Value: 1}},
+	})
+	if first == nil || len(tc.Errors()) != 0 {
+		t.Fatalf("first specialization failed: %v", tc.Errors())
+	}
+	before := len(tc.Errors())
+	second := tc.CheckExpression(&ast.InvocationExpression{
+		Function:  &ast.Identifier{Value: "restricted"},
+		Arguments: []ast.Expression{&ast.StringLiteral{Value: "different"}},
+	})
+	if second != nil || len(tc.Errors()) == before {
+		t.Fatal("template specialization reopened restricted authority")
+	}
+}
+
+func TestConditionalUnsafeBodyContributesGeneralizationBarrier(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	body := &ast.BlockStatement{Statements: []ast.Statement{
+		&ast.IfStatement{
+			Condition: &ast.Boolean{Value: true},
+			Consequence: &ast.BlockStatement{Statements: []ast.Statement{
+				&ast.UnsafeBlock{Body: &ast.BlockStatement{}},
+			}},
+		},
+	}}
+	capture := functionCaptureFacts(&ast.FunctionLiteral{Body: body}, tc.env)
+	initializer := deriveGeneralizationFacts(polymorphicIdentityType(), &ast.BlockExpression{Block: body}, tc.env)
+	if !capture.Has(GeneralizationUnsafeAssumption) || !initializer.Has(GeneralizationUnsafeAssumption) {
+		t.Fatalf("conditional hid unsafe evidence: capture=%v initializer=%v", capture, initializer)
 	}
 }

--- a/typechecker/generalization_test.go
+++ b/typechecker/generalization_test.go
@@ -3,7 +3,13 @@ package typechecker
 import (
 	"reflect"
 	"testing"
+
+	"github.com/SCKelemen/oak/ast"
+	"github.com/SCKelemen/oak/object"
+	"github.com/SCKelemen/oak/token"
 )
+
+func nilObjectEnvironment() *object.Environment { return object.NewEnvironment() }
 
 func polymorphicIdentityType() Type {
 	v := NewUnifier().FreshTypeVar("T")
@@ -83,5 +89,1611 @@ func TestBlockedGeneralizationDoesNotAffectTypeInference(t *testing.T) {
 	}
 	if len(scheme.TypeVars) != 0 {
 		t.Fatalf("unsafe binding must remain monomorphic, got %#v", scheme.TypeVars)
+	}
+}
+
+func TestFactsFromTypeClassifiesBorrowedAndOwnedAuthority(t *testing.T) {
+	element := NewUnifier().FreshTypeVar("T")
+	view := factsFromType(&ArrayType{ElementType: element, Length: -1, IsSlice: true})
+	if !view.Has(GeneralizationRegionBound) || view.Has(GeneralizationUniqueAuthority) {
+		t.Fatalf("view facts = %v", view)
+	}
+	span := factsFromType(&ArrayType{ElementType: element, Length: -1, IsSpan: true})
+	for _, barrier := range []GeneralizationBarrier{
+		GeneralizationMutableAuthority, GeneralizationUniqueAuthority, GeneralizationRegionBound,
+	} {
+		if !span.Has(barrier) {
+			t.Fatalf("span facts %v missing %v", span, barrier)
+		}
+	}
+	raw := factsFromType(&PrimitiveType{Name: "ptr"})
+	if !raw.Has(GeneralizationExternalAuthority) || !raw.Has(GeneralizationUnknownAuthority) {
+		t.Fatalf("raw pointer facts = %v", raw)
+	}
+}
+
+func TestVariableGeneralizationUsesClosureCaptureFacts(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	element := NewUnifier().FreshTypeVar("T")
+	tc.env.SetType("borrowed", &ArrayType{ElementType: element, Length: -1, IsSlice: true})
+	stmt := &ast.VariableDeclaration{
+		Name: &ast.Identifier{Value: "capture"},
+		Value: &ast.FunctionLiteral{
+			Arguments: nil,
+			Body: &ast.BlockStatement{Statements: []ast.Statement{
+				&ast.ExpressionStatement{Expression: &ast.Identifier{Value: "borrowed"}},
+			}},
+		},
+	}
+	tc.checkVariableDeclaration(stmt)
+	scheme, ok := tc.env.Get("capture")
+	if !ok || scheme == nil {
+		t.Fatal("capturing closure was not bound")
+	}
+	if len(scheme.TypeVars) != 0 {
+		t.Fatalf("captured region authority generalized to %#v", scheme.TypeVars)
+	}
+}
+
+func TestClosedFunctionLiteralAddsNoAuthorityBarrier(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	literal := &ast.FunctionLiteral{
+		Arguments: []*ast.Identifier{{Value: "x"}},
+		Body: &ast.BlockStatement{Statements: []ast.Statement{
+			&ast.ExpressionStatement{Expression: &ast.Identifier{Value: "x"}},
+		}},
+	}
+	typ := tc.checkExpression(literal)
+	facts := deriveGeneralizationFacts(typ, literal, tc.env)
+	if !facts.Safe() {
+		t.Fatalf("closed function facts = %v", facts)
+	}
+}
+
+
+func TestNestedNamedClosureContributesOuterCaptureFacts(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	element := NewUnifier().FreshTypeVar("T")
+	tc.env.SetType("borrowed", &ArrayType{ElementType: element, Length: -1, IsSlice: true})
+	inner := &ast.FunctionStatement{
+		Name: &ast.Identifier{Value: "inner"},
+		Body: &ast.Identifier{Value: "borrowed"},
+	}
+	outer := &ast.FunctionLiteral{Body: &ast.BlockStatement{Statements: []ast.Statement{
+		inner,
+		&ast.ExpressionStatement{Expression: &ast.Identifier{Value: "inner"}},
+	}}}
+	facts := functionCaptureFacts(outer, tc.env)
+	if !facts.Has(GeneralizationMutableAuthority) || !facts.Has(GeneralizationRegionBound) {
+		t.Fatalf("nested closure facts = %v", facts)
+	}
+}
+
+func TestBlockInitializerVisitsAllExecutedStatements(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	block := &ast.BlockExpression{Block: &ast.BlockStatement{Statements: []ast.Statement{
+		&ast.VariableDeclaration{
+			Name: &ast.Identifier{Value: "value"},
+			Value: &ast.InvocationExpression{Function: &ast.Identifier{Value: "unknown"}},
+		},
+		&ast.WhileStatement{
+			Condition: &ast.InvocationExpression{Function: &ast.Identifier{Value: "condition"}},
+			Body: &ast.BlockStatement{Statements: []ast.Statement{
+				&ast.AssignmentStatement{
+					Name:  &ast.Identifier{Value: "value"},
+					Value: &ast.InvocationExpression{Function: &ast.Identifier{Value: "step"}},
+				},
+			}},
+		},
+	}}}
+	facts := deriveGeneralizationFacts(polymorphicIdentityType(), block, tc.env)
+	if !facts.Has(GeneralizationEffectfulCapture) || !facts.Has(GeneralizationUnknownAuthority) {
+		t.Fatalf("executed block facts = %v", facts)
+	}
+}
+
+func TestNamedGenericFunctionUnsafeBodyRemainsMonomorphic(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	fn := &ast.FunctionStatement{
+		Name: &ast.Identifier{Value: "unsafeIdentity"},
+		TypeParams: []*ast.TypeParameter{{
+			Name: &ast.Identifier{Value: "T"},
+		}},
+		Parameters: []*ast.FunctionParameter{{
+			Name: &ast.Identifier{Value: "x"},
+			Type: &ast.Identifier{Value: "T"},
+		}},
+		ReturnType: &ast.Identifier{Value: "T"},
+		Body: &ast.BlockExpression{Block: &ast.BlockStatement{Statements: []ast.Statement{
+			&ast.UnsafeBlock{Body: &ast.BlockStatement{}},
+			&ast.ExpressionStatement{Expression: &ast.Identifier{Value: "x"}},
+		}}},
+	}
+	tc.checkFunctionStatement(fn)
+	scheme, ok := tc.env.Get("unsafeIdentity")
+	if !ok || scheme == nil {
+		t.Fatal("named function was not bound")
+	}
+	if len(scheme.TypeVars) != 0 {
+		t.Fatalf("unsafe named closure generalized to %#v", scheme.TypeVars)
+	}
+}
+
+
+
+func TestStatelessBuiltinDoesNotBecomeForwardCapture(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	fn := &ast.FunctionStatement{
+		Name: &ast.Identifier{Value: "helper"},
+		Body: &ast.InvocationExpression{
+			Function:  &ast.Identifier{Value: "i64"},
+			Arguments: []ast.Expression{&ast.IntegerLiteral{Value: 1}},
+		},
+	}
+	if facts := functionStatementCaptureFacts(fn, tc.env); !facts.Safe() {
+		t.Fatalf("stateless builtin was treated as captured authority: %v", facts)
+	}
+}
+
+func TestForwardCalleeAuthorityBlocksEarlierGenericCaller(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	caller := &ast.FunctionStatement{
+		Name: &ast.Identifier{Value: "caller"},
+		TypeParams: []*ast.TypeParameter{{
+			Name: &ast.Identifier{Value: "T"},
+		}},
+		Parameters: []*ast.FunctionParameter{{
+			Name: &ast.Identifier{Value: "x"},
+			Type: &ast.Identifier{Value: "T"},
+		}},
+		ReturnType: &ast.Identifier{Value: "T"},
+		Body: &ast.BlockExpression{Block: &ast.BlockStatement{Statements: []ast.Statement{
+			&ast.ExpressionStatement{Expression: &ast.InvocationExpression{
+				Function: &ast.Identifier{Value: "helper"},
+			}},
+			&ast.ExpressionStatement{Expression: &ast.Identifier{Value: "x"}},
+		}}},
+	}
+	helper := &ast.FunctionStatement{
+		Name: &ast.Identifier{Value: "helper"},
+		Body: &ast.BlockExpression{Block: &ast.BlockStatement{Statements: []ast.Statement{
+			&ast.UnsafeBlock{Body: &ast.BlockStatement{}},
+		}}},
+	}
+
+	tc.CheckProgram(&ast.Program{Statements: []ast.Statement{caller, helper}})
+	if len(tc.Errors()) != 0 {
+		t.Fatalf("program failed to type-check: %v", tc.Errors())
+	}
+	scheme, ok := tc.env.Get("caller")
+	if !ok || scheme == nil {
+		t.Fatal("caller was not bound")
+	}
+	if len(scheme.TypeVars) != 0 {
+		t.Fatalf("caller through unresolved forward callee generalized to %#v", scheme.TypeVars)
+	}
+	if scheme.GeneralizationBarriers&GeneralizationUnsafeAssumption == 0 {
+		t.Fatalf("caller lost the forward-callee authority barrier: %v", scheme.GeneralizationBarriers)
+	}
+}
+
+func TestSafeForwardCalleePreservesEarlierGenericCaller(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	caller := &ast.FunctionStatement{
+		Name: &ast.Identifier{Value: "caller"},
+		TypeParams: []*ast.TypeParameter{{
+			Name: &ast.Identifier{Value: "T"},
+		}},
+		Parameters: []*ast.FunctionParameter{{
+			Name: &ast.Identifier{Value: "x"},
+			Type: &ast.Identifier{Value: "T"},
+		}},
+		ReturnType: &ast.Identifier{Value: "T"},
+		Body: &ast.BlockExpression{Block: &ast.BlockStatement{Statements: []ast.Statement{
+			&ast.ExpressionStatement{Expression: &ast.InvocationExpression{
+				Function: &ast.Identifier{Value: "helper"},
+			}},
+			&ast.ExpressionStatement{Expression: &ast.Identifier{Value: "x"}},
+		}}},
+	}
+	helper := &ast.FunctionStatement{
+		Name: &ast.Identifier{Value: "helper"},
+		Body: &ast.BlockExpression{Block: &ast.BlockStatement{}},
+	}
+
+	tc.CheckProgram(&ast.Program{Statements: []ast.Statement{caller, helper}})
+	if len(tc.Errors()) != 0 {
+		t.Fatalf("program failed to type-check: %v", tc.Errors())
+	}
+	scheme, ok := tc.env.Get("caller")
+	if !ok || scheme == nil {
+		t.Fatal("caller was not bound")
+	}
+	if len(scheme.TypeVars) != 1 {
+		t.Fatalf("safe forward callee blocked caller quantification: %#v", scheme.TypeVars)
+	}
+
+	before := len(tc.Errors())
+	for _, argument := range []ast.Expression{
+		&ast.IntegerLiteral{Value: 1},
+		&ast.StringLiteral{Value: "ok"},
+	} {
+		if result := tc.checkInvocationExpression(&ast.InvocationExpression{
+			Function:  &ast.Identifier{Value: "caller"},
+			Arguments: []ast.Expression{argument},
+		}); result == nil {
+			t.Fatal("safe generic caller invocation failed")
+		}
+	}
+	if len(tc.Errors()) != before {
+		t.Fatalf("safe generic caller was not reusable: %v", tc.Errors()[before:])
+	}
+}
+
+
+func TestGenericCalleeParticipatesInForwardBarrierFixedPoint(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	helper := &ast.FunctionStatement{
+		Name: &ast.Identifier{Value: "genericHelper"},
+		TypeParams: []*ast.TypeParameter{{
+			Name: &ast.Identifier{Value: "U"},
+		}},
+		Parameters: []*ast.FunctionParameter{{
+			Name: &ast.Identifier{Value: "value"},
+			Type: &ast.Identifier{Value: "U"},
+		}},
+		ReturnType: &ast.Identifier{Value: "U"},
+		Body:       &ast.Identifier{Value: "value"},
+	}
+	caller := &ast.FunctionStatement{
+		Name: &ast.Identifier{Value: "caller"},
+		TypeParams: []*ast.TypeParameter{{
+			Name: &ast.Identifier{Value: "T"},
+		}},
+		Parameters: []*ast.FunctionParameter{{
+			Name: &ast.Identifier{Value: "x"},
+			Type: &ast.Identifier{Value: "T"},
+		}},
+		ReturnType: &ast.Identifier{Value: "T"},
+		Body: &ast.BlockExpression{Block: &ast.BlockStatement{Statements: []ast.Statement{
+			&ast.ExpressionStatement{Expression: &ast.InvocationExpression{
+				Function: &ast.Identifier{Value: "bridge"},
+			}},
+			&ast.ExpressionStatement{Expression: &ast.Identifier{Value: "x"}},
+		}}},
+	}
+	bridge := &ast.FunctionStatement{
+		Name:       &ast.Identifier{Value: "bridge"},
+		ReturnType: &ast.Identifier{Value: "int"},
+		Body: &ast.InvocationExpression{
+			Function:  &ast.Identifier{Value: "genericHelper"},
+			Arguments: []ast.Expression{&ast.IntegerLiteral{Value: 1}},
+		},
+	}
+
+	tc.CheckProgram(&ast.Program{Statements: []ast.Statement{helper, caller, bridge}})
+	if len(tc.Errors()) != 0 {
+		t.Fatalf("program failed to type-check: %v", tc.Errors())
+	}
+	scheme, ok := tc.env.Get("caller")
+	if !ok || scheme == nil || len(scheme.TypeVars) != 1 {
+		t.Fatalf("generic callee made safe forward chain monomorphic: %#v", scheme)
+	}
+
+	before := len(tc.Errors())
+	for _, argument := range []ast.Expression{
+		&ast.IntegerLiteral{Value: 1},
+		&ast.StringLiteral{Value: "ok"},
+	} {
+		if result := tc.checkInvocationExpression(&ast.InvocationExpression{
+			Function:  &ast.Identifier{Value: "caller"},
+			Arguments: []ast.Expression{argument},
+		}); result == nil {
+			t.Fatal("safe generic caller invocation failed")
+		}
+	}
+	if len(tc.Errors()) != before {
+		t.Fatalf("safe generic forward chain was not reusable: %v", tc.Errors()[before:])
+	}
+}
+
+
+func TestBlockedSchemePersistsFirstCallSubstitution(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	v := NewUnifier().FreshTypeVar("T")
+	scheme := GeneralizeWithFacts(
+		&FunctionType{Parameters: []Type{v}, ReturnType: v},
+		tc.env,
+		GeneralizationFacts{Barriers: GeneralizationUnsafeAssumption},
+	)
+	tc.env.Set("blocked", scheme)
+
+	first := &ast.InvocationExpression{
+		Function:  &ast.Identifier{Value: "blocked"},
+		Arguments: []ast.Expression{&ast.IntegerLiteral{Value: 1}},
+	}
+	if got := tc.checkInvocationExpression(first); got == nil || !got.Equals(&PrimitiveType{Name: "int"}) {
+		t.Fatalf("first call type = %v, want int", got)
+	}
+	if got := scheme.Monomorphic.Apply(v); !got.Equals(&PrimitiveType{Name: "int"}) {
+		t.Fatalf("persistent solution = %v, want int", got)
+	}
+
+	before := len(tc.Errors())
+	second := &ast.InvocationExpression{
+		Function:  &ast.Identifier{Value: "blocked"},
+		Arguments: []ast.Expression{&ast.StringLiteral{Value: "different"}},
+	}
+	tc.checkInvocationExpression(second)
+	if len(tc.Errors()) == before {
+		t.Fatal("second call with a different type reused blocked binding polymorphically")
+	}
+}
+
+func TestBlockedSchemePersistsThroughHigherOrderArguments(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	v := NewUnifier().FreshTypeVar("T")
+	blocked := GeneralizeWithFacts(
+		&FunctionType{Parameters: []Type{v}, ReturnType: v},
+		tc.env,
+		GeneralizationFacts{Barriers: GeneralizationUnsafeAssumption},
+	)
+	tc.env.Set("blocked", blocked)
+	tc.env.SetType("takesInt", &FunctionType{
+		Parameters: []Type{&FunctionType{
+			Parameters: []Type{&PrimitiveType{Name: "int"}},
+			ReturnType: &PrimitiveType{Name: "int"},
+		}},
+		ReturnType: &UnitType{},
+	})
+	tc.env.SetType("takesString", &FunctionType{
+		Parameters: []Type{&FunctionType{
+			Parameters: []Type{&StringType{}},
+			ReturnType: &StringType{},
+		}},
+		ReturnType: &UnitType{},
+	})
+
+	first := &ast.InvocationExpression{
+		Function: &ast.Identifier{Value: "takesInt"},
+		Arguments: []ast.Expression{&ast.Identifier{Value: "blocked"}},
+	}
+	tc.checkInvocationExpression(first)
+	if got := blocked.Monomorphic.Apply(v); !got.Equals(&PrimitiveType{Name: "int"}) {
+		t.Fatalf("higher-order persistent solution = %v, want int", got)
+	}
+
+	before := len(tc.Errors())
+	second := &ast.InvocationExpression{
+		Function: &ast.Identifier{Value: "takesString"},
+		Arguments: []ast.Expression{&ast.Identifier{Value: "blocked"}},
+	}
+	tc.checkInvocationExpression(second)
+	if len(tc.Errors()) == before {
+		t.Fatal("indirect uses specialized one blocked binding at incompatible types")
+	}
+}
+
+func TestBlockedSchemeCannotBeRegeneralizedByAlias(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	v := NewUnifier().FreshTypeVar("T")
+	blocked := GeneralizeWithFacts(
+		&FunctionType{Parameters: []Type{v}, ReturnType: v},
+		tc.env,
+		GeneralizationFacts{Barriers: GeneralizationUnsafeAssumption},
+	)
+	tc.env.Set("blocked", blocked)
+	tc.checkVariableDeclaration(&ast.VariableDeclaration{
+		Name: &ast.Identifier{Value: "alias"},
+		Value: &ast.Identifier{Value: "blocked"},
+	})
+	alias, ok := tc.env.Get("alias")
+	if !ok || alias == nil || len(alias.TypeVars) != 0 {
+		t.Fatal("alias reintroduced quantification for the blocked scheme")
+	}
+
+	tc.checkInvocationExpression(&ast.InvocationExpression{
+		Function: &ast.Identifier{Value: "alias"},
+		Arguments: []ast.Expression{&ast.IntegerLiteral{Value: 1}},
+	})
+	before := len(tc.Errors())
+	tc.checkInvocationExpression(&ast.InvocationExpression{
+		Function: &ast.Identifier{Value: "blocked"},
+		Arguments: []ast.Expression{&ast.StringLiteral{Value: "different"}},
+	})
+	if len(tc.Errors()) == before {
+		t.Fatal("alias re-generalized a blocked binding")
+	}
+}
+
+func TestBlockedConstrainedSchemeReusesPersistentBinding(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	v := NewUnifier().FreshTypeVar("T")
+	scheme := makeMonomorphicScheme(
+		&FunctionType{Parameters: []Type{v}, ReturnType: v},
+		[]Constraint{{Var: "T"}},
+	)
+	tc.env.Set("blockedConstrained", scheme)
+	call := func() {
+		tc.checkInvocationExpression(&ast.InvocationExpression{
+			Function: &ast.Identifier{Value: "blockedConstrained"},
+			Arguments: []ast.Expression{&ast.IntegerLiteral{Value: 1}},
+		})
+	}
+	call()
+	before := len(tc.Errors())
+	call()
+	if len(tc.Errors()) != before {
+		t.Fatalf("second constrained use rejected stored T = int: %v", tc.Errors()[before:])
+	}
+}
+
+func TestBlockedSpanInstantiationPreservesSpanIdentity(t *testing.T) {
+	element := NewUnifier().FreshTypeVar("T")
+	span := &ArrayType{ElementType: element, Length: -1, IsSpan: true}
+	scheme := GeneralizeWithFacts(
+		span,
+		NewTypeEnvironment(),
+		GeneralizationFacts{Barriers: GeneralizationRegionBound},
+	)
+	got, ok := Instantiate(scheme, NewUnifier()).(*ArrayType)
+	if !ok || !got.IsSpan || got.IsSlice || got.Length != -1 {
+		t.Fatalf("blocked span instantiated as %#v", got)
+	}
+}
+
+func TestMatchArmBindingIsNotAnOuterCapture(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	tc.env.SetType("item", &ArrayType{
+		ElementType: &PrimitiveType{Name: "u8"},
+		Length: -1,
+		IsSpan: true,
+	})
+	fn := &ast.FunctionLiteral{
+		Arguments: []*ast.Identifier{{Value: "value"}},
+		Body: &ast.BlockStatement{Statements: []ast.Statement{
+			&ast.ExpressionStatement{Expression: &ast.MatchExpression{
+				Scrutinee: &ast.Identifier{Value: "value"},
+				Arms: []*ast.MatchArm{{
+					Pattern: &ast.BindingPattern{Name: &ast.Identifier{Value: "item"}},
+					Body: &ast.Identifier{Value: "item"},
+				}},
+			}},
+		}},
+	}
+	if facts := functionCaptureFacts(fn, tc.env); !facts.Safe() {
+		t.Fatalf("match-local binder was classified as outer capture: %v", facts)
+	}
+}
+
+func TestSelectorNameIsNotAnOuterCapture(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	tc.env.SetType("field", &ArrayType{
+		ElementType: &PrimitiveType{Name: "u8"},
+		Length: -1,
+		IsSpan: true,
+	})
+	fn := &ast.FunctionLiteral{
+		Arguments: []*ast.Identifier{{Value: "record"}},
+		Body: &ast.BlockStatement{Statements: []ast.Statement{
+			&ast.ExpressionStatement{Expression: &ast.IndexExpression{
+				Token: token.Token{Literal: "."},
+				Left: &ast.Identifier{Value: "record"},
+				Index: &ast.Identifier{Value: "field"},
+			}},
+		}},
+	}
+	if facts := functionCaptureFacts(fn, tc.env); !facts.Safe() {
+		t.Fatalf("selector name was classified as outer capture: %v", facts)
+	}
+}
+
+func TestSelectorNameDoesNotPropagateInitializerBarrier(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	selectorBinding := GeneralizeWithFacts(
+		polymorphicIdentityType(),
+		tc.env,
+		GeneralizationFacts{Barriers: GeneralizationMutableAuthority},
+	)
+	tc.env.Set("field", selectorBinding)
+	projection := &ast.IndexExpression{
+		Token: token.Token{Literal: "."},
+		Left: &ast.Identifier{Value: "record"},
+		Index: &ast.Identifier{Value: "field"},
+	}
+	if facts := deriveGeneralizationFacts(polymorphicIdentityType(), projection, tc.env); !facts.Safe() {
+		t.Fatalf("selector name propagated an unrelated binding barrier: %v", facts)
+	}
+}
+
+func TestInitializerLocalBindingsDoNotResolveOuterBarriers(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	for _, name := range []string{"localValue", "localFunction"} {
+		tc.env.Set(name, GeneralizeWithFacts(
+			polymorphicIdentityType(),
+			tc.env,
+			GeneralizationFacts{Barriers: GeneralizationMutableAuthority},
+		))
+	}
+	block := &ast.BlockExpression{Block: &ast.BlockStatement{Statements: []ast.Statement{
+		&ast.VariableDeclaration{
+			Name:  &ast.Identifier{Value: "localValue"},
+			Value: &ast.IntegerLiteral{Value: 1},
+		},
+		&ast.FunctionStatement{
+			Name: &ast.Identifier{Value: "localFunction"},
+			Body: &ast.IntegerLiteral{Value: 1},
+		},
+		&ast.ExpressionStatement{Expression: &ast.Identifier{Value: "localValue"}},
+		&ast.ExpressionStatement{Expression: &ast.Identifier{Value: "localFunction"}},
+	}}}
+	if facts := deriveGeneralizationFacts(polymorphicIdentityType(), block, tc.env); !facts.Safe() {
+		t.Fatalf("initializer-local binding resolved an outer barrier: %v", facts)
+	}
+}
+
+func TestInitializerLocalAuthorityPropagatesThroughNamedCapture(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	block := &ast.BlockExpression{Block: &ast.BlockStatement{Statements: []ast.Statement{
+		&ast.VariableDeclaration{
+			Name: &ast.Identifier{Value: "local"},
+			Value: &ast.ArrayLiteral{Elements: []ast.Expression{
+				&ast.IntegerLiteral{Value: 1},
+			}},
+		},
+		&ast.FunctionStatement{
+			Name: &ast.Identifier{Value: "inner"},
+			Body: &ast.Identifier{Value: "local"},
+		},
+		&ast.ExpressionStatement{Expression: &ast.Identifier{Value: "inner"}},
+	}}}
+	facts := deriveGeneralizationFacts(polymorphicIdentityType(), block, tc.env)
+	if !facts.Has(GeneralizationMutableAuthority) {
+		t.Fatalf("initializer-local authority was lost through named capture: %v", facts)
+	}
+}
+
+func TestCompositeLocalAuthorityPropagatesThroughCapture(t *testing.T) {
+	array := func() ast.Expression {
+		return &ast.ArrayLiteral{Elements: []ast.Expression{
+			&ast.IntegerLiteral{Value: 1},
+		}}
+	}
+	cases := map[string]ast.Expression{
+		"block": &ast.BlockExpression{Block: &ast.BlockStatement{Statements: []ast.Statement{
+			&ast.ExpressionStatement{Expression: array()},
+		}}},
+		"match": &ast.MatchExpression{
+			Scrutinee: &ast.Boolean{Value: true},
+			Arms: []*ast.MatchArm{{
+				Pattern: &ast.BindingPattern{Name: &ast.Identifier{Value: "value"}},
+				Body:    array(),
+			}},
+		},
+		"variant": &ast.VariantExpression{Payload: array()},
+	}
+	for name, value := range cases {
+		t.Run(name, func(t *testing.T) {
+			tc := New(nilObjectEnvironment())
+			block := &ast.BlockExpression{Block: &ast.BlockStatement{Statements: []ast.Statement{
+				&ast.VariableDeclaration{
+					Name:  &ast.Identifier{Value: "local"},
+					Value: value,
+				},
+				&ast.FunctionStatement{
+					Name: &ast.Identifier{Value: "inner"},
+					Body: &ast.Identifier{Value: "local"},
+				},
+				&ast.ExpressionStatement{Expression: &ast.Identifier{Value: "inner"}},
+			}}}
+			facts := deriveGeneralizationFacts(polymorphicIdentityType(), block, tc.env)
+			if !facts.Has(GeneralizationMutableAuthority) {
+				t.Fatalf("composite local authority was lost through capture: %v", facts)
+			}
+		})
+	}
+}
+
+func TestMatchBinderShadowsOuterBarrierThroughLocalAlias(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	tc.env.Set("item", GeneralizeWithFacts(
+		polymorphicIdentityType(),
+		tc.env,
+		GeneralizationFacts{Barriers: GeneralizationMutableAuthority},
+	))
+	match := &ast.MatchExpression{
+		Scrutinee: &ast.Boolean{Value: true},
+		Arms: []*ast.MatchArm{{
+			Pattern: &ast.BindingPattern{Name: &ast.Identifier{Value: "item"}},
+			Body: &ast.BlockExpression{Block: &ast.BlockStatement{Statements: []ast.Statement{
+				&ast.VariableDeclaration{
+					Name:  &ast.Identifier{Value: "alias"},
+					Value: &ast.Identifier{Value: "item"},
+				},
+				&ast.FunctionStatement{
+					Name: &ast.Identifier{Value: "inner"},
+					Body: &ast.Identifier{Value: "alias"},
+				},
+				&ast.ExpressionStatement{Expression: &ast.Identifier{Value: "inner"}},
+			}}},
+		}},
+	}
+	if facts := deriveGeneralizationFacts(polymorphicIdentityType(), match, tc.env); !facts.Safe() {
+		t.Fatalf("match binder alias resolved an unrelated outer barrier: %v", facts)
+	}
+}
+
+func TestAssignedLocalAuthorityPropagatesThroughCapture(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	block := &ast.BlockExpression{Block: &ast.BlockStatement{Statements: []ast.Statement{
+		&ast.VariableDeclaration{Name: &ast.Identifier{Value: "local"}},
+		&ast.AssignmentStatement{
+			Name: &ast.Identifier{Value: "local"},
+			Value: &ast.ArrayLiteral{Elements: []ast.Expression{
+				&ast.IntegerLiteral{Value: 1},
+			}},
+		},
+		&ast.FunctionStatement{
+			Name: &ast.Identifier{Value: "inner"},
+			Body: &ast.Identifier{Value: "local"},
+		},
+		&ast.ExpressionStatement{Expression: &ast.Identifier{Value: "inner"}},
+	}}}
+	facts := deriveGeneralizationFacts(polymorphicIdentityType(), block, tc.env)
+	if !facts.Has(GeneralizationMutableAuthority) {
+		t.Fatalf("assigned local authority was lost through capture: %v", facts)
+	}
+}
+
+func TestNestedAssignmentUpdatesInheritedLocalAuthority(t *testing.T) {
+	assignment := func() *ast.AssignmentStatement {
+		return &ast.AssignmentStatement{
+			Name: &ast.Identifier{Value: "local"},
+			Value: &ast.ArrayLiteral{Elements: []ast.Expression{
+				&ast.IntegerLiteral{Value: 1},
+			}},
+		}
+	}
+	cases := map[string]ast.Statement{
+		"block": &ast.BlockStatement{Statements: []ast.Statement{assignment()}},
+		"while": &ast.WhileStatement{
+			Condition: &ast.Boolean{Value: true},
+			Body:      &ast.BlockStatement{Statements: []ast.Statement{assignment()}},
+		},
+	}
+	for name, nested := range cases {
+		t.Run(name, func(t *testing.T) {
+			tc := New(nilObjectEnvironment())
+			block := &ast.BlockExpression{Block: &ast.BlockStatement{Statements: []ast.Statement{
+				&ast.VariableDeclaration{Name: &ast.Identifier{Value: "local"}},
+				nested,
+				&ast.FunctionStatement{
+					Name: &ast.Identifier{Value: "inner"},
+					Body: &ast.Identifier{Value: "local"},
+				},
+				&ast.ExpressionStatement{Expression: &ast.Identifier{Value: "inner"}},
+			}}}
+			facts := deriveGeneralizationFacts(polymorphicIdentityType(), block, tc.env)
+			if !facts.Has(GeneralizationMutableAuthority) {
+				t.Fatalf("nested assignment update was lost at scope exit: %v", facts)
+			}
+		})
+	}
+}
+
+func TestOuterAssignmentBlocksGeneralization(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	tc.env.Set("outer", &TypeScheme{Type: &PrimitiveType{Name: "int"}})
+	block := &ast.BlockExpression{Block: &ast.BlockStatement{Statements: []ast.Statement{
+		&ast.AssignmentStatement{
+			Name:  &ast.Identifier{Value: "outer"},
+			Value: &ast.IntegerLiteral{Value: 1},
+		},
+	}}}
+	facts := deriveGeneralizationFacts(polymorphicIdentityType(), block, tc.env)
+	if !facts.Has(GeneralizationMutableAuthority) || !facts.Has(GeneralizationEffectfulCapture) {
+		t.Fatalf("outer assignment did not block generalization: %v", facts)
+	}
+}
+
+func TestNestedBlockBindingsDoNotLeakIntoCaptureScope(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	tc.env.Set("item", GeneralizeWithFacts(
+		polymorphicIdentityType(),
+		tc.env,
+		GeneralizationFacts{Barriers: GeneralizationMutableAuthority},
+	))
+	fn := &ast.FunctionLiteral{Body: &ast.BlockStatement{Statements: []ast.Statement{
+		&ast.BlockStatement{Statements: []ast.Statement{
+			&ast.VariableDeclaration{
+				Name:  &ast.Identifier{Value: "item"},
+				Value: &ast.IntegerLiteral{Value: 1},
+			},
+		}},
+		&ast.ExpressionStatement{Expression: &ast.Identifier{Value: "item"}},
+	}}}
+	if facts := functionCaptureFacts(fn, tc.env); !facts.Has(GeneralizationMutableAuthority) {
+		t.Fatalf("nested block binding leaked and hid an outer capture: %v", facts)
+	}
+}
+
+func TestMethodSelectorPropagatesResolvedSchemeBarriers(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	tc.env.SetType("receiver", &ADTType{Name: "Box"})
+	tc.env.Set("Box::touch", &TypeScheme{
+		Type: &FunctionType{ReturnType: &UnitType{}},
+		GeneralizationBarriers: GeneralizationUnsafeAssumption,
+	})
+	call := &ast.InvocationExpression{
+		Function: &ast.IndexExpression{
+			Token: token.Token{Literal: "."},
+			Left:  &ast.Identifier{Value: "receiver"},
+			Index: &ast.Identifier{Value: "touch"},
+		},
+	}
+	fn := &ast.FunctionLiteral{
+		Arguments: []*ast.Identifier{{Value: "receiver"}},
+		Body: &ast.BlockStatement{Statements: []ast.Statement{
+			&ast.ExpressionStatement{Expression: call},
+		}},
+	}
+	facts := functionCaptureFacts(fn, tc.env)
+	if !facts.Has(GeneralizationUnsafeAssumption) {
+		t.Fatalf("resolved method barrier did not propagate: %v", facts)
+	}
+	if facts.Has(GeneralizationUnknownAuthority) {
+		t.Fatalf("resolved method was treated as unknown: %v", facts)
+	}
+}
+
+func TestSafeResolvedMethodSelectorDoesNotBlockGeneralization(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	tc.env.SetType("receiver", &ADTType{Name: "Box"})
+	tc.env.Set("Box::inspect", &TypeScheme{
+		Type: &FunctionType{ReturnType: &UnitType{}},
+	})
+	fn := &ast.FunctionLiteral{
+		Arguments: []*ast.Identifier{{Value: "receiver"}},
+		Body: &ast.BlockStatement{Statements: []ast.Statement{
+			&ast.ExpressionStatement{Expression: &ast.InvocationExpression{
+				Function: &ast.IndexExpression{
+					Token: token.Token{Literal: "."},
+					Left:  &ast.Identifier{Value: "receiver"},
+					Index: &ast.Identifier{Value: "inspect"},
+				},
+			}},
+		}},
+	}
+	if facts := functionCaptureFacts(fn, tc.env); !facts.Safe() {
+		t.Fatalf("safe resolved method blocked generalization: %v", facts)
+	}
+}
+
+func TestNestedClosureInheritsMatchArmBindingScope(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	tc.env.SetType("item", &ArrayType{
+		ElementType: &PrimitiveType{Name: "u8"},
+		Length: -1,
+		IsSpan: true,
+	})
+	nested := &ast.FunctionLiteral{Body: &ast.BlockStatement{Statements: []ast.Statement{
+		&ast.ExpressionStatement{Expression: &ast.Identifier{Value: "item"}},
+	}}}
+	fn := &ast.FunctionLiteral{
+		Arguments: []*ast.Identifier{{Value: "value"}},
+		Body: &ast.BlockStatement{Statements: []ast.Statement{
+			&ast.ExpressionStatement{Expression: &ast.MatchExpression{
+				Scrutinee: &ast.Identifier{Value: "value"},
+				Arms: []*ast.MatchArm{{
+					Pattern: &ast.BindingPattern{Name: &ast.Identifier{Value: "item"}},
+					Body: nested,
+				}},
+			}},
+		}},
+	}
+	if facts := functionCaptureFacts(fn, tc.env); !facts.Safe() {
+		t.Fatalf("nested closure lost match-arm binder scope: %v", facts)
+	}
+}
+
+func TestRejectedCallDoesNotCommitPartialMonomorphicBindings(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	v := NewUnifier().FreshTypeVar("T")
+	scheme := GeneralizeWithFacts(
+		&FunctionType{
+			Parameters: []Type{v, &BoolType{}},
+			ReturnType: v,
+		},
+		tc.env,
+		GeneralizationFacts{Barriers: GeneralizationUnsafeAssumption},
+	)
+	tc.env.Set("blockedPair", scheme)
+
+	tc.checkInvocationExpression(&ast.InvocationExpression{
+		Function: &ast.Identifier{Value: "blockedPair"},
+		Arguments: []ast.Expression{
+			&ast.IntegerLiteral{Value: 1},
+			&ast.StringLiteral{Value: "not bool"},
+		},
+	})
+	if _, fixed := scheme.Monomorphic[v]; fixed {
+		t.Fatal("rejected call committed a partial monomorphic solution")
+	}
+
+	before := len(tc.Errors())
+	result := tc.checkInvocationExpression(&ast.InvocationExpression{
+		Function: &ast.Identifier{Value: "blockedPair"},
+		Arguments: []ast.Expression{
+			&ast.StringLiteral{Value: "valid"},
+			&ast.Boolean{Value: true},
+		},
+	})
+	if result == nil || !result.Equals(&StringType{}) {
+		t.Fatalf("valid later call type = %v, want string", result)
+	}
+	if len(tc.Errors()) != before {
+		t.Fatalf("valid later call cascaded after rejected call: %v", tc.Errors()[before:])
+	}
+}
+
+func TestDirectFunctionReferenceAddsNoCaptureBarrier(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	tc.env.SetType("helper", &FunctionType{
+		Parameters: []Type{&PrimitiveType{Name: "int"}},
+		ReturnType: &PrimitiveType{Name: "int"},
+	})
+	fn := &ast.FunctionLiteral{Body: &ast.BlockStatement{Statements: []ast.Statement{
+		&ast.ExpressionStatement{Expression: &ast.InvocationExpression{
+			Function: &ast.Identifier{Value: "helper"},
+			Arguments: []ast.Expression{&ast.IntegerLiteral{Value: 1}},
+		}},
+	}}}
+	if facts := functionCaptureFacts(fn, tc.env); !facts.Safe() {
+		t.Fatalf("direct function reference was classified as capture: %v", facts)
+	}
+}
+
+func TestArgumentDiagnosticPreventsMonomorphicCommit(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	v := NewUnifier().FreshTypeVar("T")
+	scheme := GeneralizeWithFacts(
+		&FunctionType{Parameters: []Type{v}, ReturnType: v},
+		tc.env,
+		GeneralizationFacts{Barriers: GeneralizationUnsafeAssumption},
+	)
+	tc.env.Set("blocked", scheme)
+	badArray := &ast.ArrayLiteral{
+		Type: &ast.IndexExpression{
+			Left: &ast.Identifier{Value: "int"},
+			Index: &ast.IntegerLiteral{Value: 1},
+		},
+		Elements: []ast.Expression{&ast.StringLiteral{Value: "bad element"}},
+	}
+	tc.checkInvocationExpression(&ast.InvocationExpression{
+		Function: &ast.Identifier{Value: "blocked"},
+		Arguments: []ast.Expression{badArray},
+	})
+	if _, fixed := scheme.Monomorphic[v]; fixed {
+		t.Fatal("argument diagnostic still committed a monomorphic solution")
+	}
+
+	before := len(tc.Errors())
+	result := tc.checkInvocationExpression(&ast.InvocationExpression{
+		Function: &ast.Identifier{Value: "blocked"},
+		Arguments: []ast.Expression{&ast.StringLiteral{Value: "valid"}},
+	})
+	if result == nil || !result.Equals(&StringType{}) {
+		t.Fatalf("later valid call type = %v, want string", result)
+	}
+	if len(tc.Errors()) != before {
+		t.Fatalf("later valid call cascaded: %v", tc.Errors()[before:])
+	}
+}
+
+func TestNestedNamedFunctionInheritsMatchArmBindingScope(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	tc.env.SetType("item", &ArrayType{
+		ElementType: &PrimitiveType{Name: "u8"},
+		Length: -1,
+		IsSpan: true,
+	})
+	inner := &ast.FunctionStatement{
+		Name: &ast.Identifier{Value: "inner"},
+		Body: &ast.Identifier{Value: "item"},
+	}
+	armBody := &ast.BlockExpression{Block: &ast.BlockStatement{Statements: []ast.Statement{
+		inner,
+		&ast.ExpressionStatement{Expression: &ast.Identifier{Value: "inner"}},
+	}}}
+	fn := &ast.FunctionLiteral{
+		Arguments: []*ast.Identifier{{Value: "value"}},
+		Body: &ast.BlockStatement{Statements: []ast.Statement{
+			&ast.ExpressionStatement{Expression: &ast.MatchExpression{
+				Scrutinee: &ast.Identifier{Value: "value"},
+				Arms: []*ast.MatchArm{{
+					Pattern: &ast.BindingPattern{Name: &ast.Identifier{Value: "item"}},
+					Body: armBody,
+				}},
+			}},
+		}},
+	}
+	if facts := functionCaptureFacts(fn, tc.env); !facts.Safe() {
+		t.Fatalf("nested named function lost match-arm binder scope: %v", facts)
+	}
+}
+
+func TestAnnotatedAliasCommitsBlockedSpecialization(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	v := NewUnifier().FreshTypeVar("T")
+	blocked := GeneralizeWithFacts(
+		&FunctionType{Parameters: []Type{v}, ReturnType: v},
+		tc.env,
+		GeneralizationFacts{Barriers: GeneralizationUnsafeAssumption},
+	)
+	tc.env.Set("blocked", blocked)
+	tc.env.SetType("IntFn", &FunctionType{
+		Parameters: []Type{&PrimitiveType{Name: "int"}},
+		ReturnType: &PrimitiveType{Name: "int"},
+	})
+	tc.env.SetType("StringFn", &FunctionType{
+		Parameters: []Type{&StringType{}},
+		ReturnType: &StringType{},
+	})
+
+	tc.checkVariableDeclaration(&ast.VariableDeclaration{
+		Name: &ast.Identifier{Value: "intAlias"},
+		Type: &ast.Identifier{Value: "IntFn"},
+		Value: &ast.Identifier{Value: "blocked"},
+	})
+	if got := blocked.Monomorphic.Apply(v); !got.Equals(&PrimitiveType{Name: "int"}) {
+		t.Fatalf("annotated alias solution = %v, want int", got)
+	}
+	before := len(tc.Errors())
+	tc.checkVariableDeclaration(&ast.VariableDeclaration{
+		Name: &ast.Identifier{Value: "stringAlias"},
+		Type: &ast.Identifier{Value: "StringFn"},
+		Value: &ast.Identifier{Value: "blocked"},
+	})
+	if len(tc.Errors()) == before {
+		t.Fatal("conflicting annotated alias reused blocked binding polymorphically")
+	}
+}
+
+func TestIndependentBlockedSchemesDoNotPolluteConstraints(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	v1 := NewUnifier().FreshTypeVar("T")
+	v2 := NewUnifier().FreshTypeVar("T")
+	first := makeMonomorphicScheme(
+		&FunctionType{Parameters: []Type{v1}, ReturnType: v1},
+		[]Constraint{{Var: "T"}},
+	)
+	second := makeMonomorphicScheme(
+		&FunctionType{Parameters: []Type{v2}, ReturnType: v2},
+		[]Constraint{{Var: "T"}},
+	)
+	tc.env.Set("first", first)
+	tc.env.Set("second", second)
+	intFn := &FunctionType{
+		Parameters: []Type{&PrimitiveType{Name: "int"}},
+		ReturnType: &PrimitiveType{Name: "int"},
+	}
+	tc.env.SetType("takesBoth", &FunctionType{
+		Parameters: []Type{intFn, intFn},
+		ReturnType: &UnitType{},
+	})
+	tc.checkInvocationExpression(&ast.InvocationExpression{
+		Function: &ast.Identifier{Value: "takesBoth"},
+		Arguments: []ast.Expression{
+			&ast.Identifier{Value: "first"},
+			&ast.Identifier{Value: "second"},
+		},
+	})
+	before := len(tc.Errors())
+	for _, name := range []string{"first", "second"} {
+		tc.checkInvocationExpression(&ast.InvocationExpression{
+			Function: &ast.Identifier{Value: name},
+			Arguments: []ast.Expression{&ast.IntegerLiteral{Value: 1}},
+		})
+	}
+	if len(tc.Errors()) != before {
+		t.Fatalf("independent same-named binders polluted constraints: %v", tc.Errors()[before:])
+	}
+}
+
+func TestBlockedLocalDoesNotCaptureEnclosingTypeBinder(t *testing.T) {
+	env := NewTypeEnvironment()
+	enclosing := NewUnifier().FreshTypeVar("T")
+	env.SetType("T", enclosing)
+	localType := &ArrayType{
+		ElementType: enclosing,
+		Length: 1,
+	}
+	scheme := GeneralizeWithFacts(
+		localType,
+		env,
+		GeneralizationFacts{Barriers: GeneralizationMutableAuthority},
+	)
+	if enclosing.Monomorphic != nil {
+		t.Fatal("blocked local tagged an enclosing generic binder")
+	}
+	if scheme.Monomorphic != nil {
+		t.Fatal("scheme gained persistent state without a local free variable")
+	}
+
+	functionType := &FunctionType{
+		Parameters: []Type{enclosing},
+		ReturnType: enclosing,
+	}
+	generalized := Generalize(functionType, NewTypeEnvironment())
+	if len(generalized.TypeVars) != 1 || generalized.Monomorphic != nil {
+		t.Fatalf("enclosing function binder was not reusable: %#v", generalized)
+	}
+}
+
+func TestCaptureMetadataSurvivesWithoutLocalFreeBinders(t *testing.T) {
+	env := NewTypeEnvironment()
+	enclosing := NewUnifier().FreshTypeVar("T")
+	env.SetType("T", enclosing)
+	authorityFunction := GeneralizeWithFacts(
+		&FunctionType{Parameters: []Type{enclosing}, ReturnType: enclosing},
+		env,
+		GeneralizationFacts{Barriers: GeneralizationMutableAuthority | GeneralizationRegionBound},
+	)
+	if authorityFunction.Monomorphic != nil {
+		t.Fatal("enclosing binder incorrectly gained persistent state")
+	}
+	if authorityFunction.GeneralizationBarriers == 0 {
+		t.Fatal("authority metadata was discarded with empty local free-variable set")
+	}
+	env.Set("authorityFunction", authorityFunction)
+
+	fn := &ast.FunctionLiteral{Body: &ast.BlockStatement{Statements: []ast.Statement{
+		&ast.ExpressionStatement{Expression: &ast.Identifier{Value: "authorityFunction"}},
+	}}}
+	facts := functionCaptureFacts(fn, env)
+	if !facts.Has(GeneralizationMutableAuthority) || !facts.Has(GeneralizationRegionBound) {
+		t.Fatalf("transitive function capture lost authority metadata: %v", facts)
+	}
+}
+
+func TestMatchInitializerDoesNotPropagateShadowedBarrierMetadata(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	outer := GeneralizeWithFacts(
+		polymorphicIdentityType(),
+		tc.env,
+		GeneralizationFacts{Barriers: GeneralizationMutableAuthority},
+	)
+	tc.env.Set("item", outer)
+	match := &ast.MatchExpression{
+		Scrutinee: &ast.Boolean{Value: true},
+		Arms: []*ast.MatchArm{{
+			Pattern: &ast.BindingPattern{Name: &ast.Identifier{Value: "item"}},
+			Body: &ast.Identifier{Value: "item"},
+		}},
+	}
+	if facts := deriveGeneralizationFacts(polymorphicIdentityType(), match, tc.env); !facts.Safe() {
+		t.Fatalf("match-local identifier propagated outer barrier metadata: %v", facts)
+	}
+}
+
+func TestMatchInitializerPassesBinderScopeIntoNestedFunctions(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	outer := GeneralizeWithFacts(
+		polymorphicIdentityType(),
+		tc.env,
+		GeneralizationFacts{Barriers: GeneralizationMutableAuthority},
+	)
+	tc.env.Set("item", outer)
+
+	namedBody := &ast.BlockExpression{Block: &ast.BlockStatement{Statements: []ast.Statement{
+		&ast.FunctionStatement{
+			Name: &ast.Identifier{Value: "inner"},
+			Body: &ast.Identifier{Value: "item"},
+		},
+		&ast.ExpressionStatement{Expression: &ast.Identifier{Value: "inner"}},
+	}}}
+	literalBody := &ast.FunctionLiteral{Body: &ast.BlockStatement{Statements: []ast.Statement{
+		&ast.ExpressionStatement{Expression: &ast.Identifier{Value: "item"}},
+	}}}
+
+	for name, body := range map[string]ast.Expression{
+		"named":   namedBody,
+		"literal": literalBody,
+	} {
+		t.Run(name, func(t *testing.T) {
+			match := &ast.MatchExpression{
+				Scrutinee: &ast.Boolean{Value: true},
+				Arms: []*ast.MatchArm{{
+					Pattern: &ast.BindingPattern{Name: &ast.Identifier{Value: "item"}},
+					Body:    body,
+				}},
+			}
+			if facts := deriveGeneralizationFacts(polymorphicIdentityType(), match, tc.env); !facts.Safe() {
+				t.Fatalf("nested function lost match-arm binder scope: %v", facts)
+			}
+		})
+	}
+}
+
+func TestFailedAnnotatedDeclarationRollsBackNestedCall(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	v := NewUnifier().FreshTypeVar("T")
+	blocked := GeneralizeWithFacts(
+		&FunctionType{Parameters: []Type{v}, ReturnType: v},
+		tc.env,
+		GeneralizationFacts{Barriers: GeneralizationUnsafeAssumption},
+	)
+	tc.env.Set("blocked", blocked)
+	tc.checkVariableDeclaration(&ast.VariableDeclaration{
+		Name: &ast.Identifier{Value: "bad"},
+		Type: &ast.Identifier{Value: "string"},
+		Value: &ast.InvocationExpression{
+			Function: &ast.Identifier{Value: "blocked"},
+			Arguments: []ast.Expression{&ast.IntegerLiteral{Value: 1}},
+		},
+	})
+	if _, fixed := blocked.Monomorphic[v]; fixed {
+		t.Fatal("failed enclosing declaration committed nested specialization")
+	}
+	before := len(tc.Errors())
+	result := tc.checkInvocationExpression(&ast.InvocationExpression{
+		Function: &ast.Identifier{Value: "blocked"},
+		Arguments: []ast.Expression{&ast.StringLiteral{Value: "valid"}},
+	})
+	if result == nil || !result.Equals(&StringType{}) {
+		t.Fatalf("later valid call type = %v, want string", result)
+	}
+	if len(tc.Errors()) != before {
+		t.Fatalf("later valid call cascaded: %v", tc.Errors()[before:])
+	}
+}
+
+func TestSiblingUsesSharePendingMonomorphicSpecialization(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	v := NewUnifier().FreshTypeVar("T")
+	blocked := GeneralizeWithFacts(
+		&FunctionType{Parameters: []Type{v}, ReturnType: v},
+		tc.env,
+		GeneralizationFacts{Barriers: GeneralizationUnsafeAssumption},
+	)
+	tc.env.Set("blocked", blocked)
+	tc.env.SetType("consume", &FunctionType{
+		Parameters: []Type{
+			&PrimitiveType{Name: "int"},
+			&StringType{},
+		},
+		ReturnType: &UnitType{},
+	})
+	callBlocked := func(argument ast.Expression) ast.Expression {
+		return &ast.InvocationExpression{
+			Function: &ast.Identifier{Value: "blocked"},
+			Arguments: []ast.Expression{argument},
+		}
+	}
+	before := len(tc.Errors())
+	tc.checkInvocationExpression(&ast.InvocationExpression{
+		Function: &ast.Identifier{Value: "consume"},
+		Arguments: []ast.Expression{
+			callBlocked(&ast.IntegerLiteral{Value: 1}),
+			callBlocked(&ast.StringLiteral{Value: "conflict"}),
+		},
+	})
+	if len(tc.Errors()) == before {
+		t.Fatal("sibling uses specialized one blocked binding incompatibly")
+	}
+	if _, fixed := blocked.Monomorphic[v]; fixed {
+		t.Fatal("failed sibling transaction committed a specialization")
+	}
+}
+
+func TestAssertFailureRollsBackNestedSpecialization(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	v := NewUnifier().FreshTypeVar("T")
+	blocked := GeneralizeWithFacts(
+		&FunctionType{Parameters: []Type{v}, ReturnType: v},
+		tc.env,
+		GeneralizationFacts{Barriers: GeneralizationUnsafeAssumption},
+	)
+	tc.env.Set("blocked", blocked)
+	tc.checkInvocationExpression(&ast.InvocationExpression{
+		Function: &ast.Identifier{Value: "assert"},
+		Arguments: []ast.Expression{
+			&ast.InvocationExpression{
+				Function: &ast.Identifier{Value: "blocked"},
+				Arguments: []ast.Expression{&ast.IntegerLiteral{Value: 1}},
+			},
+		},
+	})
+	if _, fixed := blocked.Monomorphic[v]; fixed {
+		t.Fatal("failed assert committed nested specialization")
+	}
+	before := len(tc.Errors())
+	result := tc.checkInvocationExpression(&ast.InvocationExpression{
+		Function: &ast.Identifier{Value: "blocked"},
+		Arguments: []ast.Expression{&ast.StringLiteral{Value: "valid"}},
+	})
+	if result == nil || !result.Equals(&StringType{}) {
+		t.Fatalf("later valid call type = %v, want string", result)
+	}
+	if len(tc.Errors()) != before {
+		t.Fatalf("later valid call cascaded: %v", tc.Errors()[before:])
+	}
+}
+
+func TestRepeatedBlockedArgumentsReconcileWithinCall(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	v := NewUnifier().FreshTypeVar("T")
+	blocked := GeneralizeWithFacts(
+		&FunctionType{Parameters: []Type{v}, ReturnType: v},
+		tc.env,
+		GeneralizationFacts{Barriers: GeneralizationUnsafeAssumption},
+	)
+	tc.env.Set("blocked", blocked)
+	tc.env.SetType("consumeFunctions", &FunctionType{
+		Parameters: []Type{
+			&FunctionType{
+				Parameters: []Type{&PrimitiveType{Name: "int"}},
+				ReturnType: &PrimitiveType{Name: "int"},
+			},
+			&FunctionType{
+				Parameters: []Type{&StringType{}},
+				ReturnType: &StringType{},
+			},
+		},
+		ReturnType: &UnitType{},
+	})
+	before := len(tc.Errors())
+	tc.checkInvocationExpression(&ast.InvocationExpression{
+		Function: &ast.Identifier{Value: "consumeFunctions"},
+		Arguments: []ast.Expression{
+			&ast.Identifier{Value: "blocked"},
+			&ast.Identifier{Value: "blocked"},
+		},
+	})
+	if len(tc.Errors()) == before {
+		t.Fatal("repeated blocked arguments accepted incompatible specializations")
+	}
+	if _, fixed := blocked.Monomorphic[v]; fixed {
+		t.Fatal("failed repeated-argument call committed specialization")
+	}
+}
+
+func TestFailedAssignmentRollsBackNestedSpecialization(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	tc.env.SetType("target", &StringType{})
+	v := NewUnifier().FreshTypeVar("T")
+	blocked := GeneralizeWithFacts(
+		&FunctionType{Parameters: []Type{v}, ReturnType: v},
+		tc.env,
+		GeneralizationFacts{Barriers: GeneralizationUnsafeAssumption},
+	)
+	tc.env.Set("blocked", blocked)
+	tc.checkAssignmentStatement(&ast.AssignmentStatement{
+		Name: &ast.Identifier{Value: "target"},
+		Value: &ast.InvocationExpression{
+			Function: &ast.Identifier{Value: "blocked"},
+			Arguments: []ast.Expression{&ast.IntegerLiteral{Value: 1}},
+		},
+	})
+	if _, fixed := blocked.Monomorphic[v]; fixed {
+		t.Fatal("failed assignment committed nested specialization")
+	}
+	before := len(tc.Errors())
+	result := tc.checkInvocationExpression(&ast.InvocationExpression{
+		Function: &ast.Identifier{Value: "blocked"},
+		Arguments: []ast.Expression{&ast.StringLiteral{Value: "valid"}},
+	})
+	if result == nil || !result.Equals(&StringType{}) {
+		t.Fatalf("later valid call type = %v, want string", result)
+	}
+	if len(tc.Errors()) != before {
+		t.Fatalf("later valid call cascaded: %v", tc.Errors()[before:])
+	}
+}
+
+
+func TestSiblingConstrainedUsesSeePendingMonomorphicSpecialization(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	v := NewUnifier().FreshTypeVar("T")
+	blocked := makeMonomorphicScheme(
+		&FunctionType{Parameters: []Type{v}, ReturnType: v},
+		[]Constraint{{Var: "T"}},
+	)
+	tc.env.Set("blocked", blocked)
+	tc.env.SetType("consume", &FunctionType{
+		Parameters: []Type{
+			&PrimitiveType{Name: "int"},
+			&PrimitiveType{Name: "int"},
+		},
+		ReturnType: &UnitType{},
+	})
+	callBlocked := func(value int64) ast.Expression {
+		return &ast.InvocationExpression{
+			Function: &ast.Identifier{Value: "blocked"},
+			Arguments: []ast.Expression{&ast.IntegerLiteral{Value: value}},
+		}
+	}
+
+	before := len(tc.Errors())
+	result := tc.checkInvocationExpression(&ast.InvocationExpression{
+		Function: &ast.Identifier{Value: "consume"},
+		Arguments: []ast.Expression{
+			callBlocked(1),
+			callBlocked(2),
+		},
+	})
+	if result == nil || !result.Equals(&UnitType{}) {
+		t.Fatalf("sibling constrained call type = %v, want unit", result)
+	}
+	if len(tc.Errors()) != before {
+		t.Fatalf("compatible sibling constrained calls failed: %v", tc.Errors()[before:])
+	}
+	if got := blocked.Monomorphic.Apply(v); !got.Equals(&PrimitiveType{Name: "int"}) {
+		t.Fatalf("committed constrained specialization = %v, want int", got)
+	}
+}
+
+
+func TestEscapedTypeVariableJoinsBlockedMonomorphicGroup(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	blockedVar := NewUnifier().FreshTypeVar("T")
+	blocked := makeMonomorphicScheme(
+		&FunctionType{Parameters: []Type{blockedVar}, ReturnType: blockedVar},
+		nil,
+	)
+	tc.env.Set("blocked", blocked)
+
+	polyVar := NewUnifier().FreshTypeVar("P")
+	tc.env.Set("poly", Generalize(
+		&FunctionType{Parameters: []Type{polyVar}, ReturnType: polyVar},
+		tc.env,
+	))
+	intFn := &FunctionType{
+		Parameters: []Type{&PrimitiveType{Name: "int"}},
+		ReturnType: &PrimitiveType{Name: "int"},
+	}
+	stringFn := &FunctionType{
+		Parameters: []Type{&StringType{}},
+		ReturnType: &StringType{},
+	}
+	tc.env.Set("intIdentity", &TypeScheme{Type: intFn})
+	tc.env.Set("stringIdentity", &TypeScheme{Type: stringFn})
+	callBlocked := func(name string) Type {
+		return tc.checkInvocationExpression(&ast.InvocationExpression{
+			Function: &ast.Identifier{Value: "blocked"},
+			Arguments: []ast.Expression{&ast.Identifier{Value: name}},
+		})
+	}
+
+	before := len(tc.Errors())
+	if result := callBlocked("poly"); result == nil {
+		t.Fatal("blocked binding rejected the initial polymorphic value")
+	}
+	if len(tc.Errors()) != before {
+		t.Fatalf("initial polymorphic escape failed: %v", tc.Errors()[before:])
+	}
+
+	if result := callBlocked("intIdentity"); result == nil || !result.Equals(intFn) {
+		t.Fatalf("escaped variable did not specialize to int identity: %v", result)
+	}
+	if len(tc.Errors()) != before {
+		t.Fatalf("int specialization failed: %v", tc.Errors()[before:])
+	}
+
+	callBlocked("stringIdentity")
+	if len(tc.Errors()) == before {
+		t.Fatal("escaped variable reopened blocked binding at string identity")
+	}
+}
+
+
+func TestBarredPredeclaredGenericIsPersistent(t *testing.T) {
+	tc := New(object.NewEnvironment())
+	fn := &ast.FunctionStatement{
+		Name: &ast.Identifier{Value: "unsafeIdentity"},
+		TypeParams: []*ast.TypeParameter{{
+			Name: &ast.Identifier{Value: "T"},
+		}},
+		Parameters: []*ast.FunctionParameter{{
+			Name: &ast.Identifier{Value: "value"},
+			Type: &ast.Identifier{Value: "T"},
+		}},
+		ReturnType: &ast.Identifier{Value: "T"},
+		Body: &ast.BlockExpression{Block: &ast.BlockStatement{
+			Statements: []ast.Statement{
+				&ast.UnsafeBlock{Body: &ast.BlockStatement{}},
+				&ast.ExpressionStatement{Expression: &ast.Identifier{Value: "value"}},
+			},
+		}},
+	}
+	program := &ast.Program{Statements: []ast.Statement{fn}}
+	tc.predeclareFunctionSignature(fn)
+	tc.resolvePredeclaredFunctionBarriers(program)
+
+	scheme, ok := tc.env.Get("unsafeIdentity")
+	if !ok || scheme == nil {
+		t.Fatal("barred generic was not predeclared")
+	}
+	if len(scheme.TypeVars) != 0 || scheme.Monomorphic == nil {
+		t.Fatalf("barred predeclared scheme remained polymorphic: %#v", scheme)
+	}
+
+	first := Instantiate(scheme, NewUnifier()).(*FunctionType)
+	binding := NewUnifier().Unify(first.Parameters[0], &PrimitiveType{Name: "i32"})
+	if binding == nil {
+		t.Fatal("first monomorphic use did not unify")
+	}
+	commitMonomorphicBindings(binding)
+
+	tc.checkFunctionStatement(fn)
+	finalized, ok := tc.env.Get("unsafeIdentity")
+	if !ok || finalized != scheme {
+		t.Fatal("function finalization replaced the persistent predeclared scheme")
+	}
+
+	second := Instantiate(finalized, NewUnifier()).(*FunctionType)
+	if got := NewUnifier().Unify(second.Parameters[0], &StringType{}); got != nil {
+		t.Fatalf("second incompatible use reopened barred generic: %v", got)
+	}
+}
+
+
+func TestPredeclaredMethodCallDoesNotMonomorphizeSafeGeneric(t *testing.T) {
+	box := &ast.ADTType{
+		Name: &ast.Identifier{Value: "Box"},
+		Variants: []*ast.ADTVariant{{
+			Name: &ast.Identifier{Value: "Box"},
+		}},
+	}
+	method := &ast.FunctionStatement{
+		Receiver: &ast.FunctionParameter{
+			Name: &ast.Identifier{Value: "self"},
+			Type: &ast.Identifier{Value: "Box"},
+		},
+		Name:       &ast.Identifier{Value: "read"},
+		ReturnType: &ast.Identifier{Value: "i32"},
+		Body:       &ast.IntegerLiteral{Value: 0},
+	}
+	generic := &ast.FunctionStatement{
+		Name: &ast.Identifier{Value: "keep"},
+		TypeParams: []*ast.TypeParameter{{
+			Name: &ast.Identifier{Value: "T"},
+		}},
+		Parameters: []*ast.FunctionParameter{
+			{Name: &ast.Identifier{Value: "value"}, Type: &ast.Identifier{Value: "T"}},
+			{Name: &ast.Identifier{Value: "box"}, Type: &ast.Identifier{Value: "Box"}},
+		},
+		ReturnType: &ast.Identifier{Value: "T"},
+		Body: &ast.BlockExpression{Block: &ast.BlockStatement{Statements: []ast.Statement{
+			&ast.ExpressionStatement{Expression: &ast.InvocationExpression{
+				Function: &ast.IndexExpression{
+					Token: token.Token{Literal: "."},
+					Left:  &ast.Identifier{Value: "box"},
+					Index: &ast.Identifier{Value: "read"},
+				},
+			}},
+			&ast.ExpressionStatement{Expression: &ast.Identifier{Value: "value"}},
+		}}},
+	}
+	tc := New(nilObjectEnvironment())
+	tc.CheckProgram(&ast.Program{Statements: []ast.Statement{box, method, generic}})
+	scheme, ok := tc.env.Get("keep")
+	if !ok || scheme == nil {
+		t.Fatal("safe generic method caller was not registered")
+	}
+	if scheme.GeneralizationBarriers != 0 || len(scheme.TypeVars) != 1 {
+		t.Fatalf("safe generic method caller became monomorphic: %#v", scheme)
+	}
+}
+
+
+func TestCompilerLibraryCallDoesNotCreateCaptureBarrier(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	fn := &ast.FunctionLiteral{
+		Arguments: []*ast.Identifier{{Value: "value"}},
+		Body: &ast.BlockStatement{Statements: []ast.Statement{
+			&ast.ExpressionStatement{Expression: &ast.InvocationExpression{
+				Function: &ast.IndexExpression{
+					Token: token.Token{Literal: "."},
+					Left:  &ast.Identifier{Value: "arm64"},
+					Index: &ast.Identifier{Value: "clz64"},
+				},
+				Arguments: []ast.Expression{&ast.Identifier{Value: "value"}},
+			}},
+		}},
+	}
+	if facts := functionCaptureFacts(fn, tc.env); !facts.Safe() {
+		t.Fatalf("compiler library namespace blocked generalization: %v", facts)
+	}
+}
+
+func TestPredeclaredMethodParametersResolveMethodAuthority(t *testing.T) {
+	box := &ast.ADTType{
+		Name: &ast.Identifier{Value: "Box"},
+		Variants: []*ast.ADTVariant{{Name: &ast.Identifier{Value: "Box"}}},
+	}
+	read := &ast.FunctionStatement{
+		Receiver: &ast.FunctionParameter{
+			Name: &ast.Identifier{Value: "self"}, Type: &ast.Identifier{Value: "Box"},
+		},
+		Name: &ast.Identifier{Value: "read"},
+		ReturnType: &ast.Identifier{Value: "i32"},
+		Body: &ast.IntegerLiteral{Value: 0},
+	}
+	forward := &ast.FunctionStatement{
+		Receiver: &ast.FunctionParameter{
+			Name: &ast.Identifier{Value: "self"}, Type: &ast.Identifier{Value: "Box"},
+		},
+		Name: &ast.Identifier{Value: "forward"},
+		Parameters: []*ast.FunctionParameter{{
+			Name: &ast.Identifier{Value: "other"}, Type: &ast.Identifier{Value: "Box"},
+		}},
+		ReturnType: &ast.Identifier{Value: "i32"},
+		Body: &ast.InvocationExpression{
+			Function: &ast.IndexExpression{
+				Token: token.Token{Literal: "."},
+				Left: &ast.Identifier{Value: "other"},
+				Index: &ast.Identifier{Value: "read"},
+			},
+		},
+	}
+	tc := New(nilObjectEnvironment())
+	program := &ast.Program{Statements: []ast.Statement{box, read, forward}}
+	tc.CheckProgram(program)
+	scheme, ok := tc.env.Get("Box::forward")
+	if !ok || scheme == nil {
+		t.Fatal("forwarding method was not registered")
+	}
+	if scheme.GeneralizationBarriers != 0 {
+		t.Fatalf("typed method parameter retained unknown authority: %v", scheme.GeneralizationBarriers)
+	}
+}
+
+
+func TestDeclaredLocalTypeResolvesMethodAuthority(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	tc.env.Set("Box::read", &TypeScheme{
+		Type: &FunctionType{ReturnType: &PrimitiveType{Name: "i32"}},
+	})
+	fn := &ast.FunctionLiteral{
+		Body: &ast.BlockStatement{Statements: []ast.Statement{
+			&ast.VariableDeclaration{
+				Name: &ast.Identifier{Value: "box"},
+				Type: &ast.Identifier{Value: "Box"},
+				Value: &ast.VariantExpression{
+					TypeName: &ast.Identifier{Value: "Box"},
+					Variant: &ast.Identifier{Value: "Box"},
+				},
+			},
+			&ast.ExpressionStatement{Expression: &ast.InvocationExpression{
+				Function: &ast.IndexExpression{
+					Token: token.Token{Literal: "."},
+					Left: &ast.Identifier{Value: "box"},
+					Index: &ast.Identifier{Value: "read"},
+				},
+			}},
+		}},
+	}
+	if facts := functionCaptureFacts(fn, tc.env); !facts.Safe() {
+		t.Fatalf("declared local method receiver blocked generalization: %v", facts)
+	}
+}
+
+
+func TestExpressionReceiverResolvesMethodAuthority(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	tc.env.Set("makeBox", &TypeScheme{Type: &FunctionType{ReturnType: &ADTType{Name: "Box"}}})
+	tc.env.Set("Box::read", &TypeScheme{Type: &FunctionType{ReturnType: &PrimitiveType{Name: "i32"}}})
+	fn := &ast.FunctionLiteral{Body: &ast.BlockStatement{Statements: []ast.Statement{
+		&ast.ExpressionStatement{Expression: &ast.InvocationExpression{
+			Function: &ast.IndexExpression{
+				Token: token.Token{Literal: "."},
+				Left: &ast.InvocationExpression{Function: &ast.Identifier{Value: "makeBox"}},
+				Index: &ast.Identifier{Value: "read"},
+			},
+		}},
+	}}}
+	if facts := functionCaptureFacts(fn, tc.env); !facts.Safe() {
+		t.Fatalf("expression receiver blocked generalization: %v", facts)
 	}
 }

--- a/typechecker/generalization_test.go
+++ b/typechecker/generalization_test.go
@@ -1753,6 +1753,16 @@ func TestWritesThroughParametersDoNotCaptureAuthority(t *testing.T) {
 	if facts := functionCaptureFacts(fn, tc.env); !facts.Safe() {
 		t.Fatalf("parameter write treated as captured authority: %v", facts)
 	}
+	store := fn.Body.Statements[0].(*ast.IndexAssignmentStatement)
+	store.Target = &ast.IndexExpression{
+		Dot:   true,
+		Left:  store.Target,
+		Index: &ast.Identifier{Value: "count"},
+	}
+	tc.env.Set("count", &TypeScheme{Type: &UnitType{}, GeneralizationBarriers: GeneralizationUnsafeAssumption})
+	if facts := functionCaptureFacts(fn, tc.env); !facts.Safe() {
+		t.Fatalf("field name treated as captured binding: %v", facts)
+	}
 	fn.Arguments = nil
 	tc.env.SetType("buffer", &ArrayType{Length: -1, IsSpan: true, ElementType: &PrimitiveType{Name: "i32"}})
 	facts := functionCaptureFacts(fn, tc.env)

--- a/typechecker/generalization_test.go
+++ b/typechecker/generalization_test.go
@@ -1735,3 +1735,28 @@ func TestConditionalUnsafeBodyContributesGeneralizationBarrier(t *testing.T) {
 		t.Fatalf("conditional hid unsafe evidence: capture=%v initializer=%v", capture, initializer)
 	}
 }
+
+func TestWritesThroughParametersDoNotCaptureAuthority(t *testing.T) {
+	tc := New(nilObjectEnvironment())
+	fn := &ast.FunctionLiteral{
+		Arguments: []*ast.Identifier{{Value: "buffer"}},
+		Body: &ast.BlockStatement{Statements: []ast.Statement{
+			&ast.IndexAssignmentStatement{
+				Target: &ast.IndexExpression{
+					Left:  &ast.Identifier{Value: "buffer"},
+					Index: &ast.IntegerLiteral{Value: 0},
+				},
+				Value: &ast.IntegerLiteral{Value: 1},
+			},
+		}},
+	}
+	if facts := functionCaptureFacts(fn, tc.env); !facts.Safe() {
+		t.Fatalf("parameter write treated as captured authority: %v", facts)
+	}
+	fn.Arguments = nil
+	tc.env.SetType("buffer", &ArrayType{Length: -1, IsSpan: true, ElementType: &PrimitiveType{Name: "i32"}})
+	facts := functionCaptureFacts(fn, tc.env)
+	if !facts.Has(GeneralizationMutableAuthority) || !facts.Has(GeneralizationRegionBound) {
+		t.Fatalf("outer buffer write lost capture authority: %v", facts)
+	}
+}

--- a/typechecker/generic_constraints.go
+++ b/typechecker/generic_constraints.go
@@ -215,11 +215,42 @@ func (tc *TypeChecker) constraintMismatchDetail(concreteType Type, constraint Co
 	return ""
 }
 
+// monomorphicConstraintBinding resolves a blocked scheme's original binder by
+// identity. Enclosing expression transactions may have staged its solution
+// without committing it to scheme.Monomorphic yet.
+func (tc *TypeChecker) monomorphicConstraintBinding(scheme *TypeScheme, bindings Substitution, name string) (Type, bool) {
+	var variable *TypeVar
+	for _, candidate := range typeVarsIn(scheme.Type) {
+		if candidate.Name != name {
+			continue
+		}
+		if variable != nil {
+			return nil, false
+		}
+		variable = candidate
+	}
+	if variable == nil {
+		return nil, false
+	}
+
+	concreteType := scheme.Monomorphic.Apply(variable)
+	concreteType = tc.applyPendingMonomorphic(concreteType)
+	concreteType = bindings.Apply(concreteType)
+	concreteType = tc.applyPendingMonomorphic(concreteType)
+	if len(typeVarsIn(concreteType)) != 0 {
+		return nil, false
+	}
+	return concreteType, true
+}
+
 // checkFunctionConstraintBindings discharges the qualified-type obligations
 // after generic argument inference has produced concrete type bindings.
 func (tc *TypeChecker) checkFunctionConstraintBindings(scheme *TypeScheme, bindings Substitution, expr ast.Node) {
 	for _, constraint := range scheme.Constraints {
 		concreteType, ok := bindings.LookupName(constraint.Var)
+		if scheme.Monomorphic != nil {
+			concreteType, ok = tc.monomorphicConstraintBinding(scheme, bindings, constraint.Var)
+		}
 		if !ok {
 			tc.addTypeDiagnostic(
 				expr,

--- a/typechecker/genericfn.go
+++ b/typechecker/genericfn.go
@@ -64,7 +64,13 @@ func (tc *TypeChecker) registerFunctionTemplate(stmt *ast.FunctionStatement) {
 	tc.functionTemplates[stmt.Name.Value] = stmt
 	tc.predeclareFunctionSignature(stmt)
 	if scheme, ok := tc.env.Get(stmt.Name.Value); ok && scheme != nil {
-		facts := functionStatementCaptureFacts(stmt, tc.env)
+		factsEnv := NewEnclosedTypeEnvironment(tc.env)
+		if signature, ok := scheme.Type.(*FunctionType); ok && len(signature.Parameters) == len(stmt.Parameters) {
+			for i, parameter := range stmt.Parameters {
+				factsEnv.SetType(parameter.Name.Value, signature.Parameters[i])
+			}
+		}
+		facts := functionStatementCaptureFacts(stmt, factsEnv)
 		facts.Barriers |= scheme.GeneralizationBarriers
 		if !facts.Safe() && len(scheme.TypeVars) > 0 {
 			scheme = makeMonomorphicScheme(scheme.Type, scheme.Constraints)
@@ -454,7 +460,9 @@ func substituteStmt(stmt ast.Statement, bindings map[string]ast.Expression) (ast
 		return &ast.WhileStatement{Token: s.Token, Condition: condition, Body: body}, true
 	case *ast.UnsafeBlock:
 		body, ok := substituteBlock(s.Body, bindings)
-		if !ok { return nil, false }
+		if !ok {
+			return nil, false
+		}
 		clone := *s
 		clone.Body = body
 		return &clone, true

--- a/typechecker/genericfn.go
+++ b/typechecker/genericfn.go
@@ -62,6 +62,16 @@ func (tc *TypeChecker) registerFunctionTemplate(stmt *ast.FunctionStatement) {
 		tc.functionTemplates = make(map[string]*ast.FunctionStatement)
 	}
 	tc.functionTemplates[stmt.Name.Value] = stmt
+	tc.predeclareFunctionSignature(stmt)
+	if scheme, ok := tc.env.Get(stmt.Name.Value); ok && scheme != nil {
+		facts := functionStatementCaptureFacts(stmt, tc.env)
+		facts.Barriers |= scheme.GeneralizationBarriers
+		if !facts.Safe() && len(scheme.TypeVars) > 0 {
+			scheme = makeMonomorphicScheme(scheme.Type, scheme.Constraints)
+		}
+		scheme.GeneralizationBarriers = facts.Barriers
+		tc.env.Set(stmt.Name.Value, scheme)
+	}
 }
 
 // IsFunctionTemplate reports whether name is a registered generic function.
@@ -237,6 +247,26 @@ func (tc *TypeChecker) bindTypeParams(paramType ast.Expression, argType Type, pa
 // invokeInstantiated monomorphizes the template for the given arguments,
 // rewrites the call site to the mangled name, and returns the call's type.
 func (tc *TypeChecker) invokeInstantiated(expr *ast.InvocationExpression, template *ast.FunctionStatement, args []Type) Type {
+	// A template and all of its specializations share the original binding's
+	// authority restriction. Stage equations in the enclosing call transaction.
+	if scheme, found := tc.env.Get(template.Name.Value); found && scheme.Monomorphic != nil {
+		bindings := make(Substitution)
+		for i, parameter := range template.TypeParams {
+			for _, variable := range typeVarsIn(scheme.Type) {
+				if variable.Name != parameter.Name.Value {
+					continue
+				}
+				expected := tc.applyPendingMonomorphic(bindings.Apply(variable))
+				equation := NewUnifier().Unify(expected, args[i])
+				if equation == nil {
+					tc.addError(expr, "%s cannot reuse authority at incompatible type %s (previously %s)", template.Name.Value, args[i], expected)
+					return nil
+				}
+				bindings = bindings.Compose(equation)
+			}
+		}
+		tc.stageMonomorphicBindings(bindings)
+	}
 	if !tc.validateTemplateRowArguments(expr, template, args) {
 		return nil
 	}
@@ -422,6 +452,12 @@ func substituteStmt(stmt ast.Statement, bindings map[string]ast.Expression) (ast
 			return nil, false
 		}
 		return &ast.WhileStatement{Token: s.Token, Condition: condition, Body: body}, true
+	case *ast.UnsafeBlock:
+		body, ok := substituteBlock(s.Body, bindings)
+		if !ok { return nil, false }
+		clone := *s
+		clone.Body = body
+		return &clone, true
 	case *ast.BlockStatement:
 		return substituteBlockAsStmt(s, bindings)
 	}

--- a/typechecker/hm.go
+++ b/typechecker/hm.go
@@ -15,6 +15,12 @@ type TypeScheme struct {
 	Constraints []Constraint
 	// The underlying type (τ)
 	Type Type
+	// GeneralizationBarriers preserves authority/effect evidence independently
+	// of whether this scheme has any locally free variables to specialize.
+	GeneralizationBarriers GeneralizationBarrier
+	// Monomorphic is non-nil for a generalization-blocked scheme with locally
+	// free variables. Its substitution is shared by every use.
+	Monomorphic Substitution
 }
 
 // Constraint represents an interface constraint on a type variable
@@ -61,11 +67,21 @@ func (s *TypeScheme) String() string {
 	return out
 }
 
+// monomorphicGroup is deliberately non-zero-sized so distinct allocations
+// have distinct pointer identity under the Go specification.
+type monomorphicGroup struct{ identity byte }
+
 // TypeVar represents a type variable (α, β, γ, ...)
 // Used during type inference
 type TypeVar struct {
 	Name string // e.g., "α", "β", or "T", "U"
 	ID   int    // Unique identifier for fresh type variables
+
+	// Monomorphic is shared by every occurrence descended from a blocked
+	// binding. It makes the variable participate persistently in unification
+	// even through aliases and higher-order arguments.
+	Monomorphic Substitution
+	monomorphicGroup *monomorphicGroup
 }
 
 func (tv *TypeVar) String() string {
@@ -88,7 +104,18 @@ func (sub Substitution) Apply(typ Type) Type {
 	switch t := typ.(type) {
 	case *TypeVar:
 		if replacement, ok := sub[t]; ok {
-			return replacement
+			if replacement == t {
+				return t
+			}
+			return sub.Apply(replacement)
+		}
+		if t.Monomorphic != nil {
+			if replacement, ok := t.Monomorphic[t]; ok {
+				if replacement == t {
+					return t
+				}
+				return t.Monomorphic.Apply(replacement)
+			}
 		}
 		return t
 	case *PrimitiveType:
@@ -121,8 +148,6 @@ func (sub Substitution) Apply(typ Type) Type {
 			Variadic:   t.Variadic,
 		}
 	case *ArrayType:
-		// IsSpan must survive substitution: dropping it silently strips
-		// write authority from span-typed bindings (docs/spec/50-borrowing).
 		return &ArrayType{
 			Length:      t.Length,
 			IsSlice:     t.IsSlice,
@@ -179,6 +204,16 @@ func (sub1 Substitution) Compose(sub2 Substitution) Substitution {
 	return result
 }
 
+// Commit composes bindings into this substitution without replacing the map.
+// Blocked schemes and their type variables share the same map identity.
+func (sub Substitution) Commit(bindings Substitution) {
+	composed := sub.Compose(bindings)
+	clear(sub)
+	for variable, typ := range composed {
+		sub[variable] = typ
+	}
+}
+
 // Unifier performs unification of types
 type Unifier struct {
 	nextVarID int
@@ -207,8 +242,15 @@ func (u *Unifier) FreshTypeVar(name string) *TypeVar {
 }
 
 // Unify attempts to unify two types, returning a substitution
-// that makes them equal, or nil if unification fails
+// that makes them equal, or nil if unification fails. It does not mutate
+// persistent scheme state: the enclosing successful use commits the complete
+// accumulated substitution transactionally.
 func (u *Unifier) Unify(t1, t2 Type) Substitution {
+	// Resolve solutions learned by earlier uses before solving this equation.
+	empty := make(Substitution)
+	t1 = empty.Apply(t1)
+	t2 = empty.Apply(t2)
+
 	// If types are equal, no substitution needed
 	if t1.Equals(t2) {
 		return make(Substitution)
@@ -408,6 +450,11 @@ func (u *Unifier) unifyGeneric(gen1, gen2 *GenericType) Substitution {
 // Generalize converts a type to a type scheme by quantifying over free type variables
 // This is used for let-bound variables in HM inference
 func Generalize(typ Type, env *TypeEnvironment) *TypeScheme {
+	// Aliasing a blocked value cannot re-generalize its persistent variables.
+	if persistent := findMonomorphicSubstitution(typ); persistent != nil {
+		return makeMonomorphicScheme(typ, nil)
+	}
+
 	// Find all free type variables in typ that are not bound in env
 	freeVars := findFreeTypeVars(typ, env)
 
@@ -419,6 +466,265 @@ func Generalize(typ Type, env *TypeEnvironment) *TypeScheme {
 		TypeVars:    freeVars,
 		Constraints: constraints,
 		Type:        typ,
+	}
+}
+
+func (tc *TypeChecker) beginMonomorphicTransaction() {
+	tc.monomorphicTransactions = append(tc.monomorphicTransactions, nil)
+}
+
+func (tc *TypeChecker) stageMonomorphicBindings(bindings Substitution) {
+	if len(bindings) == 0 {
+		return
+	}
+	if len(tc.monomorphicTransactions) == 0 {
+		commitMonomorphicBindings(bindings)
+		return
+	}
+	last := len(tc.monomorphicTransactions) - 1
+	tc.monomorphicTransactions[last] = append(tc.monomorphicTransactions[last], bindings)
+}
+
+func (tc *TypeChecker) applyPendingMonomorphic(typ Type) Type {
+	for _, transaction := range tc.monomorphicTransactions {
+		for _, bindings := range transaction {
+			typ = bindings.Apply(typ)
+		}
+	}
+	return typ
+}
+
+func mergeMonomorphicBindings(pending []Substitution) (Substitution, bool) {
+	combined := make(Substitution)
+	unifier := NewUnifier()
+	for _, bindings := range pending {
+		for variable, typ := range bindings {
+			left := combined.Apply(variable)
+			right := combined.Apply(typ)
+			next := unifier.Unify(left, right)
+			if next == nil {
+				return nil, false
+			}
+			combined = combined.Compose(next)
+		}
+	}
+	return combined, true
+}
+
+func (tc *TypeChecker) finishMonomorphicTransaction(success bool) {
+	last := len(tc.monomorphicTransactions) - 1
+	pending := tc.monomorphicTransactions[last]
+	tc.monomorphicTransactions = tc.monomorphicTransactions[:last]
+	if !success {
+		return
+	}
+	if len(tc.monomorphicTransactions) > 0 {
+		parent := len(tc.monomorphicTransactions) - 1
+		tc.monomorphicTransactions[parent] = append(tc.monomorphicTransactions[parent], pending...)
+		return
+	}
+	merged, compatible := mergeMonomorphicBindings(pending)
+	if !compatible {
+		tc.addError(nil, "conflicting monomorphic specializations in one expression")
+		return
+	}
+	commitMonomorphicBindings(merged)
+}
+
+func commitMonomorphicBindings(bindings Substitution) {
+	committed := make(map[*monomorphicGroup]bool)
+	for variable := range bindings {
+		if variable == nil || variable.Monomorphic == nil || variable.monomorphicGroup == nil {
+			continue
+		}
+		group := variable.monomorphicGroup
+		if committed[group] {
+			continue
+		}
+		local := make(Substitution)
+		pending := make(map[*TypeVar]bool)
+		for candidate := range bindings {
+			if candidate != nil && candidate.monomorphicGroup == group {
+				pending[candidate] = true
+			}
+		}
+		for len(pending) > 0 {
+			var current *TypeVar
+			for candidate := range pending {
+				current = candidate
+				break
+			}
+			delete(pending, current)
+			if _, included := local[current]; included {
+				continue
+			}
+			value, ok := bindings[current]
+			if !ok {
+				continue
+			}
+			local[current] = value
+			for _, dependency := range typeVarsIn(value) {
+				// A fresh variable that escapes through a blocked solution becomes
+				// part of the same persistent identity. Otherwise a later binding
+				// keyed only by that variable would be discarded and reopen the
+				// authority-bearing value polymorphically.
+				if dependency.Monomorphic == nil {
+					dependency.Monomorphic = variable.Monomorphic
+					dependency.monomorphicGroup = group
+				}
+				if dependency.monomorphicGroup != group {
+					continue
+				}
+				if _, bound := bindings[dependency]; bound {
+					pending[dependency] = true
+				}
+			}
+		}
+		variable.Monomorphic.Commit(local)
+		committed[group] = true
+	}
+}
+
+func typeVarsIn(typ Type) []*TypeVar {
+	var variables []*TypeVar
+	seen := make(map[*TypeVar]bool)
+	var visit func(Type)
+	visit = func(current Type) {
+		switch t := current.(type) {
+		case *TypeVar:
+			if !seen[t] {
+				seen[t] = true
+				variables = append(variables, t)
+			}
+		case *RecordType:
+			for _, field := range t.Fields { visit(field) }
+		case *FunctionType:
+			for _, parameter := range t.Parameters { visit(parameter) }
+			visit(t.ReturnType)
+		case *ArrayType:
+			visit(t.ElementType)
+		case *GenericType:
+			for _, argument := range t.TypeArgs { visit(argument) }
+		}
+	}
+	visit(typ)
+	return variables
+}
+
+func findMonomorphicSubstitution(typ Type) Substitution {
+	var found Substitution
+	var visit func(Type)
+	visit = func(current Type) {
+		switch t := current.(type) {
+		case *TypeVar:
+			if found == nil && t.Monomorphic != nil {
+				found = t.Monomorphic
+			}
+		case *RecordType:
+			for _, field := range t.Fields { visit(field) }
+		case *FunctionType:
+			for _, parameter := range t.Parameters { visit(parameter) }
+			visit(t.ReturnType)
+		case *ArrayType:
+			visit(t.ElementType)
+		case *GenericType:
+			for _, argument := range t.TypeArgs { visit(argument) }
+		}
+	}
+	visit(typ)
+	return found
+}
+
+func findMonomorphicGroup(typ Type) *monomorphicGroup {
+	for _, variable := range typeVarsIn(typ) {
+		if variable.monomorphicGroup != nil {
+			return variable.monomorphicGroup
+		}
+	}
+	return nil
+}
+
+func markMonomorphicTypeVars(typ Type, persistent Substitution, group *monomorphicGroup) {
+	var visit func(Type)
+	visit = func(current Type) {
+		switch t := current.(type) {
+		case *TypeVar:
+			if t.Monomorphic == nil {
+				t.Monomorphic = persistent
+				t.monomorphicGroup = group
+			}
+		case *RecordType:
+			for _, field := range t.Fields { visit(field) }
+		case *FunctionType:
+			for _, parameter := range t.Parameters { visit(parameter) }
+			visit(t.ReturnType)
+		case *ArrayType:
+			visit(t.ElementType)
+		case *GenericType:
+			for _, argument := range t.TypeArgs { visit(argument) }
+		}
+	}
+	visit(typ)
+}
+
+func makeMonomorphicScheme(typ Type, constraints []Constraint) *TypeScheme {
+	return makeMonomorphicSchemeFor(typ, constraints, typeVarsIn(typ))
+}
+
+func makeMonomorphicSchemeInEnv(typ Type, constraints []Constraint, env *TypeEnvironment) *TypeScheme {
+	bound := make(map[*TypeVar]bool)
+	for current := env; current != nil; current = current.outer {
+		for _, scheme := range current.store {
+			if scheme == nil {
+				continue
+			}
+			for _, variable := range typeVarsIn(scheme.Type) {
+				bound[variable] = true
+			}
+		}
+	}
+	var free []*TypeVar
+	for _, variable := range typeVarsIn(typ) {
+		if !bound[variable] {
+			free = append(free, variable)
+		}
+	}
+	return makeMonomorphicSchemeFor(typ, constraints, free)
+}
+
+func makeMonomorphicSchemeFor(typ Type, constraints []Constraint, variables []*TypeVar) *TypeScheme {
+	var persistent Substitution
+	var group *monomorphicGroup
+	for _, variable := range variables {
+		if persistent == nil && variable.Monomorphic != nil {
+			persistent = variable.Monomorphic
+			group = variable.monomorphicGroup
+		}
+	}
+	if len(variables) == 0 {
+		return &TypeScheme{
+			TypeVars: []string{},
+			Constraints: constraints,
+			Type: typ,
+		}
+	}
+	if persistent == nil {
+		persistent = make(Substitution)
+	}
+	if group == nil {
+		group = &monomorphicGroup{}
+	}
+	for _, variable := range variables {
+		if variable.Monomorphic == nil {
+			variable.Monomorphic = persistent
+			variable.monomorphicGroup = group
+		}
+	}
+	return &TypeScheme{
+		TypeVars: []string{},
+		Constraints: constraints,
+		Type: typ,
+		Monomorphic: persistent,
 	}
 }
 
@@ -548,6 +854,9 @@ func quantifiedSubstitution(typ Type, quantified []string, replacements map[stri
 // For qualified types (with constraints), constraints are checked but not enforced here
 // (They will be checked when the instantiated type is actually used)
 func Instantiate(scheme *TypeScheme, unifier *Unifier) Type {
+	if scheme.Monomorphic != nil {
+		return scheme.Monomorphic.Apply(scheme.Type)
+	}
 	if len(scheme.TypeVars) == 0 && len(scheme.Constraints) == 0 {
 		return scheme.Type
 	}

--- a/typechecker/hm.go
+++ b/typechecker/hm.go
@@ -80,7 +80,7 @@ type TypeVar struct {
 	// Monomorphic is shared by every occurrence descended from a blocked
 	// binding. It makes the variable participate persistently in unification
 	// even through aliases and higher-order arguments.
-	Monomorphic Substitution
+	Monomorphic      Substitution
 	monomorphicGroup *monomorphicGroup
 }
 
@@ -597,14 +597,20 @@ func typeVarsIn(typ Type) []*TypeVar {
 				variables = append(variables, t)
 			}
 		case *RecordType:
-			for _, field := range t.Fields { visit(field) }
+			for _, field := range t.Fields {
+				visit(field)
+			}
 		case *FunctionType:
-			for _, parameter := range t.Parameters { visit(parameter) }
+			for _, parameter := range t.Parameters {
+				visit(parameter)
+			}
 			visit(t.ReturnType)
 		case *ArrayType:
 			visit(t.ElementType)
 		case *GenericType:
-			for _, argument := range t.TypeArgs { visit(argument) }
+			for _, argument := range t.TypeArgs {
+				visit(argument)
+			}
 		}
 	}
 	visit(typ)
@@ -621,14 +627,20 @@ func findMonomorphicSubstitution(typ Type) Substitution {
 				found = t.Monomorphic
 			}
 		case *RecordType:
-			for _, field := range t.Fields { visit(field) }
+			for _, field := range t.Fields {
+				visit(field)
+			}
 		case *FunctionType:
-			for _, parameter := range t.Parameters { visit(parameter) }
+			for _, parameter := range t.Parameters {
+				visit(parameter)
+			}
 			visit(t.ReturnType)
 		case *ArrayType:
 			visit(t.ElementType)
 		case *GenericType:
-			for _, argument := range t.TypeArgs { visit(argument) }
+			for _, argument := range t.TypeArgs {
+				visit(argument)
+			}
 		}
 	}
 	visit(typ)
@@ -654,14 +666,20 @@ func markMonomorphicTypeVars(typ Type, persistent Substitution, group *monomorph
 				t.monomorphicGroup = group
 			}
 		case *RecordType:
-			for _, field := range t.Fields { visit(field) }
+			for _, field := range t.Fields {
+				visit(field)
+			}
 		case *FunctionType:
-			for _, parameter := range t.Parameters { visit(parameter) }
+			for _, parameter := range t.Parameters {
+				visit(parameter)
+			}
 			visit(t.ReturnType)
 		case *ArrayType:
 			visit(t.ElementType)
 		case *GenericType:
-			for _, argument := range t.TypeArgs { visit(argument) }
+			for _, argument := range t.TypeArgs {
+				visit(argument)
+			}
 		}
 	}
 	visit(typ)
@@ -703,9 +721,9 @@ func makeMonomorphicSchemeFor(typ Type, constraints []Constraint, variables []*T
 	}
 	if len(variables) == 0 {
 		return &TypeScheme{
-			TypeVars: []string{},
+			TypeVars:    []string{},
 			Constraints: constraints,
-			Type: typ,
+			Type:        typ,
 		}
 	}
 	if persistent == nil {
@@ -721,9 +739,9 @@ func makeMonomorphicSchemeFor(typ Type, constraints []Constraint, variables []*T
 		}
 	}
 	return &TypeScheme{
-		TypeVars: []string{},
+		TypeVars:    []string{},
 		Constraints: constraints,
-		Type: typ,
+		Type:        typ,
 		Monomorphic: persistent,
 	}
 }

--- a/typechecker/pattern_generalization_test.go
+++ b/typechecker/pattern_generalization_test.go
@@ -39,7 +39,6 @@ func TestVariantPatternBinderCarriesInstantiatedPayloadAuthority(t *testing.T) {
 	}
 }
 
-
 func TestWholeADTBindingCarriesReachablePayloadAuthority(t *testing.T) {
 	tc := New(object.NewEnvironment())
 	tc.adtTypes["Carrier"] = &object.ADTType{
@@ -65,7 +64,6 @@ func TestWholeADTBindingCarriesReachablePayloadAuthority(t *testing.T) {
 		t.Fatalf("whole ADT facts = %v, want mutable and unique authority", facts)
 	}
 }
-
 
 func TestExpandingRecursiveADTAuthorityTraversalTerminates(t *testing.T) {
 	tc := New(object.NewEnvironment())
@@ -96,7 +94,7 @@ func TestExpandingRecursiveADTAuthorityTraversalTerminates(t *testing.T) {
 		},
 	}
 	facts := tc.valueAuthorityFacts(&GenericType{
-		Name: "Nest",
+		Name:     "Nest",
 		TypeArgs: []Type{&PrimitiveType{Name: "i32"}},
 	}, make(map[string]bool))
 	if !facts.Has(GeneralizationRegionBound) {
@@ -104,11 +102,10 @@ func TestExpandingRecursiveADTAuthorityTraversalTerminates(t *testing.T) {
 	}
 }
 
-
 func TestIndexedStoreCreatesCaptureBarrier(t *testing.T) {
 	env := NewTypeEnvironment()
 	env.Set("values", &TypeScheme{Type: &ArrayType{
-		Length: 2,
+		Length:      2,
 		ElementType: &PrimitiveType{Name: "i32"},
 	}})
 	fn := &ast.FunctionStatement{

--- a/typechecker/pattern_generalization_test.go
+++ b/typechecker/pattern_generalization_test.go
@@ -1,0 +1,131 @@
+package typechecker
+
+import (
+	"testing"
+
+	"github.com/SCKelemen/oak/ast"
+	"github.com/SCKelemen/oak/object"
+)
+
+func TestVariantPatternBinderCarriesInstantiatedPayloadAuthority(t *testing.T) {
+	tc := New(object.NewEnvironment())
+	tc.adtTypes["Box"] = &object.ADTType{
+		Name:       "Box",
+		TypeParams: []string{"T"},
+		Variants: []*object.ADTVariantDef{{
+			Name:          "Hold",
+			Payload:       "T",
+			ResultName:    "Box",
+			ResultIndices: []string{"T"},
+		}},
+	}
+	tc.adtPayloadTypes["Box"] = map[string]Type{
+		"Hold": &ADTType{Name: "T"},
+	}
+	pattern := &ast.VariantPattern{
+		Variant: &ast.Identifier{Value: "Hold"},
+		Payload: &ast.BindingPattern{Name: &ast.Identifier{Value: "payload"}},
+	}
+	owned := &ArrayType{
+		Length:      2,
+		ElementType: &PrimitiveType{Name: "i32"},
+	}
+	facts := tc.generalizationPatternBindingFacts(pattern, &GenericType{
+		Name:     "Box",
+		TypeArgs: []Type{owned},
+	})["payload"]
+	if !facts.Has(GeneralizationMutableAuthority) || !facts.Has(GeneralizationUniqueAuthority) {
+		t.Fatalf("payload facts = %v, want mutable and unique authority", facts)
+	}
+}
+
+
+func TestWholeADTBindingCarriesReachablePayloadAuthority(t *testing.T) {
+	tc := New(object.NewEnvironment())
+	tc.adtTypes["Carrier"] = &object.ADTType{
+		Name: "Carrier",
+		Variants: []*object.ADTVariantDef{{
+			Name:       "Owned",
+			Payload:    "[2]i32",
+			ResultName: "Carrier",
+		}},
+	}
+	tc.adtPayloadTypes["Carrier"] = map[string]Type{
+		"Owned": &ArrayType{
+			Length:      2,
+			ElementType: &PrimitiveType{Name: "i32"},
+		},
+	}
+	pattern := &ast.BindingPattern{Name: &ast.Identifier{Value: "whole"}}
+	facts := tc.generalizationPatternBindingFacts(
+		pattern,
+		&ADTType{Name: "Carrier"},
+	)["whole"]
+	if !facts.Has(GeneralizationMutableAuthority) || !facts.Has(GeneralizationUniqueAuthority) {
+		t.Fatalf("whole ADT facts = %v, want mutable and unique authority", facts)
+	}
+}
+
+
+func TestExpandingRecursiveADTAuthorityTraversalTerminates(t *testing.T) {
+	tc := New(object.NewEnvironment())
+	tc.adtTypes["Nest"] = &object.ADTType{
+		Name:       "Nest",
+		TypeParams: []string{"T"},
+		Variants: []*object.ADTVariantDef{
+			{
+				Name:          "Next",
+				Payload:       "Nest[[]T]",
+				ResultName:    "Nest",
+				ResultIndices: []string{"T"},
+			},
+			{
+				Name:          "Stop",
+				ResultName:    "Nest",
+				ResultIndices: []string{"T"},
+			},
+		},
+	}
+	tc.adtPayloadTypes["Nest"] = map[string]Type{
+		"Next": &GenericType{
+			Name: "Nest",
+			TypeArgs: []Type{&ArrayType{
+				Length: -1, IsSlice: true,
+				ElementType: &ADTType{Name: "T"},
+			}},
+		},
+	}
+	facts := tc.valueAuthorityFacts(&GenericType{
+		Name: "Nest",
+		TypeArgs: []Type{&PrimitiveType{Name: "i32"}},
+	}, make(map[string]bool))
+	if !facts.Has(GeneralizationRegionBound) {
+		t.Fatalf("recursive ADT facts = %v, want nested view authority", facts)
+	}
+}
+
+
+func TestIndexedStoreCreatesCaptureBarrier(t *testing.T) {
+	env := NewTypeEnvironment()
+	env.Set("values", &TypeScheme{Type: &ArrayType{
+		Length: 2,
+		ElementType: &PrimitiveType{Name: "i32"},
+	}})
+	fn := &ast.FunctionStatement{
+		Name: &ast.Identifier{Value: "write"},
+		Body: &ast.BlockExpression{Block: &ast.BlockStatement{
+			Statements: []ast.Statement{&ast.IndexAssignmentStatement{
+				Target: &ast.IndexExpression{
+					Left:  &ast.Identifier{Value: "values"},
+					Index: &ast.IntegerLiteral{Value: 0},
+				},
+				Value: &ast.IntegerLiteral{Value: 1},
+			}},
+		}},
+	}
+	facts := functionStatementCaptureFacts(fn, env)
+	want := GeneralizationMutableAuthority | GeneralizationEffectfulCapture
+	if facts.Barriers&want != want {
+		t.Fatalf("indexed-store barriers = %v, want mutable and effectful capture", facts.Barriers)
+	}
+}

--- a/typechecker/typechecker.go
+++ b/typechecker/typechecker.go
@@ -493,6 +493,8 @@ func (t *FunctionType) Equals(other Type) bool {
 
 // TypeChecker performs type checking on AST nodes
 type TypeChecker struct {
+	adtPayloadTypes map[string]map[string]Type
+	monomorphicTransactions [][]Substitution
 	diagnostics *diagnostic.DiagnosticCollector
 	env         *TypeEnvironment
 	adtTypes    map[string]*object.ADTType // ADT type definitions
@@ -602,11 +604,11 @@ func NewWithPlatformSizes(env *object.Environment, intSize, ptrSize int) *TypeCh
 	tc := &TypeChecker{
 		diagnostics: diagnostic.NewDiagnosticCollector(),
 		env:         NewTypeEnvironment(),
-		adtTypes:    env.GetAllADTTypes(),
-		intSize:     intSize,
-		ptrSize:     ptrSize,
-
-		checkedExterns: make(map[*ast.FunctionStatement]bool),
+		adtTypes:        env.GetAllADTTypes(),
+		adtPayloadTypes: make(map[string]map[string]Type),
+		intSize:         intSize,
+		ptrSize:         ptrSize,
+		checkedExterns:   make(map[*ast.FunctionStatement]bool),
 	}
 	// Add builtin type aliases
 	tc.addBuiltinTypeAliases()
@@ -716,8 +718,13 @@ func (tc *TypeChecker) CheckProgram(program *ast.Program) {
 	for _, stmt := range program.Statements {
 		if fn, ok := stmt.(*ast.FunctionStatement); ok {
 			tc.predeclareFunctionSignature(fn)
+			if len(fn.TypeParams) > 0 && fn.Receiver == nil && !typeParamsConstrained(fn.TypeParams) {
+				if tc.functionTemplates == nil { tc.functionTemplates = make(map[string]*ast.FunctionStatement) }
+				tc.functionTemplates[fn.Name.Value] = fn
+			}
 		}
 	}
+	tc.resolvePredeclaredFunctionBarriers(program)
 	for _, stmt := range program.Statements {
 		switch stmt.(type) {
 		case *ast.ADTType, *ast.TagDeclaration:
@@ -757,7 +764,7 @@ func (tc *TypeChecker) CheckProgram(program *ast.Program) {
 // body is checked. Generic functions and methods are skipped: their schemes
 // depend on constraint machinery that runs during the full check.
 func (tc *TypeChecker) predeclareFunctionSignature(fn *ast.FunctionStatement) {
-	if fn == nil || fn.Name == nil || fn.Receiver != nil || len(fn.TypeParams) > 0 {
+	if fn == nil || fn.Name == nil || fn.Receiver != nil {
 		return
 	}
 	if hasOpenRowParameters(fn) {
@@ -777,9 +784,32 @@ func (tc *TypeChecker) predeclareFunctionSignature(fn *ast.FunctionStatement) {
 	if _, exists := tc.env.Get(fn.Name.Value); exists {
 		return
 	}
+
+	// Bind declared type parameters in an isolated signature environment so
+	// generic callables participate in forward-reference summary resolution.
+	typeVars := make([]string, 0, len(fn.TypeParams))
+	constraints := make([]Constraint, 0, len(fn.TypeParams))
+	for _, parameter := range fn.TypeParams {
+		if parameter == nil || parameter.Name == nil {
+			return // full check reports the malformed declaration
+		}
+		typeVars = append(typeVars, parameter.Name.Value)
+		if parameter.Constraint != nil {
+			interfaces := tc.extractInterfacesFromConstraint(parameter.Constraint)
+			if len(interfaces) > 0 {
+				constraints = append(constraints, Constraint{
+					Var:        parameter.Name.Value,
+					Interfaces: interfaces,
+				})
+			}
+		}
+	}
+	signatureEnv := NewEnclosedTypeEnvironment(tc.env)
+	bindConstrainedTypeVars(signatureEnv, typeVars, constraints)
+
 	paramTypes := make([]Type, 0, len(fn.Parameters))
 	for _, param := range fn.Parameters {
-		paramType := tc.parseTypeExpression(param.Type)
+		paramType := tc.parseTypeExpressionInEnv(param.Type, signatureEnv)
 		if paramType == nil {
 			return // full check reports the error with context
 		}
@@ -788,19 +818,185 @@ func (tc *TypeChecker) predeclareFunctionSignature(fn *ast.FunctionStatement) {
 		}
 		paramTypes = append(paramTypes, paramType)
 	}
-	returnType := tc.parseTypeExpression(fn.ReturnType)
+	returnType := tc.parseTypeExpressionInEnv(fn.ReturnType, signatureEnv)
 	if returnType == nil {
 		returnType = &UnitType{}
 	}
 	isVariadic := len(fn.Parameters) > 0 && fn.Parameters[len(fn.Parameters)-1].Variadic
 	tc.env.Set(fn.Name.Value, &TypeScheme{
-		Type: &FunctionType{Parameters: paramTypes, ReturnType: returnType, Variadic: isVariadic},
+		TypeVars:    typeVars,
+		Constraints: constraints,
+		Type: &FunctionType{
+			Parameters: paramTypes,
+			ReturnType: returnType,
+			Variadic:   isVariadic,
+		},
 	})
+}
+
+// resolvePredeclaredFunctionBarriers computes transitive authority summaries
+// for every function whose signature can be predeclared. Barriers
+// only accumulate, so iteration terminates over the finite barrier bitset.
+func (tc *TypeChecker) resolvePredeclaredFunctionBarriers(program *ast.Program) {
+	if program == nil {
+		return
+	}
+	// Methods are not ordinary forward-call bindings, but their authority
+	// summaries must exist while function bodies containing selectors are
+	// analyzed. Full method checking later replaces these placeholders.
+	for _, statement := range program.Statements {
+		fn, ok := statement.(*ast.FunctionStatement)
+		if !ok || fn == nil || fn.Name == nil || fn.Receiver == nil {
+			continue
+		}
+		if key := methodBarrierKey(fn); key != "" {
+			if _, exists := tc.env.Get(key); !exists {
+				if scheme := tc.predeclaredMethodBarrierScheme(fn); scheme != nil {
+					tc.env.Set(key, scheme)
+				}
+			}
+		}
+	}
+	for {
+		changed := false
+		for _, statement := range program.Statements {
+			fn, ok := statement.(*ast.FunctionStatement)
+			if !ok || fn == nil || fn.Name == nil {
+				continue
+			}
+			key := fn.Name.Value
+			if fn.Receiver != nil {
+				key = methodBarrierKey(fn)
+			}
+			if key == "" {
+				continue
+			}
+			scheme, ok := tc.env.Get(key)
+			if !ok || scheme == nil {
+				continue
+			}
+			factsEnv := NewEnclosedTypeEnvironment(tc.env)
+			if signature, ok := scheme.Type.(*FunctionType); ok &&
+				len(signature.Parameters) == len(fn.Parameters) {
+				for i, parameter := range fn.Parameters {
+					if parameter != nil && parameter.Name != nil {
+						factsEnv.SetType(parameter.Name.Value, signature.Parameters[i])
+					}
+				}
+			}
+			if fn.Receiver != nil && fn.Receiver.Name != nil {
+				if receiverName, ok := fn.Receiver.Type.(*ast.Identifier); ok {
+					factsEnv.SetType(fn.Receiver.Name.Value, &ADTType{Name: receiverName.Value})
+				}
+			}
+			facts := functionStatementCaptureFacts(fn, factsEnv)
+			joined := scheme.GeneralizationBarriers | facts.Barriers
+			if joined != scheme.GeneralizationBarriers {
+				scheme.GeneralizationBarriers = joined
+				changed = true
+			}
+		}
+		if !changed {
+			break
+		}
+	}
+
+	// Forward callers run before the declaration's full check. Barred generic
+	// schemes must therefore share one persistent substitution now; retaining
+	// quantified TypeVars here would freshen every forward use independently.
+	for _, statement := range program.Statements {
+		fn, ok := statement.(*ast.FunctionStatement)
+		if !ok || fn == nil || fn.Name == nil || fn.Receiver != nil {
+			continue
+		}
+		scheme, ok := tc.env.Get(fn.Name.Value)
+		if !ok || scheme == nil || scheme.GeneralizationBarriers == 0 ||
+			len(scheme.TypeVars) == 0 || scheme.Monomorphic != nil {
+			continue
+		}
+		wanted := make(map[string]bool, len(scheme.TypeVars))
+		for _, name := range scheme.TypeVars {
+			wanted[name] = true
+		}
+		variables := make([]*TypeVar, 0, len(scheme.TypeVars))
+		for _, variable := range typeVarsIn(scheme.Type) {
+			if wanted[variable.Name] {
+				variables = append(variables, variable)
+			}
+		}
+		monomorphic := makeMonomorphicSchemeFor(scheme.Type, scheme.Constraints, variables)
+		monomorphic.GeneralizationBarriers = scheme.GeneralizationBarriers
+		tc.env.Set(fn.Name.Value, monomorphic)
+	}
+}
+
+func (tc *TypeChecker) predeclaredMethodBarrierScheme(fn *ast.FunctionStatement) *TypeScheme {
+	typeVars := make([]string, 0, len(fn.TypeParams))
+	constraints := make([]Constraint, 0, len(fn.TypeParams))
+	for _, parameter := range fn.TypeParams {
+		if parameter == nil || parameter.Name == nil {
+			return nil
+		}
+		typeVars = append(typeVars, parameter.Name.Value)
+		if parameter.Constraint != nil {
+			interfaces := tc.extractInterfacesFromConstraint(parameter.Constraint)
+			if len(interfaces) > 0 {
+				constraints = append(constraints, Constraint{
+					Var: parameter.Name.Value, Interfaces: interfaces,
+				})
+			}
+		}
+	}
+	signatureEnv := NewEnclosedTypeEnvironment(tc.env)
+	bindConstrainedTypeVars(signatureEnv, typeVars, constraints)
+
+	parameters := make([]Type, 0, len(fn.Parameters))
+	for _, parameter := range fn.Parameters {
+		if parameter == nil {
+			return nil
+		}
+		typ := tc.parseTypeExpressionInEnv(parameter.Type, signatureEnv)
+		if typ == nil {
+			return nil
+		}
+		if parameter.Variadic {
+			typ = &ArrayType{Length: -1, IsSlice: true, ElementType: typ}
+		}
+		parameters = append(parameters, typ)
+	}
+	result := tc.parseTypeExpressionInEnv(fn.ReturnType, signatureEnv)
+	if result == nil {
+		result = &UnitType{}
+	}
+	return &TypeScheme{
+		TypeVars: typeVars, Constraints: constraints,
+		Type: &FunctionType{
+			Parameters: parameters,
+			ReturnType: result,
+			Variadic: len(fn.Parameters) > 0 && fn.Parameters[len(fn.Parameters)-1].Variadic,
+		},
+	}
+}
+
+func methodBarrierKey(fn *ast.FunctionStatement) string {
+	if fn == nil || fn.Name == nil || fn.Receiver == nil {
+		return ""
+	}
+	receiver, ok := fn.Receiver.Type.(*ast.Identifier)
+	if !ok || receiver.Value == "" {
+		return ""
+	}
+	return receiver.Value + "::" + fn.Name.Value
 }
 
 // CheckExpression type checks a single expression and returns its type
 // This is useful for REPL inspection commands like :typeof()
-func (tc *TypeChecker) CheckExpression(expr ast.Expression) Type {
+func (tc *TypeChecker) CheckExpression(expr ast.Expression) (result Type) {
+	before := len(tc.Errors())
+	tc.beginMonomorphicTransaction()
+	defer func() {
+		tc.finishMonomorphicTransaction(result != nil && len(tc.Errors()) == before)
+	}()
 	return tc.checkExpression(expr)
 }
 
@@ -812,6 +1008,12 @@ func (tc *TypeChecker) ParseTypeExpression(expr ast.Expression) Type {
 
 // checkStatement type checks a statement
 func (tc *TypeChecker) checkStatement(stmt ast.Statement) {
+	before := len(tc.Errors())
+	tc.beginMonomorphicTransaction()
+	defer func() {
+		tc.finishMonomorphicTransaction(len(tc.Errors()) == before)
+	}()
+
 	switch s := stmt.(type) {
 	case *ast.VariableDeclaration:
 		tc.checkVariableDeclaration(s)
@@ -974,9 +1176,10 @@ func (tc *TypeChecker) checkIdentifier(ident *ast.Identifier) Type {
 		tc.addError(ident, "undefined variable: %s", ident.Value)
 		return nil
 	}
-	// Instantiate the scheme to get a fresh type
+	// Instantiate the scheme to get a fresh type, then overlay equations staged
+	// by enclosing transactions so sibling uses share one monomorphic view.
 	unifier := NewUnifier()
-	return Instantiate(scheme, unifier)
+	return tc.applyPendingMonomorphic(Instantiate(scheme, unifier))
 }
 
 func (tc *TypeChecker) checkPrefixExpression(expr *ast.PrefixExpression) Type {
@@ -1348,7 +1551,12 @@ func (tc *TypeChecker) checkFunctionLiteral(fn *ast.FunctionLiteral) Type {
 	}
 }
 
-func (tc *TypeChecker) checkInvocationExpression(expr *ast.InvocationExpression) Type {
+func (tc *TypeChecker) checkInvocationExpression(expr *ast.InvocationExpression) (result Type) {
+	beforeInvocation := len(tc.Errors())
+	tc.beginMonomorphicTransaction()
+	defer func() {
+		tc.finishMonomorphicTransaction(result != nil && len(tc.Errors()) == beforeInvocation)
+	}()
 	if accessor, ok := expr.Function.(*ast.FieldAccessorExpression); ok {
 		return tc.checkFieldAccessorInvocation(accessor.Field.Value, expr)
 	}
@@ -1465,6 +1673,7 @@ func (tc *TypeChecker) checkInvocationExpression(expr *ast.InvocationExpression)
 		}
 	}
 
+	beforeCall := len(tc.Errors())
 	funcType := tc.checkExpression(expr.Function)
 	if funcType == nil {
 		return nil
@@ -1503,6 +1712,8 @@ func (tc *TypeChecker) checkInvocationExpression(expr *ast.InvocationExpression)
 	argTypes := make([]Type, len(expr.Arguments))
 	bindings := make(Substitution)
 	unifier := NewUnifier()
+	validCall := len(tc.Errors()) == beforeCall
+	beforeArguments := len(tc.Errors())
 	for i, arg := range expr.Arguments {
 		var parameterType Type
 		if fnType.Variadic && i >= fixedParams {
@@ -1516,22 +1727,43 @@ func (tc *TypeChecker) checkInvocationExpression(expr *ast.InvocationExpression)
 		expectedType := bindings.Apply(parameterType)
 		argType := tc.checkExpression(arg, expectedType)
 		if argType == nil {
+			validCall = false
 			continue
 		}
 		argTypes[i] = argType
 
 		if argSub := unifier.Unify(expectedType, argType); argSub != nil {
-			bindings = bindings.Compose(argSub)
+			merged, compatible := mergeMonomorphicBindings([]Substitution{bindings, argSub})
+			if !compatible {
+				validCall = false
+				tc.addError(expr.Arguments[i], "argument %d conflicts with an earlier type specialization", i+1)
+				continue
+			}
+			bindings = merged
 			continue
 		}
 
 		if !tc.isAssignable(argType, expectedType) {
+			validCall = false
 			tc.addError(expr.Arguments[i], "argument %d: expected %s, got %s", i+1, expectedType, argType)
 		}
 	}
+	if len(tc.Errors()) != beforeArguments {
+		validCall = false
+	}
 
 	if funcScheme != nil && len(funcScheme.Constraints) > 0 {
+		before := len(tc.Errors())
 		tc.checkFunctionConstraintBindings(funcScheme, bindings, expr)
+		if len(tc.Errors()) != before {
+			validCall = false
+		}
+	}
+
+	// Commit every tagged variable participating in this direct or indirect
+	// use only after the entire call, including constraints, succeeds.
+	if validCall {
+		tc.stageMonomorphicBindings(bindings)
 	}
 
 	return bindings.Apply(fnType.ReturnType)
@@ -2126,9 +2358,6 @@ func (tc *TypeChecker) checkMethodCall(recvExpr ast.Expression, methodName strin
 	return fnType.ReturnType
 }
 
-// checkIndexAssignmentStatement types s[i] = value: the target sequence must
-// be writable (a span [*]T or an owned array [N]T — views are read-only), the
-// index an integer, and the value assignable to the element type.
 func (tc *TypeChecker) checkIndexAssignmentStatement(stmt *ast.IndexAssignmentStatement) {
 	if stmt == nil || stmt.Target == nil {
 		return
@@ -2177,6 +2406,7 @@ func (tc *TypeChecker) checkIndexAssignmentStatement(stmt *ast.IndexAssignmentSt
 		tc.addError(stmt.Value, "cannot assign %s to element type %s", valueType, arrType.ElementType)
 	}
 }
+
 
 func (tc *TypeChecker) checkMatchExpression(expr *ast.MatchExpression, expectedType ...Type) Type {
 	var expected Type
@@ -2341,7 +2571,7 @@ func (tc *TypeChecker) checkPattern(pattern ast.Pattern, expectedType Type) Type
 					tc.addError(p, "variant %s of ADT %s does not accept a payload", variant.Name, adtName)
 					return nil
 				}
-				expectedPayload := tc.instantiateStoredType(variant.Payload, bindings)
+				expectedPayload := tc.instantiatedVariantPayload(adtName, variant, bindings)
 				if expectedPayload == nil || tc.checkPattern(p.Payload, expectedPayload) == nil {
 					return nil
 				}
@@ -2437,7 +2667,7 @@ func (tc *TypeChecker) checkVariantExpression(expr *ast.VariantExpression, expec
 			tc.addError(expr, "variant %s of ADT %s does not accept a payload", variant.Name, adtTypeName)
 			return nil
 		}
-		expectedPayload := tc.instantiateStoredType(variant.Payload, bindings)
+		expectedPayload := tc.instantiatedVariantPayload(adtTypeName, variant, bindings)
 		actualPayload := tc.checkExpression(expr.Payload, expectedPayload)
 		if expectedPayload == nil || actualPayload == nil || !tc.isAssignable(actualPayload, expectedPayload) {
 			tc.addError(expr.Payload, "variant %s payload: expected %s, got %s", variant.Name, expectedPayload, actualPayload)
@@ -2712,6 +2942,12 @@ func (tc *TypeChecker) checkSliceExpression(expr *ast.SliceExpression) Type {
 }
 
 func (tc *TypeChecker) checkVariableDeclaration(stmt *ast.VariableDeclaration) {
+	beforeDeclaration := len(tc.Errors())
+	tc.beginMonomorphicTransaction()
+	defer func() {
+		tc.finishMonomorphicTransaction(len(tc.Errors()) == beforeDeclaration)
+	}()
+
 	if stmt == nil || stmt.Name == nil {
 		// Defense in depth against parser error-recovery artifacts.
 		return
@@ -2758,6 +2994,8 @@ func (tc *TypeChecker) checkVariableDeclaration(stmt *ast.VariableDeclaration) {
 
 		// If there's an initializer, check that it matches the type (with coercion)
 		// Pass expected type for context-based inference (e.g., for integer literals)
+		var initializerBindings Substitution
+		beforeInitializer := len(tc.Errors())
 		if stmt.Value != nil {
 			valueType := tc.checkExpression(stmt.Value, varType)
 			if valueType != nil {
@@ -2770,14 +3008,20 @@ func (tc *TypeChecker) checkVariableDeclaration(stmt *ast.VariableDeclaration) {
 						tc.addError(stmt, "variable %s: expected type %s, got %s", stmt.Name.Value, varType, valueType)
 					}
 				} else {
-					// Apply substitution to get the unified type
+					// Apply substitution to get the unified type. Commit equations
+					// for a blocked initializer only after the complete declaration succeeds.
 					varType = sub.Apply(varType)
+					initializerBindings = sub
 				}
 			}
 		}
 
+		if initializerBindings != nil && len(tc.Errors()) == beforeInitializer {
+			tc.stageMonomorphicBindings(initializerBindings)
+		}
+
 		// Generalize the type (quantify over free type variables)
-		scheme := Generalize(varType, tc.env)
+		scheme := GeneralizeWithFacts(varType, tc.env, deriveGeneralizationFacts(varType, stmt.Value, tc.env, tc))
 		tc.env.Set(stmt.Name.Value, scheme)
 	} else {
 		// Type inference from initializer (HM-style)
@@ -2793,7 +3037,7 @@ func (tc *TypeChecker) checkVariableDeclaration(stmt *ast.VariableDeclaration) {
 					return
 				}
 				// Generalize: convert to a type scheme
-				scheme := Generalize(inferredType, tc.env)
+				scheme := GeneralizeWithFacts(inferredType, tc.env, deriveGeneralizationFacts(inferredType, stmt.Value, tc.env, tc))
 				tc.env.Set(stmt.Name.Value, scheme)
 			}
 		} else {
@@ -2841,6 +3085,12 @@ func (tc *TypeChecker) isAssignable(valueType, varType Type) bool {
 }
 
 func (tc *TypeChecker) checkAssignmentStatement(stmt *ast.AssignmentStatement) {
+	before := len(tc.Errors())
+	tc.beginMonomorphicTransaction()
+	defer func() {
+		tc.finishMonomorphicTransaction(len(tc.Errors()) == before)
+	}()
+
 	// Assignment: x = expr
 	// Rule: x must already be bound in the current scope, otherwise it's a compile-time error
 	// This prevents accidental "silent declaration by typo" (e.g., cont = 1 vs count = 1)
@@ -2885,6 +3135,12 @@ func (tc *TypeChecker) checkAssignmentStatement(stmt *ast.AssignmentStatement) {
 }
 
 func (tc *TypeChecker) checkFunctionStatement(stmt *ast.FunctionStatement) {
+	before := len(tc.Errors())
+	tc.beginMonomorphicTransaction()
+	defer func() {
+		tc.finishMonomorphicTransaction(len(tc.Errors()) == before)
+	}()
+
 	// Check for nil function statement
 	if stmt == nil {
 		return
@@ -3044,6 +3300,10 @@ func (tc *TypeChecker) checkFunctionStatement(stmt *ast.FunctionStatement) {
 	// Restore environment
 	tc.env = oldEnv
 
+	// Preserve any persistent state committed by callers that appeared before
+	// this declaration; finalization must not reopen a barred generic.
+	predeclared, _ := tc.env.Get(stmt.Name.Value)
+
 	// Store function type in environment
 	funcType := &FunctionType{
 		Parameters: paramTypes,
@@ -3051,18 +3311,33 @@ func (tc *TypeChecker) checkFunctionStatement(stmt *ast.FunctionStatement) {
 		Variadic:   isVariadic,
 	}
 
-	// Generalize function type to a scheme with constraints
-	funcScheme := Generalize(funcType, tc.env)
+	// A named function is a closure binding too. Captured authority and unsafe
+	// assumptions gate both inferred and explicitly declared quantification.
+	functionFacts := functionStatementCaptureFacts(stmt, funcEnv)
+	funcScheme := GeneralizeWithFacts(funcType, tc.env, functionFacts)
 
-	// Add type parameters and constraints to the scheme
+	// Explicit type parameters remain quantified only when the closure evidence
+	// permits generalization; annotations never erase authority barriers.
 	if len(typeVars) > 0 || len(constraints) > 0 {
+		quantified := typeVars
+		if !functionFacts.Safe() {
+			quantified = nil
+		}
 		funcScheme = &TypeScheme{
-			TypeVars:    typeVars,
-			Constraints: constraints,
-			Type:        funcScheme.Type,
+			TypeVars:               quantified,
+			Constraints:            constraints,
+			Type:                   funcScheme.Type,
+			GeneralizationBarriers: funcScheme.GeneralizationBarriers,
+			Monomorphic:            funcScheme.Monomorphic,
 		}
 	}
 
+	if predeclared != nil && predeclared.Monomorphic != nil &&
+		funcScheme.GeneralizationBarriers != 0 {
+		predeclared.Constraints = constraints
+		predeclared.GeneralizationBarriers |= funcScheme.GeneralizationBarriers
+		funcScheme = predeclared
+	}
 	tc.env.Set(stmt.Name.Value, funcScheme)
 
 	// If this is a method, also store it with TypeName::methodName key
@@ -3175,6 +3450,7 @@ func (tc *TypeChecker) checkADTType(stmt *ast.ADTType) {
 	}
 
 	tc.adtTypes[stmt.Name.Value] = adtType
+	tc.adtPayloadTypes[stmt.Name.Value] = make(map[string]Type)
 
 	// Now verify the ADT is well-formed (after registration)
 	variantNames := make(map[string]bool)
@@ -3197,6 +3473,8 @@ func (tc *TypeChecker) checkADTType(stmt *ast.ADTType) {
 			}
 			if payloadType == nil {
 				tc.addError(variant.Payload, "ADT %s variant %s: invalid payload type", stmt.Name.Value, variantName)
+			} else {
+				tc.adtPayloadTypes[stmt.Name.Value][variantName] = payloadType
 			}
 		}
 
@@ -3369,6 +3647,12 @@ func (tc *TypeChecker) checkIfStatement(stmt *ast.IfStatement) {
 }
 
 func (tc *TypeChecker) checkWhileStatement(stmt *ast.WhileStatement) {
+	before := len(tc.Errors())
+	tc.beginMonomorphicTransaction()
+	defer func() {
+		tc.finishMonomorphicTransaction(len(tc.Errors()) == before)
+	}()
+
 	conditionType := tc.checkExpression(stmt.Condition)
 	if conditionType != nil && !conditionType.Equals(&BoolType{}) {
 		tc.addError(stmt.Condition, "while condition must be bool, got %s", conditionType)
@@ -3464,6 +3748,24 @@ func (tc *TypeChecker) checkArrayLiteral(expr *ast.ArrayLiteral, expectedType ..
 			}
 		}
 
+		return expectedArray
+	}
+
+	// An untyped literal inherits an expected array/view shape. This gives
+	// every element the declared context (notably sized integer literals) and
+	// preserves owned-array length instead of degrading [N]T to []T.
+	if expectedArray, ok := expected.(*ArrayType); ok {
+		if !expectedArray.IsSlice && !expectedArray.IsSpan &&
+			int64(len(expr.Elements)) != expectedArray.Length {
+			tc.addError(expr, "array literal has %d elements, expected %d", len(expr.Elements), expectedArray.Length)
+			return nil
+		}
+		for i, elem := range expr.Elements {
+			elemType := tc.checkExpression(elem, expectedArray.ElementType)
+			if elemType != nil && !tc.isAssignable(elemType, expectedArray.ElementType) {
+				tc.addError(elem, "array element %d: expected type %s, got %s", i, expectedArray.ElementType, elemType)
+			}
+		}
 		return expectedArray
 	}
 
@@ -3828,8 +4130,8 @@ func (tc *TypeChecker) parseTypeExpressionNonIntersection(expr ast.Expression) T
 	}
 
 	// Handle all other type expressions (same as parseTypeExpression but without intersection handling)
+	// Library-qualified types (c.Int32, ...): docs/spec/92-ffi.md.
 	if ident, ok := expr.(*ast.Identifier); ok {
-		// Library-qualified types (c.Int32, ...): docs/spec/92-ffi.md.
 		if libraryType, isLibrary := tc.libraryQualifiedType(ident); isLibrary {
 			return libraryType
 		}

--- a/typechecker/typechecker.go
+++ b/typechecker/typechecker.go
@@ -493,13 +493,13 @@ func (t *FunctionType) Equals(other Type) bool {
 
 // TypeChecker performs type checking on AST nodes
 type TypeChecker struct {
-	adtPayloadTypes map[string]map[string]Type
+	adtPayloadTypes         map[string]map[string]Type
 	monomorphicTransactions [][]Substitution
-	diagnostics *diagnostic.DiagnosticCollector
-	env         *TypeEnvironment
-	adtTypes    map[string]*object.ADTType // ADT type definitions
-	intSize     int                        // Platform size for int/uint (default: 64)
-	ptrSize     int                        // Platform size for ptr/uptr (default: 64)
+	diagnostics             *diagnostic.DiagnosticCollector
+	env                     *TypeEnvironment
+	adtTypes                map[string]*object.ADTType // ADT type definitions
+	intSize                 int                        // Platform size for int/uint (default: 64)
+	ptrSize                 int                        // Platform size for ptr/uptr (default: 64)
 	// checkedExterns marks extern bindings already validated, so the
 	// predeclare pass and the statement pass never double-report.
 	checkedExterns map[*ast.FunctionStatement]bool
@@ -602,13 +602,13 @@ func New(env *object.Environment) *TypeChecker {
 
 func NewWithPlatformSizes(env *object.Environment, intSize, ptrSize int) *TypeChecker {
 	tc := &TypeChecker{
-		diagnostics: diagnostic.NewDiagnosticCollector(),
-		env:         NewTypeEnvironment(),
+		diagnostics:     diagnostic.NewDiagnosticCollector(),
+		env:             NewTypeEnvironment(),
 		adtTypes:        env.GetAllADTTypes(),
 		adtPayloadTypes: make(map[string]map[string]Type),
 		intSize:         intSize,
 		ptrSize:         ptrSize,
-		checkedExterns:   make(map[*ast.FunctionStatement]bool),
+		checkedExterns:  make(map[*ast.FunctionStatement]bool),
 	}
 	// Add builtin type aliases
 	tc.addBuiltinTypeAliases()
@@ -719,7 +719,9 @@ func (tc *TypeChecker) CheckProgram(program *ast.Program) {
 		if fn, ok := stmt.(*ast.FunctionStatement); ok {
 			tc.predeclareFunctionSignature(fn)
 			if len(fn.TypeParams) > 0 && fn.Receiver == nil && !typeParamsConstrained(fn.TypeParams) {
-				if tc.functionTemplates == nil { tc.functionTemplates = make(map[string]*ast.FunctionStatement) }
+				if tc.functionTemplates == nil {
+					tc.functionTemplates = make(map[string]*ast.FunctionStatement)
+				}
 				tc.functionTemplates[fn.Name.Value] = fn
 			}
 		}
@@ -973,7 +975,7 @@ func (tc *TypeChecker) predeclaredMethodBarrierScheme(fn *ast.FunctionStatement)
 		Type: &FunctionType{
 			Parameters: parameters,
 			ReturnType: result,
-			Variadic: len(fn.Parameters) > 0 && fn.Parameters[len(fn.Parameters)-1].Variadic,
+			Variadic:   len(fn.Parameters) > 0 && fn.Parameters[len(fn.Parameters)-1].Variadic,
 		},
 	}
 }
@@ -2406,7 +2408,6 @@ func (tc *TypeChecker) checkIndexAssignmentStatement(stmt *ast.IndexAssignmentSt
 		tc.addError(stmt.Value, "cannot assign %s to element type %s", valueType, arrType.ElementType)
 	}
 }
-
 
 func (tc *TypeChecker) checkMatchExpression(expr *ast.MatchExpression, expectedType ...Type) Type {
 	var expected Type


### PR DESCRIPTION
Local bindings previously generalized without consulting authority evidence. Removing quantifiers alone also allowed later calls to independently specialize a supposedly monomorphic value.

This reconstruction carries the generalization-safety subsystem from `408263ba210bac55654c05bde14810353174c862` onto `c942fb5c62c84fb167aea5ee7fb9ad53e1f613bf`.

- Derive barriers from owned and borrowed storage, atomic storage, captures, calls, unsafe bodies, and conditional control flow.
- Preserve persistent type substitutions through aliases, higher-order calls, constraints, and transactional error recovery.
- Resolve forward function and method summaries to a fixed point.
- Apply the same restriction to the current generic template specialization path.
- Retain regression tests and add template-reuse and conditional-unsafe cases.
- Add a focused race-enabled typechecker and formatting check.

The patch is limited to checker integration, its tests, the inference specification, Lean barrier laws, and the focused workflow. Validation requires CI, standard library, golden files, formal verification, and generalization safety to pass on the final head.

The Lean model proves the abstract barrier laws; it does not establish full refinement of the Go implementation. Compiler-wide ownership/effect/region evidence integration remains future work.