### PR TITLE
Specify and implement core happens-before model

### DIFF
--- a/docs/spec/65-machine-memory.md
+++ b/docs/spec/65-machine-memory.md
@@ -214,8 +214,10 @@ strong-CAS relation. It proves, among other facts:
 - every source CAS constructor has a legal success/failure pair;
 - no source CAS can expose release/acq-rel failure ordering.
 
-These are language-level proofs. C/ISA refinement and the complete
-happens-before model remain separate proof obligations.
+The execution-level meaning of publication, happens-before, conflicting access,
+and data races is specified separately in `66-memory-model.md` and modeled in
+`spec/lean/Oak/HappensBefore.lean`. These are language-level proofs. C/ISA
+refinement remains a separate proof obligation.
 
 ## 11. End-to-end tests
 
@@ -250,12 +252,13 @@ Acceptance spans the whole executable stack:
 | compiler semantic lookup allocation | tested at zero allocations |
 | contended CAS linearized final value | native-tested |
 | CAS retry instrumentation | native-tested |
+| core happens-before/data-race relations | specified + implemented + Lean-modeled in chapter 66 |
+| complete memory-model closure (fences/release sequences/SC) | not yet complete |
 | C/ISA formal refinement | not yet proved |
-| complete happens-before/data-race model | not yet specified |
 | AArch64 weak-memory litmus suite | not yet implemented |
 | target-specific lock-free admission | not yet implemented |
 
-Next machine-memory work should define Oak's complete happens-before/data-race
-model and then verify the AArch64 refinement with weak-memory litmus tests. Only
-then should higher-level SPSC/MPSC queue proofs rely on these atomics as their
-shared memory foundation.
+The next closure work is fence-mediated synchronization, release sequences, and
+sequential-consistency constraints in the execution model, followed by C/AArch64
+refinement and weak-memory litmus tests. Higher-level SPSC/MPSC proofs should
+consume that closed contract rather than invent their own memory semantics.

