### PR TITLE
Add release sequences and fence synchronization

### DIFF
--- a/docs/spec/66-memory-model.md
+++ b/docs/spec/66-memory-model.md
@@ -12,18 +12,19 @@ The governing rule is:
 This chapter intentionally separates two questions:
 
 1. **What is happens-before and what constitutes a data race?** This chapter
-   specifies and implements those core relations now.
-2. **Which architecture/backend executions are valid?** Fence synchronization,
-   release sequences, sequential-consistency total order, compiler refinement,
-   and AArch64 litmus validation extend the execution witness and are tracked as
-   remaining work before the complete machine memory model is declared closed.
+   specifies and implements those core relations.
+2. **Which synchronization witnesses are valid?** `67-memory-ordering.md`
+   extends the same execution model with modification order, release sequences,
+   and fence-mediated synchronization. Sequential consistency, backend
+   refinement, and AArch64 litmus validation remain closure work before the
+   complete machine memory model is declared finished.
 
 ## 1. Execution events
 
 A memory-model execution is a finite set of indexed events. Event identity is a
 compact integer index rather than a pointer or heap object.
 
-Each event carries:
+The core event vocabulary carries:
 
 ```text
 thread
@@ -34,6 +35,9 @@ atomic
 order        // only for atomic events
 reads_from?  // only for atomic reads/RMW
 ```
+
+Chapter 67 extends write-like atomic events with explicit per-location
+modification-order indices while preserving these identities and relations.
 
 `location` is semantic storage identity. It is not required to be a virtual or
 physical machine address.
@@ -74,8 +78,7 @@ provenance.
 
 Synchronizes-with is an explicit, validated inter-thread edge.
 
