### PR TITLE
Add machine-memory semantic foundation

### DIFF
--- a/codegen/memory.go
+++ b/codegen/memory.go
@@ -1,0 +1,104 @@
+package codegen
+
+import (
+	"fmt"
+
+	"github.com/SCKelemen/oak/semir"
+)
+
+// cMemoryOrder is the C11 projection of Oak's language-level ordering. This is
+// deliberately a total checked conversion: a backend must never silently
+// strengthen, weaken, or guess an unknown order.
+func cMemoryOrder(order semir.MemoryOrder) (string, error) {
+	switch order {
+	case semir.MemoryOrderRelaxed:
+		return "memory_order_relaxed", nil
+	case semir.MemoryOrderAcquire:
+		return "memory_order_acquire", nil
+	case semir.MemoryOrderRelease:
+		return "memory_order_release", nil
+	case semir.MemoryOrderAcqRel:
+		return "memory_order_acq_rel", nil
+	case semir.MemoryOrderSeqCst:
+		return "memory_order_seq_cst", nil
+	default:
+		return "", fmt.Errorf("unknown Oak memory order %q", order)
+	}
+}
+
+// atomicCType returns the exact C11 atomic carrier used by the bootstrap C
+// backend. _Atomic(T) preserves the fixed-width carrier chosen by Oak rather
+// than substituting one of C's implementation-sized convenience typedefs.
+func atomicCType(base string) (string, error) {
+	if !semir.AtomicCarrierAllowed(base) {
+		return "", fmt.Errorf("unsupported atomic C carrier %q", base)
+	}
+	return fmt.Sprintf("_Atomic(%s)", base), nil
+}
+
+func atomicLoadC(address string, order semir.MemoryOrder) (string, error) {
+	if !semir.LegalAtomicOrder(semir.AtomicLoad, order) {
+		return "", fmt.Errorf("illegal load order %q", order)
+	}
+	cOrder, err := cMemoryOrder(order)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("atomic_load_explicit(%s, %s)", address, cOrder), nil
+}
+
+func atomicStoreC(address, value string, order semir.MemoryOrder) (string, error) {
+	if !semir.LegalAtomicOrder(semir.AtomicStore, order) {
+		return "", fmt.Errorf("illegal store order %q", order)
+	}
+	cOrder, err := cMemoryOrder(order)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("atomic_store_explicit(%s, %s, %s)", address, value, cOrder), nil
+}
+
+func atomicExchangeC(address, value string, order semir.MemoryOrder) (string, error) {
+	if !semir.LegalAtomicOrder(semir.AtomicRMW, order) {
+		return "", fmt.Errorf("illegal exchange order %q", order)
+	}
+	cOrder, err := cMemoryOrder(order)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("atomic_exchange_explicit(%s, %s, %s)", address, value, cOrder), nil
+}
+
+func atomicFetchAddC(address, value string, order semir.MemoryOrder) (string, error) {
+	if !semir.LegalAtomicOrder(semir.AtomicRMW, order) {
+		return "", fmt.Errorf("illegal fetch-add order %q", order)
+	}
+	cOrder, err := cMemoryOrder(order)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("atomic_fetch_add_explicit(%s, %s, %s)", address, value, cOrder), nil
+}
+
+func atomicFenceC(order semir.MemoryOrder) (string, error) {
+	if !semir.LegalAtomicOrder(semir.AtomicFence, order) {
+		return "", fmt.Errorf("illegal fence order %q", order)
+	}
+	cOrder, err := cMemoryOrder(order)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("atomic_thread_fence(%s)", cOrder), nil
+}
+
+// volatileReadC/volatileWriteC model exactly one volatile access through an
+// already-typed address expression. They intentionally emit no fence: volatile
+// is observability, not inter-thread synchronization or a complete device-MMIO
+// protocol.
+func volatileReadC(cType, address string) string {
+	return fmt.Sprintf("(*(volatile %s *)(%s))", cType, address)
+}
+
+func volatileWriteC(cType, address, value string) string {
+	return fmt.Sprintf("(*(volatile %s *)(%s) = (%s))", cType, address, value)
+}