--- a/docs/spec/66-memory-model.md
+++ b/docs/spec/66-memory-model.md
@@ -1,0 +1,276 @@
+# Memory model: executions, happens-before, and data races
+
+This chapter defines the execution-graph core beneath Oak concurrency. It is the
+semantic bridge between source-level atomic operations and higher-level queues,
+channels, schedulers, device protocols, and realtime code.
+
+The governing rule is:
+
+> Shared-memory correctness is an explicit relation between events, not an
+> accidental consequence of compiler or processor behavior.
+
+This chapter intentionally separates two questions:
+
+1. **What is happens-before and what constitutes a data race?** This chapter
+   specifies and implements those core relations now.
+2. **Which architecture/backend executions are valid?** Fence synchronization,
+   release sequences, sequential-consistency total order, compiler refinement,
+   and AArch64 litmus validation extend the execution witness and are tracked as
+   remaining work before the complete machine memory model is declared closed.
+
+## 1. Execution events
+
+A memory-model execution is a finite set of indexed events. Event identity is a
+compact integer index rather than a pointer or heap object.
+
+Each event carries:
+
+```text
+thread
+sequence
+location
+access       // read, write, read-write, or fence
+atomic
+order        // only for atomic events
+reads_from?  // only for atomic reads/RMW
+```
+
+`location` is semantic storage identity. It is not required to be a virtual or
+physical machine address.
+
+Within one thread, `sequence` is unique. The execution model therefore derives
+per-thread ordering without constructing or allocating an explicit edge list.
+
+## 2. Sequenced-before
+
+For events `a` and `b`:
+
+```text
+sequenced_before(a, b) :=
+    a.thread == b.thread
+    && a.sequence < b.sequence
+```
+
+Sequenced-before is irreflexive and defines the source/execution order visible
+to the memory model within one thread.
+
+## 3. Reads-from
+
+An atomic read or read-modify-write may identify the atomic write/RMW event from
+which it observed its value.
+
+A valid reads-from witness requires:
+
+- source and target are atomic;
+- source writes;
+- target reads;
+- source and target name the same semantic location;
+- the referenced source event exists.
+
+Reads-from is explicit because value equality alone does not identify causal
+provenance.
+
+## 4. Synchronizes-with
+
+Synchronizes-with is an explicit, validated inter-thread edge.
+
+The first executable synchronization rule is direct release/acquire
+publication:
+
+```text
+release-like atomic write/RMW
+        |
+        | reads-from
+        v
+acquire-like atomic read/RMW
+```
+
+Release-like orders are:
+
+```text
+release
+acq-rel
+seq-cst
+```
+
+Acquire-like orders are:
+
+```text
+acquire
+acq-rel
+seq-cst
+```
+
+A direct synchronization edge is valid only when the target's reads-from
+witness names the source event and both access the same location.
+
+Relaxed operations therefore do not silently acquire or release merely because
+they happen to observe the same value.
+
+The edge representation is extensible. Fence-mediated synchronization and
+release-sequence witnesses will add new synchronization reasons without
+changing the definition of happens-before.
+
+## 5. Happens-before
+
+Oak defines happens-before as the transitive closure of:
+
+```text
+sequenced-before ∪ synchronizes-with
+```
+
+It is deliberately not reflexive.
+
+The canonical publication chain is:
+
+```text
+thread 0                         thread 1
+
+payload write
+    |
+    | sequenced-before
+    v
+release flag write
+    |
+    | synchronizes-with
+    v
+                              acquire flag read
+                                   |
+                                   | sequenced-before
+                                   v
+                              payload read
+```
+
+Therefore:
+
+```text
+payload write happens-before payload read
+```
+
+This theorem is formalized in Lean and execution-tested in the Semantic IR
+model. It is the core fact required by an SPSC publication/consumption proof.
+
+## 6. Conflicting accesses
+
+Two memory events conflict when:
+
+- they name the same location;
+- neither is a fence;
+- at least one writes.
+
+Two reads alone do not conflict.
+
+## 7. Data races
+
+Two events constitute a data race when all of the following hold:
+
+```text
+different threads
+&& conflicting accesses
+&& at least one access is non-atomic
+&& !happens_before(a, b)
+&& !happens_before(b, a)
+```
+
+Oak deliberately treats mixed atomic/non-atomic conflicting access as subject
+to the race rule. Making one side atomic does not bless an otherwise unordered
+non-atomic access.
+
+At the language level, ordinary `Atomic[T]` storage cannot currently be read or
+written through ordinary value operations, which removes a large class of such
+mixed accesses by construction. The execution definition remains fail-closed so
+future unsafe/raw-memory facilities cannot weaken the semantic rule.
+
+A data-race-free program may rely on the specified shared-memory semantics. The
+language must not assign portable meaning to an execution containing a data
+race merely because a particular backend appears to produce stable results.
+
+## 8. Allocation and bounded-work contract
+
+The executable Semantic IR model is intended for compiler verification,
+property tests, deterministic simulation, and small-state execution checking.
+It is not a hidden runtime service.
+
+Its graph queries obey these structural rules:
+
+1. event and synchronization arrays are supplied by the caller;
+2. `happens-before` receives caller-owned `visited` and stack storage;
+3. no map, queue, recursion, closure capture, or heap allocation occurs inside
+   HB traversal;
+4. race queries reuse the same workspace;
+5. the maximum traversal stack is exactly the event count;
+6. traversal work is finite and bounded by the supplied execution size;
+7. zero internal allocations are regression-tested with `testing.AllocsPerRun`.
+
+The reference implementation currently favors simple auditable bounded scans
+over sophisticated graph indexing. Faster representations may be added later as
+refinements while preserving this semantic model.
+
+## 9. Formal verification
+
+`spec/lean/Oak/HappensBefore.lean` proves the abstract core relation laws:
+
+- sequenced-before implies happens-before;
+- synchronizes-with implies happens-before;
+- happens-before is closed under transitivity;
+- the release/acquire publication chain establishes HB from payload write to
+  payload read;
+- an established HB edge excludes the data-race predicate;
+- therefore the canonical published payload pair is not a data race;
+- the release-like and acquire-like order classifications used by direct
+  publication contain the intended orders and exclude relaxed.
+
+These are mathematical language-level theorems. They do not yet constitute a
+formal refinement proof from Go graph traversal to Lean or from generated C to
+AArch64 instructions.
+
+## 10. Executable verification
+
+`semir/memory_model.go` and its tests exercise the same execution vocabulary:
+
+- valid release/acquire publication;
+- transitive HB across both thread-local and synchronization edges;
+- an unsynchronized non-atomic conflict is a race;
+- a mixed atomic/non-atomic unordered conflict is still a race;
+- same-thread conflicting accesses are ordered and do not race;
+- a relaxed reader cannot witness an acquire synchronization edge;
+- a synchronization edge must agree with its reads-from source;
+- undersized scratch fails explicitly;
+- HB traversal performs zero internal allocations;
+- race queries perform zero internal allocations.
+
+The full repository Go/race suite and Lean build remain CI acceptance gates.
+
+## 11. Status
+
+| Layer | Status |
+| --- | --- |
+| event/reads-from vocabulary | specified + implemented |
+| sequenced-before | specified + implemented |
+| direct release/acquire synchronizes-with | specified + implemented + tested |
+| happens-before definition | specified + implemented + Lean-modeled |
+| publication theorem | proved in Lean + execution-tested |
+| data-race definition | specified + implemented + Lean-modeled |
+| zero-allocation HB/race traversal | regression-tested |
+| Go-to-Lean refinement | not yet proved |
+| fence-mediated synchronization | next |
+| release-sequence semantics | next |
+| seq-cst global order | next |
+| compiler/C refinement | not yet proved |
+| AArch64 weak-memory litmus suite | not yet implemented |
+
+## 12. Next closure steps
+
+Before higher-level lock-free structures depend on the memory model as a closed
+contract, Oak should add:
+
+1. fence-mediated synchronization witnesses and proofs;
+2. explicit release-sequence semantics for RMW chains;
+3. the sequential-consistency total-order constraints;
+4. backend/compiler refinement tests;
+5. AArch64 MP/SB/LB/IRIW-style litmus coverage and assembly inspection;
+6. target lock-free admission rules for realtime profiles.
+
+Only after those pieces are explicit should `SpscRing[T, N]` be treated as a
+proof consumer of the complete machine-memory model rather than as an isolated
+algorithm test.