-The first executable synchronization rule is direct release/acquire
-publication:
+The foundational synchronization rule is direct release/acquire publication:
 
 ```text
 release-like atomic write/RMW
@@ -107,9 +110,9 @@ witness names the source event and both access the same location.
 Relaxed operations therefore do not silently acquire or release merely because
 they happen to observe the same value.
 
-The edge representation is extensible. Fence-mediated synchronization and
-release-sequence witnesses will add new synchronization reasons without
-changing the definition of happens-before.
+Chapter 67 adds explicit synchronization reasons for release sequences and
+release/acquire fences without changing the definition of happens-before. The
+reason and its witness event IDs remain visible in Semantic IR.
 
 ## 5. Happens-before
 
@@ -149,6 +152,7 @@ payload write happens-before payload read
 
 This theorem is formalized in Lean and execution-tested in the Semantic IR
 model. It is the core fact required by an SPSC publication/consumption proof.
+The richer synchronization rules in chapter 67 feed the same HB closure.
 
 ## 6. Conflicting accesses
 
@@ -202,6 +206,9 @@ Its graph queries obey these structural rules:
 6. traversal work is finite and bounded by the supplied execution size;
 7. zero internal allocations are regression-tested with `testing.AllocsPerRun`.
 
+Chapter 67 preserves the same rule for release-sequence traversal: it walks
+existing reads-from links with an event-count bound and no internal allocation.
+
 The reference implementation currently favors simple auditable bounded scans
 over sophisticated graph indexing. Faster representations may be added later as
 refinements while preserving this semantic model.
@@ -217,8 +224,12 @@ refinements while preserving this semantic model.
   payload read;
 - an established HB edge excludes the data-race predicate;
 - therefore the canonical published payload pair is not a data race;
-- the release-like and acquire-like order classifications used by direct
-  publication contain the intended orders and exclude relaxed.
+- the release-like and acquire-like order classifications contain the intended
+  orders and exclude relaxed.
+
+The same Lean module now also models release sequences and the fence
+synchronization constructors from chapter 67, with publication theorems for
+those paths.
 
 These are mathematical language-level theorems. They do not yet constitute a
 formal refinement proof from Go graph traversal to Lean or from generated C to
@@ -237,7 +248,9 @@ AArch64 instructions.
 - a synchronization edge must agree with its reads-from source;
 - undersized scratch fails explicitly;
 - HB traversal performs zero internal allocations;
-- race queries perform zero internal allocations.
+- race queries perform zero internal allocations;
+- chapter-67 tests add modification-order, RMW-chain, release-sequence, and
+  fence-mediated publication coverage.
 
 The full repository Go/race suite and Lean build remain CI acceptance gates.
 
@@ -252,9 +265,10 @@ The full repository Go/race suite and Lean build remain CI acceptance gates.
 | publication theorem | proved in Lean + execution-tested |
 | data-race definition | specified + implemented + Lean-modeled |
 | zero-allocation HB/race traversal | regression-tested |
+| modification order | specified + implemented in chapter 67 |
+| release-sequence semantics | specified + implemented + Lean-modeled in chapter 67 |
+| fence-mediated synchronization | specified + implemented + Lean-modeled in chapter 67 |
 | Go-to-Lean refinement | not yet proved |
-| fence-mediated synchronization | next |
-| release-sequence semantics | next |
 | seq-cst global order | next |
 | compiler/C refinement | not yet proved |
 | AArch64 weak-memory litmus suite | not yet implemented |
@@ -264,12 +278,10 @@ The full repository Go/race suite and Lean build remain CI acceptance gates.
 Before higher-level lock-free structures depend on the memory model as a closed
 contract, Oak should add:
 
-1. fence-mediated synchronization witnesses and proofs;
-2. explicit release-sequence semantics for RMW chains;
-3. the sequential-consistency total-order constraints;
-4. backend/compiler refinement tests;
-5. AArch64 MP/SB/LB/IRIW-style litmus coverage and assembly inspection;
-6. target lock-free admission rules for realtime profiles.
+1. sequential-consistency total-order constraints;
+2. backend/compiler refinement tests;
+3. AArch64 MP/SB/LB/IRIW-style litmus coverage and assembly inspection;
+4. target lock-free admission rules for realtime profiles.
 
 Only after those pieces are explicit should `SpscRing[T, N]` be treated as a
 proof consumer of the complete machine-memory model rather than as an isolated

--- a/docs/spec/67-memory-ordering.md
+++ b/docs/spec/67-memory-ordering.md
@@ -1,0 +1,325 @@
+# Memory ordering: modification order, release sequences, and fences
+
+This chapter extends the core execution model in `66-memory-model.md` with the
+ordering witnesses needed by lock-free algorithms: per-location atomic
+modification order, release sequences, and explicit fence-mediated
+synchronization.
+
+The governing rule is:
+
+> If synchronization matters to correctness, the execution witness must say
+> exactly which write, read, RMW chain, or fence established it.
+
+Oak does not infer synchronization from equal values, wall-clock order, source
+proximity, or a backend instruction that merely looks strong enough.
+
+## 1. Per-location modification order
+
+Every represented atomic write or read-modify-write carries:
+
+```text
+has_modification = true
+modification : u32
+```
+
+The index belongs to the semantic atomic location. Two represented writes to
+the same location may not have the same modification index.
+
+For write-like atomic events `a` and `b`:
+
+```text
+modification_before(a, b) :=
+    a.location == b.location
+    && a.has_modification
+    && b.has_modification
+    && a.modification < b.modification
+```
+
+Modification order is separate from:
+
+- per-thread sequenced-before;
+- reads-from;
+- synchronizes-with;
+- happens-before.
+
+They answer different questions and are never conflated in Semantic IR.
+
+### 1.1 RMW adjacency
+
+An RMW replaces the value it observes. For represented modification `n > 0`,
+Oak therefore requires the RMW's reads-from witness to identify modification
+`n - 1` on the same location.
+
+An RMW at modification zero may observe the implicit initialized value and has
+no represented reads-from source.
+
+This rule gives Oak an explicit causal witness for the RMW chain rather than
+reconstructing one later from integer indices alone.
+
+## 2. Release sequences
+
+A release sequence has:
+
+1. a release-like atomic write/RMW head;
+2. zero or more following RMW members;
+3. every following member reads-from the immediately preceding modification.
+
+Release-like means:
+
+```text
+release
+acq-rel
+seq-cst
+```
+
+An ordinary atomic store by any thread terminates the sequence. Relaxed RMWs do
+not: their RMW/read-from relation preserves the causal chain back to the release
+head.
+
+For example:
+
+```text
+M0: release store
+      |
+      | next RMW / reads-from
+      v
+M1: relaxed RMW
+      |
+      v
+M2: relaxed RMW
+```
+
+`M0`, `M1`, and `M2` are all members of the release sequence headed by `M0`.
+
+If an acquire-like atomic read observes `M2`, the synchronizes-with edge is from
+**M0**, not merely from M2. Thus payload state sequenced before M0 is published
+to code sequenced after the acquire.
+
+This rule is directly useful for CAS loops and future MPSC structures.
+
+## 3. Fence events
+
+A fence is an atomic ordering event with no memory location, reads-from edge, or
+modification-order index.
+
+Release-like fences are:
+
+```text
+release fence
+acq-rel fence
+seq-cst fence
+```
+
+Acquire-like fences are:
+
+```text
+acquire fence
+acq-rel fence
+seq-cst fence
+```
+
+Fences do not synchronize merely by existing. A fence synchronization edge
+requires ordinary atomic read/write witnesses around it.
+
+## 4. Explicit synchronization kinds
+
+Semantic IR retains the reason for every synchronization edge.
+
+### 4.1 Direct release/acquire
+
+```text
+release-like atomic write W
+             |
+             | reads-from
+             v
+acquire-like atomic read R
+```
+
+The edge is `W -> R`.
+
+### 4.2 Release-sequence/acquire
+
+```text
+release head H -> RMW ... -> member M
+                              |
+                              | reads-from
+                              v
+                        acquire read R
+```
+
+The edge is `H -> R`.
+
+### 4.3 Release fence -> acquire read
+
+```text
+release fence F
+      |
+      | sequenced-before
+      v
+atomic write W
+      |
+      | reads-from
+      v
+acquire read R
+```
+
+The edge is `F -> R`.
+
+The write may itself be relaxed. The fence supplies the release semantics; the
+write/read pair supplies the inter-thread value witness.
+
+### 4.4 Release write/sequence -> acquire fence
+
+```text
+release head H -> optional RMW sequence -> member M
+                                            |
+                                            | reads-from
+                                            v
+                                      atomic read R
+                                            |
+                                            | sequenced-before
+                                            v
+                                      acquire fence F
+```
+
+The edge is `H -> F`.
+
+The intervening read may be relaxed. The acquire fence supplies the acquire
+semantics.
+
+### 4.5 Release fence -> acquire fence
+
+```text
+release fence F0
+      |
+      | sequenced-before
+      v
+atomic write W
+      |
+      | reads-from
+      v
+atomic read R
+      |
+      | sequenced-before
+      v
+acquire fence F1
+```
+
+The edge is `F0 -> F1`.
+
+Both witness event IDs are retained in Semantic IR so a debugger or proof
+projection can explain exactly why the fences synchronize.
+
+## 5. Happens-before remains simple
+
+None of these rules changes the definition from chapter 66:
+
+```text
+happens-before = transitive closure(
+    sequenced-before union synchronizes-with
+)
+```
+
+The richer ordering layer only determines which synchronizes-with edges are
+valid.
+
+That separation is intentional. Higher-level proofs can reason about HB without
+reimplementing every hardware-facing synchronization rule.
+
+## 6. Fail-closed witness validation
+
+The execution validator rejects, among other malformed executions:
+
+- an atomic write/RMW with no modification index;
+- a read/fence/non-atomic event carrying a modification index;
+- duplicate modification indices on one location;
+- an RMW whose represented predecessor is not modification `n - 1`;
+- a release sequence that crosses an ordinary store;
+- a release-sequence edge whose acquire does not read a sequence member;
+- a release fence whose write witness is not sequenced after it;
+- an acquire fence whose read witness is not sequenced before it;
+- a fence-fence edge whose read did not read from the named write;
+- witness IDs that are absent, out of range, or semantically the wrong kind.
+
+A malformed witness never degrades to a stronger implicit synchronization rule.
+
+## 7. Allocation and performance contract
+
+The ordering model remains verification/tooling infrastructure rather than a
+runtime scheduler service.
+
+Structural requirements:
+
+1. event arrays and synchronization edges are caller-owned;
+2. modification order is an inline integer field on write-like events;
+3. release-sequence membership walks existing reads-from links;
+4. the maximum release-sequence walk is bounded by event count;
+5. no hash map, linked node, recursive stack, or heap-backed worklist is needed;
+6. release-sequence membership performs zero internal allocations;
+7. HB/race traversal retains its caller-owned scratch contract from chapter 66.
+
+The current representation intentionally chooses straightforward bounded scans
+and links over premature graph indexing. A later optimized representation must
+be a refinement of these semantics and demonstrate a real workload benefit.
+
+## 8. Formal verification
+
+`spec/lean/Oak/HappensBefore.lean` now includes:
+
+- an inductive release-sequence relation headed by a release operation and
+  extended one RMW step at a time;
+- a synchronization relation with distinct proof constructors for direct
+  release/acquire, release-sequence/acquire, release-fence/acquire,
+  release/acquire-fence, and release-fence/acquire-fence;
+- a theorem that reading any release-sequence member with an acquire operation
+  carries the head's publication to later payload reads;
+- a theorem for release-fence publication;
+- a theorem for fence-to-fence publication;
+- the existing fact that any established HB edge excludes the data-race
+  predicate.
+
+The Lean relation is mathematical language semantics. A direct refinement proof
+between the Go validator/walk and the Lean definitions remains future work.
+
+## 9. Executable tests
+
+The Semantic IR test suite includes:
+
+- a multi-thread release head followed by relaxed RMWs and an acquire consumer;
+- exact per-location modification-order checks;
+- a non-RMW store breaking the release sequence;
+- rejection of an RMW that skips its immediate predecessor;
+- rejection of duplicate modification indices;
+- release-fence -> acquire-read publication;
+- release-write -> acquire-fence publication;
+- release-fence -> acquire-fence publication;
+- rejection when fence witnesses appear on the wrong side of a fence;
+- zero-allocation release-sequence membership regression;
+- all chapter-66 HB/race tests under the stronger event validation rules.
+
+## 10. Verification status
+
+| Layer | Status |
+| --- | --- |
+| per-location modification-order vocabulary | specified + implemented |
+| RMW predecessor rule | specified + implemented + tested |
+| release-sequence relation | specified + implemented + Lean-modeled |
+| release-sequence publication | Lean-proved + execution-tested |
+| release-fence -> acquire | specified + implemented + tested |
+| release -> acquire-fence | specified + implemented + tested |
+| release-fence -> acquire-fence | specified + implemented + Lean-modeled + tested |
+| zero-allocation release-sequence walk | regression-tested |
+| implementation-to-Lean refinement | not yet proved |
+| sequential-consistency total order | next |
+| C/backend weak-memory refinement | not yet proved |
+| AArch64 litmus/assembly validation | not yet implemented |
+
+## 11. Next closure step: sequential consistency
+
+`seq-cst` must not mean merely "stronger local acquire/release." Oak still needs
+an explicit global SC-order witness with constraints tying it to program order,
+modification order, and the values observed by SC loads/RMWs.
+
+That should be modeled and tested as a separate relation. After SC is closed,
+the memory model can move to compiler/backend and AArch64 refinement before a
+lock-free queue is allowed to treat it as a trusted proof dependency.

--- a/semir/memory_model.go
+++ b/semir/memory_model.go
@@ -35,32 +35,49 @@ func (k MemoryAccessKind) writes() bool {
 
 // MemoryEvent is one event in an abstract execution witness. Event identity is
 // its slice index; this keeps graph traversal compact and deterministic.
+//
+// Atomic writes and RMWs carry a per-location Modification index. RMWs after
+// modification zero must read-from the immediately preceding modification;
+// that explicit causal chain is also the witness used for release sequences.
 type MemoryEvent struct {
-	Thread       MemoryThreadID
-	Sequence     uint32
-	Location     MemoryLocationID
-	Access       MemoryAccessKind
-	Atomic       bool
-	Order        MemoryOrder
-	HasReadsFrom bool
-	ReadsFrom    MemoryEventID
+	Thread          MemoryThreadID
+	Sequence        uint32
+	Location        MemoryLocationID
+	Access          MemoryAccessKind
+	Atomic          bool
+	Order           MemoryOrder
+	HasReadsFrom    bool
+	ReadsFrom       MemoryEventID
+	HasModification bool
+	Modification    uint32
 }
 
 // MemorySyncKind identifies why an inter-thread synchronizes-with edge exists.
-// The first executable slice admits direct release/acquire publication edges.
-// Fence/release-sequence witnesses extend this enum without changing HB itself.
+// Each rule is explicit so debuggers/proof projections retain causal provenance
+// instead of collapsing every synchronization into an unexplained graph edge.
 type MemorySyncKind uint8
 
 const (
 	MemorySyncInvalid MemorySyncKind = iota
 	MemorySyncReleaseAcquire
+	MemorySyncReleaseSequenceAcquire
+	MemorySyncReleaseFenceAcquire
+	MemorySyncReleaseAcquireFence
+	MemorySyncReleaseFenceAcquireFence
 )
 
-// MemorySyncEdge is a validated synchronizes-with edge.
+// MemorySyncEdge is a validated synchronizes-with edge. Fence-mediated rules
+// use explicit witness event IDs. Flags are required because event zero is a
+// valid witness and must not be overloaded as "missing".
 type MemorySyncEdge struct {
 	From MemoryEventID
 	To   MemoryEventID
 	Kind MemorySyncKind
+
+	HasWriteWitness bool
+	WriteWitness    MemoryEventID
+	HasReadWitness  bool
+	ReadWitness     MemoryEventID
 }
 
 // MemoryExecution is an explicit execution graph. Slices are supplied by the
@@ -78,7 +95,7 @@ type MemoryWorkspace struct {
 }
 
 var (
-	ErrMemoryEventOutOfRange  = errors.New("memory event id out of range")
+	ErrMemoryEventOutOfRange   = errors.New("memory event id out of range")
 	ErrMemoryWorkspaceTooSmall = errors.New("memory workspace too small")
 )
 
@@ -108,6 +125,79 @@ func legalEventOrder(event MemoryEvent) bool {
 	}
 }
 
+func (x MemoryExecution) event(id MemoryEventID) (MemoryEvent, bool) {
+	if int(id) >= len(x.Events) {
+		return MemoryEvent{}, false
+	}
+	return x.Events[id], true
+}
+
+func (x MemoryExecution) readsFrom(write, read MemoryEventID) bool {
+	w, wok := x.event(write)
+	r, rok := x.event(read)
+	return wok && rok && w.Atomic && w.Access.writes() && r.Atomic && r.Access.reads() &&
+		w.Location == r.Location && r.HasReadsFrom && r.ReadsFrom == write
+}
+
+func (x MemoryExecution) isReleaseFence(id MemoryEventID) bool {
+	e, ok := x.event(id)
+	return ok && e.Atomic && e.Access == MemoryAccessFence && releaseLike(e.Order)
+}
+
+func (x MemoryExecution) isAcquireFence(id MemoryEventID) bool {
+	e, ok := x.event(id)
+	return ok && e.Atomic && e.Access == MemoryAccessFence && acquireLike(e.Order)
+}
+
+// InReleaseSequence reports whether member belongs to the release sequence
+// headed by head. A sequence is the head itself followed by zero or more
+// contiguous RMW modifications. Every RMW member explicitly reads-from the
+// immediately preceding modification. The walk is bounded by len(Events) and
+// allocates no storage.
+func (x MemoryExecution) InReleaseSequence(head, member MemoryEventID) (bool, error) {
+	h, ok := x.event(head)
+	if !ok {
+		return false, ErrMemoryEventOutOfRange
+	}
+	m, ok := x.event(member)
+	if !ok {
+		return false, ErrMemoryEventOutOfRange
+	}
+	if !h.Atomic || !h.Access.writes() || !releaseLike(h.Order) || !h.HasModification ||
+		!m.Atomic || !m.Access.writes() || !m.HasModification || h.Location != m.Location ||
+		m.Modification < h.Modification {
+		return false, nil
+	}
+	if head == member {
+		return true, nil
+	}
+
+	current := member
+	for steps := 0; steps < len(x.Events); steps++ {
+		if current == head {
+			return true, nil
+		}
+		e := x.Events[current]
+		if e.Access != MemoryAccessReadWrite || !e.HasReadsFrom || e.Modification == 0 {
+			return false, nil
+		}
+		previous := e.ReadsFrom
+		p, ok := x.event(previous)
+		if !ok || !p.Atomic || !p.Access.writes() || !p.HasModification ||
+			p.Location != h.Location || p.Modification == ^uint32(0) ||
+			p.Modification+1 != e.Modification {
+			return false, nil
+		}
+		current = previous
+	}
+	// More links than events implies a malformed cycle/repeated witness.
+	return false, nil
+}
+
+func (edge MemorySyncEdge) noWitnesses() bool {
+	return !edge.HasWriteWitness && !edge.HasReadWitness
+}
+
 // Validate checks the structural execution witness. It is deliberately
 // separate from graph queries so hot verification/model-checking loops can
 // validate once and reuse allocation-free reachability operations many times.
@@ -116,13 +206,23 @@ func (x MemoryExecution) Validate() error {
 		if !legalEventOrder(event) {
 			return fmt.Errorf("event %d has illegal atomic/non-atomic order", i)
 		}
+
 		if event.Access == MemoryAccessFence {
-			if !event.Atomic || event.HasReadsFrom {
+			if !event.Atomic || event.HasReadsFrom || event.HasModification {
 				return fmt.Errorf("event %d has invalid fence shape", i)
 			}
 		} else if event.Access == MemoryAccessNone {
 			return fmt.Errorf("event %d has no memory access", i)
 		}
+
+		if event.Atomic && event.Access.writes() {
+			if !event.HasModification {
+				return fmt.Errorf("atomic write event %d lacks modification-order index", i)
+			}
+		} else if event.HasModification {
+			return fmt.Errorf("non-writing event %d carries modification-order index", i)
+		}
+
 		if event.HasReadsFrom {
 			if !event.Atomic || !event.Access.reads() {
 				return fmt.Errorf("event %d has reads-from but is not an atomic read", i)
@@ -135,13 +235,40 @@ func (x MemoryExecution) Validate() error {
 				return fmt.Errorf("event %d has invalid reads-from source %d", i, event.ReadsFrom)
 			}
 		}
+
+		// An RMW observes and replaces the immediately preceding modification.
+		// Modification zero may observe the implicit initial value and therefore
+		// has no represented reads-from source.
+		if event.Atomic && event.Access == MemoryAccessReadWrite {
+			if event.Modification == 0 {
+				if event.HasReadsFrom {
+					return fmt.Errorf("initial RMW event %d cannot read-from a represented modification", i)
+				}
+			} else {
+				if !event.HasReadsFrom {
+					return fmt.Errorf("RMW event %d lacks previous-modification reads-from witness", i)
+				}
+				source := x.Events[event.ReadsFrom]
+				if !source.HasModification || source.Modification == ^uint32(0) ||
+					source.Modification+1 != event.Modification {
+					return fmt.Errorf("RMW event %d does not read the immediately preceding modification", i)
+				}
+			}
+		}
 	}
 
 	// Sequence numbers define per-thread source order and must be unique.
+	// Modification indices define a total order among represented atomic writes
+	// on one location and must likewise be unique.
 	for i := 0; i < len(x.Events); i++ {
 		for j := i + 1; j < len(x.Events); j++ {
 			if x.Events[i].Thread == x.Events[j].Thread && x.Events[i].Sequence == x.Events[j].Sequence {
 				return fmt.Errorf("events %d and %d duplicate thread sequence", i, j)
+			}
+			if x.Events[i].HasModification && x.Events[j].HasModification &&
+				x.Events[i].Location == x.Events[j].Location &&
+				x.Events[i].Modification == x.Events[j].Modification {
+				return fmt.Errorf("events %d and %d duplicate modification index", i, j)
 			}
 		}
 	}
@@ -153,19 +280,82 @@ func (x MemoryExecution) Validate() error {
 		if edge.From == edge.To {
 			return fmt.Errorf("sync edge %d is self-referential", i)
 		}
+
+		from := x.Events[edge.From]
+		to := x.Events[edge.To]
 		switch edge.Kind {
 		case MemorySyncReleaseAcquire:
-			from := x.Events[edge.From]
-			to := x.Events[edge.To]
+			if !edge.noWitnesses() {
+				return fmt.Errorf("direct sync edge %d has unexpected witnesses", i)
+			}
 			if !from.Atomic || !from.Access.writes() || !releaseLike(from.Order) {
 				return fmt.Errorf("sync edge %d source is not a release-like atomic write", i)
 			}
 			if !to.Atomic || !to.Access.reads() || !acquireLike(to.Order) {
 				return fmt.Errorf("sync edge %d target is not an acquire-like atomic read", i)
 			}
-			if from.Location != to.Location || !to.HasReadsFrom || to.ReadsFrom != edge.From {
+			if !x.readsFrom(edge.From, edge.To) {
 				return fmt.Errorf("sync edge %d is not witnessed by reads-from on one location", i)
 			}
+
+		case MemorySyncReleaseSequenceAcquire:
+			if !edge.noWitnesses() || !to.Atomic || !to.Access.reads() || !acquireLike(to.Order) || !to.HasReadsFrom {
+				return fmt.Errorf("release-sequence sync edge %d has invalid target/witness shape", i)
+			}
+			member := to.ReadsFrom
+			inSequence, err := x.InReleaseSequence(edge.From, member)
+			if err != nil || !inSequence {
+				return fmt.Errorf("release-sequence sync edge %d is not witnessed by a valid release sequence", i)
+			}
+
+		case MemorySyncReleaseFenceAcquire:
+			if !x.isReleaseFence(edge.From) || !to.Atomic || !to.Access.reads() || !acquireLike(to.Order) ||
+				!edge.HasWriteWitness || edge.HasReadWitness {
+				return fmt.Errorf("release-fence sync edge %d has invalid shape", i)
+			}
+			write, ok := x.event(edge.WriteWitness)
+			if !ok || !write.Atomic || !write.Access.writes() ||
+				!x.SequencedBefore(edge.From, edge.WriteWitness) || !x.readsFrom(edge.WriteWitness, edge.To) {
+				return fmt.Errorf("release-fence sync edge %d lacks write/read-from witness", i)
+			}
+
+		case MemorySyncReleaseAcquireFence:
+			if !from.Atomic || !from.Access.writes() || !releaseLike(from.Order) ||
+				!x.isAcquireFence(edge.To) || edge.HasWriteWitness || !edge.HasReadWitness {
+				return fmt.Errorf("acquire-fence sync edge %d has invalid shape", i)
+			}
+			read, ok := x.event(edge.ReadWitness)
+			if !ok || !read.Atomic || !read.Access.reads() || !read.HasReadsFrom ||
+				!x.SequencedBefore(edge.ReadWitness, edge.To) {
+				return fmt.Errorf("acquire-fence sync edge %d lacks preceding atomic read", i)
+			}
+			member := read.ReadsFrom
+			if member == edge.From {
+				if !x.readsFrom(edge.From, edge.ReadWitness) {
+					return fmt.Errorf("acquire-fence sync edge %d has invalid direct reads-from", i)
+				}
+			} else {
+				inSequence, err := x.InReleaseSequence(edge.From, member)
+				if err != nil || !inSequence {
+					return fmt.Errorf("acquire-fence sync edge %d lacks release-sequence witness", i)
+				}
+			}
+
+		case MemorySyncReleaseFenceAcquireFence:
+			if !x.isReleaseFence(edge.From) || !x.isAcquireFence(edge.To) ||
+				!edge.HasWriteWitness || !edge.HasReadWitness {
+				return fmt.Errorf("fence-fence sync edge %d has invalid shape", i)
+			}
+			write, wok := x.event(edge.WriteWitness)
+			read, rok := x.event(edge.ReadWitness)
+			if !wok || !rok || !write.Atomic || !write.Access.writes() ||
+				!read.Atomic || !read.Access.reads() ||
+				!x.SequencedBefore(edge.From, edge.WriteWitness) ||
+				!x.SequencedBefore(edge.ReadWitness, edge.To) ||
+				!x.readsFrom(edge.WriteWitness, edge.ReadWitness) {
+				return fmt.Errorf("fence-fence sync edge %d lacks write/read witnesses", i)
+			}
+
 		default:
 			return fmt.Errorf("sync edge %d has unknown kind", i)
 		}
@@ -181,6 +371,17 @@ func (x MemoryExecution) SequencedBefore(from, to MemoryEventID) bool {
 	a := x.Events[from]
 	b := x.Events[to]
 	return a.Thread == b.Thread && a.Sequence < b.Sequence
+}
+
+// ModificationBefore is the represented per-location atomic modification order.
+func (x MemoryExecution) ModificationBefore(from, to MemoryEventID) bool {
+	if int(from) >= len(x.Events) || int(to) >= len(x.Events) || from == to {
+		return false
+	}
+	a := x.Events[from]
+	b := x.Events[to]
+	return a.HasModification && b.HasModification && a.Location == b.Location &&
+		a.Modification < b.Modification
 }
 
 // SynchronizesWith checks validated explicit inter-thread synchronization.

--- a/semir/memory_model_test.go
+++ b/semir/memory_model_test.go
@@ -15,11 +15,77 @@ func releaseAcquirePublication() MemoryExecution {
 	return MemoryExecution{
 		Events: []MemoryEvent{
 			{Thread: 0, Sequence: 0, Location: 1, Access: MemoryAccessWrite},
-			{Thread: 0, Sequence: 1, Location: 2, Access: MemoryAccessWrite, Atomic: true, Order: MemoryOrderRelease},
+			{Thread: 0, Sequence: 1, Location: 2, Access: MemoryAccessWrite, Atomic: true, Order: MemoryOrderRelease, HasModification: true, Modification: 0},
 			{Thread: 1, Sequence: 0, Location: 2, Access: MemoryAccessRead, Atomic: true, Order: MemoryOrderAcquire, HasReadsFrom: true, ReadsFrom: 1},
 			{Thread: 1, Sequence: 1, Location: 1, Access: MemoryAccessRead},
 		},
 		Synchronizes: []MemorySyncEdge{{From: 1, To: 2, Kind: MemorySyncReleaseAcquire}},
+	}
+}
+
+func releaseSequencePublication() MemoryExecution {
+	// T0 publishes payload through release store M0. Two other threads perform
+	// relaxed RMW M1/M2, and the consumer acquire-load observes M2.
+	return MemoryExecution{
+		Events: []MemoryEvent{
+			{Thread: 0, Sequence: 0, Location: 1, Access: MemoryAccessWrite},
+			{Thread: 0, Sequence: 1, Location: 2, Access: MemoryAccessWrite, Atomic: true, Order: MemoryOrderRelease, HasModification: true, Modification: 0},
+			{Thread: 2, Sequence: 0, Location: 2, Access: MemoryAccessReadWrite, Atomic: true, Order: MemoryOrderRelaxed, HasReadsFrom: true, ReadsFrom: 1, HasModification: true, Modification: 1},
+			{Thread: 3, Sequence: 0, Location: 2, Access: MemoryAccessReadWrite, Atomic: true, Order: MemoryOrderRelaxed, HasReadsFrom: true, ReadsFrom: 2, HasModification: true, Modification: 2},
+			{Thread: 1, Sequence: 0, Location: 2, Access: MemoryAccessRead, Atomic: true, Order: MemoryOrderAcquire, HasReadsFrom: true, ReadsFrom: 3},
+			{Thread: 1, Sequence: 1, Location: 1, Access: MemoryAccessRead},
+		},
+		Synchronizes: []MemorySyncEdge{{From: 1, To: 4, Kind: MemorySyncReleaseSequenceAcquire}},
+	}
+}
+
+func releaseFencePublication() MemoryExecution {
+	return MemoryExecution{
+		Events: []MemoryEvent{
+			{Thread: 0, Sequence: 0, Location: 1, Access: MemoryAccessWrite},
+			{Thread: 0, Sequence: 1, Access: MemoryAccessFence, Atomic: true, Order: MemoryOrderRelease},
+			{Thread: 0, Sequence: 2, Location: 2, Access: MemoryAccessWrite, Atomic: true, Order: MemoryOrderRelaxed, HasModification: true, Modification: 0},
+			{Thread: 1, Sequence: 0, Location: 2, Access: MemoryAccessRead, Atomic: true, Order: MemoryOrderAcquire, HasReadsFrom: true, ReadsFrom: 2},
+			{Thread: 1, Sequence: 1, Location: 1, Access: MemoryAccessRead},
+		},
+		Synchronizes: []MemorySyncEdge{{
+			From: 1, To: 3, Kind: MemorySyncReleaseFenceAcquire,
+			HasWriteWitness: true, WriteWitness: 2,
+		}},
+	}
+}
+
+func acquireFencePublication() MemoryExecution {
+	return MemoryExecution{
+		Events: []MemoryEvent{
+			{Thread: 0, Sequence: 0, Location: 1, Access: MemoryAccessWrite},
+			{Thread: 0, Sequence: 1, Location: 2, Access: MemoryAccessWrite, Atomic: true, Order: MemoryOrderRelease, HasModification: true, Modification: 0},
+			{Thread: 1, Sequence: 0, Location: 2, Access: MemoryAccessRead, Atomic: true, Order: MemoryOrderRelaxed, HasReadsFrom: true, ReadsFrom: 1},
+			{Thread: 1, Sequence: 1, Access: MemoryAccessFence, Atomic: true, Order: MemoryOrderAcquire},
+			{Thread: 1, Sequence: 2, Location: 1, Access: MemoryAccessRead},
+		},
+		Synchronizes: []MemorySyncEdge{{
+			From: 1, To: 3, Kind: MemorySyncReleaseAcquireFence,
+			HasReadWitness: true, ReadWitness: 2,
+		}},
+	}
+}
+
+func fenceFencePublication() MemoryExecution {
+	return MemoryExecution{
+		Events: []MemoryEvent{
+			{Thread: 0, Sequence: 0, Location: 1, Access: MemoryAccessWrite},
+			{Thread: 0, Sequence: 1, Access: MemoryAccessFence, Atomic: true, Order: MemoryOrderRelease},
+			{Thread: 0, Sequence: 2, Location: 2, Access: MemoryAccessWrite, Atomic: true, Order: MemoryOrderRelaxed, HasModification: true, Modification: 0},
+			{Thread: 1, Sequence: 0, Location: 2, Access: MemoryAccessRead, Atomic: true, Order: MemoryOrderRelaxed, HasReadsFrom: true, ReadsFrom: 2},
+			{Thread: 1, Sequence: 1, Access: MemoryAccessFence, Atomic: true, Order: MemoryOrderAcquire},
+			{Thread: 1, Sequence: 2, Location: 1, Access: MemoryAccessRead},
+		},
+		Synchronizes: []MemorySyncEdge{{
+			From: 1, To: 4, Kind: MemorySyncReleaseFenceAcquireFence,
+			HasWriteWitness: true, WriteWitness: 2,
+			HasReadWitness: true, ReadWitness: 3,
+		}},
 	}
 }
 
@@ -35,6 +101,104 @@ func TestReleaseAcquirePublicationCreatesHappensBefore(t *testing.T) {
 	}
 	if race, err := x.IsDataRace(0, 3, workspace); err != nil || race {
 		t.Fatalf("published payload should not race: race=%v err=%v", race, err)
+	}
+}
+
+func TestReleaseSequenceCarriesPublicationAcrossRelaxedRMWs(t *testing.T) {
+	x := releaseSequencePublication()
+	if err := x.Validate(); err != nil {
+		t.Fatalf("valid release sequence rejected: %v", err)
+	}
+	if in, err := x.InReleaseSequence(1, 3); err != nil || !in {
+		t.Fatalf("M2 should belong to release sequence headed by M0: in=%v err=%v", in, err)
+	}
+	if !x.ModificationBefore(1, 2) || !x.ModificationBefore(2, 3) {
+		t.Fatal("expected M0 < M1 < M2 in per-location modification order")
+	}
+	workspace := memoryWorkspace(len(x.Events))
+	if hb, err := x.HappensBefore(0, 5, workspace); err != nil || !hb {
+		t.Fatalf("release sequence should publish payload: hb=%v err=%v", hb, err)
+	}
+	if race, err := x.IsDataRace(0, 5, workspace); err != nil || race {
+		t.Fatalf("release-sequence-published payload should not race: race=%v err=%v", race, err)
+	}
+}
+
+func TestNonRMWModificationBreaksReleaseSequence(t *testing.T) {
+	x := releaseSequencePublication()
+	x.Events[2] = MemoryEvent{
+		Thread: 2, Sequence: 0, Location: 2, Access: MemoryAccessWrite,
+		Atomic: true, Order: MemoryOrderRelaxed, HasModification: true, Modification: 1,
+	}
+	// M2 remains a valid RMW immediately after the intervening store, so the
+	// execution is structurally valid; only the release-sequence edge is false.
+	if err := x.Validate(); err == nil {
+		t.Fatal("release-sequence edge unexpectedly crossed a non-RMW modification")
+	}
+	x.Synchronizes = nil
+	if err := x.Validate(); err != nil {
+		t.Fatalf("execution without invalid sync edge should remain valid: %v", err)
+	}
+	if in, err := x.InReleaseSequence(1, 3); err != nil || in {
+		t.Fatalf("non-RMW store must break release sequence: in=%v err=%v", in, err)
+	}
+}
+
+func TestRMWMustReadImmediatelyPreviousModification(t *testing.T) {
+	x := releaseSequencePublication()
+	x.Events[2].Modification = 2
+	if err := x.Validate(); err == nil {
+		t.Fatal("RMW that skips a modification index unexpectedly validated")
+	}
+}
+
+func TestModificationOrderIndicesUniquePerLocation(t *testing.T) {
+	x := releaseSequencePublication()
+	x.Events[3].Modification = 1
+	x.Events[3].ReadsFrom = 1
+	if err := x.Validate(); err == nil {
+		t.Fatal("duplicate modification index unexpectedly validated")
+	}
+}
+
+func TestReleaseFencePublishesThroughRelaxedStore(t *testing.T) {
+	x := releaseFencePublication()
+	if err := x.Validate(); err != nil {
+		t.Fatalf("valid release-fence publication rejected: %v", err)
+	}
+	workspace := memoryWorkspace(len(x.Events))
+	if hb, err := x.HappensBefore(0, 4, workspace); err != nil || !hb {
+		t.Fatalf("release fence should publish payload: hb=%v err=%v", hb, err)
+	}
+}
+
+func TestAcquireFenceConsumesReleasePublication(t *testing.T) {
+	x := acquireFencePublication()
+	if err := x.Validate(); err != nil {
+		t.Fatalf("valid acquire-fence publication rejected: %v", err)
+	}
+	workspace := memoryWorkspace(len(x.Events))
+	if hb, err := x.HappensBefore(0, 4, workspace); err != nil || !hb {
+		t.Fatalf("acquire fence should consume publication: hb=%v err=%v", hb, err)
+	}
+}
+
+func TestReleaseFenceSynchronizesWithAcquireFence(t *testing.T) {
+	x := fenceFencePublication()
+	if err := x.Validate(); err != nil {
+		t.Fatalf("valid fence-fence publication rejected: %v", err)
+	}
+	workspace := memoryWorkspace(len(x.Events))
+	if hb, err := x.HappensBefore(0, 5, workspace); err != nil || !hb {
+		t.Fatalf("fence-fence chain should publish payload: hb=%v err=%v", hb, err)
+	}
+}
+
+func TestFenceWitnessMustBeSequencedAroundAtomicPair(t *testing.T) {
+	x := fenceFencePublication()
+	x.Events[2].Sequence = 0 // write is now before the release fence.
+	if err := x.Validate(); err == nil {
+		t.Fatal("release fence after write unexpectedly validated as publication")
 	}
 }
 
@@ -58,7 +222,7 @@ func TestUnsynchronizedConflictingNonAtomicAccessesRace(t *testing.T) {
 
 func TestAtomicAndNonAtomicConflictStillRaces(t *testing.T) {
 	x := MemoryExecution{Events: []MemoryEvent{
-		{Thread: 0, Sequence: 0, Location: 4, Access: MemoryAccessWrite, Atomic: true, Order: MemoryOrderRelaxed},
+		{Thread: 0, Sequence: 0, Location: 4, Access: MemoryAccessWrite, Atomic: true, Order: MemoryOrderRelaxed, HasModification: true, Modification: 0},
 		{Thread: 1, Sequence: 0, Location: 4, Access: MemoryAccessRead},
 	}}
 	if err := x.Validate(); err != nil {
@@ -81,7 +245,8 @@ func TestRelaxedReadCannotWitnessAcquireSynchronization(t *testing.T) {
 func TestReadsFromMustMatchSynchronizationSource(t *testing.T) {
 	x := releaseAcquirePublication()
 	x.Events = append(x.Events, MemoryEvent{
-		Thread: 2, Sequence: 0, Location: 2, Access: MemoryAccessWrite, Atomic: true, Order: MemoryOrderRelease,
+		Thread: 2, Sequence: 0, Location: 2, Access: MemoryAccessWrite, Atomic: true,
+		Order: MemoryOrderRelease, HasModification: true, Modification: 1,
 	})
 	x.Events[2].ReadsFrom = 4
 	if err := x.Validate(); err == nil {
@@ -127,6 +292,22 @@ func TestHappensBeforeTraversalAllocatesNothing(t *testing.T) {
 	})
 	if allocs != 0 {
 		t.Fatalf("HB traversal allocated %.2f objects per run; want zero", allocs)
+	}
+}
+
+func TestReleaseSequenceWalkAllocatesNothing(t *testing.T) {
+	x := releaseSequencePublication()
+	if err := x.Validate(); err != nil {
+		t.Fatalf("execution rejected: %v", err)
+	}
+	allocs := testing.AllocsPerRun(1000, func() {
+		in, err := x.InReleaseSequence(1, 3)
+		if err != nil || !in {
+			panic("unexpected release-sequence result")
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("release-sequence walk allocated %.2f objects per run; want zero", allocs)
 	}
 }
 

--- a/spec/lean/Oak/HappensBefore.lean
+++ b/spec/lean/Oak/HappensBefore.lean
@@ -27,6 +27,83 @@ theorem seqCst_is_acquireLike : acquireLike .seqCst = true := rfl
 theorem relaxed_not_releaseLike : releaseLike .relaxed = false := rfl
 theorem relaxed_not_acquireLike : acquireLike .relaxed = false := rfl
 
+/-- A release sequence is its release head followed by zero or more contiguous
+    RMW steps. `nextRmw a b` is the abstract proof that b is an RMW that reads
+    from and immediately follows a in modification order. -/
+inductive ReleaseSequence {Event : Type u}
+    (nextRmw : Event -> Event -> Prop) (head : Event) : Event -> Prop where
+  | head : ReleaseSequence nextRmw head head
+  | step {previous member}
+      (hPrevious : ReleaseSequence nextRmw head previous)
+      (hNext : nextRmw previous member) :
+      ReleaseSequence nextRmw head member
+
+theorem release_sequence_contains_head
+    {Event : Type u} {nextRmw : Event -> Event -> Prop} {head : Event} :
+    ReleaseSequence nextRmw head head :=
+  .head
+
+theorem release_sequence_extends_by_rmw
+    {Event : Type u} {nextRmw : Event -> Event -> Prop}
+    {head previous member : Event}
+    (hPrevious : ReleaseSequence nextRmw head previous)
+    (hNext : nextRmw previous member) :
+    ReleaseSequence nextRmw head member :=
+  .step hPrevious hNext
+
+/-- Explicit synchronization reasons. Keeping these constructors distinct makes
+    the proof object retain the same causal provenance as Semantic IR. -/
+inductive SynchronizesWith {Event : Type u}
+    (sequencedBefore readsFrom nextRmw : Event -> Event -> Prop)
+    (isReleaseWrite isAcquireRead isReleaseFence isAcquireFence
+      isAtomicWrite isAtomicRead : Event -> Prop) :
+    Event -> Event -> Prop where
+  | releaseAcquire {write read}
+      (hRelease : isReleaseWrite write)
+      (hAcquire : isAcquireRead read)
+      (hReads : readsFrom write read) :
+      SynchronizesWith sequencedBefore readsFrom nextRmw
+        isReleaseWrite isAcquireRead isReleaseFence isAcquireFence
+        isAtomicWrite isAtomicRead write read
+  | releaseSequenceAcquire {head member read}
+      (hRelease : isReleaseWrite head)
+      (hAcquire : isAcquireRead read)
+      (hSequence : ReleaseSequence nextRmw head member)
+      (hReads : readsFrom member read) :
+      SynchronizesWith sequencedBefore readsFrom nextRmw
+        isReleaseWrite isAcquireRead isReleaseFence isAcquireFence
+        isAtomicWrite isAtomicRead head read
+  | releaseFenceAcquire {fence write read}
+      (hFence : isReleaseFence fence)
+      (hWrite : isAtomicWrite write)
+      (hAcquire : isAcquireRead read)
+      (hFenceBeforeWrite : sequencedBefore fence write)
+      (hReads : readsFrom write read) :
+      SynchronizesWith sequencedBefore readsFrom nextRmw
+        isReleaseWrite isAcquireRead isReleaseFence isAcquireFence
+        isAtomicWrite isAtomicRead fence read
+  | releaseAcquireFence {head member read fence}
+      (hRelease : isReleaseWrite head)
+      (hRead : isAtomicRead read)
+      (hFence : isAcquireFence fence)
+      (hSequence : ReleaseSequence nextRmw head member)
+      (hReads : readsFrom member read)
+      (hReadBeforeFence : sequencedBefore read fence) :
+      SynchronizesWith sequencedBefore readsFrom nextRmw
+        isReleaseWrite isAcquireRead isReleaseFence isAcquireFence
+        isAtomicWrite isAtomicRead head fence
+  | releaseFenceAcquireFence {releaseFence write read acquireFence}
+      (hReleaseFence : isReleaseFence releaseFence)
+      (hWrite : isAtomicWrite write)
+      (hRead : isAtomicRead read)
+      (hAcquireFence : isAcquireFence acquireFence)
+      (hReleaseBeforeWrite : sequencedBefore releaseFence write)
+      (hReads : readsFrom write read)
+      (hReadBeforeAcquire : sequencedBefore read acquireFence) :
+      SynchronizesWith sequencedBefore readsFrom nextRmw
+        isReleaseWrite isAcquireRead isReleaseFence isAcquireFence
+        isAtomicWrite isAtomicRead releaseFence acquireFence
+
 /-- Oak happens-before is the transitive closure of per-thread
     sequenced-before and inter-thread synchronizes-with. -/
 inductive HappensBefore {Event : Type u}
@@ -57,17 +134,7 @@ theorem hb_transitive
     HappensBefore sb sw a c :=
   .trans hab hbc
 
-/-- The publication chain used by queues and message passing:
-
-      payload write
-          sb
-      release publication
-          sw
-      acquire consumption
-          sb
-      payload read
-
-    establishes happens-before from payload write to payload read. -/
+/-- The generic publication chain used by queues and message passing. -/
 theorem release_acquire_publication
     {Event : Type u} {sb sw : Event -> Event -> Prop}
     {payloadWrite releaseWrite acquireRead payloadRead : Event}
@@ -80,6 +147,83 @@ theorem release_acquire_publication
     (.trans
       (.base (Or.inr hPublication))
       (.base (Or.inl hAcquirePayload)))
+
+/-- Reading any member of a release sequence with an acquire operation carries
+    the release head's publication to subsequent payload reads. -/
+theorem release_sequence_publication
+    {Event : Type u}
+    {sb rf nextRmw : Event -> Event -> Prop}
+    {isReleaseWrite isAcquireRead isReleaseFence isAcquireFence
+      isAtomicWrite isAtomicRead : Event -> Prop}
+    {payloadWrite head member acquireRead payloadRead : Event}
+    (hPayloadHead : sb payloadWrite head)
+    (hRelease : isReleaseWrite head)
+    (hAcquire : isAcquireRead acquireRead)
+    (hSequence : ReleaseSequence nextRmw head member)
+    (hReads : rf member acquireRead)
+    (hAcquirePayload : sb acquireRead payloadRead) :
+    HappensBefore sb
+      (SynchronizesWith sb rf nextRmw
+        isReleaseWrite isAcquireRead isReleaseFence isAcquireFence
+        isAtomicWrite isAtomicRead)
+      payloadWrite payloadRead := by
+  apply release_acquire_publication hPayloadHead
+  · exact SynchronizesWith.releaseSequenceAcquire
+      hRelease hAcquire hSequence hReads
+  · exact hAcquirePayload
+
+/-- A release fence before an atomic write can publish through an acquire read
+    that reads from that write. -/
+theorem release_fence_publication
+    {Event : Type u}
+    {sb rf nextRmw : Event -> Event -> Prop}
+    {isReleaseWrite isAcquireRead isReleaseFence isAcquireFence
+      isAtomicWrite isAtomicRead : Event -> Prop}
+    {payloadWrite fence write acquireRead payloadRead : Event}
+    (hPayloadFence : sb payloadWrite fence)
+    (hFence : isReleaseFence fence)
+    (hWrite : isAtomicWrite write)
+    (hAcquire : isAcquireRead acquireRead)
+    (hFenceWrite : sb fence write)
+    (hReads : rf write acquireRead)
+    (hAcquirePayload : sb acquireRead payloadRead) :
+    HappensBefore sb
+      (SynchronizesWith sb rf nextRmw
+        isReleaseWrite isAcquireRead isReleaseFence isAcquireFence
+        isAtomicWrite isAtomicRead)
+      payloadWrite payloadRead := by
+  apply release_acquire_publication hPayloadFence
+  · exact SynchronizesWith.releaseFenceAcquire
+      hFence hWrite hAcquire hFenceWrite hReads
+  · exact hAcquirePayload
+
+/-- A release fence and acquire fence can form the publication edge when an
+    intervening atomic read observes an atomic write sequenced after release. -/
+theorem fence_fence_publication
+    {Event : Type u}
+    {sb rf nextRmw : Event -> Event -> Prop}
+    {isReleaseWrite isAcquireRead isReleaseFence isAcquireFence
+      isAtomicWrite isAtomicRead : Event -> Prop}
+    {payloadWrite releaseFence write read acquireFence payloadRead : Event}
+    (hPayloadRelease : sb payloadWrite releaseFence)
+    (hReleaseFence : isReleaseFence releaseFence)
+    (hWrite : isAtomicWrite write)
+    (hRead : isAtomicRead read)
+    (hAcquireFence : isAcquireFence acquireFence)
+    (hReleaseWrite : sb releaseFence write)
+    (hReads : rf write read)
+    (hReadAcquire : sb read acquireFence)
+    (hAcquirePayload : sb acquireFence payloadRead) :
+    HappensBefore sb
+      (SynchronizesWith sb rf nextRmw
+        isReleaseWrite isAcquireRead isReleaseFence isAcquireFence
+        isAtomicWrite isAtomicRead)
+      payloadWrite payloadRead := by
+  apply release_acquire_publication hPayloadRelease
+  · exact SynchronizesWith.releaseFenceAcquireFence
+      hReleaseFence hWrite hRead hAcquireFence
+      hReleaseWrite hReads hReadAcquire
+  · exact hAcquirePayload
 
 /-- Abstract language-level data-race predicate. At least one conflicting
     access is non-atomic and neither access happens-before the other. -/


### PR DESCRIPTION
Closes the next language-level memory-ordering layer above Oak's core happens-before model.

Semantics:
- Adds explicit per-location modification-order indices to atomic writes/RMWs.
- Validates unique modification indices per location.
- RMW modification n>0 must read-from modification n-1; modification zero may observe the implicit initialized value.
- Adds allocation-free release-sequence membership: release-like head followed by a contiguous reads-from chain of RMW modifications.
- Acquire reads can synchronize with the original release head when they observe any member of its release sequence.
- Adds explicit synchronization reasons/witnesses for release-fence -> acquire-read, release/release-sequence -> acquire-fence, and release-fence -> acquire-fence.
- Keeps sequenced-before, modification order, reads-from, synchronizes-with, and happens-before as distinct relations.

Correctness:
- Fail-closed validation rejects missing/duplicate modification indices, skipped RMW predecessors, ordinary stores crossing a release sequence, and malformed fence witness ordering.
- Lean `Oak.HappensBefore` now models release sequences inductively and retains distinct proof constructors for every synchronization kind.
- Lean proves release-sequence publication, release-fence publication, and fence-to-fence publication while reusing the same HB closure/data-race theorem.

Performance/boundedness:
- Release-sequence membership walks existing reads-from links only.
- Walk is bounded by event count and performs no internal allocation.
- Existing HB/race queries remain caller-scratch, allocation-free.
- Regression tests use `testing.AllocsPerRun` for release-sequence membership as well as HB/race queries.

Tests:
- Multi-thread release head + relaxed RMW chain + acquire consumer.
- Exact modification-order checks.
- Non-RMW store breaks release sequence.
- Skipped and duplicate modification indices rejected.
- Positive/negative release-fence and acquire-fence publication witnesses.
- Existing chapter-66 race/HB tests run under the stronger validator.

Docs:
- New normative `67-memory-ordering.md`.
- `66-memory-model.md` now points to the ordering extension and accurately leaves seq-cst/backend/AArch64 closure outstanding.

Still intentionally open: explicit global sequential-consistency order and constraints, Go-to-Lean refinement, compiler/C weak-memory refinement, AArch64 litmus/assembly validation, and target lock-free admission.