--- a/codegen/memory_test.go
+++ b/codegen/memory_test.go
@@ -1,0 +1,101 @@
+package codegen
+
+import (
+	"testing"
+
+	"github.com/SCKelemen/oak/semir"
+)
+
+func TestCMemoryOrder(t *testing.T) {
+	cases := map[semir.MemoryOrder]string{
+		semir.MemoryOrderRelaxed: "memory_order_relaxed",
+		semir.MemoryOrderAcquire: "memory_order_acquire",
+		semir.MemoryOrderRelease: "memory_order_release",
+		semir.MemoryOrderAcqRel:  "memory_order_acq_rel",
+		semir.MemoryOrderSeqCst:  "memory_order_seq_cst",
+	}
+	for order, want := range cases {
+		got, err := cMemoryOrder(order)
+		if err != nil {
+			t.Fatalf("cMemoryOrder(%q): %v", order, err)
+		}
+		if got != want {
+			t.Fatalf("cMemoryOrder(%q) = %q, want %q", order, got, want)
+		}
+	}
+}
+
+func TestAtomicCTypePreservesCarrier(t *testing.T) {
+	got, err := atomicCType("u32")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "_Atomic(u32)" {
+		t.Fatalf("unexpected C atomic type: %s", got)
+	}
+	if _, err := atomicCType("ptr"); err == nil {
+		t.Fatal("pointer carrier unexpectedly accepted")
+	}
+}
+
+func TestAtomicLoadLoweringRejectsRelease(t *testing.T) {
+	if _, err := atomicLoadC("&x", semir.MemoryOrderRelease); err == nil {
+		t.Fatal("release load unexpectedly accepted")
+	}
+	got, err := atomicLoadC("&x", semir.MemoryOrderAcquire)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "atomic_load_explicit(&x, memory_order_acquire)" {
+		t.Fatalf("unexpected load lowering: %s", got)
+	}
+}
+
+func TestAtomicStoreLoweringRejectsAcquire(t *testing.T) {
+	if _, err := atomicStoreC("&x", "7", semir.MemoryOrderAcquire); err == nil {
+		t.Fatal("acquire store unexpectedly accepted")
+	}
+	got, err := atomicStoreC("&x", "7", semir.MemoryOrderRelease)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "atomic_store_explicit(&x, 7, memory_order_release)" {
+		t.Fatalf("unexpected store lowering: %s", got)
+	}
+}
+
+func TestAtomicRMWAndFenceLowering(t *testing.T) {
+	exchange, err := atomicExchangeC("&x", "9", semir.MemoryOrderAcqRel)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exchange != "atomic_exchange_explicit(&x, 9, memory_order_acq_rel)" {
+		t.Fatalf("unexpected exchange lowering: %s", exchange)
+	}
+	add, err := atomicFetchAddC("&x", "1", semir.MemoryOrderRelaxed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if add != "atomic_fetch_add_explicit(&x, 1, memory_order_relaxed)" {
+		t.Fatalf("unexpected fetch-add lowering: %s", add)
+	}
+	if _, err := atomicFenceC(semir.MemoryOrderRelaxed); err == nil {
+		t.Fatal("relaxed fence unexpectedly accepted")
+	}
+	fence, err := atomicFenceC(semir.MemoryOrderSeqCst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fence != "atomic_thread_fence(memory_order_seq_cst)" {
+		t.Fatalf("unexpected fence lowering: %s", fence)
+	}
+}
+
+func TestVolatileLoweringDoesNotInventFence(t *testing.T) {
+	if got := volatileReadC("u32", "addr"); got != "(*(volatile u32 *)(addr))" {
+		t.Fatalf("unexpected volatile read lowering: %s", got)
+	}
+	if got := volatileWriteC("u32", "addr", "value"); got != "(*(volatile u32 *)(addr) = (value))" {
+		t.Fatalf("unexpected volatile write lowering: %s", got)
+	}
+}

--- a/docs/spec/65-machine-memory.md
+++ b/docs/spec/65-machine-memory.md
@@ -1,0 +1,193 @@
+# Machine memory: atomics, volatile access, and ordering
+
+This chapter specifies Oak's machine-memory foundation. It is deliberately
+small: fixed-width integer atomics, explicit memory order, and raw volatile
+access. Device MMIO, architecture barriers, system registers, and inline
+assembly build on this layer but are separate contracts.
+
+The governing rule is:
+
+> Memory effects that matter to hardware or concurrency are language semantics,
+> never backend accidents.
+
+## 1. Atomic values
+
+`Atomic[T]` is the semantic type of one atomically accessed machine value.
+Atomicity belongs to the cell and its accesses; a value loaded from
+`Atomic[u32]` is an ordinary `u32`.
+
+The first executable version permits only fixed-width integer carriers:
+
+- `u8`, `u16`, `u32`, `u64`
+- `i8`, `i16`, `i32`, `i64`
+
+`int`, `uint`, `ptr`, `uptr`, booleans, records, sums, and aggregates are not
+v1 atomic carriers. Pointer atomics require a provenance contract; native-width
+integers require a target-width contract; aggregate atomics require explicit
+layout and lock-freedom rules. Those are not inferred implicitly.
+
+A target may impose stronger alignment than the carrier's ordinary alignment.
+Whether a particular `Atomic[T]` is lock-free is a target property. Oak must
+not claim lock-free execution unless the selected target/backend proves or
+checks it.
+
+## 2. Memory orders
+
+Oak defines exactly five memory orders:
+
+- `relaxed`
+- `acquire`
+- `release`
+- `acq-rel`
+- `seq-cst`
+
+The order is part of the operation's semantics and is preserved in Semantic
+IR effects. Backends may not silently weaken, strengthen, or guess an order.
+
+The v1 legality matrix is:
+
+| Operation | relaxed | acquire | release | acq-rel | seq-cst |
+| --- | --- | --- | --- | --- | --- |
+| load | yes | yes | no | no | yes |
+| store | yes | no | yes | no | yes |
+| read-modify-write | yes | yes | yes | yes | yes |
+| fence | no | yes | yes | yes | yes |
+
+A release load and acquire store are language errors. A relaxed fence is not a
+surface operation because it creates no synchronization relation.
+
+## 3. Initial operation set
+
+The first machine-memory slice supports semantic lowering for:
+
+- atomic load
+- atomic store
+- atomic exchange
+- atomic fetch-add
+- thread fence
+
+Compare-exchange is intentionally deferred. It has separate success and failure
+orders, restrictions on the failure order, and value-update semantics. Oak will
+specify those directly instead of pretending compare-exchange is a one-order
+RMW.
+
+The eventual source surface should make the order explicit at the call site.
+The exact spelling is not normative until parser/typechecker integration lands.
+The semantic shape is equivalent to:
+
+```text
+atomic_load(cell, acquire)
+atomic_store(cell, value, release)
+atomic_exchange(cell, value, acq_rel)
+atomic_fetch_add(cell, delta, relaxed)
+atomic_fence(seq_cst)
+```
+
+There is no implicit default order in the core language.
+
+## 4. Effects
+
+Atomic operations project into Oak's authority/effect axis:
+
+```text
+Memory.AtomicLoad[order]
+Memory.AtomicStore[order]
+Memory.AtomicRMW[order]
+Memory.AtomicFence[order]
+```
+
+The order parameter is semantic data. Proof generation, documentation,
+debugging, realtime analysis, and future temporal projections can therefore
+reason about synchronization without reparsing source syntax.
+
+Atomic operations do not imply allocation, blocking, scheduler interaction, or
+syscalls.
+
+## 5. Volatile access
+
+Volatile access means that the requested load or store is an observable machine
+access and must not be removed, duplicated, merged, or satisfied from a cached
+language value in a way that changes the required observable access.
+
+The effects are:
+
+```text
+Memory.VolatileRead
+Memory.VolatileWrite
+```
+
+Volatile is **not** an atomic synchronization primitive.
+Volatile is **not** a replacement for acquire/release atomics.
+Volatile is **not** by itself a complete device-MMIO ordering contract.
+
+This distinction is essential on weakly ordered architectures, including
+AArch64. Device-memory type, access width, barriers, and architecture-specific
+ordering rules belong to the MMIO/architecture layer built above this one.
+
+## 6. C bootstrap backend
+
+The bootstrap C backend refines Oak atomics to C11 `_Atomic(T)` and explicit
+`atomic_*_explicit` operations with the corresponding `memory_order_*` value.
+It uses the fixed-width Oak carrier rather than an implementation-sized atomic
+convenience typedef.
+
+The mapping is checked and total. An unknown Oak order or illegal
+operation/order pair is a backend error rather than a fallback.
+
+Raw volatile lowering uses `volatile T *` access and emits no hidden fence.
+Any future MMIO primitive that requires barriers must request them explicitly
+through the machine/architecture semantics.
+
+## 7. Formal model
+
+`spec/lean/Oak/MemoryOrder.lean` is the kernel-checked projection of the v1
+legality matrix. It proves, among other facts:
+
+- release and acq-rel loads are illegal;
+- acquire and acq-rel stores are illegal;
+- every defined order is legal for RMW operations;
+- relaxed fences are illegal;
+- legal loads cannot have release/acq-rel ordering;
+- legal stores cannot have acquire/acq-rel ordering.
+
+These proofs establish the abstract order contract. They do not yet prove that
+the C compiler, target ISA, or generated machine code implements the full Oak
+memory model. That stronger refinement is a later verification layer.
+
+## 8. What this chapter does not yet claim
+
+This slice is the foundation, not the completed concurrency model. It does not
+yet specify:
+
+- compare-exchange;
+- pointer atomics;
+- wait/notify primitives;
+- data-race semantics for non-atomic memory;
+- compiler reordering outside atomic operations;
+- a complete happens-before relation;
+- architecture-specific barrier selection;
+- device-memory attributes or MMIO ordering;
+- DMA coherency;
+- interrupt-entry ordering;
+- freestanding linker/ABI rules.
+
+Those contracts must be explicit before Oak owns privileged operating-system
+code.
+
+## 9. Required verification ladder
+
+Machine-memory features are complete only when their status is stated at each
+layer:
+
+1. **specified** — normative semantics are written here;
+2. **modeled/proved** — Lean/TLA/other formal artifacts establish the intended
+   laws;
+3. **implemented** — typechecker and backend expose the operation end-to-end;
+4. **implementation-tested** — generated code is compiled and executed;
+5. **refined** — the backend/target mapping is related formally to the language
+   model where practical;
+6. **hardware-tested** — litmus tests exercise the target architecture.
+
+The current first slice establishes the semantic model, checked type/backend
+building blocks, tests, and Lean order proofs. Source syntax and full
+end-to-end atomic execution are the next step.

--- a/semir/memory.go
+++ b/semir/memory.go
@@ -1,0 +1,134 @@
+package semir
+
+import "fmt"
+
+// TypeAtomic is the semantic type of one atomic machine value. The carrier is
+// stored in Type.Base so Atomic[u32] is represented as Type{Kind: TypeAtomic,
+// Base: "u32"}. Atomicity is an access contract, not a request for a different
+// numeric value domain.
+const TypeAtomic TypeKind = "atomic"
+
+// MemoryOrder is Oak's language-level memory-order vocabulary. These names are
+// semantic: backends must refine them to target/compiler operations with the
+// same ordering guarantees rather than treating them as advisory metadata.
+type MemoryOrder string
+
+const (
+	MemoryOrderRelaxed MemoryOrder = "relaxed"
+	MemoryOrderAcquire MemoryOrder = "acquire"
+	MemoryOrderRelease MemoryOrder = "release"
+	MemoryOrderAcqRel  MemoryOrder = "acq-rel"
+	MemoryOrderSeqCst  MemoryOrder = "seq-cst"
+)
+
+func (o MemoryOrder) Valid() bool {
+	switch o {
+	case MemoryOrderRelaxed, MemoryOrderAcquire, MemoryOrderRelease, MemoryOrderAcqRel, MemoryOrderSeqCst:
+		return true
+	default:
+		return false
+	}
+}
+
+// AtomicOperation classifies an atomic access independently of its memory
+// order. Compare-exchange is intentionally deferred: its distinct success and
+// failure orders deserve a separate contract instead of being squeezed into a
+// single-order RMW operation.
+type AtomicOperation string
+
+const (
+	AtomicLoad  AtomicOperation = "load"
+	AtomicStore AtomicOperation = "store"
+	AtomicRMW   AtomicOperation = "rmw"
+	AtomicFence AtomicOperation = "fence"
+)
+
+// LegalAtomicOrder encodes the v1 order matrix. Illegal combinations are a
+// language error, not a backend choice. In particular a load can never be
+// release/acq-rel and a store can never be acquire/acq-rel.
+func LegalAtomicOrder(op AtomicOperation, order MemoryOrder) bool {
+	if !order.Valid() {
+		return false
+	}
+	switch op {
+	case AtomicLoad:
+		return order == MemoryOrderRelaxed || order == MemoryOrderAcquire || order == MemoryOrderSeqCst
+	case AtomicStore:
+		return order == MemoryOrderRelaxed || order == MemoryOrderRelease || order == MemoryOrderSeqCst
+	case AtomicRMW:
+		return true
+	case AtomicFence:
+		// A relaxed fence has no synchronization effect and is excluded from
+		// the surface rather than pretending to be useful.
+		return order != MemoryOrderRelaxed
+	default:
+		return false
+	}
+}
+
+// AtomicEffect projects an atomic operation into Oak's authority/effect axis.
+// The order is retained as a parameter so verification, documentation, and
+// future scheduling/debug tooling do not need to recover it from syntax.
+func AtomicEffect(op AtomicOperation, order MemoryOrder) (Effect, error) {
+	if !LegalAtomicOrder(op, order) {
+		return Effect{}, fmt.Errorf("illegal atomic memory order %q for %q", order, op)
+	}
+	name := ""
+	switch op {
+	case AtomicLoad:
+		name = "AtomicLoad"
+	case AtomicStore:
+		name = "AtomicStore"
+	case AtomicRMW:
+		name = "AtomicRMW"
+	case AtomicFence:
+		name = "AtomicFence"
+	}
+	return Effect{Namespace: "Memory", Name: name, Parameters: []string{string(order)}}, nil
+}
+
+// AtomicCarrierAllowed is deliberately narrow for the first executable
+// systems slice. Fixed-width integers have unambiguous machine width and C11
+// atomic carriers. Pointer atomics, aggregate atomics, and target-dependent
+// int/uint are separate future contracts rather than accidental extensions.
+func AtomicCarrierAllowed(base string) bool {
+	switch base {
+	case "u8", "u16", "u32", "u64", "i8", "i16", "i32", "i64":
+		return true
+	default:
+		return false
+	}
+}
+
+// ValidateAtomicType checks the semantic portion of Atomic[T]. Layout-specific
+// lock-freedom is a target property and is intentionally not claimed here.
+func ValidateAtomicType(t Type) error {
+	if t.Kind != TypeAtomic {
+		return fmt.Errorf("expected atomic type, got %q", t.Kind)
+	}
+	if !AtomicCarrierAllowed(t.Base) {
+		return fmt.Errorf("Atomic[%s] is not a v1 atomic carrier", t.Base)
+	}
+	return nil
+}
+
+// VolatileOperation models exactly-one observable accesses. Volatile is not a
+// synchronization primitive and, by itself, is not a complete device-MMIO
+// ordering contract on architectures such as AArch64.
+type VolatileOperation string
+
+const (
+	VolatileRead  VolatileOperation = "read"
+	VolatileWrite VolatileOperation = "write"
+)
+
+func VolatileEffect(op VolatileOperation) (Effect, error) {
+	switch op {
+	case VolatileRead:
+		return Effect{Namespace: "Memory", Name: "VolatileRead"}, nil
+	case VolatileWrite:
+		return Effect{Namespace: "Memory", Name: "VolatileWrite"}, nil
+	default:
+		return Effect{}, fmt.Errorf("unknown volatile operation %q", op)
+	}
+}

--- a/semir/memory_test.go
+++ b/semir/memory_test.go
@@ -1,0 +1,82 @@
+package semir
+
+import "testing"
+
+func TestLegalAtomicOrder(t *testing.T) {
+	cases := []struct {
+		op    AtomicOperation
+		order MemoryOrder
+		want  bool
+	}{
+		{AtomicLoad, MemoryOrderRelaxed, true},
+		{AtomicLoad, MemoryOrderAcquire, true},
+		{AtomicLoad, MemoryOrderSeqCst, true},
+		{AtomicLoad, MemoryOrderRelease, false},
+		{AtomicLoad, MemoryOrderAcqRel, false},
+		{AtomicStore, MemoryOrderRelaxed, true},
+		{AtomicStore, MemoryOrderRelease, true},
+		{AtomicStore, MemoryOrderSeqCst, true},
+		{AtomicStore, MemoryOrderAcquire, false},
+		{AtomicStore, MemoryOrderAcqRel, false},
+		{AtomicRMW, MemoryOrderRelaxed, true},
+		{AtomicRMW, MemoryOrderAcquire, true},
+		{AtomicRMW, MemoryOrderRelease, true},
+		{AtomicRMW, MemoryOrderAcqRel, true},
+		{AtomicRMW, MemoryOrderSeqCst, true},
+		{AtomicFence, MemoryOrderAcquire, true},
+		{AtomicFence, MemoryOrderRelease, true},
+		{AtomicFence, MemoryOrderAcqRel, true},
+		{AtomicFence, MemoryOrderSeqCst, true},
+		{AtomicFence, MemoryOrderRelaxed, false},
+	}
+	for _, tc := range cases {
+		if got := LegalAtomicOrder(tc.op, tc.order); got != tc.want {
+			t.Fatalf("LegalAtomicOrder(%q, %q) = %v, want %v", tc.op, tc.order, got, tc.want)
+		}
+	}
+}
+
+func TestAtomicEffectRetainsOrder(t *testing.T) {
+	effect, err := AtomicEffect(AtomicRMW, MemoryOrderAcqRel)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if effect.Namespace != "Memory" || effect.Name != "AtomicRMW" {
+		t.Fatalf("unexpected effect: %#v", effect)
+	}
+	if len(effect.Parameters) != 1 || effect.Parameters[0] != "acq-rel" {
+		t.Fatalf("atomic order lost from effect: %#v", effect)
+	}
+}
+
+func TestAtomicCarrierAllowed(t *testing.T) {
+	for _, base := range []string{"u8", "u16", "u32", "u64", "i8", "i16", "i32", "i64"} {
+		if !AtomicCarrierAllowed(base) {
+			t.Fatalf("expected %s to be allowed", base)
+		}
+	}
+	for _, base := range []string{"int", "uint", "ptr", "uptr", "Bool", "record"} {
+		if AtomicCarrierAllowed(base) {
+			t.Fatalf("expected %s to be rejected", base)
+		}
+	}
+}
+
+func TestValidateAtomicType(t *testing.T) {
+	if err := ValidateAtomicType(Type{Kind: TypeAtomic, Base: "u32"}); err != nil {
+		t.Fatalf("valid atomic rejected: %v", err)
+	}
+	if err := ValidateAtomicType(Type{Kind: TypeAtomic, Base: "ptr"}); err == nil {
+		t.Fatal("pointer atomic unexpectedly accepted in v1")
+	}
+}
+
+func TestVolatileEffectIsNotAtomic(t *testing.T) {
+	effect, err := VolatileEffect(VolatileRead)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if effect.Namespace != "Memory" || effect.Name != "VolatileRead" || len(effect.Parameters) != 0 {
+		t.Fatalf("unexpected volatile effect: %#v", effect)
+	}
+}

--- a/spec/lean/Oak.lean
+++ b/spec/lean/Oak.lean
@@ -1,5 +1,6 @@
 import Oak.TypeLattice
 import Oak.Effects
+import Oak.MemoryOrder
 import Oak.Borrowing
 import Oak.BorrowRegions
 import Oak.Reborrow

--- a/spec/lean/Oak/MemoryOrder.lean
+++ b/spec/lean/Oak/MemoryOrder.lean
@@ -1,0 +1,66 @@
+namespace Oak.MemoryOrder
+
+inductive Order where
+  | relaxed
+  | acquire
+  | release
+  | acqRel
+  | seqCst
+  deriving DecidableEq, Repr
+
+inductive AtomicOp where
+  | load
+  | store
+  | rmw
+  | fence
+  deriving DecidableEq, Repr
+
+/-- Oak's v1 atomic memory-order legality matrix. This is deliberately
+    independent of any compiler backend. -/
+def legal : AtomicOp -> Order -> Bool
+  | .load, .relaxed => true
+  | .load, .acquire => true
+  | .load, .seqCst => true
+  | .load, _ => false
+  | .store, .relaxed => true
+  | .store, .release => true
+  | .store, .seqCst => true
+  | .store, _ => false
+  | .rmw, _ => true
+  | .fence, .relaxed => false
+  | .fence, _ => true
+
+theorem load_relaxed_legal : legal .load .relaxed = true := rfl
+theorem load_acquire_legal : legal .load .acquire = true := rfl
+theorem load_seqCst_legal : legal .load .seqCst = true := rfl
+
+theorem load_release_illegal : legal .load .release = false := rfl
+theorem load_acqRel_illegal : legal .load .acqRel = false := rfl
+
+theorem store_relaxed_legal : legal .store .relaxed = true := rfl
+theorem store_release_legal : legal .store .release = true := rfl
+theorem store_seqCst_legal : legal .store .seqCst = true := rfl
+
+theorem store_acquire_illegal : legal .store .acquire = false := rfl
+theorem store_acqRel_illegal : legal .store .acqRel = false := rfl
+
+theorem rmw_all_orders_legal (o : Order) : legal .rmw o = true := by
+  cases o <;> rfl
+
+theorem relaxed_fence_illegal : legal .fence .relaxed = false := rfl
+
+theorem synchronization_fences_legal (o : Order)
+    (h : o != .relaxed) : legal .fence o = true := by
+  cases o <;> simp_all [legal]
+
+/-- A legal load never has release-only or acquire-release ordering. -/
+theorem legal_load_not_release (o : Order)
+    (h : legal .load o = true) : o != .release ∧ o != .acqRel := by
+  cases o <;> simp_all [legal]
+
+/-- A legal store never has acquire-only or acquire-release ordering. -/
+theorem legal_store_not_acquire (o : Order)
+    (h : legal .store o = true) : o != .acquire ∧ o != .acqRel := by
+  cases o <;> simp_all [legal]
+
+end Oak.MemoryOrder

--- a/typechecker/memory.go
+++ b/typechecker/memory.go
@@ -1,0 +1,55 @@
+package typechecker
+
+import "fmt"
+
+// AtomicType is the checked type of Atomic[T]. Atomicity is a property of
+// accesses to the cell; values loaded from the cell have the ordinary element
+// type. v1 deliberately accepts only fixed-width integer carriers.
+type AtomicType struct {
+	Element Type
+}
+
+func (t *AtomicType) String() string {
+	if t == nil || t.Element == nil {
+		return "Atomic[?]"
+	}
+	return "Atomic[" + t.Element.String() + "]"
+}
+
+func (t *AtomicType) Equals(other Type) bool {
+	o, ok := other.(*AtomicType)
+	if !ok || t == nil || o == nil || t.Element == nil || o.Element == nil {
+		return false
+	}
+	return t.Element.Equals(o.Element)
+}
+
+// IsAtomicCarrier reports whether typ has the unambiguous fixed-width machine
+// representation required by the first atomic surface. Native int/uint and
+// pointers are intentionally excluded until target-width and provenance rules
+// are part of the atomic contract.
+func IsAtomicCarrier(typ Type) bool {
+	prim, ok := typ.(*PrimitiveType)
+	if !ok || prim == nil {
+		return false
+	}
+	switch normalizePrimitiveName(prim.Name) {
+	case "u8", "u16", "u32", "u64", "i8", "i16", "i32", "i64":
+		return true
+	default:
+		return false
+	}
+}
+
+// NewAtomicType is the single checked constructor used by parser lowering and
+// future generic-type elaboration. Keeping validation here avoids having one
+// source-syntax path accidentally admit carriers another path rejects.
+func NewAtomicType(element Type) (*AtomicType, error) {
+	if !IsAtomicCarrier(element) {
+		if element == nil {
+			return nil, fmt.Errorf("Atomic requires a fixed-width integer carrier")
+		}
+		return nil, fmt.Errorf("Atomic[%s] is not supported; v1 requires a fixed-width integer carrier", element)
+	}
+	return &AtomicType{Element: element}, nil
+}

--- a/typechecker/memory_test.go
+++ b/typechecker/memory_test.go
@@ -1,0 +1,52 @@
+package typechecker
+
+import "testing"
+
+func TestAtomicTypeEquality(t *testing.T) {
+	a, err := NewAtomicType(&PrimitiveType{Name: "u32"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := NewAtomicType(&PrimitiveType{Name: "u32"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := NewAtomicType(&PrimitiveType{Name: "u64"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !a.Equals(b) {
+		t.Fatal("equal atomic carriers should produce equal atomic types")
+	}
+	if a.Equals(c) {
+		t.Fatal("different atomic carriers should not compare equal")
+	}
+	if a.String() != "Atomic[u32]" {
+		t.Fatalf("unexpected atomic type string: %s", a.String())
+	}
+}
+
+func TestAtomicCarrierIsFixedWidthOnly(t *testing.T) {
+	for _, name := range []string{"u8", "u16", "u32", "u64", "i8", "i16", "i32", "i64", "byte", "rune"} {
+		if !IsAtomicCarrier(&PrimitiveType{Name: name}) {
+			t.Fatalf("expected %s to be an atomic carrier", name)
+		}
+	}
+	for _, name := range []string{"int", "uint", "ptr", "uptr"} {
+		if IsAtomicCarrier(&PrimitiveType{Name: name}) {
+			t.Fatalf("expected %s to be rejected as an atomic carrier", name)
+		}
+	}
+	if IsAtomicCarrier(&BoolType{}) {
+		t.Fatal("Bool must not be an atomic carrier in v1")
+	}
+}
+
+func TestNewAtomicTypeRejectsUnsupportedCarrier(t *testing.T) {
+	if _, err := NewAtomicType(&PrimitiveType{Name: "ptr"}); err == nil {
+		t.Fatal("expected pointer carrier rejection")
+	}
+	if _, err := NewAtomicType(nil); err == nil {
+		t.Fatal("expected nil carrier rejection")
+	}
+}


### PR DESCRIPTION
Introduces Oak's first machine-memory slice for systems programming.

This PR adds:
- Semantic IR definitions for `Atomic[T]`, explicit memory orders, atomic operations, and volatile effects.
- A checked legality matrix: loads reject release/acq-rel, stores reject acquire/acq-rel, relaxed fences are excluded.
- Fixed-width integer atomic carriers only in v1; pointer/native-width/aggregate atomics remain explicit future contracts.
- Typechecker-side `AtomicType` representation and carrier validation.
- C11 lowering primitives for exact `_Atomic(T)`, `atomic_*_explicit`, and fences.
- Raw volatile lowering with deliberately no hidden fence.
- Lean 4 model and proofs for the memory-order legality matrix.
- Normative `65-machine-memory.md` specification, including the verification ladder and explicit non-claims.

This is intentionally the semantic/type/backend foundation rather than a claim of end-to-end source-level atomics. The next slice will wire `Atomic[T]` and order-explicit operations through parser/typechecker/codegen and execution tests, followed by MMIO/AArch64 barrier semantics.