--- a/semir/memory_model.go
+++ b/semir/memory_model.go
@@ -1,0 +1,294 @@
+package semir
+
+import (
+	"errors"
+	"fmt"
+)
+
+// MemoryEventID is an O(1) index into MemoryExecution.Events.
+type MemoryEventID uint32
+
+// MemoryThreadID identifies one execution thread in a memory-model witness.
+type MemoryThreadID uint32
+
+// MemoryLocationID is semantic storage identity, not a machine address.
+type MemoryLocationID uint64
+
+// MemoryAccessKind classifies the observable memory action of an event.
+type MemoryAccessKind uint8
+
+const (
+	MemoryAccessNone MemoryAccessKind = iota
+	MemoryAccessRead
+	MemoryAccessWrite
+	MemoryAccessReadWrite
+	MemoryAccessFence
+)
+
+func (k MemoryAccessKind) reads() bool {
+	return k == MemoryAccessRead || k == MemoryAccessReadWrite
+}
+
+func (k MemoryAccessKind) writes() bool {
+	return k == MemoryAccessWrite || k == MemoryAccessReadWrite
+}
+
+// MemoryEvent is one event in an abstract execution witness. Event identity is
+// its slice index; this keeps graph traversal compact and deterministic.
+type MemoryEvent struct {
+	Thread       MemoryThreadID
+	Sequence     uint32
+	Location     MemoryLocationID
+	Access       MemoryAccessKind
+	Atomic       bool
+	Order        MemoryOrder
+	HasReadsFrom bool
+	ReadsFrom    MemoryEventID
+}
+
+// MemorySyncKind identifies why an inter-thread synchronizes-with edge exists.
+// The first executable slice admits direct release/acquire publication edges.
+// Fence/release-sequence witnesses extend this enum without changing HB itself.
+type MemorySyncKind uint8
+
+const (
+	MemorySyncInvalid MemorySyncKind = iota
+	MemorySyncReleaseAcquire
+)
+
+// MemorySyncEdge is a validated synchronizes-with edge.
+type MemorySyncEdge struct {
+	From MemoryEventID
+	To   MemoryEventID
+	Kind MemorySyncKind
+}
+
+// MemoryExecution is an explicit execution graph. Slices are supplied by the
+// caller; the model does not allocate storage internally.
+type MemoryExecution struct {
+	Events       []MemoryEvent
+	Synchronizes []MemorySyncEdge
+}
+
+// MemoryWorkspace is caller-owned traversal scratch. Reusing it keeps HB/race
+// analysis allocation-free after setup.
+type MemoryWorkspace struct {
+	Visited []bool
+	Stack   []MemoryEventID
+}
+
+var (
+	ErrMemoryEventOutOfRange  = errors.New("memory event id out of range")
+	ErrMemoryWorkspaceTooSmall = errors.New("memory workspace too small")
+)
+
+func releaseLike(order MemoryOrder) bool {
+	return order == MemoryOrderRelease || order == MemoryOrderAcqRel || order == MemoryOrderSeqCst
+}
+
+func acquireLike(order MemoryOrder) bool {
+	return order == MemoryOrderAcquire || order == MemoryOrderAcqRel || order == MemoryOrderSeqCst
+}
+
+func legalEventOrder(event MemoryEvent) bool {
+	if !event.Atomic {
+		return event.Order == ""
+	}
+	switch event.Access {
+	case MemoryAccessRead:
+		return LegalAtomicOrder(AtomicLoad, event.Order)
+	case MemoryAccessWrite:
+		return LegalAtomicOrder(AtomicStore, event.Order)
+	case MemoryAccessReadWrite:
+		return LegalAtomicOrder(AtomicRMW, event.Order)
+	case MemoryAccessFence:
+		return LegalAtomicOrder(AtomicFence, event.Order)
+	default:
+		return false
+	}
+}
+
+// Validate checks the structural execution witness. It is deliberately
+// separate from graph queries so hot verification/model-checking loops can
+// validate once and reuse allocation-free reachability operations many times.
+func (x MemoryExecution) Validate() error {
+	for i, event := range x.Events {
+		if !legalEventOrder(event) {
+			return fmt.Errorf("event %d has illegal atomic/non-atomic order", i)
+		}
+		if event.Access == MemoryAccessFence {
+			if !event.Atomic || event.HasReadsFrom {
+				return fmt.Errorf("event %d has invalid fence shape", i)
+			}
+		} else if event.Access == MemoryAccessNone {
+			return fmt.Errorf("event %d has no memory access", i)
+		}
+		if event.HasReadsFrom {
+			if !event.Atomic || !event.Access.reads() {
+				return fmt.Errorf("event %d has reads-from but is not an atomic read", i)
+			}
+			if int(event.ReadsFrom) >= len(x.Events) {
+				return fmt.Errorf("event %d reads-from out-of-range event %d", i, event.ReadsFrom)
+			}
+			source := x.Events[event.ReadsFrom]
+			if !source.Atomic || !source.Access.writes() || source.Location != event.Location {
+				return fmt.Errorf("event %d has invalid reads-from source %d", i, event.ReadsFrom)
+			}
+		}
+	}
+
+	// Sequence numbers define per-thread source order and must be unique.
+	for i := 0; i < len(x.Events); i++ {
+		for j := i + 1; j < len(x.Events); j++ {
+			if x.Events[i].Thread == x.Events[j].Thread && x.Events[i].Sequence == x.Events[j].Sequence {
+				return fmt.Errorf("events %d and %d duplicate thread sequence", i, j)
+			}
+		}
+	}
+
+	for i, edge := range x.Synchronizes {
+		if int(edge.From) >= len(x.Events) || int(edge.To) >= len(x.Events) {
+			return fmt.Errorf("sync edge %d references an out-of-range event", i)
+		}
+		if edge.From == edge.To {
+			return fmt.Errorf("sync edge %d is self-referential", i)
+		}
+		switch edge.Kind {
+		case MemorySyncReleaseAcquire:
+			from := x.Events[edge.From]
+			to := x.Events[edge.To]
+			if !from.Atomic || !from.Access.writes() || !releaseLike(from.Order) {
+				return fmt.Errorf("sync edge %d source is not a release-like atomic write", i)
+			}
+			if !to.Atomic || !to.Access.reads() || !acquireLike(to.Order) {
+				return fmt.Errorf("sync edge %d target is not an acquire-like atomic read", i)
+			}
+			if from.Location != to.Location || !to.HasReadsFrom || to.ReadsFrom != edge.From {
+				return fmt.Errorf("sync edge %d is not witnessed by reads-from on one location", i)
+			}
+		default:
+			return fmt.Errorf("sync edge %d has unknown kind", i)
+		}
+	}
+	return nil
+}
+
+// SequencedBefore is per-thread source/execution order.
+func (x MemoryExecution) SequencedBefore(from, to MemoryEventID) bool {
+	if int(from) >= len(x.Events) || int(to) >= len(x.Events) || from == to {
+		return false
+	}
+	a := x.Events[from]
+	b := x.Events[to]
+	return a.Thread == b.Thread && a.Sequence < b.Sequence
+}
+
+// SynchronizesWith checks validated explicit inter-thread synchronization.
+func (x MemoryExecution) SynchronizesWith(from, to MemoryEventID) bool {
+	for i := range x.Synchronizes {
+		edge := x.Synchronizes[i]
+		if edge.From == from && edge.To == to {
+			return true
+		}
+	}
+	return false
+}
+
+func (x MemoryExecution) baseBefore(from, to MemoryEventID) bool {
+	return x.SequencedBefore(from, to) || x.SynchronizesWith(from, to)
+}
+
+// HappensBefore is the transitive closure of sequenced-before union
+// synchronizes-with. It performs no internal allocation: callers provide one
+// visited bit per event and one stack slot per event.
+func (x MemoryExecution) HappensBefore(from, to MemoryEventID, workspace MemoryWorkspace) (bool, error) {
+	if int(from) >= len(x.Events) || int(to) >= len(x.Events) {
+		return false, ErrMemoryEventOutOfRange
+	}
+	if len(workspace.Visited) < len(x.Events) || len(workspace.Stack) < len(x.Events) {
+		return false, ErrMemoryWorkspaceTooSmall
+	}
+	if from == to {
+		return false, nil
+	}
+	for i := 0; i < len(x.Events); i++ {
+		workspace.Visited[i] = false
+	}
+
+	top := 0
+	workspace.Stack[top] = from
+	top++
+	workspace.Visited[from] = true
+
+	for top > 0 {
+		top--
+		current := workspace.Stack[top]
+		for next := 0; next < len(x.Events); next++ {
+			nextID := MemoryEventID(next)
+			if workspace.Visited[next] || !x.baseBefore(current, nextID) {
+				continue
+			}
+			if nextID == to {
+				return true, nil
+			}
+			workspace.Visited[next] = true
+			workspace.Stack[top] = nextID
+			top++
+		}
+	}
+	return false, nil
+}
+
+// Conflicts is the language-level conflicting-access predicate.
+func (x MemoryExecution) Conflicts(a, b MemoryEventID) bool {
+	if int(a) >= len(x.Events) || int(b) >= len(x.Events) || a == b {
+		return false
+	}
+	left := x.Events[a]
+	right := x.Events[b]
+	if left.Access == MemoryAccessFence || right.Access == MemoryAccessFence || left.Location != right.Location {
+		return false
+	}
+	return left.Access.writes() || right.Access.writes()
+}
+
+// IsDataRace follows Oak's fail-closed race definition: different threads,
+// conflicting accesses, at least one non-atomic access, and no HB edge in
+// either direction. Mixing atomic and non-atomic access does not escape the
+// race rule.
+func (x MemoryExecution) IsDataRace(a, b MemoryEventID, workspace MemoryWorkspace) (bool, error) {
+	if int(a) >= len(x.Events) || int(b) >= len(x.Events) {
+		return false, ErrMemoryEventOutOfRange
+	}
+	left := x.Events[a]
+	right := x.Events[b]
+	if left.Thread == right.Thread || !x.Conflicts(a, b) || (left.Atomic && right.Atomic) {
+		return false, nil
+	}
+	ab, err := x.HappensBefore(a, b, workspace)
+	if err != nil || ab {
+		return false, err
+	}
+	ba, err := x.HappensBefore(b, a, workspace)
+	if err != nil || ba {
+		return false, err
+	}
+	return true, nil
+}
+
+// FirstDataRace deterministically returns the lexicographically first event
+// pair that races. It reuses caller scratch and allocates no storage itself.
+func (x MemoryExecution) FirstDataRace(workspace MemoryWorkspace) (MemoryEventID, MemoryEventID, bool, error) {
+	for i := 0; i < len(x.Events); i++ {
+		for j := i + 1; j < len(x.Events); j++ {
+			race, err := x.IsDataRace(MemoryEventID(i), MemoryEventID(j), workspace)
+			if err != nil {
+				return 0, 0, false, err
+			}
+			if race {
+				return MemoryEventID(i), MemoryEventID(j), true, nil
+			}
+		}
+	}
+	return 0, 0, false, nil
+}

