### PR TITLE
Implement strong compare-exchange end to end

### DIFF
--- a/codegen/compare_exchange.go
+++ b/codegen/compare_exchange.go
@@ -2,7 +2,6 @@ package codegen
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/SCKelemen/oak/ast"
 	"github.com/SCKelemen/oak/semir"
@@ -184,7 +183,3 @@ func compareExchangeMacro(spec semir.AtomicBuiltinSpec) (string, error) {
 	}
 	return "__oak_cas_" + suffix, nil
 }
-
-// Keep strings imported intentionally exercised at compile time: macro output
-// must never carry an order token supplied by a runtime Oak value.
-var _ = strings.Builder{}

--- a/codegen/compare_exchange.go
+++ b/codegen/compare_exchange.go
@@ -1,0 +1,190 @@
+package codegen
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/SCKelemen/oak/ast"
+	"github.com/SCKelemen/oak/semir"
+)
+
+var atomicCarriers = []string{"u8", "u16", "u32", "u64", "i8", "i16", "i32", "i64"}
+
+func memoryOrderIdentifier(order semir.MemoryOrder) (string, error) {
+	switch order {
+	case semir.MemoryOrderRelaxed:
+		return "relaxed", nil
+	case semir.MemoryOrderAcquire:
+		return "acquire", nil
+	case semir.MemoryOrderRelease:
+		return "release", nil
+	case semir.MemoryOrderAcqRel:
+		return "acq_rel", nil
+	case semir.MemoryOrderSeqCst:
+		return "seq_cst", nil
+	default:
+		return "", fmt.Errorf("unsupported memory order identifier %q", order)
+	}
+}
+
+func compareExchangeSuffix(spec semir.AtomicBuiltinSpec) (string, error) {
+	if spec.Kind != semir.AtomicBuiltinCompareExchange || !spec.Legal() {
+		return "", fmt.Errorf("invalid compare-exchange builtin %q", spec.Name)
+	}
+	success, err := memoryOrderIdentifier(spec.Order)
+	if err != nil {
+		return "", err
+	}
+	failure, err := memoryOrderIdentifier(spec.FailureOrder)
+	if err != nil {
+		return "", err
+	}
+	return success + "_" + failure, nil
+}
+
+// compareExchangeSpecsUsed collects only the order pairs actually present in
+// the program. Generated C therefore pays helper-source cost only for used CAS
+// variants, while _Generic carrier selection remains compile-time only.
+func compareExchangeSpecsUsed(program *ast.Program) []semir.AtomicBuiltinSpec {
+	seen := map[string]bool{}
+	var result []semir.AtomicBuiltinSpec
+	var visitExpr func(ast.Expression)
+	var visitStmt func(ast.Statement)
+
+	visitExpr = func(expr ast.Expression) {
+		switch e := expr.(type) {
+		case *ast.InvocationExpression:
+			if id, ok := e.Function.(*ast.Identifier); ok {
+				if spec, found := semir.LookupAtomicBuiltin(id.Value); found && spec.Kind == semir.AtomicBuiltinCompareExchange && !seen[spec.Name] {
+					seen[spec.Name] = true
+					result = append(result, spec)
+				}
+			}
+			visitExpr(e.Function)
+			for _, arg := range e.Arguments {
+				visitExpr(arg)
+			}
+		case *ast.BlockExpression:
+			if e.Block != nil {
+				for _, stmt := range e.Block.Statements {
+					visitStmt(stmt)
+				}
+			}
+		case *ast.InfixExpression:
+			visitExpr(e.Left)
+			visitExpr(e.Right)
+		case *ast.PrefixExpression:
+			visitExpr(e.Right)
+		case *ast.IndexExpression:
+			visitExpr(e.Left)
+			visitExpr(e.Index)
+		case *ast.SliceExpression:
+			visitExpr(e.Seq)
+			visitExpr(e.Low)
+			visitExpr(e.High)
+		case *ast.VariantExpression:
+			visitExpr(e.Payload)
+		case *ast.MatchExpression:
+			visitExpr(e.Scrutinee)
+			for _, arm := range e.Arms {
+				visitExpr(arm.Body)
+			}
+		case *ast.RecordLiteral:
+			for _, field := range e.Fields {
+				visitExpr(field)
+			}
+		case *ast.ArrayLiteral:
+			for _, item := range e.Elements {
+				visitExpr(item)
+			}
+		}
+	}
+
+	visitStmt = func(stmt ast.Statement) {
+		switch s := stmt.(type) {
+		case *ast.VariableDeclaration:
+			visitExpr(s.Value)
+		case *ast.ExpressionStatement:
+			visitExpr(s.Expression)
+		case *ast.AssignmentStatement:
+			visitExpr(s.Value)
+		case *ast.IndexAssignmentStatement:
+			visitExpr(s.Target)
+			visitExpr(s.Value)
+		case *ast.FunctionStatement:
+			visitExpr(s.Body)
+		case *ast.WhileStatement:
+			visitExpr(s.Condition)
+			if s.Body != nil {
+				for _, inner := range s.Body.Statements {
+					visitStmt(inner)
+				}
+			}
+		case *ast.BlockStatement:
+			for _, inner := range s.Statements {
+				visitStmt(inner)
+			}
+		case *ast.UnsafeBlock:
+			if s.Body != nil {
+				for _, inner := range s.Body.Statements {
+					visitStmt(inner)
+				}
+			}
+		}
+	}
+
+	for _, stmt := range program.Statements {
+		visitStmt(stmt)
+	}
+	return result
+}
+
+func (cg *CodeGenerator) emitCompareExchangeHelpers(program *ast.Program) {
+	for _, spec := range compareExchangeSpecsUsed(program) {
+		suffix, err := compareExchangeSuffix(spec)
+		if err != nil {
+			continue
+		}
+		success, err := cMemoryOrder(spec.Order)
+		if err != nil {
+			continue
+		}
+		failure, err := cMemoryOrder(spec.FailureOrder)
+		if err != nil {
+			continue
+		}
+
+		cg.write("/* strong compare-exchange: returns the value observed at the compare */\n")
+		for _, carrier := range atomicCarriers {
+			cg.write(fmt.Sprintf("static inline %s __oak_cas_%s_%s(_Atomic(%s) *cell, %s expected, %s desired) {\n", carrier, carrier, suffix, carrier, carrier, carrier))
+			cg.write(fmt.Sprintf("  %s observed = expected;\n", carrier))
+			cg.write(fmt.Sprintf("  (void)atomic_compare_exchange_strong_explicit(cell, &observed, desired, %s, %s);\n", success, failure))
+			cg.write("  return observed;\n")
+			cg.write("}\n")
+		}
+
+		macro := "__oak_cas_" + suffix
+		cg.write("#define " + macro + "(cell, expected, desired) \\\n")
+		cg.write("  _Generic((cell), \\\n")
+		for i, carrier := range atomicCarriers {
+			end := ", \\\n"
+			if i == len(atomicCarriers)-1 {
+				end = ")((cell), (expected), (desired))\n"
+			}
+			cg.write(fmt.Sprintf("    _Atomic(%s) *: __oak_cas_%s_%s%s", carrier, carrier, suffix, end))
+		}
+		cg.write("\n")
+	}
+}
+
+func compareExchangeMacro(spec semir.AtomicBuiltinSpec) (string, error) {
+	suffix, err := compareExchangeSuffix(spec)
+	if err != nil {
+		return "", err
+	}
+	return "__oak_cas_" + suffix, nil
+}
+
+// Keep strings imported intentionally exercised at compile time: macro output
+// must never carry an order token supplied by a runtime Oak value.
+var _ = strings.Builder{}

--- a/codegen/compare_exchange_e2e_test.go
+++ b/codegen/compare_exchange_e2e_test.go
@@ -1,0 +1,115 @@
+package codegen
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const compareExchangeSource = `
+package main
+counter: Atomic[u64]
+
+fn cas(expected: u64, desired: u64) -> u64
+  atomic_compare_exchange_acq_rel_acquire(counter, expected, desired)
+
+fn cas_relaxed(expected: u64, desired: u64) -> u64
+  atomic_compare_exchange_relaxed_relaxed(counter, expected, desired)
+
+fn read() -> u64
+  atomic_load_acquire(counter)
+`
+
+func TestCompareExchangeLowersToStrongC11WithoutHeapOrOrderDispatch(t *testing.T) {
+	generated := generateSourceC(t, compareExchangeSource)
+	for _, required := range []string{
+		"atomic_compare_exchange_strong_explicit",
+		"memory_order_acq_rel, memory_order_acquire",
+		"memory_order_relaxed, memory_order_relaxed",
+		"_Generic((cell)",
+		"__oak_cas_acq_rel_acquire(&(counter)",
+	} {
+		if !strings.Contains(generated, required) {
+			t.Fatalf("generated CAS C missing %q:\n%s", required, generated)
+		}
+	}
+	for _, forbidden := range []string{"malloc(", "calloc(", "realloc(", "free(", "switch (__oak_cas", "memory_order success", "memory_order failure"} {
+		if strings.Contains(generated, forbidden) {
+			t.Fatalf("CAS lowering introduced hidden cost/runtime order dispatch %q", forbidden)
+		}
+	}
+}
+
+func TestCompareExchangeGeneratedCUnderContention(t *testing.T) {
+	cc, err := exec.LookPath("cc")
+	if err != nil {
+		t.Skip("cc is required for native compare-exchange execution test")
+	}
+	generated := generateSourceC(t, compareExchangeSource)
+	harness := `
+#include <pthread.h>
+#include <stdio.h>
+#define OAK_THREADS 4
+#define OAK_ITERS 25000
+static _Atomic(u64) attempts = 0;
+static _Atomic(u64) retries = 0;
+
+static void* worker(void* ignored) {
+  (void)ignored;
+  for (int i = 0; i < OAK_ITERS; ++i) {
+    u64 expected = oak_read();
+    for (;;) {
+      atomic_fetch_add_explicit(&attempts, 1, memory_order_relaxed);
+      u64 observed = oak_cas(expected, expected + 1);
+      if (observed == expected) break;
+      atomic_fetch_add_explicit(&retries, 1, memory_order_relaxed);
+      expected = observed;
+    }
+  }
+  return NULL;
+}
+
+int main(void) {
+  if (oak_cas_relaxed(7, 9) != 0) return 10;
+  if (oak_read() != 0) return 11;
+  if (oak_cas_relaxed(0, 1) != 0) return 12;
+  if (oak_read() != 1) return 13;
+
+  pthread_t threads[OAK_THREADS];
+  for (int i = 0; i < OAK_THREADS; ++i)
+    if (pthread_create(&threads[i], NULL, worker, NULL) != 0) return 20;
+  for (int i = 0; i < OAK_THREADS; ++i)
+    if (pthread_join(threads[i], NULL) != 0) return 30;
+
+  const u64 expected_final = 1 + (u64)OAK_THREADS * (u64)OAK_ITERS;
+  const u64 final = oak_read();
+  const u64 a = atomic_load_explicit(&attempts, memory_order_relaxed);
+  const u64 r = atomic_load_explicit(&retries, memory_order_relaxed);
+  if (final != expected_final) return 40;
+  if (a < (u64)OAK_THREADS * (u64)OAK_ITERS) return 41;
+  if (r > a) return 42;
+  printf("attempts=%llu retries=%llu final=%llu\n",
+         (unsigned long long)a, (unsigned long long)r, (unsigned long long)final);
+  return 0;
+}
+`
+	dir := t.TempDir()
+	cPath := filepath.Join(dir, "cas_e2e.c")
+	binPath := filepath.Join(dir, "cas_e2e")
+	if err := os.WriteFile(cPath, []byte(generated+harness), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(cc, "-std=c11", "-O2", "-Wall", "-Wextra", "-Werror", "-Wno-unused-function", "-pthread", cPath, "-o", binPath)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("compile generated CAS C: %v\n%s\n--- C ---\n%s", err, output, generated+harness)
+	}
+	output, err := exec.Command(binPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("native CAS program failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "attempts=") || !strings.Contains(string(output), "retries=") {
+		t.Fatalf("CAS contention instrumentation missing: %s", output)
+	}
+}

--- a/codegen/memory.go
+++ b/codegen/memory.go
@@ -84,6 +84,7 @@ func programUsesAtomics(program *ast.Program) bool {
 						return true
 					}
 				}
