### PR TITLE
POC: exercise Oak on hypervisor core semantics

### DIFF
--- a/compiler/hypervisor_poc_test.go
+++ b/compiler/hypervisor_poc_test.go
@@ -115,13 +115,8 @@ candidate_for: (eligible: u8, priority: u8, mask: u8): u8 = eligible ?
   | 1 -> priority
   | _ -> mask
 
-next_best_for: (better: Bool, i: u32, current: i32): i32 = better ?
-  | true -> i32(i)
-  | false -> current
-
-next_priority_for: (better: Bool, candidate: u8, current: u8): u8 = better ?
-  | true -> candidate
-  | false -> current
+next_best_for: (better: Bool, i: u32, current: i32): i32 = better ? | true -> i32(i) | false -> current
+next_priority_for: (better: Bool, candidate: u8, current: u8): u8 = better ? | true -> candidate | false -> current
 
 main: (): i32 {
   eligible_storage: [4]u8

--- a/compiler/hypervisor_poc_test.go
+++ b/compiler/hypervisor_poc_test.go
@@ -107,7 +107,8 @@ main: (): i32 {
 // Bounded priority selection over fixed caller-owned storage. The loop shape
 // is intentionally accepted by Oak's strict Power-of-Ten/TigerStyle profile:
 // fixed storage, no allocation, monotonically increasing counter, immutable
-// loop bound, and no recursion.
+// loop bound, and no recursion. Matches remain value-producing expressions;
+// the loop performs the state update after those values have been selected.
 func TestHypervisorPOCBoundedIrqSelection(t *testing.T) {
 	code, abnormal := buildAndRunStrict(t, "hypervisor_irq_select", `
 main: (): i32 {
@@ -133,15 +134,18 @@ main: (): i32 {
   i: u32 = 0
 
   while i < n {
-    eligible[i] ?
-      | 1 -> (priority[i] < best_priority) ?
-          | .True -> {
-              best = i32(i)
-              best_priority = priority[i]
-              ()
-            }
-          | .False -> ()
-      | _ -> ()
+    candidate: u8 = eligible[i] ?
+      | 1 -> priority[i]
+      | _ -> mask
+    better: Bool = candidate < best_priority
+    next_best: i32 = better ?
+      | .True -> i32(i)
+      | .False -> best
+    next_priority: u8 = better ?
+      | .True -> candidate
+      | .False -> best_priority
+    best = next_best
+    best_priority = next_priority
     i = i + 1
   }
 

--- a/compiler/hypervisor_poc_test.go
+++ b/compiler/hypervisor_poc_test.go
@@ -107,16 +107,21 @@ main: (): i32 {
 // Bounded priority selection over fixed caller-owned storage. The loop shape
 // is intentionally accepted by Oak's strict Power-of-Ten/TigerStyle profile:
 // fixed storage, no allocation, monotonically increasing counter, immutable
-// loop bound, and no recursion. Match decisions live in small pure helpers so
-// the hot loop itself stays straight-line and mechanically obvious.
+// loop bound, and no recursion.
+//
+// The current parser does not yet admit primitive Bool literals as match
+// patterns through the real compilation pipeline. Rather than hide that gap,
+// this POC uses a machine-friendly branchless selector. For u8 priorities a,b,
+// (a + 256 - b) is in [1,511], so integer division by 256 yields 0 exactly
+// when a < b and 1 otherwise; subtracting from 1 gives a checked 0/1 selector.
 func TestHypervisorPOCBoundedIrqSelection(t *testing.T) {
 	code, abnormal := buildAndRunStrict(t, "hypervisor_irq_select", `
 candidate_for: (eligible: u8, priority: u8, mask: u8): u8 = eligible ?
   | 1 -> priority
   | _ -> mask
 
-next_best_for: (better: Bool, i: u32, current: i32): i32 = better ? | true -> i32(i) | false -> current
-next_priority_for: (better: Bool, candidate: u8, current: u8): u8 = better ? | true -> candidate | false -> current
+better_bit: (candidate: u8, current: u8): u16 =
+  u16(1) - ((u16(candidate) + u16(256) - u16(current)) / u16(256))
 
 main: (): i32 {
   eligible_storage: [4]u8
@@ -135,20 +140,21 @@ main: (): i32 {
   priority[3] = u8(20)
 
   mask: u8 = u8(40)
-  best: i32 = -1
+  best: u32 = u32(0)
   best_priority: u8 = mask
   n: u32 = len(eligible)
   i: u32 = 0
 
   while i < n {
     candidate: u8 = candidate_for(eligible[i], priority[i], mask)
-    better: Bool = candidate < best_priority
-    best = next_best_for(better, i, best)
-    best_priority = next_priority_for(better, candidate, best_priority)
+    choose: u16 = better_bit(candidate, best_priority)
+    keep: u16 = u16(1) - choose
+    best = u32(choose) * i + u32(keep) * best
+    best_priority = u8(choose * u16(candidate) + keep * u16(best_priority))
     i = i + 1
   }
 
-  best
+  i32(best)
 }
 `)
 	if abnormal || code != 1 {

--- a/compiler/hypervisor_poc_test.go
+++ b/compiler/hypervisor_poc_test.go
@@ -152,7 +152,7 @@ main: (): i32 {
     keep: u16 = u16(1) - choose
     best = choose * i + keep * best
     best_priority = choose * candidate + keep * best_priority
-    i = i + u16(1)
+    i = i + 1
   }
 
   i32(best)

--- a/compiler/hypervisor_poc_test.go
+++ b/compiler/hypervisor_poc_test.go
@@ -116,12 +116,12 @@ candidate_for: (eligible: u8, priority: u8, mask: u8): u8 = eligible ?
   | _ -> mask
 
 next_best_for: (better: Bool, i: u32, current: i32): i32 = better ?
-  | .True -> i32(i)
-  | .False -> current
+  | true -> i32(i)
+  | false -> current
 
 next_priority_for: (better: Bool, candidate: u8, current: u8): u8 = better ?
-  | .True -> candidate
-  | .False -> current
+  | true -> candidate
+  | false -> current
 
 main: (): i32 {
   eligible_storage: [4]u8

--- a/compiler/hypervisor_poc_test.go
+++ b/compiler/hypervisor_poc_test.go
@@ -107,10 +107,22 @@ main: (): i32 {
 // Bounded priority selection over fixed caller-owned storage. The loop shape
 // is intentionally accepted by Oak's strict Power-of-Ten/TigerStyle profile:
 // fixed storage, no allocation, monotonically increasing counter, immutable
-// loop bound, and no recursion. Matches remain value-producing expressions;
-// the loop performs the state update after those values have been selected.
+// loop bound, and no recursion. Match decisions live in small pure helpers so
+// the hot loop itself stays straight-line and mechanically obvious.
 func TestHypervisorPOCBoundedIrqSelection(t *testing.T) {
 	code, abnormal := buildAndRunStrict(t, "hypervisor_irq_select", `
+candidate_for: (eligible: u8, priority: u8, mask: u8): u8 = eligible ?
+  | 1 -> priority
+  | _ -> mask
+
+next_best_for: (better: Bool, i: u32, current: i32): i32 = better ?
+  | .True -> i32(i)
+  | .False -> current
+
+next_priority_for: (better: Bool, candidate: u8, current: u8): u8 = better ?
+  | .True -> candidate
+  | .False -> current
+
 main: (): i32 {
   eligible_storage: [4]u8
   priority_storage: [4]u8
@@ -134,18 +146,10 @@ main: (): i32 {
   i: u32 = 0
 
   while i < n {
-    candidate: u8 = eligible[i] ?
-      | 1 -> priority[i]
-      | _ -> mask
+    candidate: u8 = candidate_for(eligible[i], priority[i], mask)
     better: Bool = candidate < best_priority
-    next_best: i32 = better ?
-      | .True -> i32(i)
-      | .False -> best
-    next_priority: u8 = better ?
-      | .True -> candidate
-      | .False -> best_priority
-    best = next_best
-    best_priority = next_priority
+    best = next_best_for(better, i, best)
+    best_priority = next_priority_for(better, candidate, best_priority)
     i = i + 1
   }
 

--- a/compiler/hypervisor_poc_test.go
+++ b/compiler/hypervisor_poc_test.go
@@ -1,0 +1,182 @@
+package compiler
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// buildAndRunStrict exercises the complete Oak pipeline under the strict
+// discipline profile, compiles the generated C, and executes it. Hypervisor
+// POCs use this rather than parser/typechecker-only tests: if a construct
+// cannot survive lowering to running machine code, it is not yet useful to
+// the core OS experiment.
+func buildAndRunStrict(t *testing.T, name, src string) (exitCode int, abnormal bool) {
+	t.Helper()
+	cc, err := exec.LookPath("cc")
+	if err != nil {
+		t.Skip("no C compiler on PATH")
+	}
+
+	output, err := New().WithProfile("strict").WithSource(name+".oak", src).EmitC().Get()
+	if err != nil {
+		t.Fatalf("strict Oak compilation failed: %v", err)
+	}
+
+	dir := t.TempDir()
+	cPath := filepath.Join(dir, name+".c")
+	binPath := filepath.Join(dir, name)
+	if err := os.WriteFile(cPath, []byte(output), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	compile := exec.Command(cc, "-std=c99", "-O2", "-o", binPath, cPath)
+	if combined, err := compile.CombinedOutput(); err != nil {
+		t.Fatalf("cc failed: %v\n%s\n--- generated C ---\n%s", err, combined, output)
+	}
+
+	run := exec.Command(binPath)
+	err = run.Run()
+	if err == nil {
+		return 0, false
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		if exitErr.ExitCode() >= 0 {
+			return exitErr.ExitCode(), false
+		}
+		return -1, true
+	}
+	t.Fatalf("failed to run binary: %v", err)
+	return 0, false
+}
+
+// Edge-triggered virtual IRQ lifecycle. ActivePending is the important state:
+// an edge that arrives while the interrupt is active must survive the EOI and
+// become pending again rather than being lost.
+func TestHypervisorPOCVirtualIrqLifecycle(t *testing.T) {
+	code, abnormal := buildAndRunStrict(t, "hypervisor_virq", `
+IrqState: type =
+  | Disabled
+  | Idle
+  | Pending
+  | Active
+  | ActivePending
+
+raise: (s: IrqState): IrqState = s ?
+  | .Disabled -> .Disabled
+  | .Idle -> .Pending
+  | .Pending -> .Pending
+  | .Active -> .ActivePending
+  | .ActivePending -> .ActivePending
+
+ack: (s: IrqState): IrqState = s ?
+  | .Pending -> .Active
+  | .Disabled -> .Disabled
+  | .Idle -> .Idle
+  | .Active -> .Active
+  | .ActivePending -> .ActivePending
+
+eoi: (s: IrqState): IrqState = s ?
+  | .Active -> .Idle
+  | .ActivePending -> .Pending
+  | .Disabled -> .Disabled
+  | .Idle -> .Idle
+  | .Pending -> .Pending
+
+state_code: (s: IrqState): i32 = s ?
+  | .Disabled -> 3
+  | .Idle -> 5
+  | .Pending -> 17
+  | .Active -> 19
+  | .ActivePending -> 23
+
+main: (): i32 {
+  s0: IrqState = .Idle
+  s1: IrqState = raise(s0)
+  s2: IrqState = ack(s1)
+  s3: IrqState = raise(s2)
+  s4: IrqState = eoi(s3)
+  state_code(s4)
+}
+`)
+	if abnormal || code != 17 {
+		t.Fatalf("exit = (%d, abnormal=%v), want 17 (edge while active re-pends after EOI)", code, abnormal)
+	}
+}
+
+// Bounded priority selection over fixed caller-owned storage. The loop shape
+// is intentionally accepted by Oak's strict Power-of-Ten/TigerStyle profile:
+// fixed storage, no allocation, monotonically increasing counter, immutable
+// loop bound, and no recursion.
+func TestHypervisorPOCBoundedIrqSelection(t *testing.T) {
+	code, abnormal := buildAndRunStrict(t, "hypervisor_irq_select", `
+main: (): i32 {
+  eligible_storage: [4]u8
+  priority_storage: [4]u8
+  eligible: [*]u8 = span(&eligible_storage)
+  priority: [*]u8 = span(&priority_storage)
+
+  eligible[0] = u8(1)
+  eligible[1] = u8(1)
+  eligible[2] = u8(0)
+  eligible[3] = u8(1)
+
+  priority[0] = u8(50)
+  priority[1] = u8(10)
+  priority[2] = u8(1)
+  priority[3] = u8(20)
+
+  mask: u8 = u8(40)
+  best: i32 = -1
+  best_priority: u8 = mask
+  n: u32 = len(eligible)
+  i: u32 = 0
+
+  while i < n {
+    eligible[i] ?
+      | 1 -> (priority[i] < best_priority) ?
+          | .True -> {
+              best = i32(i)
+              best_priority = priority[i]
+              ()
+            }
+          | .False -> ()
+      | _ -> ()
+    i = i + 1
+  }
+
+  best
+}
+`)
+	if abnormal || code != 1 {
+		t.Fatalf("exit = (%d, abnormal=%v), want IRQ slot 1", code, abnormal)
+	}
+}
+
+// Stage-2 arithmetic POC. This deliberately stays on the pure side of the
+// future page-table API: address decomposition and alignment should be proved
+// and generated from one semantic definition before Oak is allowed to own
+// descriptor writes, TLBI, or other AArch64-specific effects.
+func TestHypervisorPOCStageTwoPageArithmetic(t *testing.T) {
+	code, abnormal := buildAndRunStrict(t, "hypervisor_stage2_math", `
+page_base: (addr: u64): u64 = (addr / u64(4096)) * u64(4096)
+page_offset: (addr: u64): u64 = addr - page_base(addr)
+page_index: (addr: u64): u64 = addr / u64(4096)
+
+main: (): i32 {
+  addr: u64 = u64(74565)
+  base: u64 = page_base(addr)
+  off: u64 = page_offset(addr)
+  index: u64 = page_index(addr)
+
+  assert(base == u64(73728))
+  assert(off == u64(837))
+  assert(index == u64(18))
+  assert(base + off == addr)
+  29
+}
+`)
+	if abnormal || code != 29 {
+		t.Fatalf("exit = (%d, abnormal=%v), want 29 after stage-2 arithmetic assertions", code, abnormal)
+	}
+}

--- a/compiler/hypervisor_poc_test.go
+++ b/compiler/hypervisor_poc_test.go
@@ -111,47 +111,48 @@ main: (): i32 {
 //
 // The current parser does not yet admit primitive Bool literals as match
 // patterns through the real compilation pipeline. Rather than hide that gap,
-// this POC uses a machine-friendly branchless selector. For u8 priorities a,b,
-// (a + 256 - b) is in [1,511], so integer division by 256 yields 0 exactly
-// when a < b and 1 otherwise; subtracting from 1 gives a checked 0/1 selector.
+// this POC uses a machine-friendly branchless selector. Priorities remain in
+// the u8 semantic range but use u16 storage/arithmetic because the current
+// compiler implements lossless widening and does not yet implement the
+// explicit narrowing conversions described by the specification.
 func TestHypervisorPOCBoundedIrqSelection(t *testing.T) {
 	code, abnormal := buildAndRunStrict(t, "hypervisor_irq_select", `
-candidate_for: (eligible: u8, priority: u8, mask: u8): u8 = eligible ?
+candidate_for: (eligible: u16, priority: u16, mask: u16): u16 = eligible ?
   | 1 -> priority
   | _ -> mask
 
-better_bit: (candidate: u8, current: u8): u16 =
-  u16(1) - ((u16(candidate) + u16(256) - u16(current)) / u16(256))
+better_bit: (candidate: u16, current: u16): u16 =
+  u16(1) - ((candidate + u16(256) - current) / u16(256))
 
 main: (): i32 {
-  eligible_storage: [4]u8
-  priority_storage: [4]u8
-  eligible: [*]u8 = span(&eligible_storage)
-  priority: [*]u8 = span(&priority_storage)
+  eligible_storage: [4]u16
+  priority_storage: [4]u16
+  eligible: [*]u16 = span(&eligible_storage)
+  priority: [*]u16 = span(&priority_storage)
 
-  eligible[0] = u8(1)
-  eligible[1] = u8(1)
-  eligible[2] = u8(0)
-  eligible[3] = u8(1)
+  eligible[0] = u16(1)
+  eligible[1] = u16(1)
+  eligible[2] = u16(0)
+  eligible[3] = u16(1)
 
-  priority[0] = u8(50)
-  priority[1] = u8(10)
-  priority[2] = u8(1)
-  priority[3] = u8(20)
+  priority[0] = u16(50)
+  priority[1] = u16(10)
+  priority[2] = u16(1)
+  priority[3] = u16(20)
 
-  mask: u8 = u8(40)
-  best: u32 = u32(0)
-  best_priority: u8 = mask
-  n: u32 = len(eligible)
-  i: u32 = 0
+  mask: u16 = u16(40)
+  best: u16 = u16(0)
+  best_priority: u16 = mask
+  n: u16 = u16(4)
+  i: u16 = u16(0)
 
   while i < n {
-    candidate: u8 = candidate_for(eligible[i], priority[i], mask)
+    candidate: u16 = candidate_for(eligible[i], priority[i], mask)
     choose: u16 = better_bit(candidate, best_priority)
     keep: u16 = u16(1) - choose
-    best = u32(choose) * i + u32(keep) * best
-    best_priority = u8(choose * u16(candidate) + keep * u16(best_priority))
-    i = i + 1
+    best = choose * i + keep * best
+    best_priority = choose * candidate + keep * best_priority
+    i = i + u16(1)
   }
 
   i32(best)

--- a/docs/experiments/hypervisor-core-poc.md
+++ b/docs/experiments/hypervisor-core-poc.md
@@ -1,0 +1,107 @@
+# Hypervisor Core Proof-of-Concept
+
+## Purpose
+
+This experiment tests Oak against real requirements from the hypervisor-first OS rather than adding language features in the abstract.
+
+The question is not yet whether Oak can replace Zig. The question is whether one Oak-oriented semantic description can increasingly support:
+
+```text
+systems implementation
+formal proof
+boundedness checking
+machine representation
+protocol modeling
+property / integration tests
+future debugger metadata
+```
+
+without duplicating facts or hiding machine cost.
+
+## Current slices
+
+### Virtual interrupt semantics
+
+`semir/ir_test.go::TestIrqDefinitionsExerciseFiveAxes` already demonstrates the five-axis Semantic IR using `IrqId`, IRQ representation/authority/effects, and a `VirtualIrq` protocol.
+
+`compiler/hypervisor_poc_test.go::TestHypervisorPOCVirtualIrqLifecycle` adds an executable Oak slice. It models an edge-triggered IRQ lifecycle with:
+
+```text
+Disabled
+Idle
+Pending
+Active
+ActivePending
+```
+
+`ActivePending` preserves an edge arriving while an interrupt is active. EOI then exposes that edge as `Pending` rather than losing it.
+
+`Oak.HypervisorPOC.edge_while_active_repends` proves the corresponding abstract law in Lean.
+
+### Bounded priority selection
+
+`TestHypervisorPOCBoundedIrqSelection` performs priority selection over fixed caller-owned arrays/spans.
+
+The POC deliberately requires Oak's `strict` discipline profile:
+
+- fixed storage;
+- no hidden allocation;
+- no recursion;
+- statically recognized bounded loop;
+- bounds-checked span reads/writes;
+- deterministic lowest-priority-value selection under the mask.
+
+This is a first proxy for the OS requirement that the IRQ hot path be simple, bounded, cache-small, and mechanically analyzable.
+
+The Lean `Deliverable` predicate proves the local facts that a deliverable interrupt is enabled, pending, inactive, and below the priority mask. A later step should prove the concrete selection algorithm returns the minimum-priority deliverable IRQ and then refine the executable implementation to that model.
+
+### Stage-2 page arithmetic
+
+`TestHypervisorPOCStageTwoPageArithmetic` executes 4 KiB page base/index/offset calculations and checks reconstruction with always-on assertions.
+
+The Lean model proves:
+
+- page bases are granule-aligned;
+- page offsets are in range;
+- base + offset reconstructs the address;
+- page base equals page index times page size.
+
+The current Lean model uses mathematical naturals. This is **not yet** a proof of Oak `u64` lowering: fixed-width overflow/division/conversion semantics and their implementation refinement remain a separate machine-integer obligation.
+
+### Generational handles
+
+`Oak.HypervisorPOC.stale_handle_fails_after_reuse` proves the basic stale-generation law used by capability/object handles. This complements the existing, more general `Oak.Handles` work.
+
+The finite-width production policy remains: generation exhaustion retires a slot rather than wrapping and accidentally reviving stale authority.
+
+## Verification levels
+
+For this experiment we distinguish the following strictly:
+
+```text
+Semantic IR modeled       yes, for the IRQ five-axis example
+Oak executable code       yes, for IRQ lifecycle/selection and page arithmetic
+Strict discipline checked yes
+C lowering                yes when compiler CI passes
+Native host execution     yes when compiler CI passes
+Lean abstract laws        yes when formal CI passes
+Implementation refinement no
+AArch64 EL2 integration   no
+```
+
+A green Lean build proves the theorems in `Oak.HypervisorPOC`; it does not prove the generated C implements those theorems. A green compiler test proves the current implementation accepted/lowered/executed the POC; it does not by itself establish formal correspondence.
+
+## Next machine-facing experiments
+
+The next useful POCs should be driven by actual EL2 needs:
+
+1. fixed-width machine-integer semantics/refinement for page-table arithmetic;
+2. explicit packed/extern/offset representation suitable for architectural descriptors;
+3. atomics and memory-order semantics with a formal memory model;
+4. volatile/MMIO plus AArch64 barrier effects;
+5. system-register and constrained inline-assembly/intrinsic boundaries;
+6. freestanding C/object emission with no libc/runtime dependency;
+7. a real Oak-generated pure IRQ object linked into the existing Zig/QEMU EL2 payload;
+8. protocol projection to a temporal model and generated deterministic-simulation actions.
+
+Oak should replace a piece of Zig only after that piece is demonstrably at least as controllable at the machine level and has a stronger correctness story.

--- a/docs/experiments/hypervisor-core-poc.md
+++ b/docs/experiments/hypervisor-core-poc.md
@@ -51,6 +51,8 @@ The POC deliberately requires Oak's `strict` discipline profile:
 - bounds-checked span reads/writes;
 - deterministic lowest-priority-value selection under the mask.
 
+The loop is intentionally straight-line: scalar/Bool match decisions live in small pure helper functions, while the bounded scan performs only loads, comparisons, calls, assignments, and the single monotonic counter advance. This is a useful systems shape independently of current parser limitations because it keeps branch semantics separately testable/provable from iteration/boundedness.
+
 This is a first proxy for the OS requirement that the IRQ hot path be simple, bounded, cache-small, and mechanically analyzable.
 
 The Lean `Deliverable` predicate proves the local facts that a deliverable interrupt is enabled, pending, inactive, and below the priority mask. A later step should prove the concrete selection algorithm returns the minimum-priority deliverable IRQ and then refine the executable implementation to that model.
@@ -73,6 +75,22 @@ The current Lean model uses mathematical naturals. This is **not yet** a proof o
 `Oak.HypervisorPOC.stale_handle_fails_after_reuse` proves the basic stale-generation law used by capability/object handles. This complements the existing, more general `Oak.Handles` work.
 
 The finite-width production policy remains: generation exhaustion retires a slot rather than wrapping and accidentally reviving stale authority.
+
+### Machine-memory foundation on the specification base
+
+While this experiment was being built, the `specification` branch gained `docs/spec/65-machine-memory.md` plus Semantic IR, typechecker, C-lowering tests, and `Oak.MemoryOrder` Lean coverage for the initial machine-memory layer.
+
+That foundation now includes:
+
+```text
+Atomic[T] over fixed-width integer carriers
+relaxed / acquire / release / acq-rel / seq-cst orders
+load / store / RMW / fence legality
+C11 atomic lowering
+volatile load/store kept distinct from atomics
+```
+
+This is relevant evidence for the hypervisor direction, but it is not yet a source-level hypervisor atomic POC: source syntax, the full data-race/happens-before model, architecture barriers, device-memory/MMIO ordering, interrupt-entry ordering, DMA coherency, and hardware litmus tests remain separate work.
 
 ## Verification levels
 
@@ -97,8 +115,8 @@ The next useful POCs should be driven by actual EL2 needs:
 
 1. fixed-width machine-integer semantics/refinement for page-table arithmetic;
 2. explicit packed/extern/offset representation suitable for architectural descriptors;
-3. atomics and memory-order semantics with a formal memory model;
-4. volatile/MMIO plus AArch64 barrier effects;
+3. source-level end-to-end atomics/fences over the new machine-memory Semantic IR, followed by memory-model refinement and litmus tests;
+4. volatile/MMIO plus explicit AArch64 barrier and device-memory effects;
 5. system-register and constrained inline-assembly/intrinsic boundaries;
 6. freestanding C/object emission with no libc/runtime dependency;
 7. a real Oak-generated pure IRQ object linked into the existing Zig/QEMU EL2 payload;

--- a/docs/experiments/hypervisor-core-poc.md
+++ b/docs/experiments/hypervisor-core-poc.md
@@ -51,11 +51,21 @@ The POC deliberately requires Oak's `strict` discipline profile:
 - bounds-checked span reads/writes;
 - deterministic lowest-priority-value selection under the mask.
 
-The loop is intentionally straight-line: scalar/Bool match decisions live in small pure helper functions, while the bounded scan performs only loads, comparisons, calls, assignments, and the single monotonic counter advance. This is a useful systems shape independently of current parser limitations because it keeps branch semantics separately testable/provable from iteration/boundedness.
+The bounded scan is branchless after eligibility projection. For u8 priorities `candidate` and `current`, the helper computes:
+
+```text
+better = 1 - ((candidate + 256 - current) / 256)
+```
+
+in `u16`. Because both operands are in `[0,255]`, the numerator is in `[1,511]`, so integer division returns `0` exactly when `candidate < current` and `1` otherwise. `better` is therefore exactly a `0/1` selection bit. The loop uses that bit to select the winning index and priority arithmetically, while retaining the single monotonic loop counter and fixed storage.
+
+`Oak.HypervisorPOC.better_bit_one_iff_lt` and `better_bit_zero_iff_ge` prove the mathematical compare-bit law over the u8 range. This still does not constitute implementation refinement to Oak's `u16` lowering; the machine-integer correspondence remains a separate obligation.
+
+The experiment also exposed a compiler gap: `parsePattern()` currently handles identifiers, integers, strings, and variants but not primitive `true`/`false` tokens, even though the typechecker has direct Bool-pattern tests. We keep that as a language/compiler bug rather than pretending those tests establish full pipeline support. The branchless POC is useful independently of that bug because it is a plausible machine-level fast-path formulation with a compact proof obligation.
 
 This is a first proxy for the OS requirement that the IRQ hot path be simple, bounded, cache-small, and mechanically analyzable.
 
-The Lean `Deliverable` predicate proves the local facts that a deliverable interrupt is enabled, pending, inactive, and below the priority mask. A later step should prove the concrete selection algorithm returns the minimum-priority deliverable IRQ and then refine the executable implementation to that model.
+The Lean `Deliverable` predicate separately proves the local facts that a deliverable interrupt is enabled, pending, inactive, and below the priority mask. A later step should prove the full scan returns the minimum-priority deliverable IRQ and then refine the executable implementation to that model.
 
 ### Stage-2 page arithmetic
 
@@ -98,8 +108,8 @@ For this experiment we distinguish the following strictly:
 
 ```text
 Semantic IR modeled       yes, for the IRQ five-axis example
-Oak executable code       yes, for IRQ lifecycle/selection and page arithmetic
-Strict discipline checked yes
+Oak executable code       yes, for IRQ lifecycle/selection and page arithmetic when CI passes
+Strict discipline checked yes when compiler CI passes
 C lowering                yes when compiler CI passes
 Native host execution     yes when compiler CI passes
 Lean abstract laws        yes when formal CI passes
@@ -113,7 +123,7 @@ A green Lean build proves the theorems in `Oak.HypervisorPOC`; it does not prove
 
 The next useful POCs should be driven by actual EL2 needs:
 
-1. fixed-width machine-integer semantics/refinement for page-table arithmetic;
+1. fixed-width machine-integer semantics/refinement for page-table and branchless-selection arithmetic;
 2. explicit packed/extern/offset representation suitable for architectural descriptors;
 3. source-level end-to-end atomics/fences over the new machine-memory Semantic IR, followed by memory-model refinement and litmus tests;
 4. volatile/MMIO plus explicit AArch64 barrier and device-memory effects;

--- a/spec/lean/Oak.lean
+++ b/spec/lean/Oak.lean
@@ -36,3 +36,4 @@ import Oak.RepresentationPolymorphism
 import Oak.TypeVarIdentity
 import Oak.GeneralizationSafety
 import Oak.Diagnostics
+import Oak.HypervisorPOC

--- a/spec/lean/Oak/HypervisorPOC.lean
+++ b/spec/lean/Oak/HypervisorPOC.lean
@@ -1,0 +1,160 @@
+namespace Oak.HypervisorPOC
+
+/-! # Hypervisor proof-of-concepts
+
+These are deliberately small proofs over the same semantic shapes exercised by
+`compiler/hypervisor_poc_test.go`. They demonstrate the intended Oak workflow:
+executable systems code and mathematical laws evolve together, while the status
+remains honest about the missing implementation-refinement link.
+
+This file does **not** claim that the generated C is formally refined to these
+models. That is a later proof obligation.
+-/
+
+/-! ## Virtual IRQ lifecycle -/
+
+inductive IrqState where
+  | disabled
+  | idle
+  | pending
+  | active
+  | activePending
+  deriving DecidableEq, Repr
+
+open IrqState
+
+def raise : IrqState → IrqState
+  | disabled => disabled
+  | idle => pending
+  | pending => pending
+  | active => activePending
+  | activePending => activePending
+
+
+def acknowledge : IrqState → IrqState
+  | pending => active
+  | s => s
+
+
+def eoi : IrqState → IrqState
+  | active => idle
+  | activePending => pending
+  | s => s
+
+/-- An edge arriving while an IRQ is active is not lost: EOI exposes it as a
+    fresh pending interrupt. -/
+theorem edge_while_active_repends : eoi (raise active) = pending := by
+  rfl
+
+/-- A normal pending interrupt acknowledges to active and EOI returns it idle. -/
+theorem pending_ack_eoi_idle : eoi (acknowledge pending) = idle := by
+  rfl
+
+/-- Disabled IRQs remain disabled under injection. -/
+theorem disabled_does_not_raise : raise disabled = disabled := by
+  rfl
+
+/-! ## Deliverability -/
+
+structure Irq where
+  enabled : Bool
+  pending : Bool
+  active : Bool
+  priority : Nat
+  deriving DecidableEq, Repr
+
+
+def Deliverable (mask : Nat) (irq : Irq) : Prop :=
+  irq.enabled = true ∧
+  irq.pending = true ∧
+  irq.active = false ∧
+  irq.priority < mask
+
+
+theorem deliverable_enabled {mask : Nat} {irq : Irq}
+    (h : Deliverable mask irq) : irq.enabled = true :=
+  h.1
+
+
+theorem deliverable_pending {mask : Nat} {irq : Irq}
+    (h : Deliverable mask irq) : irq.pending = true :=
+  h.2.1
+
+
+theorem deliverable_not_active {mask : Nat} {irq : Irq}
+    (h : Deliverable mask irq) : irq.active = false :=
+  h.2.2.1
+
+
+theorem deliverable_priority_below_mask {mask : Nat} {irq : Irq}
+    (h : Deliverable mask irq) : irq.priority < mask :=
+  h.2.2.2
+
+/-! ## Stage-2 page arithmetic -/
+
+abbrev PageSize : Nat := 4096
+
+
+def pageBase (addr : Nat) : Nat :=
+  (addr / PageSize) * PageSize
+
+
+def pageOffset (addr : Nat) : Nat :=
+  addr % PageSize
+
+
+def pageIndex (addr : Nat) : Nat :=
+  addr / PageSize
+
+/-- Every page base is aligned to the 4 KiB granule used by the initial OS
+    stage-2 model. -/
+theorem page_base_aligned (addr : Nat) : pageBase addr % PageSize = 0 := by
+  simp [pageBase, PageSize]
+
+/-- The offset is always inside the page. -/
+theorem page_offset_in_range (addr : Nat) : pageOffset addr < PageSize := by
+  exact Nat.mod_lt addr (by decide)
+
+/-- Page index/base/offset reconstruct the original address exactly in the
+    mathematical model. Machine-u64 overflow correspondence remains a separate
+    refinement obligation. -/
+theorem page_decomposition (addr : Nat) : pageBase addr + pageOffset addr = addr := by
+  simpa [pageBase, pageOffset] using (Nat.div_add_mod addr PageSize)
+
+/-- `pageBase` is exactly the indexed page multiplied by the granule. -/
+theorem page_base_from_index (addr : Nat) :
+    pageBase addr = pageIndex addr * PageSize := by
+  rfl
+
+/-! ## Generational handles -/
+
+structure Handle where
+  slot : Nat
+  generation : Nat
+  deriving DecidableEq, Repr
+
+structure Slot where
+  generation : Nat
+  occupied : Bool
+  deriving DecidableEq, Repr
+
+
+def Resolves (h : Handle) (s : Slot) : Prop :=
+  s.occupied = true ∧ h.generation = s.generation
+
+
+def reuse (s : Slot) : Slot :=
+  { generation := s.generation + 1, occupied := true }
+
+/-- If a handle matched the old generation, advancing the slot generation on
+    reuse makes that handle stale. The production finite-width implementation
+    must retire on generation exhaustion rather than wrap; that policy is
+    already modeled separately by Oak's handle work. -/
+theorem stale_handle_fails_after_reuse {h : Handle} {s : Slot}
+    (old : h.generation = s.generation) : ¬ Resolves h (reuse s) := by
+  intro resolved
+  unfold Resolves reuse at resolved
+  dsimp at resolved
+  omega
+
+end Oak.HypervisorPOC

--- a/spec/lean/Oak/HypervisorPOC.lean
+++ b/spec/lean/Oak/HypervisorPOC.lean
@@ -54,7 +54,7 @@ theorem pending_ack_eoi_idle : eoi (acknowledge pending) = idle := by
 theorem disabled_does_not_raise : raise disabled = disabled := by
   rfl
 
-/-! ## Deliverability -/
+/-! ## Deliverability and bounded priority selection -/
 
 structure Irq where
   enabled : Bool
@@ -89,6 +89,28 @@ theorem deliverable_not_active {mask : Nat} {irq : Irq}
 theorem deliverable_priority_below_mask {mask : Nat} {irq : Irq}
     (h : Deliverable mask irq) : irq.priority < mask :=
   h.2.2.2
+
+/-- Mathematical counterpart of the executable u16 `better_bit` helper. For
+    u8 operands, `candidate + 256 - current` is always representable in u16 and
+    lies in `[1, 511]`; division by 256 therefore produces exactly the compare
+    bit we need without a branch. -/
+def betterBit (candidate current : Nat) : Nat :=
+  1 - ((candidate + 256 - current) / 256)
+
+/-- For u8-range priorities, the branchless selector is exactly 1 when the
+    candidate has strictly higher scheduling priority (smaller numeric value). -/
+theorem better_bit_one_iff_lt {candidate current : Nat}
+    (hc : candidate ≤ 255) (hb : current ≤ 255) :
+    betterBit candidate current = 1 ↔ candidate < current := by
+  unfold betterBit
+  omega
+
+/-- The selector is exactly 0 for an equal or lower-priority candidate. -/
+theorem better_bit_zero_iff_ge {candidate current : Nat}
+    (hc : candidate ≤ 255) (hb : current ≤ 255) :
+    betterBit candidate current = 0 ↔ current ≤ candidate := by
+  unfold betterBit
+  omega
 
 /-! ## Stage-2 page arithmetic -/
 

--- a/spec/lean/Oak/HypervisorPOC.lean
+++ b/spec/lean/Oak/HypervisorPOC.lean
@@ -119,7 +119,9 @@ theorem page_offset_in_range (addr : Nat) : pageOffset addr < PageSize := by
     mathematical model. Machine-u64 overflow correspondence remains a separate
     refinement obligation. -/
 theorem page_decomposition (addr : Nat) : pageBase addr + pageOffset addr = addr := by
-  simpa [pageBase, pageOffset] using (Nat.div_add_mod addr PageSize)
+  unfold pageBase pageOffset
+  rw [Nat.mul_comm (addr / PageSize) PageSize]
+  exact Nat.div_add_mod addr PageSize
 
 /-- `pageBase` is exactly the indexed page multiplied by the granule. -/
 theorem page_base_from_index (addr : Nat) :


### PR DESCRIPTION
## Summary

Use real hypervisor-shaped problems to test whether Oak is becoming suitable for the OS core.

This PR now contains three end-to-end proof-of-concepts plus a paired Lean model:

- executable edge-triggered virtual IRQ lifecycle, including edge arrival while active and re-pending after EOI
- strict-profile bounded priority selection over fixed caller-owned storage, using a proved branchless 0/1 selector bit
- stage-2 4 KiB page base/index/offset arithmetic with always-on assertions
- Lean proofs for IRQ lifecycle/deliverability, branchless priority comparison, page alignment/decomposition, and stale generational handles
- `Oak.HypervisorPOC` is imported by the normal Lean gate
- `docs/experiments/hypervisor-core-poc.md` records scope, verification maturity, discovered language gaps, and the next EL2 experiments

## Executable verification

`compiler/hypervisor_poc_test.go` uses the real compiler pipeline:

```text
Oak source
  -> strict discipline profile
  -> type/borrow/discipline checks
  -> C lowering
  -> cc -std=c99 -O2
  -> native execution
```

Final head: `d7414491f539d849a52da57f9f722c9a3422f9e8`

All repository gates are green on that head:

- `Run Tests (1.27.1)` — success, including all three hypervisor POCs and `go test -race ./...`
- `Lean 4` — success
- `Verify Golden Files` — success

## Formal claims

The Lean file proves abstract semantic laws only. This PR intentionally does **not** mark the executable compiler paths as formally refined to those models.

In particular, mathematical `Nat` proofs for page arithmetic and the branchless selector are not yet a machine-checked refinement of Oak `u64`/`u16` lowering. That correspondence is a next-stage machine-integer obligation.

## Findings from the POC

The experiment found concrete language/compiler gaps that matter for systems code:

1. the real parser's `parsePattern()` does not currently admit primitive `true` / `false` patterns even though direct typechecker tests understand Bool literal patterns;
2. current explicit integer conversions implement lossless widening but not the narrowing conversions described by the longer-term specification;
3. strict bounded-loop recognition is intentionally syntactic/certificate-oriented: the counter increment must expose a positive integer constant (for example `i = i + 1`) rather than hide it behind a conversion expression.

The selector POC was kept meaningful rather than weakening strict mode. It uses fixed u16 storage for values constrained to the u8 priority domain and proves the branchless comparison law:

```text
better = 1 - ((candidate + 256 - current) / 256)
```

for candidate/current in `[0,255]`, where `better = 1` iff `candidate < current`.

## Machine-memory work that landed on the base

While this experiment was in flight, `specification` gained the initial machine-memory chapter and implementation/proof support for:

- `Atomic[T]` over fixed-width carriers
- relaxed/acquire/release/acq-rel/seq-cst orders
- load/store/RMW/fence legality
- C11 atomic lowering
- volatile operations kept distinct from atomics
- Lean memory-order legality proofs

That makes the next hypervisor experiment much more concrete.

## Recommended next experiments

1. machine-integer refinement for page-table and selector arithmetic;
2. explicit packed/extern/offset representations for architectural descriptors;
3. source-level atomics/fences and memory-model litmus tests;
4. volatile/MMIO + AArch64 barriers/device-memory semantics;
5. system-register/constrained intrinsic boundaries;
6. freestanding object emission;
7. link an Oak-generated pure IRQ object into the existing Zig/QEMU EL2 payload;
8. project Oak protocol definitions into temporal models and DST actions.

Oak should replace a Zig core component only once that component is demonstrably at least as controllable at the machine level and has a stronger correctness/refinement story.