--- a/semir/memory_model_test.go
+++ b/semir/memory_model_test.go
@@ -1,0 +1,148 @@
+package semir
+
+import "testing"
+
+func memoryWorkspace(n int) MemoryWorkspace {
+	return MemoryWorkspace{
+		Visited: make([]bool, n),
+		Stack:   make([]MemoryEventID, n),
+	}
+}
+
+func releaseAcquirePublication() MemoryExecution {
+	// T0: payload=7; release flag=1
+	// T1: acquire flag (reads-from release); read payload
+	return MemoryExecution{
+		Events: []MemoryEvent{
+			{Thread: 0, Sequence: 0, Location: 1, Access: MemoryAccessWrite},
+			{Thread: 0, Sequence: 1, Location: 2, Access: MemoryAccessWrite, Atomic: true, Order: MemoryOrderRelease},
+			{Thread: 1, Sequence: 0, Location: 2, Access: MemoryAccessRead, Atomic: true, Order: MemoryOrderAcquire, HasReadsFrom: true, ReadsFrom: 1},
+			{Thread: 1, Sequence: 1, Location: 1, Access: MemoryAccessRead},
+		},
+		Synchronizes: []MemorySyncEdge{{From: 1, To: 2, Kind: MemorySyncReleaseAcquire}},
+	}
+}
+
+func TestReleaseAcquirePublicationCreatesHappensBefore(t *testing.T) {
+	x := releaseAcquirePublication()
+	if err := x.Validate(); err != nil {
+		t.Fatalf("valid publication execution rejected: %v", err)
+	}
+	workspace := memoryWorkspace(len(x.Events))
+
+	if got, err := x.HappensBefore(0, 3, workspace); err != nil || !got {
+		t.Fatalf("payload write should happen-before payload read: got=%v err=%v", got, err)
+	}
+	if race, err := x.IsDataRace(0, 3, workspace); err != nil || race {
+		t.Fatalf("published payload should not race: race=%v err=%v", race, err)
+	}
+}
+
+func TestUnsynchronizedConflictingNonAtomicAccessesRace(t *testing.T) {
+	x := MemoryExecution{Events: []MemoryEvent{
+		{Thread: 0, Sequence: 0, Location: 9, Access: MemoryAccessWrite},
+		{Thread: 1, Sequence: 0, Location: 9, Access: MemoryAccessRead},
+	}}
+	if err := x.Validate(); err != nil {
+		t.Fatalf("execution rejected: %v", err)
+	}
+	workspace := memoryWorkspace(len(x.Events))
+	if race, err := x.IsDataRace(0, 1, workspace); err != nil || !race {
+		t.Fatalf("unordered conflicting accesses must race: race=%v err=%v", race, err)
+	}
+	left, right, found, err := x.FirstDataRace(workspace)
+	if err != nil || !found || left != 0 || right != 1 {
+		t.Fatalf("first race = (%d,%d,%v,%v), want (0,1,true,nil)", left, right, found, err)
+	}
+}
+
+func TestAtomicAndNonAtomicConflictStillRaces(t *testing.T) {
+	x := MemoryExecution{Events: []MemoryEvent{
+		{Thread: 0, Sequence: 0, Location: 4, Access: MemoryAccessWrite, Atomic: true, Order: MemoryOrderRelaxed},
+		{Thread: 1, Sequence: 0, Location: 4, Access: MemoryAccessRead},
+	}}
+	if err := x.Validate(); err != nil {
+		t.Fatalf("execution rejected: %v", err)
+	}
+	workspace := memoryWorkspace(len(x.Events))
+	if race, err := x.IsDataRace(0, 1, workspace); err != nil || !race {
+		t.Fatalf("mixed atomic/non-atomic conflict must race: race=%v err=%v", race, err)
+	}
+}
+
+func TestRelaxedReadCannotWitnessAcquireSynchronization(t *testing.T) {
+	x := releaseAcquirePublication()
+	x.Events[2].Order = MemoryOrderRelaxed
+	if err := x.Validate(); err == nil {
+		t.Fatal("relaxed reader unexpectedly admitted as acquire synchronization")
+	}
+}
+
+func TestReadsFromMustMatchSynchronizationSource(t *testing.T) {
+	x := releaseAcquirePublication()
+	x.Events = append(x.Events, MemoryEvent{
+		Thread: 2, Sequence: 0, Location: 2, Access: MemoryAccessWrite, Atomic: true, Order: MemoryOrderRelease,
+	})
+	x.Events[2].ReadsFrom = 4
+	if err := x.Validate(); err == nil {
+		t.Fatal("sync edge with mismatched reads-from witness unexpectedly validated")
+	}
+}
+
+func TestSameThreadConflictIsOrderedNotRace(t *testing.T) {
+	x := MemoryExecution{Events: []MemoryEvent{
+		{Thread: 0, Sequence: 2, Location: 1, Access: MemoryAccessWrite},
+		{Thread: 0, Sequence: 5, Location: 1, Access: MemoryAccessRead},
+	}}
+	if err := x.Validate(); err != nil {
+		t.Fatalf("execution rejected: %v", err)
+	}
+	workspace := memoryWorkspace(len(x.Events))
+	if hb, err := x.HappensBefore(0, 1, workspace); err != nil || !hb {
+		t.Fatalf("same-thread sequence should be HB: hb=%v err=%v", hb, err)
+	}
+	if race, err := x.IsDataRace(0, 1, workspace); err != nil || race {
+		t.Fatalf("same-thread conflict cannot race: race=%v err=%v", race, err)
+	}
+}
+
+func TestHappensBeforeRequiresCallerWorkspace(t *testing.T) {
+	x := releaseAcquirePublication()
+	if _, err := x.HappensBefore(0, 3, MemoryWorkspace{}); err != ErrMemoryWorkspaceTooSmall {
+		t.Fatalf("small workspace error = %v, want %v", err, ErrMemoryWorkspaceTooSmall)
+	}
+}
+
+func TestHappensBeforeTraversalAllocatesNothing(t *testing.T) {
+	x := releaseAcquirePublication()
+	if err := x.Validate(); err != nil {
+		t.Fatalf("execution rejected: %v", err)
+	}
+	workspace := memoryWorkspace(len(x.Events))
+	allocs := testing.AllocsPerRun(1000, func() {
+		hb, err := x.HappensBefore(0, 3, workspace)
+		if err != nil || !hb {
+			panic("unexpected HB result")
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("HB traversal allocated %.2f objects per run; want zero", allocs)
+	}
+}
+
+func TestRaceQueryAllocatesNothing(t *testing.T) {
+	x := MemoryExecution{Events: []MemoryEvent{
+		{Thread: 0, Sequence: 0, Location: 7, Access: MemoryAccessWrite},
+		{Thread: 1, Sequence: 0, Location: 7, Access: MemoryAccessRead},
+	}}
+	workspace := memoryWorkspace(len(x.Events))
+	allocs := testing.AllocsPerRun(1000, func() {
+		race, err := x.IsDataRace(0, 1, workspace)
+		if err != nil || !race {
+			panic("unexpected race result")
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("race query allocated %.2f objects per run; want zero", allocs)
+	}
+}

--- a/spec/lean/Oak.lean
+++ b/spec/lean/Oak.lean
@@ -1,6 +1,7 @@
 import Oak.TypeLattice
 import Oak.Effects
 import Oak.MemoryOrder
+import Oak.HappensBefore
 import Oak.Borrowing
 import Oak.BorrowRegions
 import Oak.Reborrow

--- a/spec/lean/Oak/HappensBefore.lean
+++ b/spec/lean/Oak/HappensBefore.lean
@@ -89,7 +89,7 @@ def DataRace {Event : Type u}
     (conflict : Event -> Event -> Prop)
     (atomic : Event -> Bool)
     (a b : Event) : Prop :=
-  thread a != thread b ∧
+  thread a ≠ thread b ∧
   conflict a b ∧
   (atomic a = false ∨ atomic b = false) ∧
   ¬ hb a b ∧

--- a/spec/lean/Oak/HappensBefore.lean
+++ b/spec/lean/Oak/HappensBefore.lean
@@ -1,0 +1,129 @@
+import Oak.MemoryOrder
+
+namespace Oak.HappensBefore
+
+open Oak.MemoryOrder
+
+universe u
+
+/-- Release-like orders may publish a write to another thread. -/
+def releaseLike : Order -> Bool
+  | .release | .acqRel | .seqCst => true
+  | _ => false
+
+/-- Acquire-like orders may consume a published write from another thread. -/
+def acquireLike : Order -> Bool
+  | .acquire | .acqRel | .seqCst => true
+  | _ => false
+
+theorem release_is_releaseLike : releaseLike .release = true := rfl
+theorem acqRel_is_releaseLike : releaseLike .acqRel = true := rfl
+theorem seqCst_is_releaseLike : releaseLike .seqCst = true := rfl
+
+theorem acquire_is_acquireLike : acquireLike .acquire = true := rfl
+theorem acqRel_is_acquireLike : acquireLike .acqRel = true := rfl
+theorem seqCst_is_acquireLike : acquireLike .seqCst = true := rfl
+
+theorem relaxed_not_releaseLike : releaseLike .relaxed = false := rfl
+theorem relaxed_not_acquireLike : acquireLike .relaxed = false := rfl
+
+/-- Oak happens-before is the transitive closure of per-thread
+    sequenced-before and inter-thread synchronizes-with. -/
+inductive HappensBefore {Event : Type u}
+    (sequencedBefore synchronizesWith : Event -> Event -> Prop) :
+    Event -> Event -> Prop where
+  | base {a b}
+      (h : sequencedBefore a b ∨ synchronizesWith a b) :
+      HappensBefore sequencedBefore synchronizesWith a b
+  | trans {a b c}
+      (hab : HappensBefore sequencedBefore synchronizesWith a b)
+      (hbc : HappensBefore sequencedBefore synchronizesWith b c) :
+      HappensBefore sequencedBefore synchronizesWith a c
+
+theorem sequencedBefore_implies_hb
+    {Event : Type u} {sb sw : Event -> Event -> Prop} {a b : Event}
+    (h : sb a b) : HappensBefore sb sw a b :=
+  .base (Or.inl h)
+
+theorem synchronizesWith_implies_hb
+    {Event : Type u} {sb sw : Event -> Event -> Prop} {a b : Event}
+    (h : sw a b) : HappensBefore sb sw a b :=
+  .base (Or.inr h)
+
+theorem hb_transitive
+    {Event : Type u} {sb sw : Event -> Event -> Prop} {a b c : Event}
+    (hab : HappensBefore sb sw a b)
+    (hbc : HappensBefore sb sw b c) :
+    HappensBefore sb sw a c :=
+  .trans hab hbc
+
+/-- The publication chain used by queues and message passing:
+
+      payload write
+          sb
+      release publication
+          sw
+      acquire consumption
+          sb
+      payload read
+
+    establishes happens-before from payload write to payload read. -/
+theorem release_acquire_publication
+    {Event : Type u} {sb sw : Event -> Event -> Prop}
+    {payloadWrite releaseWrite acquireRead payloadRead : Event}
+    (hPayloadRelease : sb payloadWrite releaseWrite)
+    (hPublication : sw releaseWrite acquireRead)
+    (hAcquirePayload : sb acquireRead payloadRead) :
+    HappensBefore sb sw payloadWrite payloadRead := by
+  exact .trans
+    (.base (Or.inl hPayloadRelease))
+    (.trans
+      (.base (Or.inr hPublication))
+      (.base (Or.inl hAcquirePayload)))
+
+/-- Abstract language-level data-race predicate. At least one conflicting
+    access is non-atomic and neither access happens-before the other. -/
+def DataRace {Event : Type u}
+    (hb : Event -> Event -> Prop)
+    (thread : Event -> Nat)
+    (conflict : Event -> Event -> Prop)
+    (atomic : Event -> Bool)
+    (a b : Event) : Prop :=
+  thread a != thread b ∧
+  conflict a b ∧
+  (atomic a = false ∨ atomic b = false) ∧
+  ¬ hb a b ∧
+  ¬ hb b a
+
+/-- Any established happens-before edge excludes a data race in that pair. -/
+theorem hb_excludes_data_race
+    {Event : Type u}
+    {hb : Event -> Event -> Prop}
+    {thread : Event -> Nat}
+    {conflict : Event -> Event -> Prop}
+    {atomic : Event -> Bool}
+    {a b : Event}
+    (hab : hb a b) :
+    ¬ DataRace hb thread conflict atomic a b := by
+  intro race
+  rcases race with ⟨_, _, _, hNotAB, _⟩
+  exact hNotAB hab
+
+/-- Therefore a correctly published payload cannot constitute a data race
+    between the publishing write and consuming read. -/
+theorem publication_excludes_data_race
+    {Event : Type u} {sb sw : Event -> Event -> Prop}
+    {thread : Event -> Nat}
+    {conflict : Event -> Event -> Prop}
+    {atomic : Event -> Bool}
+    {payloadWrite releaseWrite acquireRead payloadRead : Event}
+    (hPayloadRelease : sb payloadWrite releaseWrite)
+    (hPublication : sw releaseWrite acquireRead)
+    (hAcquirePayload : sb acquireRead payloadRead) :
+    ¬ DataRace (HappensBefore sb sw) thread conflict atomic
+        payloadWrite payloadRead := by
+  apply hb_excludes_data_race
+  exact release_acquire_publication
+    hPayloadRelease hPublication hAcquirePayload
+
+end Oak.HappensBefore


### PR DESCRIPTION
Adds the first executable execution-graph layer above Oak atomics.

Core semantics:
- Finite indexed memory events with thread, per-thread sequence, semantic location, access kind, atomic flag/order, and explicit reads-from provenance.
- Sequenced-before derived directly from thread/sequence without allocating an edge list.
- Validated direct release/acquire synchronizes-with edges require release-like source, acquire-like target, same location, and target reads-from the source.
- Happens-before is the non-reflexive transitive closure of sequenced-before union synchronizes-with.
- Conflicting accesses are same-location accesses where at least one writes.
- Data race = different threads + conflict + at least one non-atomic + no HB ordering in either direction. Mixed atomic/non-atomic access remains subject to the race rule.

Correctness/verification:
- Lean `Oak.HappensBefore` proves SB->HB, SW->HB, transitivity, the canonical release/acquire publication theorem, and that established HB excludes a data race.
- Execution tests verify publication, unsynchronized races, mixed atomic/non-atomic races, same-thread ordering, relaxed-not-acquire behavior, and reads-from/synchronization consistency.
- Validation fails closed for illegal event orders and malformed witnesses.

Performance/boundedness:
- Events and synchronization edges are caller-owned slices.
- HB traversal requires caller-owned visited/stack scratch.
- No maps, recursion, queues, heap-backed worklists, or hidden allocation inside HB/race queries.
- HB and race queries are regression-tested with `testing.AllocsPerRun` at zero internal allocations.
- Traversal stack bound is exactly the event count; current implementation favors simple auditable bounded scans over indexing complexity.

Documentation:
- New normative `docs/spec/66-memory-model.md`.
- `65-machine-memory.md` now links atomic order semantics to the execution model and distinguishes core HB/race completion from remaining fence/release-sequence/seq-cst closure.

Intentionally still open before calling the full memory model closed: fence-mediated synchronization, release sequences, sequential-consistency global-order constraints, Go-to-Lean refinement, compiler/C refinement, AArch64 weak-memory litmus tests, and target-specific lock-free admission.