+			}
 		case *ast.InfixExpression:
 			return exprUses(e.Left) || exprUses(e.Right)
 		case *ast.PrefixExpression:
@@ -147,11 +148,13 @@ func programUsesAtomics(program *ast.Program) bool {
 						return true
 					}
 				}
+			}
 		case *ast.BlockStatement:
 			for _, inner := range s.Statements {
 				if stmtUses(inner) {
 					return true
 				}
+			}
 		case *ast.UnsafeBlock:
 			if s.Body != nil {
 				for _, inner := range s.Body.Statements {
@@ -159,6 +162,7 @@ func programUsesAtomics(program *ast.Program) bool {
 						return true
 					}
 				}
+			}
 		}
 		return false
 	}

--- a/codegen/memory.go
+++ b/codegen/memory.go
@@ -8,9 +8,6 @@ import (
 	"github.com/SCKelemen/oak/typechecker"
 )
 
-// cMemoryOrder is the checked refinement from Oak's semantic memory orders to
-// C11. There is deliberately no default: a new language order must teach the
-// backend how to preserve it before code generation can succeed.
 func cMemoryOrder(order semir.MemoryOrder) (string, error) {
 	switch order {
 	case semir.MemoryOrderRelaxed:
@@ -28,8 +25,6 @@ func cMemoryOrder(order semir.MemoryOrder) (string, error) {
 	}
 }
 
-// atomicCType lowers an already validated fixed-width carrier to exact C11
-// atomic storage. It does not use implementation-sized convenience typedefs.
 func atomicCType(carrier string) (string, error) {
 	if !semir.AtomicCarrierAllowed(carrier) {
 		return "", fmt.Errorf("unsupported atomic carrier %q", carrier)
@@ -37,8 +32,6 @@ func atomicCType(carrier string) (string, error) {
 	return "_Atomic(" + carrier + ")", nil
 }
 
-// atomicTypeCarrier recognizes the parser's Atomic[T] IndexExpression and
-// returns the exact fixed-width carrier spelling. Invalid forms fail closed.
 func atomicTypeCarrier(expr ast.Expression) (string, bool) {
 	index, ok := expr.(*ast.IndexExpression)
 	if !ok || index == nil {
@@ -64,9 +57,6 @@ func atomicTypeC(expr ast.Expression) (string, bool) {
 	return cType, err == nil
 }
 
-// programUsesAtomics is a compile-time AST scan used solely to make the C11
-// atomic dependency pay-for-use. Non-atomic programs keep byte-for-byte stable
-// C output and do not include <stdatomic.h>.
 func programUsesAtomics(program *ast.Program) bool {
 	var exprUses func(ast.Expression) bool
 	var stmtUses func(ast.Statement) bool
@@ -94,7 +84,6 @@ func programUsesAtomics(program *ast.Program) bool {
 						return true
 					}
 				}
-			}
 		case *ast.InfixExpression:
 			return exprUses(e.Left) || exprUses(e.Right)
 		case *ast.PrefixExpression:
@@ -158,13 +147,11 @@ func programUsesAtomics(program *ast.Program) bool {
 						return true
 					}
 				}
-			}
 		case *ast.BlockStatement:
 			for _, inner := range s.Statements {
 				if stmtUses(inner) {
 					return true
 				}
-			}
 		case *ast.UnsafeBlock:
 			if s.Body != nil {
 				for _, inner := range s.Body.Statements {
@@ -172,7 +159,6 @@ func programUsesAtomics(program *ast.Program) bool {
 						return true
 					}
 				}
-			}
 		}
 		return false
 	}
@@ -185,9 +171,8 @@ func programUsesAtomics(program *ast.Program) bool {
 	return false
 }
 
-// emitAtomicGlobals emits the atomic C dependency only for programs that use
-// atomics, then package-scope Atomic[T] cells as zero-initialized static storage.
-// There is no wrapper object and no heap allocation.
+// emitAtomicGlobals emits the C11 dependency only for programs that use
+// atomics, package-scope inline cells, and any used CAS helper family.
 func (cg *CodeGenerator) emitAtomicGlobals(program *ast.Program) {
 	if !programUsesAtomics(program) {
 		return
@@ -217,11 +202,13 @@ func (cg *CodeGenerator) emitAtomicGlobals(program *ast.Program) {
 	if emitted {
 		cg.write("\n")
 	}
+	cg.emitCompareExchangeHelpers(program)
 }
 
-// emitAtomicInvocation emits one source builtin directly as one C11 atomic
-// primitive. The order is compile-time semantic data: there is no runtime
-// order switch, wrapper allocation, or helper call in the generated hot path.
+// emitAtomicInvocation emits each source builtin directly as a C11 atomic
+// primitive. Order data is compile-time semantic data. Compare-exchange uses a
+// C11 _Generic-selected static inline helper so it can return the observed
+// value without a mutable Oak out-parameter or runtime order dispatch.
 func (cg *CodeGenerator) emitAtomicInvocation(call *ast.InvocationExpression, tc *typechecker.TypeChecker) bool {
 	ident, ok := call.Function.(*ast.Identifier)
 	if !ok {
@@ -231,17 +218,17 @@ func (cg *CodeGenerator) emitAtomicInvocation(call *ast.InvocationExpression, tc
 	if !ok {
 		return false
 	}
-	if len(call.Arguments) != int(spec.Arity) || !semir.LegalAtomicOrder(spec.Operation, spec.Order) {
+	if len(call.Arguments) != int(spec.Arity) || !spec.Legal() {
 		cg.output.WriteString("OAK_INVALID_ATOMIC_OPERATION")
-		return true
-	}
-	order, err := cMemoryOrder(spec.Order)
-	if err != nil {
-		cg.output.WriteString("OAK_INVALID_ATOMIC_ORDER")
 		return true
 	}
 
 	if spec.Kind == semir.AtomicBuiltinFence {
+		order, err := cMemoryOrder(spec.Order)
+		if err != nil {
+			cg.output.WriteString("OAK_INVALID_ATOMIC_ORDER")
+			return true
+		}
 		cg.output.WriteString("atomic_thread_fence(")
 		cg.output.WriteString(order)
 		cg.output.WriteString(")")
@@ -255,6 +242,28 @@ func (cg *CodeGenerator) emitAtomicInvocation(call *ast.InvocationExpression, tc
 	}
 	address := "&(" + cell.Value + ")"
 
+	if spec.Kind == semir.AtomicBuiltinCompareExchange {
+		macro, err := compareExchangeMacro(spec)
+		if err != nil {
+			cg.output.WriteString("OAK_INVALID_COMPARE_EXCHANGE")
+			return true
+		}
+		cg.output.WriteString(macro)
+		cg.output.WriteString("(")
+		cg.output.WriteString(address)
+		cg.output.WriteString(", ")
+		cg.emitExpressionFragment(call.Arguments[1], tc)
+		cg.output.WriteString(", ")
+		cg.emitExpressionFragment(call.Arguments[2], tc)
+		cg.output.WriteString(")")
+		return true
+	}
+
+	order, err := cMemoryOrder(spec.Order)
+	if err != nil {
+		cg.output.WriteString("OAK_INVALID_ATOMIC_ORDER")
+		return true
+	}
 	switch spec.Kind {
 	case semir.AtomicBuiltinLoad:
 		cg.output.WriteString("atomic_load_explicit(")
@@ -284,8 +293,6 @@ func (cg *CodeGenerator) emitAtomicInvocation(call *ast.InvocationExpression, tc
 	return true
 }
 
-// The string helpers below are retained for direct backend unit tests and for
-// future Semantic-IR-only compilation paths.
 func atomicLoadC(address string, order semir.MemoryOrder) (string, error) {
 	if !semir.LegalAtomicOrder(semir.AtomicLoad, order) {
 		return "", fmt.Errorf("illegal atomic load order %q", order)
@@ -328,6 +335,18 @@ func atomicFetchAddC(address, value string, order semir.MemoryOrder) (string, er
 		return "", err
 	}
 	return fmt.Sprintf("atomic_fetch_add_explicit(%s, %s, %s)", address, value, cOrder), nil
+}
+
+func atomicCompareExchangeC(cellType, address, expected, desired string, success, failure semir.MemoryOrder) (string, error) {
+	if !semir.AtomicCarrierAllowed(cellType) || !semir.LegalCompareExchangeOrders(success, failure) {
+		return "", fmt.Errorf("invalid compare-exchange lowering for %s success=%s failure=%s", cellType, success, failure)
+	}
+	spec := semir.AtomicBuiltinSpec{Kind: semir.AtomicBuiltinCompareExchange, Operation: semir.AtomicCompareExchange, Order: success, FailureOrder: failure, Arity: 3}
+	macro, err := compareExchangeMacro(spec)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s(%s, %s, %s)", macro, address, expected, desired), nil
 }
 
 func atomicFenceC(order semir.MemoryOrder) (string, error) {

--- a/docs/spec/65-machine-memory.md
+++ b/docs/spec/65-machine-memory.md
@@ -1,12 +1,10 @@
 # Machine memory: atomics, volatile access, and ordering
 
-This chapter specifies Oak's first executable machine-memory contract. It is
-small on purpose: fixed-width integer atomic cells, explicit memory order,
+This chapter specifies Oak's executable machine-memory contract: fixed-width
+integer atomic cells, explicit memory order, strong compare-exchange,
 allocation-free source operations, and raw volatile access. Device MMIO,
 architecture barriers, system registers, and inline assembly build on this
 layer but remain separate contracts.
-
-The governing rule is:
 
 > Memory effects that matter to hardware or concurrency are language semantics,
 > never backend accidents.
@@ -14,18 +12,13 @@ The governing rule is:
 ## 1. Atomic cells
 
 `Atomic[T]` is storage identity for one atomically accessed machine cell.
-Atomicity belongs to the cell and its accesses; a value loaded from
-`Atomic[u32]` is an ordinary `u32`.
+Atomicity belongs to the cell and its accesses; a value loaded or returned by
+an RMW/CAS from `Atomic[u32]` is an ordinary `u32`.
 
-The v1 carriers are exactly:
-
-- `u8`, `u16`, `u32`, `u64`;
-- `i8`, `i16`, `i32`, `i64`.
-
-`int`, `uint`, `ptr`, `uptr`, booleans, records, sums, and aggregates are not
-v1 atomic carriers. Pointer atomics require a provenance contract; native-width
-integers require a target-width contract; aggregate atomics require explicit
-layout and lock-freedom rules. Oak does not infer any of those contracts.
+The v1 carriers are exactly `u8/u16/u32/u64` and `i8/i16/i32/i64`.
+Native-width integers, pointers, booleans, records, sums, and aggregates are not
+v1 carriers. Their width, provenance, layout, or lock-freedom contracts must be
+specified before they can become atomic carriers.
 
 A source cell is declared directly:
 
@@ -33,44 +26,17 @@ A source cell is declared directly:
 counter: Atomic[u64]
 ```
 
-A v1 `Atomic[T]` declaration has no initializer. The cell is zero-initialized
-and must subsequently be changed with an explicit atomic store/RMW operation.
-This keeps construction deterministic and prevents an ordinary write from
-being confused with an atomic publication operation.
+It is zero-initialized and has storage identity. Direct assignment/copy,
+ordinary arithmetic/matching, by-value argument/return transport, aggregate
+embedding, and temporary-cell operands are rejected. A future borrowed
+`AtomicRef[T]` may transport cell identity without copying it; v1 does not
+manufacture an implicit pointer or heap wrapper.
 
-### 1.1 Storage identity and non-copy rules
+## 2. Single-operation memory orders
 
-`Atomic[T]` is not an ordinary copyable value in v1. The following are rejected:
-
-- direct assignment to an atomic cell;
-- copying/inference from an atomic cell into another value binding;
-- ordinary arithmetic, comparison, matching, or prefix operations on the cell;
-- passing an atomic cell by value to a function;
-- returning an atomic cell by value;
-- embedding atomic storage in arrays, records, ADT payloads, or generic values.
-
-Atomic source operations require a named cell as their first operand. A loaded
-or RMW-returned value is the ordinary carrier `T` and can then participate in
-normal value semantics.
-
-This restriction is deliberate. A future `AtomicRef[T]`/borrowed-place contract
-may permit safe transport of cell identity without copying storage, but v1 does
-not manufacture an implicit pointer or wrapper to make that appear to work.
-
-## 2. Memory orders
-
-Oak defines exactly five memory orders:
-
-- `relaxed`;
-- `acquire`;
-- `release`;
-- `acq-rel`;
-- `seq-cst`.
-
-The order is part of the operation's semantics and is retained in Semantic IR
-effects. Backends may not silently weaken, strengthen, or guess an order.
-
-The legality matrix is:
+Oak defines `relaxed`, `acquire`, `release`, `acq-rel`, and `seq-cst`.
+Orders are semantic compile-time facts and backends may not guess or silently
+change them.
 
 | Operation | relaxed | acquire | release | acq-rel | seq-cst |
 | --- | --- | --- | --- | --- | --- |
@@ -79,13 +45,63 @@ The legality matrix is:
 | read-modify-write | yes | yes | yes | yes | yes |
 | fence | no | yes | yes | yes | yes |
 
-A release load, acquire store, and relaxed fence are not merely rejected at
-runtime: the v1 source surface has no constructor for them.
+Illegal combinations such as release-load, acquire-store, and relaxed-fence
+have no source builtin.
 
-## 3. Normative v1 source surface
+## 3. Strong compare-exchange
 
-Order is encoded in the builtin name. There is no runtime order enum, no
-implicit default, and no order-dispatch branch in generated code.
+Compare-exchange has two orders because success performs an RMW while failure
+performs only a read. The legal `(success, failure)` pairs are exactly:
+
+| success | legal failure orders |
+| --- | --- |
+| relaxed | relaxed |
+| acquire | relaxed, acquire |
+| release | relaxed |
+| acq-rel | relaxed, acquire |
+| seq-cst | relaxed, acquire, seq-cst |
+
+Failure can never be `release` or `acq-rel`, and it can never be stronger than
+success.
+
+Oak exposes **strong** CAS only in this slice: no spurious failure. Its API is
+value-oriented rather than C's mutable `expected*` convention:
+
+```text
+observed = atomic_compare_exchange_<success>_<failure>(cell, expected, desired)
+```
+
+The operation atomically compares the cell with `expected`. If equal, it writes
+`desired` and returns `expected`. If unequal, it does not write and returns the
+value observed by the failed comparison. Therefore:
+
+```text
+observed == expected    => success
+observed != expected    => failure; observed is the retry value
+```
+
+For fixed-width integer carriers this preserves all information needed by a
+CAS loop without adding an out-parameter, reference wrapper, allocation, or
+second mandatory load.
+
+The exact source constructors are:
+
+```text
+atomic_compare_exchange_relaxed_relaxed
+atomic_compare_exchange_acquire_relaxed
+atomic_compare_exchange_acquire_acquire
+atomic_compare_exchange_release_relaxed
+atomic_compare_exchange_acq_rel_relaxed
+atomic_compare_exchange_acq_rel_acquire
+atomic_compare_exchange_seq_cst_relaxed
+atomic_compare_exchange_seq_cst_acquire
+atomic_compare_exchange_seq_cst_seq_cst
+```
+
+Each takes `(cell, expected, desired)` and returns carrier `T`. No other order
+pair has a source constructor.
+
+## 4. Other normative atomic operations
 
 Loads:
 
@@ -103,211 +119,143 @@ atomic_store_release(cell, value) -> ()
 atomic_store_seq_cst(cell, value) -> ()
 ```
 
-Fetch-add read-modify-write operations return the value that existed before the
-addition:
+Fetch-add returns the pre-add value and exists for all five orders. Fences exist
+for acquire, release, acq-rel, and seq-cst. Atomic exchange remains a backend
+building block but is not yet a normative source builtin.
 
-```text
-atomic_fetch_add_relaxed(cell, delta) -> T
-atomic_fetch_add_acquire(cell, delta) -> T
-atomic_fetch_add_release(cell, delta) -> T
-atomic_fetch_add_acq_rel(cell, delta) -> T
-atomic_fetch_add_seq_cst(cell, delta) -> T
-```
+## 5. Effects and shared semantic authority
 
-Fences:
-
-```text
-atomic_fence_acquire() -> ()
-atomic_fence_release() -> ()
-atomic_fence_acq_rel() -> ()
-atomic_fence_seq_cst() -> ()
-```
-
-Compare-exchange is intentionally deferred. It has independent success/failure
-orders, restrictions on failure order, and expected-value update semantics.
-Oak will specify those facts directly instead of pretending compare-exchange is
-a one-order RMW.
-
-Atomic exchange remains a backend/Semantic-IR building block but is not part of
-the normative v1 source surface in this chapter.
-
-## 4. Effects and semantic authority
-
-Atomic operations project into Oak's authority/effect axis:
+Atomic operations project into the effect axis as:
 
 ```text
 Memory.AtomicLoad[order]
 Memory.AtomicStore[order]
 Memory.AtomicRMW[order]
+Memory.AtomicCompareExchange[success_order, failure_order]
 Memory.AtomicFence[order]
 ```
 
-The compiler uses one semantic builtin descriptor for source identity, arity,
-operation class, order, result shape, effect projection, type checking, and
-backend lowering. Verification and implementation therefore do not maintain
-independent order tables that can silently drift.
+One Semantic-IR builtin descriptor owns source identity, operation kind, arity,
+order(s), result shape, legality, effect projection, checker behavior, evaluator
+behavior, and backend selection. CAS legality is therefore not independently
+reimplemented as unrelated source and backend tables.
 
 Atomic operations do not semantically imply allocation, blocking, scheduler
 interaction, I/O, or syscalls.
 
-## 5. Allocation and performance contract
+## 6. Allocation and performance contract
 
-The v1 performance contract is structural rather than aspirational:
+The machine-memory performance contract is structural:
 
-1. an `Atomic[T]` cell lowers to inline `_Atomic(T)` storage;
-2. an atomic operation allocates no Oak heap object;
-3. memory order is compile-time data, not a runtime parameter;
-4. each source load/store/fetch-add/fence lowers directly to the corresponding
-   explicit C11 primitive rather than an Oak runtime wrapper;
-5. the compiler's atomic-builtin semantic lookup allocates zero objects per
-   lookup (regression-tested with `testing.AllocsPerRun`);
-6. `<stdatomic.h>` is emitted only when the program actually uses atomics, so
-   non-atomic generated C remains unchanged;
-7. generated atomic C is checked for accidental `malloc`, `calloc`, `realloc`,
-   `free`, or runtime order-switch scaffolding.
+1. `Atomic[T]` lowers to inline `_Atomic(T)` storage;
+2. atomic operations allocate no Oak heap object;
+3. all memory orders are compile-time data; there is no runtime order enum;
+4. load/store/fetch-add/fence lower directly to explicit C11 primitives;
+5. strong CAS lowers to `atomic_compare_exchange_strong_explicit` through
+   `static inline` helpers and C11 `_Generic` carrier selection;
+6. CAS helpers carry success/failure orders as constants, never runtime
+   `memory_order` arguments;
+7. semantic builtin lookup is regression-tested at zero Go allocations;
+8. `<stdatomic.h>` and CAS helper source are pay-for-use;
+9. generated hot paths are checked for accidental heap calls or order switches.
 
-These rules eliminate language/runtime overhead around the machine primitive.
-They do **not** claim that every C target implements every `_Atomic(T)` without
-an internal library lock. Lock-freedom is a target property. A freestanding or
-hard-realtime target profile must separately establish the required carrier is
-lock-free before relying on a bounded atomic WCET.
+This removes Oak runtime overhead around the primitive. It does not claim every
+backend/target implements every carrier lock-free. Freestanding and hard-RT
+target profiles must establish required atomic operations are lock-free (or
+otherwise have an accepted bounded implementation) before admission.
 
-Correctness takes precedence over an unsupported lock-free claim.
+CAS retry count is not intrinsically bounded under contention. Realtime code
+must account for that explicitly; lock-free does not mean hard-realtime.
 
-## 6. C bootstrap backend
+## 7. C11 bootstrap refinement
 
-The bootstrap C backend refines Oak atomics to C11 `_Atomic(T)` and explicit
-`atomic_*_explicit` operations with the exact corresponding `memory_order_*`.
-It uses the fixed-width Oak carrier rather than an implementation-sized atomic
-convenience typedef.
+The bootstrap backend uses `_Atomic(T)`, `atomic_*_explicit`, and exact
+`memory_order_*` constants. Strong CAS uses a local C `observed` value initialized
+to Oak's expected value, invokes `atomic_compare_exchange_strong_explicit`, and
+returns the resulting `observed`. C's expected-value update semantics therefore
+refine directly to Oak's value-returning CAS contract.
 
-The mapping is checked and total. An unknown Oak order, illegal operation/order
-pair, temporary cell operand, or unsupported carrier fails closed rather than
-falling back to a weaker or stronger operation.
+C11 `_Generic` selects the fixed-width carrier helper at compile time. There is
+no Oak runtime type/order dispatch and no heap allocation.
 
-For example:
+This is an executable backend refinement, not yet a formal proof that every C
+compiler and ISA implementation satisfies Oak's complete memory model.
 
-```text
-atomic_fetch_add_relaxed(counter, u64(1))
-```
+## 8. Reference evaluator
 
-lowers directly to the semantic equivalent of:
+The Go evaluator keeps one persistent `sync/atomic.Int64` cell per Oak atomic
+cell. It executes load/store/fetch-add and sequential strong-CAS value semantics.
+Go atomics over-strengthen several Oak order variants, so the evaluator is not
+a weak-memory oracle. Exact order behavior belongs to generated-C/ISA tests and
+the formal memory model.
 
-```c
-atomic_fetch_add_explicit(&(counter), (u64)1, memory_order_relaxed)
-```
+## 9. Volatile access
 
-The C atomic dependency is pay-for-use: non-atomic programs do not include
-`<stdatomic.h>`.
+Volatile means the requested observable machine access must not be removed,
+duplicated, or replaced by an ordinary cached language value. Its effects are
+`Memory.VolatileRead` and `Memory.VolatileWrite`.
 
-## 7. Reference evaluator
+Volatile is not atomic synchronization and is not by itself a complete MMIO
+ordering contract. AArch64 device-memory type, access width, DMB/DSB/ISB, DMA
+coherency, and interrupt-entry ordering belong to later machine chapters. Raw
+volatile C lowering intentionally adds no hidden fence.
 
-The Go evaluator represents an Oak atomic declaration as one persistent
-`sync/atomic.Int64` cell object and mutates that cell in place. It is a
-reference for storage identity and value semantics, including fetch-add's
-old-value result.
+## 10. Formal verification
 
-Go's atomic operations are stronger than several Oak order variants, so the
-evaluator is **not** a weak-memory litmus engine and is not used to validate the
-precise acquire/release/relaxed distinctions. Exact order refinement is tested
-through generated C11 code and is modeled separately in Lean.
+`spec/lean/Oak/MemoryOrder.lean` kernel-checks both the single-order matrix and
+strong-CAS relation. It proves, among other facts:
 
-## 8. Volatile access
+- illegal load/store/fence orders are absent;
+- every ordinary source builtin satisfies the applicable legality rule;
+- CAS failure can never be release or acq-rel;
+- relaxed-success CAS permits only relaxed failure;
+- release-success CAS permits only relaxed failure;
+- the exact nine CAS source constructors all satisfy `casLegal`;
+- every source CAS constructor has a legal success/failure pair;
+- no source CAS can expose release/acq-rel failure ordering.
 
-Volatile access means the requested load or store is an observable machine
-access and must not be removed, duplicated, merged, or satisfied from a cached
-language value in a way that changes the required observable access.
+These are language-level proofs. C/ISA refinement and the complete
+happens-before model remain separate proof obligations.
 
-The effects are:
+## 11. End-to-end tests
 
-```text
-Memory.VolatileRead
-Memory.VolatileWrite
-```
+Acceptance spans the whole executable stack:
 
-Volatile is **not** an atomic synchronization primitive, a replacement for
-acquire/release atomics, or by itself a complete device-MMIO ordering contract.
+- parser/typechecker validate the exact CAS spellings, cell identity, arity, and
+  carrier-typed expected/desired values;
+- Semantic IR tests enumerate legal/illegal CAS pairs and keep lookup
+  zero-allocation;
+- evaluator tests execute both success and mismatch paths, including returned
+  observed values and unchanged-on-failure storage;
+- generated C is checked for strong C11 CAS, exact order constants, no heap
+  calls, and no runtime order dispatch;
+- native C execution validates CAS success/failure semantics;
+- four pthreads perform 25,000 CAS-loop increments each against the same
+  Oak-generated atomic cell; the exact final value is checked;
+- the contention harness records total attempts and retries so CAS retry cost is
+  explicit and measurable rather than hidden;
+- ordinary Go CI, race-enabled integration where configured, golden output, and
+  Lean proofs gate merge.
 
-This distinction is essential on weakly ordered architectures including
-AArch64. Device-memory type, access width, barriers, and architecture-specific
-ordering rules belong to the MMIO/architecture layer built above this one.
-Raw volatile C lowering intentionally emits no hidden fence.
-
-## 9. Formal verification
-
-`spec/lean/Oak/MemoryOrder.lean` is the kernel-checked projection of the v1
-legality matrix and exact source builtin set. It proves:
-
-- release and acq-rel loads are illegal;
-- acquire and acq-rel stores are illegal;
-- every defined order is legal for RMW operations;
-- relaxed fences are illegal;
-- legal loads cannot have release/acq-rel ordering;
-- legal stores cannot have acquire/acq-rel ordering;
-- **every source builtin maps to a legal `(operation, order)` pair**;
-- the source surface cannot express release/acq-rel loads;
-- the source surface cannot express acquire/acq-rel stores;
-- the source surface cannot express a relaxed fence.
-
-These proofs establish the language-level order/surface contract. They do not
-prove that a particular C compiler or ISA implements the entire Oak memory
-model; that stronger backend/ISA refinement remains a later layer.
-
-## 10. End-to-end implementation tests
-
-The executable v1 slice is tested across all current layers:
-
-- parser: `Atomic[T]` and order-specific builtin calls parse as ordinary Oak
-  syntax without special parser magic;
-- typechecker: valid calls return the carrier/unit type and invalid carriers,
-  copied cells, initializers, by-value transport, temporary operands, and wrong
-  value types are rejected;
-- Semantic IR: every source builtin is checked against the same legality/effect
-  descriptor and the lookup is zero-allocation;
-- evaluator: cell identity, store/load, fetch-add old-value semantics, and
-  direct-assignment rejection are executed;
-- backend: generated C contains exact C11 explicit atomics and no hidden
-  allocation/runtime order dispatch;
-- pay-for-use: a non-atomic source program does not acquire the C atomic header
-  or atomic storage;
-- native execution: generated C is compiled with C11 and pthreads, four host
-  threads perform 100,000 contended Oak-generated relaxed fetch-add operations,
-  and an acquire load verifies the exact final count;
-- repository regression: the complete Go suite is run with the Go race detector
-  and the existing golden corpus remains unchanged for non-atomic programs;
-- Lean: the abstract legality matrix and exact source surface are kernel-checked.
-
-This is the acceptance bar for calling the v1 source atomic slice implemented,
-not merely scaffolded.
-
-## 11. Verification status and remaining layers
-
-For the source atomic slice in this chapter:
+## 12. Verification status
 
 | Layer | Status |
 | --- | --- |
-| normative source/storage semantics | specified |
-| order matrix | proved in Lean |
-| exact source builtin legality | proved in Lean |
-| parser/typechecker/evaluator | implemented and tested |
-| C11 source refinement | implemented and execution-tested |
-| compiler-path allocation regression | tested at zero allocations |
-| native contended RMW correctness | execution-tested |
+| atomic storage/source semantics | specified |
+| single-order legality | proved in Lean |
+| strong-CAS success/failure legality | proved in Lean |
+| exact CAS source constructors | proved in Lean |
+| parser/typechecker/evaluator | implemented + tested |
+| C11 strong-CAS lowering | implemented + native-tested |
+| compiler semantic lookup allocation | tested at zero allocations |
+| contended CAS linearized final value | native-tested |
+| CAS retry instrumentation | native-tested |
 | C/ISA formal refinement | not yet proved |
-| weak-memory architecture litmus suite | not yet implemented |
-| hardware-specific lock-free admission | not yet implemented |
+| complete happens-before/data-race model | not yet specified |
+| AArch64 weak-memory litmus suite | not yet implemented |
+| target-specific lock-free admission | not yet implemented |
 
-The remaining concurrency/machine contracts include:
-
-- compare-exchange;
-- pointer atomics and provenance;
-- wait/notify primitives;
-- the complete non-atomic data-race and happens-before model;
-- compiler-reordering refinement beyond the atomic primitives;
-- AArch64 barrier selection and weak-memory litmus tests;
-- device-memory attributes/MMIO ordering;
-- DMA coherency and interrupt-entry ordering;
-- freestanding linker/ABI rules.
-
-Those contracts must remain explicit before Oak owns the corresponding
-privileged operating-system mechanisms.
+Next machine-memory work should define Oak's complete happens-before/data-race
+model and then verify the AArch64 refinement with weak-memory litmus tests. Only
+then should higher-level SPSC/MPSC queue proofs rely on these atomics as their
+shared memory foundation.

--- a/evaluator/compare_exchange_test.go
+++ b/evaluator/compare_exchange_test.go
@@ -1,0 +1,49 @@
+package evaluator
+
+import (
+	"testing"
+
+	"github.com/SCKelemen/oak/object"
+	"github.com/SCKelemen/oak/parser"
+	"github.com/SCKelemen/oak/scanner"
+)
+
+func evalCompareExchangeProgram(t *testing.T, input string) object.Object {
+	t.Helper()
+	p := parser.New(scanner.New(input))
+	program := p.ParseProgram()
+	if errs := p.Errors(); len(errs) != 0 {
+		t.Fatalf("parser errors: %v", errs)
+	}
+	return Eval(program, object.NewEnvironment())
+}
+
+func TestCompareExchangeEvaluatorReturnsExpectedOnSuccess(t *testing.T) {
+	result := evalCompareExchangeProgram(t, `
+package main
+counter: Atomic[u64]
+atomic_store_relaxed(counter, u64(7))
+observed: u64 = atomic_compare_exchange_acq_rel_acquire(counter, u64(7), u64(9))
+assert(observed == u64(7))
+atomic_load_relaxed(counter)
+`)
+	integer, ok := result.(*object.Integer)
+	if !ok || integer.Value != 9 {
+		t.Fatalf("successful CAS result = %T %v, want final integer 9", result, result)
+	}
+}
+
+func TestCompareExchangeEvaluatorReturnsObservedOnFailure(t *testing.T) {
+	result := evalCompareExchangeProgram(t, `
+package main
+counter: Atomic[u64]
+atomic_store_relaxed(counter, u64(11))
+observed: u64 = atomic_compare_exchange_relaxed_relaxed(counter, u64(7), u64(9))
+assert(observed == u64(11))
+atomic_load_relaxed(counter)
+`)
+	integer, ok := result.(*object.Integer)
+	if !ok || integer.Value != 11 {
+		t.Fatalf("failed CAS result = %T %v, want unchanged integer 11", result, result)
+	}
+}

--- a/evaluator/memory.go
+++ b/evaluator/memory.go
@@ -19,10 +19,22 @@ func isAtomicTypeExpression(expr ast.Expression) bool {
 	return ok && semir.AtomicCarrierAllowed(carrier.Value)
 }
 
-// evalAtomicInvocation evaluates the value semantics of Oak atomics. Go's
-// sync/atomic implementation is at least as strong as every Oak order exposed
-// here; the evaluator is therefore a reference for cell identity and returned
-// values, not a weak-memory litmus-test engine.
+func evalAtomicInteger(name string, expr ast.Expression, env *object.Environment) (*object.Integer, object.Object) {
+	value := Eval(expr, env)
+	if isError(value) {
+		return nil, value
+	}
+	integer, ok := value.(*object.Integer)
+	if !ok {
+		return nil, newError("%s value must be an integer", name)
+	}
+	return integer, nil
+}
+
+// evalAtomicInvocation evaluates Oak's atomic value semantics. Go's sync/atomic
+// implementation is stronger than several Oak order variants, so this is a
+// reference for storage identity and sequential return values, not the
+// weak-memory oracle. Native generated-code tests validate C11 order lowering.
 func evalAtomicInvocation(name string, args []ast.Expression, env *object.Environment) (object.Object, bool) {
 	spec, recognized := semir.LookupAtomicBuiltin(name)
 	if !recognized {
@@ -50,20 +62,41 @@ func evalAtomicInvocation(name string, args []ast.Expression, env *object.Enviro
 	switch spec.Kind {
 	case semir.AtomicBuiltinLoad:
 		return &object.Integer{Value: cell.Value.Load()}, true
+
 	case semir.AtomicBuiltinStore, semir.AtomicBuiltinFetchAdd:
-		value := Eval(args[1], env)
-		if isError(value) {
-			return value, true
-		}
-		integer, ok := value.(*object.Integer)
-		if !ok {
-			return newError("%s value must be an integer", name), true
+		integer, errObj := evalAtomicInteger(name, args[1], env)
+		if errObj != nil {
+			return errObj, true
 		}
 		if spec.Kind == semir.AtomicBuiltinStore {
 			cell.Value.Store(integer.Value)
 			return NULL, true
 		}
 		return &object.Integer{Value: cell.Value.Add(integer.Value) - integer.Value}, true
+
+	case semir.AtomicBuiltinCompareExchange:
+		expected, errObj := evalAtomicInteger(name+" expected", args[1], env)
+		if errObj != nil {
+			return errObj, true
+		}
+		desired, errObj := evalAtomicInteger(name+" desired", args[2], env)
+		if errObj != nil {
+			return errObj, true
+		}
+
+		// Strong CAS: success is observed == expected. On failure the Oak
+		// result is the observed cell value, mirroring C11's updated expected.
+		// The evaluator is exercised sequentially; concurrent weak-memory
+		// behavior belongs to generated C/ISA tests rather than Go's model.
+		observed := cell.Value.Load()
+		if observed != expected.Value {
+			return &object.Integer{Value: observed}, true
+		}
+		if cell.Value.CompareAndSwap(expected.Value, desired.Value) {
+			return &object.Integer{Value: expected.Value}, true
+		}
+		return &object.Integer{Value: cell.Value.Load()}, true
+
 	default:
 		return newError("unsupported atomic builtin: %s", name), true
 	}

--- a/semir/compare_exchange_test.go
+++ b/semir/compare_exchange_test.go
@@ -1,0 +1,87 @@
+package semir
+
+import "testing"
+
+func TestCompareExchangeOrderRelation(t *testing.T) {
+	legal := [][2]MemoryOrder{
+		{MemoryOrderRelaxed, MemoryOrderRelaxed},
+		{MemoryOrderAcquire, MemoryOrderRelaxed},
+		{MemoryOrderAcquire, MemoryOrderAcquire},
+		{MemoryOrderRelease, MemoryOrderRelaxed},
+		{MemoryOrderAcqRel, MemoryOrderRelaxed},
+		{MemoryOrderAcqRel, MemoryOrderAcquire},
+		{MemoryOrderSeqCst, MemoryOrderRelaxed},
+		{MemoryOrderSeqCst, MemoryOrderAcquire},
+		{MemoryOrderSeqCst, MemoryOrderSeqCst},
+	}
+	for _, pair := range legal {
+		if !LegalCompareExchangeOrders(pair[0], pair[1]) {
+			t.Fatalf("legal CAS pair rejected: success=%s failure=%s", pair[0], pair[1])
+		}
+	}
+
+	illegal := [][2]MemoryOrder{
+		{MemoryOrderRelaxed, MemoryOrderAcquire},
+		{MemoryOrderRelaxed, MemoryOrderRelease},
+		{MemoryOrderAcquire, MemoryOrderSeqCst},
+		{MemoryOrderRelease, MemoryOrderAcquire},
+		{MemoryOrderAcqRel, MemoryOrderSeqCst},
+		{MemoryOrderSeqCst, MemoryOrderRelease},
+		{MemoryOrderSeqCst, MemoryOrderAcqRel},
+	}
+	for _, pair := range illegal {
+		if LegalCompareExchangeOrders(pair[0], pair[1]) {
+			t.Fatalf("illegal CAS pair accepted: success=%s failure=%s", pair[0], pair[1])
+		}
+	}
+}
+
+func TestCompareExchangeSurfaceIsExactlyLegalPairs(t *testing.T) {
+	names := []string{
+		"atomic_compare_exchange_relaxed_relaxed",
+		"atomic_compare_exchange_acquire_relaxed",
+		"atomic_compare_exchange_acquire_acquire",
+		"atomic_compare_exchange_release_relaxed",
+		"atomic_compare_exchange_acq_rel_relaxed",
+		"atomic_compare_exchange_acq_rel_acquire",
+		"atomic_compare_exchange_seq_cst_relaxed",
+		"atomic_compare_exchange_seq_cst_acquire",
+		"atomic_compare_exchange_seq_cst_seq_cst",
+	}
+	for _, name := range names {
+		spec, ok := LookupAtomicBuiltin(name)
+		if !ok || spec.Kind != AtomicBuiltinCompareExchange || !spec.Legal() {
+			t.Fatalf("CAS builtin %s missing or illegal: %+v", name, spec)
+		}
+		if spec.Arity != 3 || !spec.ReturnsValue() {
+			t.Fatalf("CAS builtin %s has wrong surface contract: %+v", name, spec)
+		}
+		if _, err := spec.Effect(); err != nil {
+			t.Fatalf("CAS builtin %s has invalid effect: %v", name, err)
+		}
+	}
+
+	for _, name := range []string{
+		"atomic_compare_exchange_relaxed_acquire",
+		"atomic_compare_exchange_release_acquire",
+		"atomic_compare_exchange_acq_rel_seq_cst",
+		"atomic_compare_exchange_seq_cst_release",
+		"atomic_compare_exchange_seq_cst_acq_rel",
+	} {
+		if _, ok := LookupAtomicBuiltin(name); ok {
+			t.Fatalf("illegal CAS source builtin unexpectedly exists: %s", name)
+		}
+	}
+}
+
+func TestCompareExchangeLookupAllocatesNothing(t *testing.T) {
+	allocs := testing.AllocsPerRun(1000, func() {
+		spec, ok := LookupAtomicBuiltin("atomic_compare_exchange_acq_rel_acquire")
+		if !ok || !spec.Legal() {
+			panic("CAS lookup failed")
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("CAS semantic lookup allocated %.2f objects per call; want zero", allocs)
+	}
+}

--- a/semir/memory.go
+++ b/semir/memory.go
@@ -31,19 +31,20 @@ func (o MemoryOrder) Valid() bool {
 }
 
 // AtomicOperation classifies an atomic access independently of its memory
-// order. Compare-exchange is intentionally separate future work because it has
-// independent success/failure orders and failure-side value-update semantics.
+// order. Compare-exchange is a distinct class because it has independent
+// success/failure orders.
 type AtomicOperation string
 
 const (
-	AtomicLoad  AtomicOperation = "load"
-	AtomicStore AtomicOperation = "store"
-	AtomicRMW   AtomicOperation = "rmw"
-	AtomicFence AtomicOperation = "fence"
+	AtomicLoad            AtomicOperation = "load"
+	AtomicStore           AtomicOperation = "store"
+	AtomicRMW             AtomicOperation = "rmw"
+	AtomicCompareExchange AtomicOperation = "compare-exchange"
+	AtomicFence           AtomicOperation = "fence"
 )
 
-// LegalAtomicOrder encodes the v1 order matrix. Illegal combinations are a
-// language error, not a backend choice.
+// LegalAtomicOrder encodes the single-order v1 matrix. Compare-exchange must
+// use LegalCompareExchangeOrders because its two orders are related.
 func LegalAtomicOrder(op AtomicOperation, order MemoryOrder) bool {
 	if !order.Valid() {
 		return false
@@ -62,6 +63,32 @@ func LegalAtomicOrder(op AtomicOperation, order MemoryOrder) bool {
 	}
 }
 
+// LegalCompareExchangeOrders is Oak's strong compare-exchange order relation.
+// Failure never performs a write, so release/acq-rel failure orders are
+// forbidden. Failure may also not be stronger than the success order.
+func LegalCompareExchangeOrders(success, failure MemoryOrder) bool {
+	if !success.Valid() || !failure.Valid() {
+		return false
+	}
+	if failure == MemoryOrderRelease || failure == MemoryOrderAcqRel {
+		return false
+	}
+	switch success {
+	case MemoryOrderRelaxed:
+		return failure == MemoryOrderRelaxed
+	case MemoryOrderAcquire:
+		return failure == MemoryOrderRelaxed || failure == MemoryOrderAcquire
+	case MemoryOrderRelease:
+		return failure == MemoryOrderRelaxed
+	case MemoryOrderAcqRel:
+		return failure == MemoryOrderRelaxed || failure == MemoryOrderAcquire
+	case MemoryOrderSeqCst:
+		return failure == MemoryOrderRelaxed || failure == MemoryOrderAcquire || failure == MemoryOrderSeqCst
+	default:
+		return false
+	}
+}
+
 // AtomicBuiltinKind identifies the exact source operation while AtomicOperation
 // captures the memory-model class shared by proofs/effects.
 type AtomicBuiltinKind uint8
@@ -71,72 +98,120 @@ const (
 	AtomicBuiltinLoad
 	AtomicBuiltinStore
 	AtomicBuiltinFetchAdd
+	AtomicBuiltinCompareExchange
 	AtomicBuiltinFence
 )
 
 // AtomicBuiltinSpec is the single semantic descriptor used by the checker,
-// evaluator, and backend. Arity and order are compile-time facts. Lookup uses a
-// switch rather than a map so the compiler's hot semantic lookup path performs
-// no heap allocation and has no initialization state.
+// evaluator, and backend. Order and FailureOrder are compile-time facts.
+// FailureOrder is empty for every non-CAS builtin. Lookup uses a switch rather
+// than a map so the compiler's hot semantic lookup path performs no heap
+// allocation and has no initialization state.
 type AtomicBuiltinSpec struct {
-	Name      string
-	Kind      AtomicBuiltinKind
-	Operation AtomicOperation
-	Order     MemoryOrder
-	Arity     uint8
+	Name         string
+	Kind         AtomicBuiltinKind
+	Operation    AtomicOperation
+	Order        MemoryOrder
+	FailureOrder MemoryOrder
+	Arity        uint8
 }
 
 func (s AtomicBuiltinSpec) ReturnsValue() bool {
-	return s.Kind == AtomicBuiltinLoad || s.Kind == AtomicBuiltinFetchAdd
+	return s.Kind == AtomicBuiltinLoad || s.Kind == AtomicBuiltinFetchAdd || s.Kind == AtomicBuiltinCompareExchange
+}
+
+func (s AtomicBuiltinSpec) Legal() bool {
+	if s.Kind == AtomicBuiltinCompareExchange {
+		return LegalCompareExchangeOrders(s.Order, s.FailureOrder)
+	}
+	return LegalAtomicOrder(s.Operation, s.Order)
 }
 
 func (s AtomicBuiltinSpec) Effect() (Effect, error) {
+	if s.Kind == AtomicBuiltinCompareExchange {
+		return AtomicCompareExchangeEffect(s.Order, s.FailureOrder)
+	}
 	return AtomicEffect(s.Operation, s.Order)
 }
 
-// LookupAtomicBuiltin defines the complete v1 source surface. Order-specific
-// names make illegal operation/order pairs unrepresentable rather than asking a
-// runtime enum or backend fallback to reject them.
+func atomicBuiltin(name string, kind AtomicBuiltinKind, op AtomicOperation, order MemoryOrder, arity uint8) AtomicBuiltinSpec {
+	return AtomicBuiltinSpec{Name: name, Kind: kind, Operation: op, Order: order, Arity: arity}
+}
+
+func compareExchangeBuiltin(name string, success, failure MemoryOrder) AtomicBuiltinSpec {
+	return AtomicBuiltinSpec{
+		Name:         name,
+		Kind:         AtomicBuiltinCompareExchange,
+		Operation:    AtomicCompareExchange,
+		Order:        success,
+		FailureOrder: failure,
+		Arity:        3,
+	}
+}
+
+// LookupAtomicBuiltin defines the complete source surface. Order-specific names
+// make illegal operation/order pairs unrepresentable rather than asking a
+// runtime enum or backend fallback to reject them. Compare-exchange names encode
+// success order first and failure order second.
 func LookupAtomicBuiltin(name string) (AtomicBuiltinSpec, bool) {
 	switch name {
 	case "atomic_load_relaxed":
-		return AtomicBuiltinSpec{name, AtomicBuiltinLoad, AtomicLoad, MemoryOrderRelaxed, 1}, true
+		return atomicBuiltin(name, AtomicBuiltinLoad, AtomicLoad, MemoryOrderRelaxed, 1), true
 	case "atomic_load_acquire":
-		return AtomicBuiltinSpec{name, AtomicBuiltinLoad, AtomicLoad, MemoryOrderAcquire, 1}, true
+		return atomicBuiltin(name, AtomicBuiltinLoad, AtomicLoad, MemoryOrderAcquire, 1), true
 	case "atomic_load_seq_cst":
-		return AtomicBuiltinSpec{name, AtomicBuiltinLoad, AtomicLoad, MemoryOrderSeqCst, 1}, true
+		return atomicBuiltin(name, AtomicBuiltinLoad, AtomicLoad, MemoryOrderSeqCst, 1), true
 	case "atomic_store_relaxed":
-		return AtomicBuiltinSpec{name, AtomicBuiltinStore, AtomicStore, MemoryOrderRelaxed, 2}, true
+		return atomicBuiltin(name, AtomicBuiltinStore, AtomicStore, MemoryOrderRelaxed, 2), true
 	case "atomic_store_release":
-		return AtomicBuiltinSpec{name, AtomicBuiltinStore, AtomicStore, MemoryOrderRelease, 2}, true
+		return atomicBuiltin(name, AtomicBuiltinStore, AtomicStore, MemoryOrderRelease, 2), true
 	case "atomic_store_seq_cst":
-		return AtomicBuiltinSpec{name, AtomicBuiltinStore, AtomicStore, MemoryOrderSeqCst, 2}, true
+		return atomicBuiltin(name, AtomicBuiltinStore, AtomicStore, MemoryOrderSeqCst, 2), true
 	case "atomic_fetch_add_relaxed":
-		return AtomicBuiltinSpec{name, AtomicBuiltinFetchAdd, AtomicRMW, MemoryOrderRelaxed, 2}, true
+		return atomicBuiltin(name, AtomicBuiltinFetchAdd, AtomicRMW, MemoryOrderRelaxed, 2), true
 	case "atomic_fetch_add_acquire":
-		return AtomicBuiltinSpec{name, AtomicBuiltinFetchAdd, AtomicRMW, MemoryOrderAcquire, 2}, true
+		return atomicBuiltin(name, AtomicBuiltinFetchAdd, AtomicRMW, MemoryOrderAcquire, 2), true
 	case "atomic_fetch_add_release":
-		return AtomicBuiltinSpec{name, AtomicBuiltinFetchAdd, AtomicRMW, MemoryOrderRelease, 2}, true
+		return atomicBuiltin(name, AtomicBuiltinFetchAdd, AtomicRMW, MemoryOrderRelease, 2), true
 	case "atomic_fetch_add_acq_rel":
-		return AtomicBuiltinSpec{name, AtomicBuiltinFetchAdd, AtomicRMW, MemoryOrderAcqRel, 2}, true
+		return atomicBuiltin(name, AtomicBuiltinFetchAdd, AtomicRMW, MemoryOrderAcqRel, 2), true
 	case "atomic_fetch_add_seq_cst":
-		return AtomicBuiltinSpec{name, AtomicBuiltinFetchAdd, AtomicRMW, MemoryOrderSeqCst, 2}, true
+		return atomicBuiltin(name, AtomicBuiltinFetchAdd, AtomicRMW, MemoryOrderSeqCst, 2), true
+
+	case "atomic_compare_exchange_relaxed_relaxed":
+		return compareExchangeBuiltin(name, MemoryOrderRelaxed, MemoryOrderRelaxed), true
+	case "atomic_compare_exchange_acquire_relaxed":
+		return compareExchangeBuiltin(name, MemoryOrderAcquire, MemoryOrderRelaxed), true
+	case "atomic_compare_exchange_acquire_acquire":
+		return compareExchangeBuiltin(name, MemoryOrderAcquire, MemoryOrderAcquire), true
+	case "atomic_compare_exchange_release_relaxed":
+		return compareExchangeBuiltin(name, MemoryOrderRelease, MemoryOrderRelaxed), true
+	case "atomic_compare_exchange_acq_rel_relaxed":
+		return compareExchangeBuiltin(name, MemoryOrderAcqRel, MemoryOrderRelaxed), true
+	case "atomic_compare_exchange_acq_rel_acquire":
+		return compareExchangeBuiltin(name, MemoryOrderAcqRel, MemoryOrderAcquire), true
+	case "atomic_compare_exchange_seq_cst_relaxed":
+		return compareExchangeBuiltin(name, MemoryOrderSeqCst, MemoryOrderRelaxed), true
+	case "atomic_compare_exchange_seq_cst_acquire":
+		return compareExchangeBuiltin(name, MemoryOrderSeqCst, MemoryOrderAcquire), true
+	case "atomic_compare_exchange_seq_cst_seq_cst":
+		return compareExchangeBuiltin(name, MemoryOrderSeqCst, MemoryOrderSeqCst), true
+
 	case "atomic_fence_acquire":
-		return AtomicBuiltinSpec{name, AtomicBuiltinFence, AtomicFence, MemoryOrderAcquire, 0}, true
+		return atomicBuiltin(name, AtomicBuiltinFence, AtomicFence, MemoryOrderAcquire, 0), true
 	case "atomic_fence_release":
-		return AtomicBuiltinSpec{name, AtomicBuiltinFence, AtomicFence, MemoryOrderRelease, 0}, true
+		return atomicBuiltin(name, AtomicBuiltinFence, AtomicFence, MemoryOrderRelease, 0), true
 	case "atomic_fence_acq_rel":
-		return AtomicBuiltinSpec{name, AtomicBuiltinFence, AtomicFence, MemoryOrderAcqRel, 0}, true
+		return atomicBuiltin(name, AtomicBuiltinFence, AtomicFence, MemoryOrderAcqRel, 0), true
 	case "atomic_fence_seq_cst":
-		return AtomicBuiltinSpec{name, AtomicBuiltinFence, AtomicFence, MemoryOrderSeqCst, 0}, true
+		return atomicBuiltin(name, AtomicBuiltinFence, AtomicFence, MemoryOrderSeqCst, 0), true
 	default:
 		return AtomicBuiltinSpec{}, false
 	}
 }
 
-// AtomicEffect projects an atomic operation into Oak's authority/effect axis.
-// The order is retained as a parameter so verification, documentation, and
-// future scheduling/debug tooling do not need to recover it from syntax.
+// AtomicEffect projects a single-order atomic operation into Oak's
+// authority/effect axis.
 func AtomicEffect(op AtomicOperation, order MemoryOrder) (Effect, error) {
 	if !LegalAtomicOrder(op, order) {
 		return Effect{}, fmt.Errorf("illegal atomic memory order %q for %q", order, op)
@@ -153,6 +228,19 @@ func AtomicEffect(op AtomicOperation, order MemoryOrder) (Effect, error) {
 		name = "AtomicFence"
 	}
 	return Effect{Namespace: "Memory", Name: name, Parameters: []string{string(order)}}, nil
+}
+
+// AtomicCompareExchangeEffect retains both orders as semantic data so later
+// happens-before proofs and tooling do not need to recover them from a name.
+func AtomicCompareExchangeEffect(success, failure MemoryOrder) (Effect, error) {
+	if !LegalCompareExchangeOrders(success, failure) {
+		return Effect{}, fmt.Errorf("illegal compare-exchange orders success=%q failure=%q", success, failure)
+	}
+	return Effect{
+		Namespace:  "Memory",
+		Name:       "AtomicCompareExchange",
+		Parameters: []string{string(success), string(failure)},
+	}, nil
 }
 
 // AtomicCarrierAllowed is deliberately narrow for the first executable

--- a/spec/lean/Oak/MemoryOrder.lean
+++ b/spec/lean/Oak/MemoryOrder.lean
@@ -12,11 +12,12 @@ inductive AtomicOp where
   | load
   | store
   | rmw
+  | compareExchange
   | fence
   deriving DecidableEq, Repr
 
-/-- Oak's v1 atomic memory-order legality matrix. This is deliberately
-    independent of any compiler backend. -/
+/-- Oak's single-order atomic legality matrix. Compare-exchange is checked by
+    `casLegal` because success and failure orders are related. -/
 def legal : AtomicOp -> Order -> Bool
   | .load, .relaxed => true
   | .load, .acquire => true
@@ -27,20 +28,33 @@ def legal : AtomicOp -> Order -> Bool
   | .store, .seqCst => true
   | .store, _ => false
   | .rmw, _ => true
+  | .compareExchange, _ => false
   | .fence, .relaxed => false
   | .fence, _ => true
+
+/-- Strong compare-exchange legality. Failure never writes, hence release and
+    acq-rel are forbidden, and failure may not be stronger than success. -/
+def casLegal : Order -> Order -> Bool
+  | .relaxed, .relaxed => true
+  | .acquire, .relaxed => true
+  | .acquire, .acquire => true
+  | .release, .relaxed => true
+  | .acqRel, .relaxed => true
+  | .acqRel, .acquire => true
+  | .seqCst, .relaxed => true
+  | .seqCst, .acquire => true
+  | .seqCst, .seqCst => true
+  | _, _ => false
 
 theorem load_relaxed_legal : legal .load .relaxed = true := rfl
 theorem load_acquire_legal : legal .load .acquire = true := rfl
 theorem load_seqCst_legal : legal .load .seqCst = true := rfl
-
 theorem load_release_illegal : legal .load .release = false := rfl
 theorem load_acqRel_illegal : legal .load .acqRel = false := rfl
 
 theorem store_relaxed_legal : legal .store .relaxed = true := rfl
 theorem store_release_legal : legal .store .release = true := rfl
 theorem store_seqCst_legal : legal .store .seqCst = true := rfl
-
 theorem store_acquire_illegal : legal .store .acquire = false := rfl
 theorem store_acqRel_illegal : legal .store .acqRel = false := rfl
 
@@ -53,19 +67,33 @@ theorem synchronization_fences_legal (o : Order)
     (h : o != .relaxed) : legal .fence o = true := by
   cases o <;> simp_all [legal]
 
-/-- A legal load never has release-only or acquire-release ordering. -/
 theorem legal_load_not_release (o : Order)
     (h : legal .load o = true) : o != .release ∧ o != .acqRel := by
   cases o <;> simp_all [legal]
 
-/-- A legal store never has acquire-only or acquire-release ordering. -/
 theorem legal_store_not_acquire (o : Order)
     (h : legal .store o = true) : o != .acquire ∧ o != .acqRel := by
   cases o <;> simp_all [legal]
 
-/-- The exact source-level atomic builtin set. Memory order is encoded in the
-    builtin identity, so the program never carries a runtime order enum and an
-    illegal operation/order pair has no source constructor. -/
+/-- Failure ordering of a legal CAS can never have release semantics. -/
+theorem cas_failure_not_release (success failure : Order)
+    (h : casLegal success failure = true) :
+    failure != .release ∧ failure != .acqRel := by
+  cases success <;> cases failure <;> simp_all [casLegal]
+
+/-- Relaxed success permits only relaxed failure. -/
+theorem relaxed_cas_failure_relaxed (failure : Order)
+    (h : casLegal .relaxed failure = true) : failure = .relaxed := by
+  cases failure <;> simp_all [casLegal]
+
+/-- Release-only success cannot acquire on failure. -/
+theorem release_cas_failure_relaxed (failure : Order)
+    (h : casLegal .release failure = true) : failure = .relaxed := by
+  cases failure <;> simp_all [casLegal]
+
+/-- The exact source-level atomic builtin set. Order is encoded in builtin
+    identity, so no runtime order enum exists. CAS names encode success then
+    failure order. -/
 inductive Builtin where
   | loadRelaxed
   | loadAcquire
@@ -78,6 +106,15 @@ inductive Builtin where
   | fetchAddRelease
   | fetchAddAcqRel
   | fetchAddSeqCst
+  | compareExchangeRelaxedRelaxed
+  | compareExchangeAcquireRelaxed
+  | compareExchangeAcquireAcquire
+  | compareExchangeReleaseRelaxed
+  | compareExchangeAcqRelRelaxed
+  | compareExchangeAcqRelAcquire
+  | compareExchangeSeqCstRelaxed
+  | compareExchangeSeqCstAcquire
+  | compareExchangeSeqCstSeqCst
   | fenceAcquire
   | fenceRelease
   | fenceAcqRel
@@ -89,6 +126,15 @@ def builtinOp : Builtin -> AtomicOp
   | .storeRelaxed | .storeRelease | .storeSeqCst => .store
   | .fetchAddRelaxed | .fetchAddAcquire | .fetchAddRelease
   | .fetchAddAcqRel | .fetchAddSeqCst => .rmw
+  | .compareExchangeRelaxedRelaxed
+  | .compareExchangeAcquireRelaxed
+  | .compareExchangeAcquireAcquire
+  | .compareExchangeReleaseRelaxed
+  | .compareExchangeAcqRelRelaxed
+  | .compareExchangeAcqRelAcquire
+  | .compareExchangeSeqCstRelaxed
+  | .compareExchangeSeqCstAcquire
+  | .compareExchangeSeqCstSeqCst => .compareExchange
   | .fenceAcquire | .fenceRelease | .fenceAcqRel | .fenceSeqCst => .fence
 
 def builtinOrder : Builtin -> Order
@@ -103,32 +149,66 @@ def builtinOrder : Builtin -> Order
   | .fetchAddRelease => .release
   | .fetchAddAcqRel => .acqRel
   | .fetchAddSeqCst => .seqCst
+  | .compareExchangeRelaxedRelaxed => .relaxed
+  | .compareExchangeAcquireRelaxed | .compareExchangeAcquireAcquire => .acquire
+  | .compareExchangeReleaseRelaxed => .release
+  | .compareExchangeAcqRelRelaxed | .compareExchangeAcqRelAcquire => .acqRel
+  | .compareExchangeSeqCstRelaxed | .compareExchangeSeqCstAcquire
+  | .compareExchangeSeqCstSeqCst => .seqCst
   | .fenceAcquire => .acquire
   | .fenceRelease => .release
   | .fenceAcqRel => .acqRel
   | .fenceSeqCst => .seqCst
 
-/-- Every operation expressible by Oak's v1 source surface is legal according
-    to the language memory-order matrix. -/
-theorem source_builtin_legal (b : Builtin) :
-    legal (builtinOp b) (builtinOrder b) = true := by
+def builtinFailureOrder : Builtin -> Option Order
+  | .compareExchangeRelaxedRelaxed => some .relaxed
+  | .compareExchangeAcquireRelaxed => some .relaxed
+  | .compareExchangeAcquireAcquire => some .acquire
+  | .compareExchangeReleaseRelaxed => some .relaxed
+  | .compareExchangeAcqRelRelaxed => some .relaxed
+  | .compareExchangeAcqRelAcquire => some .acquire
+  | .compareExchangeSeqCstRelaxed => some .relaxed
+  | .compareExchangeSeqCstAcquire => some .acquire
+  | .compareExchangeSeqCstSeqCst => some .seqCst
+  | _ => none
+
+def builtinLegal (b : Builtin) : Bool :=
+  match builtinFailureOrder b with
+  | some failure => casLegal (builtinOrder b) failure
+  | none => legal (builtinOp b) (builtinOrder b)
+
+/-- Every operation expressible by the source surface satisfies the applicable
+    single-order or compare-exchange legality relation. -/
+theorem source_builtin_legal (b : Builtin) : builtinLegal b = true := by
   cases b <;> rfl
 
-/-- The source surface cannot express a release/acq-rel load. -/
 theorem source_load_not_release (b : Builtin)
     (h : builtinOp b = .load) :
     builtinOrder b != .release ∧ builtinOrder b != .acqRel := by
   cases b <;> simp_all [builtinOp, builtinOrder]
 
-/-- The source surface cannot express an acquire/acq-rel store. -/
 theorem source_store_not_acquire (b : Builtin)
     (h : builtinOp b = .store) :
     builtinOrder b != .acquire ∧ builtinOrder b != .acqRel := by
   cases b <;> simp_all [builtinOp, builtinOrder]
 
-/-- A source fence can never be relaxed. -/
 theorem source_fence_not_relaxed (b : Builtin)
     (h : builtinOp b = .fence) : builtinOrder b != .relaxed := by
   cases b <;> simp_all [builtinOp, builtinOrder]
+
+/-- Any source CAS constructor has a failure order and that pair is legal. -/
+theorem source_cas_pair_legal (b : Builtin) (failure : Order)
+    (hOp : builtinOp b = .compareExchange)
+    (hFailure : builtinFailureOrder b = some failure) :
+    casLegal (builtinOrder b) failure = true := by
+  cases b <;> simp_all [builtinOp, builtinFailureOrder, builtinOrder, casLegal]
+
+/-- No source CAS can express release/acq-rel failure ordering. -/
+theorem source_cas_failure_not_release (b : Builtin) (failure : Order)
+    (hOp : builtinOp b = .compareExchange)
+    (hFailure : builtinFailureOrder b = some failure) :
+    failure != .release ∧ failure != .acqRel := by
+  have hLegal := source_cas_pair_legal b failure hOp hFailure
+  exact cas_failure_not_release (builtinOrder b) failure hLegal
 
 end Oak.MemoryOrder

--- a/spec/lean/Oak/MemoryOrder.lean
+++ b/spec/lean/Oak/MemoryOrder.lean
@@ -201,7 +201,8 @@ theorem source_cas_pair_legal (b : Builtin) (failure : Order)
     (hOp : builtinOp b = .compareExchange)
     (hFailure : builtinFailureOrder b = some failure) :
     casLegal (builtinOrder b) failure = true := by
-  cases b <;> simp_all [builtinOp, builtinFailureOrder, builtinOrder, casLegal]
+  cases b <;> cases failure <;>
+    simp_all [builtinOp, builtinFailureOrder, builtinOrder, casLegal]
 
 /-- No source CAS can express release/acq-rel failure ordering. -/
 theorem source_cas_failure_not_release (b : Builtin) (failure : Order)

--- a/typechecker/compare_exchange_test.go
+++ b/typechecker/compare_exchange_test.go
@@ -1,0 +1,38 @@
+package typechecker
+
+import "testing"
+
+func TestCompareExchangeTypesAndReturnsObservedCarrier(t *testing.T) {
+	errs := checkAtomicSource(t, `
+package main
+counter: Atomic[u64]
+fn cas(expected: u64, desired: u64) -> u64
+  atomic_compare_exchange_acq_rel_acquire(counter, expected, desired)
+`)
+	if len(errs) != 0 {
+		t.Fatalf("valid compare-exchange rejected: %v", errs)
+	}
+}
+
+func TestCompareExchangeRejectsWrongExpectedAndDesiredTypes(t *testing.T) {
+	errs := checkAtomicSource(t, `
+package main
+counter: Atomic[u64]
+fn bad() -> u64 {
+  atomic_compare_exchange_acq_rel_acquire(counter, "wrong", u64(2))
+  atomic_compare_exchange_acq_rel_acquire(counter, u64(1), "wrong")
+}
+`)
+	requireAtomicErrorContains(t, errs, "expected value must be u64")
+	requireAtomicErrorContains(t, errs, "desired value must be u64")
+}
+
+func TestCompareExchangeRejectsTemporaryCell(t *testing.T) {
+	errs := checkAtomicSource(t, `
+package main
+counter: Atomic[u64]
+fn bad() -> u64
+  atomic_compare_exchange_relaxed_relaxed(atomic_load_relaxed(counter), u64(0), u64(1))
+`)
+	requireAtomicErrorContains(t, errs, "requires a named Atomic[T] cell")
+}

--- a/typechecker/memory.go
+++ b/typechecker/memory.go
@@ -29,10 +29,6 @@ func (t *AtomicType) Equals(other Type) bool {
 	return t.Element.Equals(o.Element)
 }
 
-// IsAtomicCarrier reports whether typ has the unambiguous fixed-width machine
-// representation required by the first atomic surface. Native int/uint and
-// pointers are intentionally excluded until target-width and provenance rules
-// are part of the atomic contract.
 func IsAtomicCarrier(typ Type) bool {
 	prim, ok := typ.(*PrimitiveType)
 	if !ok || prim == nil {
@@ -46,7 +42,6 @@ func IsAtomicCarrier(typ Type) bool {
 	}
 }
 
-// NewAtomicType is the single checked constructor used by type elaboration.
 func NewAtomicType(element Type) (*AtomicType, error) {
 	if !IsAtomicCarrier(element) {
 		if element == nil {
@@ -57,10 +52,6 @@ func NewAtomicType(element Type) (*AtomicType, error) {
 	return &AtomicType{Element: element}, nil
 }
 
-// ContainsAtomicStorage detects atomic cell identity nested inside another
-// value. v1 permits Atomic[T] only as a direct local/package cell: aggregate
-// embedding and by-value function transport remain rejected until Oak has a
-// non-copy storage/borrow contract for them.
 func ContainsAtomicStorage(typ Type) bool {
 	switch t := typ.(type) {
 	case *AtomicType:
@@ -94,10 +85,19 @@ func atomicCellIdentifier(expr ast.Expression) bool {
 	return ok
 }
 
+func (tc *TypeChecker) checkAtomicValueArgument(name string, arg ast.Expression, expected Type) bool {
+	valueType := tc.checkExpression(arg, expected)
+	if valueType != nil && !tc.isAssignable(valueType, expected) {
+		tc.addError(arg, "%s value must be %s, got %s", name, expected, valueType)
+		return false
+	}
+	return true
+}
+
 // checkAtomicInvocation types every source-level atomic builtin from the
 // semantic descriptor in semir. The first operand is an identifier naming a
-// cell, never a temporary value: this preserves storage identity and prevents
-// an implicit atomic copy at the call boundary.
+// cell, never a temporary value. Strong compare-exchange takes expected and
+// desired carrier values and returns the value observed by the atomic compare.
 func (tc *TypeChecker) checkAtomicInvocation(name string, expr *ast.InvocationExpression) (Type, bool) {
 	spec, recognized := semir.LookupAtomicBuiltin(name)
 	if !recognized {
@@ -126,18 +126,27 @@ func (tc *TypeChecker) checkAtomicInvocation(name string, expr *ast.InvocationEx
 		return nil, true
 	}
 
-	if spec.Kind == semir.AtomicBuiltinStore || spec.Kind == semir.AtomicBuiltinFetchAdd {
-		valueType := tc.checkExpression(expr.Arguments[1], cell.Element)
-		if valueType != nil && !tc.isAssignable(valueType, cell.Element) {
-			tc.addError(expr.Arguments[1], "%s value must be %s, got %s", name, cell.Element, valueType)
+	switch spec.Kind {
+	case semir.AtomicBuiltinStore, semir.AtomicBuiltinFetchAdd:
+		if !tc.checkAtomicValueArgument(name, expr.Arguments[1], cell.Element) {
+			return nil, true
+		}
+	case semir.AtomicBuiltinCompareExchange:
+		okExpected := tc.checkAtomicValueArgument(name+" expected", expr.Arguments[1], cell.Element)
+		okDesired := tc.checkAtomicValueArgument(name+" desired", expr.Arguments[2], cell.Element)
+		if !okExpected || !okDesired {
 			return nil, true
 		}
 	}
 
-	// This is also a defensive executable check that the source descriptor
-	// remains inside the formally specified legality matrix.
-	if !semir.LegalAtomicOrder(spec.Operation, spec.Order) {
-		tc.addError(expr, "internal atomic builtin %s has illegal order %s", name, spec.Order)
+	// Defensive executable check that the source descriptor remains inside the
+	// formally specified legality relation. CAS validates the related order pair.
+	if !spec.Legal() {
+		if spec.Kind == semir.AtomicBuiltinCompareExchange {
+			tc.addError(expr, "internal compare-exchange builtin %s has illegal orders success=%s failure=%s", name, spec.Order, spec.FailureOrder)
+		} else {
+			tc.addError(expr, "internal atomic builtin %s has illegal order %s", name, spec.Order)
+		}
 		return nil, true
 	}
 


### PR DESCRIPTION
Adds Oak's first strong compare-exchange surface as a complete machine-memory vertical slice.

Design:
- Strong, value-returning CAS: `atomic_compare_exchange_<success>_<failure>(cell, expected, desired) -> T`.
- Success iff returned observed value equals `expected`; on failure the returned value is the value observed by the failed compare, avoiding an out-parameter and supporting efficient retry loops.
- Exactly nine legal success/failure order pairs are exposed. Failure can never be release/acq-rel and can never be stronger than success.
- One Semantic-IR descriptor carries operation class, success order, failure order, arity, result shape, legality, and effect.
- Typechecker requires a named `Atomic[T]` cell and carrier-typed expected/desired values.
- Evaluator implements sequential strong-CAS value semantics; generated C/ISA tests remain the weak-memory/order oracle.
- C11 backend uses `atomic_compare_exchange_strong_explicit`, compile-time order constants, static-inline helpers, and C11 `_Generic` carrier selection. No Oak heap allocation or runtime order dispatch.
- Native contention test drives 4 threads x 25,000 increments through Oak-generated CAS, verifies the exact final value, and records attempts/retries so contention cost remains visible.
- Semantic lookup remains zero-allocation.
- Lean extends the memory-order model with the exact CAS legality relation and exact source CAS constructors, proving all exposed pairs legal and release/acq-rel failure impossible.
- `docs/spec/65-machine-memory.md` now normatively specifies CAS semantics, performance constraints, verification status, and the next happens-before/AArch64 refinement work.

Intentionally still out of scope: pointer atomics/provenance, weak CAS/spurious failure, wait/notify, the complete non-atomic data-race/happens-before model, formal C/ISA refinement, AArch64 weak-memory litmus tests, and target-specific freestanding lock-free admission.