### PR TITLE
Add explicit sequential consistency witness

### DIFF
--- a/docs/spec/65-machine-memory.md
+++ b/docs/spec/65-machine-memory.md
@@ -214,10 +214,18 @@ strong-CAS relation. It proves, among other facts:
 - every source CAS constructor has a legal success/failure pair;
 - no source CAS can expose release/acq-rel failure ordering.
 
-The execution-level meaning of publication, happens-before, conflicting access,
-and data races is specified separately in `66-memory-model.md` and modeled in
-`spec/lean/Oak/HappensBefore.lean`. These are language-level proofs. C/ISA
-refinement remains a separate proof obligation.
+The execution-level meaning is specified by the next three chapters:
+
+- `66-memory-model.md`: reads-from, synchronizes-with, happens-before, conflicts,
+  and data races;
+- `67-memory-ordering.md`: modification order, RMW adjacency, release sequences,
+  and fence-mediated synchronization;
+- `68-sequential-consistency.md`: one explicit global SC order and SC-read
+  visibility constraints.
+
+Lean models these layers in `Oak.HappensBefore` and `Oak.SequentialConsistency`.
+These are language-level proofs; C/ISA refinement remains a separate proof and
+testing obligation.
 
 ## 11. End-to-end tests
 
@@ -236,6 +244,8 @@ Acceptance spans the whole executable stack:
   Oak-generated atomic cell; the exact final value is checked;
 - the contention harness records total attempts and retries so CAS retry cost is
   explicit and measurable rather than hidden;
+- Semantic IR execution tests cover HB/race, modification order, release
+  sequences, fences, and global SC validation;
 - ordinary Go CI, race-enabled integration where configured, golden output, and
   Lean proofs gate merge.
 
@@ -253,12 +263,15 @@ Acceptance spans the whole executable stack:
 | contended CAS linearized final value | native-tested |
 | CAS retry instrumentation | native-tested |
 | core happens-before/data-race relations | specified + implemented + Lean-modeled in chapter 66 |
-| complete memory-model closure (fences/release sequences/SC) | not yet complete |
+| modification order/release sequences/fences | specified + implemented + Lean-modeled in chapter 67 |
+| global seq-cst order/read visibility | specified + implemented + Lean-modeled in chapter 68 |
+| language-level memory relation set | explicit through seq-cst |
 | C/ISA formal refinement | not yet proved |
-| AArch64 weak-memory litmus suite | not yet implemented |
+| AArch64 weak-memory litmus suite | next major layer |
 | target-specific lock-free admission | not yet implemented |
 
-The next closure work is fence-mediated synchronization, release sequences, and
-sequential-consistency constraints in the execution model, followed by C/AArch64
-refinement and weak-memory litmus tests. Higher-level SPSC/MPSC proofs should
-consume that closed contract rather than invent their own memory semantics.
+The next work is no longer to invent additional language-level memory-order
+semantics. It is to **refine and test the projection**: generated C, emitted
+AArch64 instructions, weak-memory litmus outcomes, and target lock-free
+admission. Higher-level SPSC/MPSC proofs should consume that demonstrated
+compiler-to-machine contract rather than re-specifying atomics locally.

--- a/docs/spec/66-memory-model.md
+++ b/docs/spec/66-memory-model.md
@@ -9,15 +9,19 @@ The governing rule is:
 > Shared-memory correctness is an explicit relation between events, not an
 > accidental consequence of compiler or processor behavior.
 
-This chapter intentionally separates two questions:
+This chapter intentionally separates the layers:
 
 1. **What is happens-before and what constitutes a data race?** This chapter
    specifies and implements those core relations.
 2. **Which synchronization witnesses are valid?** `67-memory-ordering.md`
    extends the same execution model with modification order, release sequences,
-   and fence-mediated synchronization. Sequential consistency, backend
-   refinement, and AArch64 litmus validation remain closure work before the
-   complete machine memory model is declared finished.
+   and fence-mediated synchronization.
+3. **How are all seq-cst events globally ordered?** `68-sequential-consistency.md`
+   defines the separate SC witness and its HB, modification-order, and read
+   visibility constraints.
+
+Backend refinement and AArch64 litmus validation remain before the complete
+compiler-to-machine story is closed.
 
 ## 1. Execution events
 
@@ -206,8 +210,8 @@ Its graph queries obey these structural rules:
 6. traversal work is finite and bounded by the supplied execution size;
 7. zero internal allocations are regression-tested with `testing.AllocsPerRun`.
 
-Chapter 67 preserves the same rule for release-sequence traversal: it walks
-existing reads-from links with an event-count bound and no internal allocation.
+Chapter 67 preserves the same rule for release-sequence traversal, and chapter
+68 keeps the global SC witness caller-owned while reusing the HB workspace.
 
 The reference implementation currently favors simple auditable bounded scans
 over sophisticated graph indexing. Faster representations may be added later as
@@ -227,9 +231,9 @@ refinements while preserving this semantic model.
 - the release-like and acquire-like order classifications contain the intended
   orders and exclude relaxed.
 
-The same Lean module now also models release sequences and the fence
-synchronization constructors from chapter 67, with publication theorems for
-those paths.
+The same Lean module also models release sequences and the fence synchronization
+constructors from chapter 67. `Oak.SequentialConsistency` models the global SC
+order, its HB/MO consistency, and SC-read visibility from chapter 68.
 
 These are mathematical language-level theorems. They do not yet constitute a
 formal refinement proof from Go graph traversal to Lean or from generated C to
@@ -249,8 +253,9 @@ AArch64 instructions.
 - undersized scratch fails explicitly;
 - HB traversal performs zero internal allocations;
 - race queries perform zero internal allocations;
-- chapter-67 tests add modification-order, RMW-chain, release-sequence, and
-  fence-mediated publication coverage.
+- chapter-67 tests cover modification order, RMW chains, release sequences, and
+  fence-mediated publication;
+- chapter-68 tests cover global SC membership/order and SC-read visibility.
 
 The full repository Go/race suite and Lean build remain CI acceptance gates.
 
@@ -268,21 +273,22 @@ The full repository Go/race suite and Lean build remain CI acceptance gates.
 | modification order | specified + implemented in chapter 67 |
 | release-sequence semantics | specified + implemented + Lean-modeled in chapter 67 |
 | fence-mediated synchronization | specified + implemented + Lean-modeled in chapter 67 |
+| seq-cst global order and read visibility | specified + implemented + Lean-modeled in chapter 68 |
 | Go-to-Lean refinement | not yet proved |
-| seq-cst global order | next |
-| compiler/C refinement | not yet proved |
-| AArch64 weak-memory litmus suite | not yet implemented |
+| compiler/C refinement | next major layer |
+| AArch64 weak-memory litmus suite | next major layer |
 
 ## 12. Next closure steps
 
-Before higher-level lock-free structures depend on the memory model as a closed
-contract, Oak should add:
+The language-level relation set is now explicit. Before higher-level lock-free
+structures depend on it end to end, Oak should verify refinement through:
 
-1. sequential-consistency total-order constraints;
-2. backend/compiler refinement tests;
-3. AArch64 MP/SB/LB/IRIW-style litmus coverage and assembly inspection;
-4. target lock-free admission rules for realtime profiles.
+1. generated-C memory-order/assembly tests;
+2. AArch64 MP/SB/LB/IRIW-style litmus coverage and instruction inspection;
+3. target lock-free admission rules for realtime profiles;
+4. direct implementation-to-Lean refinement for the most load-bearing pieces
+   where the proof cost is justified.
 
-Only after those pieces are explicit should `SpscRing[T, N]` be treated as a
-proof consumer of the complete machine-memory model rather than as an isolated
-algorithm test.
+Only after the compiler/machine projection is demonstrated should
+`SpscRing[T, N]` be treated as a proof consumer of Oak's memory model rather
+than as an isolated algorithm test.

--- a/docs/spec/67-memory-ordering.md
+++ b/docs/spec/67-memory-ordering.md
@@ -310,16 +310,17 @@ The Semantic IR test suite includes:
 | release-fence -> acquire-fence | specified + implemented + Lean-modeled + tested |
 | zero-allocation release-sequence walk | regression-tested |
 | implementation-to-Lean refinement | not yet proved |
-| sequential-consistency total order | next |
-| C/backend weak-memory refinement | not yet proved |
-| AArch64 litmus/assembly validation | not yet implemented |
+| sequential-consistency total order | specified + implemented + Lean-modeled in chapter 68 |
+| C/backend weak-memory refinement | next major layer |
+| AArch64 litmus/assembly validation | next major layer |
 
-## 11. Next closure step: sequential consistency
+## 11. Next closure layer: backend refinement
 
-`seq-cst` must not mean merely "stronger local acquire/release." Oak still needs
-an explicit global SC-order witness with constraints tying it to program order,
-modification order, and the values observed by SC loads/RMWs.
+Chapter 68 defines the explicit global seq-cst witness and ties it to HB,
+modification order, and read visibility. The language-level relation set is
+therefore explicit enough to stop inventing semantics in the backend.
 
-That should be modeled and tested as a separate relation. After SC is closed,
-the memory model can move to compiler/backend and AArch64 refinement before a
-lock-free queue is allowed to treat it as a trusted proof dependency.
+The next work is to verify that generated C and AArch64 code preserve these
+relations through assembly inspection and weak-memory litmus tests. Only then
+should a lock-free queue be accepted as relying on Oak's memory model end to
+end.

--- a/docs/spec/68-sequential-consistency.md
+++ b/docs/spec/68-sequential-consistency.md
@@ -1,0 +1,257 @@
+# Sequential consistency: one explicit global order
+
+This chapter closes the language-level `seq-cst` ordering contract above the
+execution, happens-before, modification-order, release-sequence, and fence
+relations defined in chapters 66 and 67.
+
+The governing rule is:
+
+> `seq-cst` is a single global ordering constraint, not merely a stronger local
+> acquire/release annotation.
+
+## 1. The SC witness
+
+Every execution that contains seq-cst events may be paired with a
+`SequentialConsistencyWitness`:
+
+```text
+S = [event_0, event_1, ... event_n]
+```
+
+Position in `S` is the event's global SC rank.
+
+`S` is deliberately separate from `MemoryEvent`. Program order, reads-from,
+modification order, happens-before, and global SC order remain distinct facts.
+
+The witness is caller-owned. The reference verifier does not allocate an
+internal list, tree, or map to construct it.
+
+## 2. Exact membership
+
+The witness must contain:
+
+- every seq-cst event in the execution;
+- only seq-cst events;
+- every such event exactly once.
+
+A concrete list with exact membership gives a strict total order by
+construction. No pairwise Boolean order matrix is stored.
+
+The reference implementation uses bounded linear position lookup. That is
+intentional: the verification model values auditability and zero hidden
+allocation over premature indexing. An optimized index may later refine this
+representation if measurements justify it.
+
+## 3. Happens-before consistency
+
+For seq-cst events `A` and `B`:
+
+```text
+A happens-before B
+    =>
+A SC-before B
+```
+
+Therefore the global SC order may never reverse an established happens-before
+edge.
+
+This includes same-thread sequenced-before because sequenced-before is one of
+the generators of happens-before.
+
+## 4. Modification-order consistency
+
+For seq-cst write-like events `A` and `B` to the same atomic location:
+
+```text
+A modification-before B
+    =>
+A SC-before B
+```
+
+Thus one location cannot appear to move backward merely because the global SC
+witness chose a different order.
+
+This constraint is independent of HB: concurrent seq-cst writes still have a
+per-location modification order that the global order must respect.
+
+## 5. SC read visibility
+
+A global order that ignores observed values is insufficient. Oak therefore
+validates the source of every seq-cst read or read-modify-write.
+
+Suppose seq-cst read `R` reads-from modification `W`.
+
+### 5.1 Seq-cst source
+
+If `W` itself is seq-cst:
+
+```text
+W SC-before R
+```
+
+must hold.
+
+An SC read cannot observe an SC write that globally occurs after the read.
+
+### 5.2 Later visible modifications
+
+For every modification `L` later than `W` on the same location, the execution
+is rejected if either is true:
+
+```text
+L happens-before R
+```
+
+or:
+
+```text
+L is seq-cst
+&& L SC-before R
+```
+
+In other words, `R` may not skip a later modification that is already visible
+before it through the language's causal or global SC relations.
+
+This allows a seq-cst read to observe a concurrent non-SC write when no later
+write is already visible before the read. Oak therefore does not falsely imply
+that seq-cst operations exclude all interaction with weaker atomics.
+
+### 5.3 Implicit initialized value
+
+A seq-cst read with no represented reads-from source observes the location's
+implicit initialized value.
+
+That is valid only if there is no represented write to the location that is
+already visible before the read through HB or, for a seq-cst write, through the
+SC order.
+
+Thus an initial-value read cannot pretend a known prior write did not happen.
+
+## 6. RMW interaction
+
+Chapter 67 already requires an RMW at modification `n > 0` to read-from the
+immediately preceding modification `n - 1`.
+
+For a seq-cst RMW, both contracts apply:
+
+- the RMW source is fixed by immediate modification-order predecessor;
+- the RMW itself appears exactly once in global SC order;
+- if the source is seq-cst, the source is SC-before the RMW;
+- the global order may not reverse HB or modification order.
+
+This avoids giving CAS/fetch-add a separate ad-hoc SC model.
+
+## 7. Fences
+
+Seq-cst fences participate in the same global SC witness even though they do not
+name a memory location or occupy modification order.
+
+Their relative placement is constrained by HB just like every other seq-cst
+event. The release/acquire synchronization paths that produce those HB edges
+remain the explicit witness rules from chapter 67.
+
+The SC witness does not invent fence synchronization by itself.
+
+## 8. Allocation and bounded-work contract
+
+`ValidateSequentialConsistency` is verification/tooling machinery, not a hidden
+runtime service.
+
+Its success path obeys:
+
+1. the SC order slice is caller-owned;
+2. HB scratch is caller-owned and reused;
+3. no hash map, balanced tree, linked list, recursive walk, or heap-backed queue
+   is constructed;
+4. membership and position queries are bounded linear scans;
+5. HB/MO/visibility validation uses bounded nested scans over the finite
+   execution;
+6. zero internal allocations are regression-tested with
+   `testing.AllocsPerRun`.
+
+The current verifier intentionally accepts higher asymptotic verification cost
+in exchange for an extremely small, deterministic implementation. It is not on
+the OS runtime hot path. If large trace verification later requires indexing,
+the optimized implementation must refine the same semantics and retain an
+explicit allocation budget.
+
+## 9. Formal verification
+
+`spec/lean/Oak/SequentialConsistency.lean` defines an abstract strict total
+order over seq-cst events and formalizes:
+
+- consistency of SC order with happens-before;
+- consistency of SC order with modification order for seq-cst writes;
+- visibility of the write source observed by an SC read;
+- the rule forbidding a later HB-visible modification from being skipped;
+- the rule forbidding a later seq-cst modification already SC-before the read
+  from being skipped;
+- the rule that an observed seq-cst source must be SC-before its read;
+- the rule that an initial-value SC read cannot have a seq-cst write already
+  SC-before it.
+
+Lean proves that an HB-consistent SC order cannot reverse HB and that an
+MO-consistent SC order cannot reverse per-location modification order.
+
+As with the earlier memory-model chapters, these are mathematical language
+proofs. A direct Go-to-Lean refinement proof remains separate work.
+
+## 10. Executable tests
+
+The Semantic IR tests cover:
+
+- a valid seq-cst release/acquire publication;
+- rejection when global SC order reverses HB;
+- rejection when global SC order reverses modification order;
+- rejection when an SC read skips a later SC write already before it in S;
+- acceptance of an SC read observing a concurrent non-SC write;
+- rejection when such a non-SC source is followed by a later SC write already
+  SC-before the read;
+- rejection of an initial-value SC read after a visible write;
+- acceptance of an initial-value SC read with no visible write;
+- exact witness membership: missing, duplicate, and non-SC entries fail;
+- explicit caller-workspace failure;
+- zero-allocation validation on a valid execution.
+
+## 11. Verification status
+
+| Layer | Status |
+| --- | --- |
+| explicit global SC witness | specified + implemented |
+| exact SC-event membership | specified + implemented + tested |
+| SC/HB consistency | specified + implemented + Lean-modeled |
+| SC/modification-order consistency | specified + implemented + Lean-modeled |
+| SC source visibility | specified + implemented + Lean-modeled |
+| implicit-initial SC visibility | specified + implemented + Lean-modeled |
+| zero-allocation SC validation | regression-tested |
+| implementation-to-Lean refinement | not yet proved |
+| compiler/C weak-memory refinement | next major layer |
+| AArch64 assembly/litmus validation | next major layer |
+| target lock-free admission | not yet implemented |
+
+## 12. Language-level memory model closure
+
+With chapters 65 through 68, Oak has explicit language-level definitions for:
+
+```text
+atomic operation legality
+reads-from
+sequenced-before
+per-location modification order
+release sequences
+fence synchronization
+synchronizes-with
+happens-before
+conflicting accesses
+data races
+global sequential consistency
+SC read visibility
+```
+
+That is enough to stop inventing new language semantics when implementing the
+backend.
+
+The next work is **refinement**: demonstrate that generated C and AArch64 code
+preserve these relations with litmus tests, assembly inspection, and eventually
+formal refinement where practical. Only after that should a lock-free queue be
+accepted as relying on Oak's memory model end to end.

--- a/semir/sequential_consistency.go
+++ b/semir/sequential_consistency.go
@@ -1,0 +1,208 @@
+package semir
+
+import "fmt"
+
+// SequentialConsistencyWitness is the global total order over all seq-cst
+// events in one execution. Position in Order is semantic SC rank. Keeping this
+// witness separate from MemoryEvent prevents the global relation from being
+// confused with program order, reads-from, or per-location modification order.
+// The caller owns the slice; validation allocates no hidden storage.
+type SequentialConsistencyWitness struct {
+	Order []MemoryEventID
+}
+
+func isSeqCstEvent(event MemoryEvent) bool {
+	return event.Atomic && event.Order == MemoryOrderSeqCst
+}
+
+// Position returns the SC rank of event. Linear lookup is intentional in the
+// reference verifier: bounded, allocation-free, and easy to audit. Optimized
+// indexes may later refine this representation if measurements justify them.
+func (s SequentialConsistencyWitness) Position(event MemoryEventID) (int, bool) {
+	for i := range s.Order {
+		if s.Order[i] == event {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+func (s SequentialConsistencyWitness) Before(a, b MemoryEventID) bool {
+	pa, oka := s.Position(a)
+	pb, okb := s.Position(b)
+	return oka && okb && pa < pb
+}
+
+func (s SequentialConsistencyWitness) validateMembership(x MemoryExecution) error {
+	seqCstCount := 0
+	for i := range x.Events {
+		if isSeqCstEvent(x.Events[i]) {
+			seqCstCount++
+		}
+	}
+	if len(s.Order) != seqCstCount {
+		return fmt.Errorf("seq-cst witness has %d entries for %d seq-cst events", len(s.Order), seqCstCount)
+	}
+
+	for i, id := range s.Order {
+		if int(id) >= len(x.Events) {
+			return fmt.Errorf("seq-cst rank %d references out-of-range event %d", i, id)
+		}
+		if !isSeqCstEvent(x.Events[id]) {
+			return fmt.Errorf("seq-cst rank %d references non-seq-cst event %d", i, id)
+		}
+		for j := i + 1; j < len(s.Order); j++ {
+			if s.Order[j] == id {
+				return fmt.Errorf("seq-cst event %d appears more than once", id)
+			}
+		}
+	}
+
+	for id := range x.Events {
+		if !isSeqCstEvent(x.Events[id]) {
+			continue
+		}
+		if _, ok := s.Position(MemoryEventID(id)); !ok {
+			return fmt.Errorf("seq-cst event %d is absent from global order", id)
+		}
+	}
+	return nil
+}
+
+// visibleWriteSkipped reports whether a seq-cst read observes source while a
+// later modification is already ordered before the read by HB or by the global
+// SC order. Such an execution would allow the read to skip a write that is
+// already semantically visible to it.
+func (s SequentialConsistencyWitness) visibleWriteSkipped(
+	x MemoryExecution,
+	read MemoryEventID,
+	source MemoryEventID,
+	workspace MemoryWorkspace,
+) (bool, error) {
+	sourceEvent := x.Events[source]
+	for candidate := range x.Events {
+		candidateID := MemoryEventID(candidate)
+		write := x.Events[candidate]
+		if candidateID == source || !write.Atomic || !write.Access.writes() ||
+			!write.HasModification || write.Location != sourceEvent.Location ||
+			write.Modification <= sourceEvent.Modification {
+			continue
+		}
+
+		hb, err := x.HappensBefore(candidateID, read, workspace)
+		if err != nil {
+			return false, err
+		}
+		if hb {
+			return true, nil
+		}
+		if isSeqCstEvent(write) && s.Before(candidateID, read) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// initialWriteSkipped reports whether an SC read claiming the implicit initial
+// value has any represented write already visible before it by HB or SC order.
+func (s SequentialConsistencyWitness) initialWriteSkipped(
+	x MemoryExecution,
+	read MemoryEventID,
+	workspace MemoryWorkspace,
+) (bool, error) {
+	readEvent := x.Events[read]
+	for candidate := range x.Events {
+		candidateID := MemoryEventID(candidate)
+		write := x.Events[candidate]
+		if !write.Atomic || !write.Access.writes() || write.Location != readEvent.Location {
+			continue
+		}
+		hb, err := x.HappensBefore(candidateID, read, workspace)
+		if err != nil {
+			return false, err
+		}
+		if hb || (isSeqCstEvent(write) && s.Before(candidateID, read)) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// ValidateSequentialConsistency validates Oak's global SC witness after the
+// core execution graph. It uses only caller-owned MemoryWorkspace and bounded
+// scans over Events/Order; the success path performs no hidden allocation.
+//
+// Constraints:
+//   1. every and only seq-cst event appears exactly once in S;
+//   2. S is consistent with happens-before among seq-cst events;
+//   3. S is consistent with per-location modification order among seq-cst
+//      writes/RMWs;
+//   4. an SC read/RMW may not skip a later modification that is already visible
+//      before it through HB or the SC order;
+//   5. an SC read of the implicit initial value may not have any visible write
+//      before it.
+func (x MemoryExecution) ValidateSequentialConsistency(
+	s SequentialConsistencyWitness,
+	workspace MemoryWorkspace,
+) error {
+	if err := x.Validate(); err != nil {
+		return err
+	}
+	if len(workspace.Visited) < len(x.Events) || len(workspace.Stack) < len(x.Events) {
+		return ErrMemoryWorkspaceTooSmall
+	}
+	if err := s.validateMembership(x); err != nil {
+		return err
+	}
+
+	// Since s.Order is a concrete sequence, totality/transitivity are by
+	// construction. Reject any pair whose required HB or modification direction
+	// contradicts that sequence.
+	for earlier := 0; earlier < len(s.Order); earlier++ {
+		for later := earlier + 1; later < len(s.Order); later++ {
+			a := s.Order[earlier]
+			b := s.Order[later]
+
+			reverseHB, err := x.HappensBefore(b, a, workspace)
+			if err != nil {
+				return err
+			}
+			if reverseHB {
+				return fmt.Errorf("seq-cst order places event %d before happens-before predecessor %d", a, b)
+			}
+			if x.ModificationBefore(b, a) {
+				return fmt.Errorf("seq-cst order reverses modification order between events %d and %d", a, b)
+			}
+		}
+	}
+
+	for _, readID := range s.Order {
+		read := x.Events[readID]
+		if !read.Access.reads() {
+			continue
+		}
+		if read.HasReadsFrom {
+			source := read.ReadsFrom
+			if isSeqCstEvent(x.Events[source]) && !s.Before(source, readID) {
+				return fmt.Errorf("seq-cst read %d observes seq-cst write %d that is not SC-before it", readID, source)
+			}
+			skipped, err := s.visibleWriteSkipped(x, readID, source, workspace)
+			if err != nil {
+				return err
+			}
+			if skipped {
+				return fmt.Errorf("seq-cst read %d skips a later visible modification", readID)
+			}
+			continue
+		}
+
+		skipped, err := s.initialWriteSkipped(x, readID, workspace)
+		if err != nil {
+			return err
+		}
+		if skipped {
+			return fmt.Errorf("seq-cst read %d observes initial value after a visible write", readID)
+		}
+	}
+	return nil
+}

--- a/semir/sequential_consistency_test.go
+++ b/semir/sequential_consistency_test.go
@@ -1,0 +1,150 @@
+package semir
+
+import "testing"
+
+func seqCstPublicationExecution() MemoryExecution {
+	return MemoryExecution{
+		Events: []MemoryEvent{
+			{Thread: 0, Sequence: 0, Location: 1, Access: MemoryAccessWrite},
+			{Thread: 0, Sequence: 1, Location: 2, Access: MemoryAccessWrite, Atomic: true, Order: MemoryOrderSeqCst, HasModification: true, Modification: 0},
+			{Thread: 1, Sequence: 0, Location: 2, Access: MemoryAccessRead, Atomic: true, Order: MemoryOrderSeqCst, HasReadsFrom: true, ReadsFrom: 1},
+			{Thread: 1, Sequence: 1, Location: 1, Access: MemoryAccessRead},
+		},
+		Synchronizes: []MemorySyncEdge{{From: 1, To: 2, Kind: MemorySyncReleaseAcquire}},
+	}
+}
+
+func TestSeqCstWitnessAcceptsPublicationOrder(t *testing.T) {
+	x := seqCstPublicationExecution()
+	workspace := memoryWorkspace(len(x.Events))
+	witness := SequentialConsistencyWitness{Order: []MemoryEventID{1, 2}}
+	if err := x.ValidateSequentialConsistency(witness, workspace); err != nil {
+		t.Fatalf("valid SC publication rejected: %v", err)
+	}
+	if !witness.Before(1, 2) || witness.Before(2, 1) {
+		t.Fatal("SC witness order lookup is inconsistent")
+	}
+}
+
+func TestSeqCstWitnessRejectsHappensBeforeReversal(t *testing.T) {
+	x := seqCstPublicationExecution()
+	workspace := memoryWorkspace(len(x.Events))
+	witness := SequentialConsistencyWitness{Order: []MemoryEventID{2, 1}}
+	if err := x.ValidateSequentialConsistency(witness, workspace); err == nil {
+		t.Fatal("SC order that reverses happens-before unexpectedly validated")
+	}
+}
+
+func TestSeqCstWitnessRejectsModificationOrderReversal(t *testing.T) {
+	x := MemoryExecution{Events: []MemoryEvent{
+		{Thread: 0, Sequence: 0, Location: 7, Access: MemoryAccessWrite, Atomic: true, Order: MemoryOrderSeqCst, HasModification: true, Modification: 0},
+		{Thread: 1, Sequence: 0, Location: 7, Access: MemoryAccessWrite, Atomic: true, Order: MemoryOrderSeqCst, HasModification: true, Modification: 1},
+	}}
+	workspace := memoryWorkspace(len(x.Events))
+	witness := SequentialConsistencyWitness{Order: []MemoryEventID{1, 0}}
+	if err := x.ValidateSequentialConsistency(witness, workspace); err == nil {
+		t.Fatal("SC order that reverses per-location modification order unexpectedly validated")
+	}
+}
+
+func TestSeqCstReadCannotSkipLaterSCWriteAlreadyBeforeIt(t *testing.T) {
+	x := MemoryExecution{Events: []MemoryEvent{
+		{Thread: 0, Sequence: 0, Location: 5, Access: MemoryAccessWrite, Atomic: true, Order: MemoryOrderSeqCst, HasModification: true, Modification: 0},
+		{Thread: 1, Sequence: 0, Location: 5, Access: MemoryAccessWrite, Atomic: true, Order: MemoryOrderSeqCst, HasModification: true, Modification: 1},
+		{Thread: 2, Sequence: 0, Location: 5, Access: MemoryAccessRead, Atomic: true, Order: MemoryOrderSeqCst, HasReadsFrom: true, ReadsFrom: 0},
+	}}
+	workspace := memoryWorkspace(len(x.Events))
+	witness := SequentialConsistencyWitness{Order: []MemoryEventID{0, 1, 2}}
+	if err := x.ValidateSequentialConsistency(witness, workspace); err == nil {
+		t.Fatal("SC read that skips a later SC-before modification unexpectedly validated")
+	}
+}
+
+func TestSeqCstReadMayObserveConcurrentNonSCWrite(t *testing.T) {
+	x := MemoryExecution{Events: []MemoryEvent{
+		{Thread: 0, Sequence: 0, Location: 5, Access: MemoryAccessWrite, Atomic: true, Order: MemoryOrderRelaxed, HasModification: true, Modification: 0},
+		{Thread: 1, Sequence: 0, Location: 5, Access: MemoryAccessRead, Atomic: true, Order: MemoryOrderSeqCst, HasReadsFrom: true, ReadsFrom: 0},
+	}}
+	workspace := memoryWorkspace(len(x.Events))
+	witness := SequentialConsistencyWitness{Order: []MemoryEventID{1}}
+	if err := x.ValidateSequentialConsistency(witness, workspace); err != nil {
+		t.Fatalf("SC read of concurrent non-SC write rejected: %v", err)
+	}
+}
+
+func TestSeqCstReadCannotSkipNonSCSourcePastLaterSCWrite(t *testing.T) {
+	x := MemoryExecution{Events: []MemoryEvent{
+		{Thread: 0, Sequence: 0, Location: 5, Access: MemoryAccessWrite, Atomic: true, Order: MemoryOrderRelaxed, HasModification: true, Modification: 0},
+		{Thread: 1, Sequence: 0, Location: 5, Access: MemoryAccessWrite, Atomic: true, Order: MemoryOrderSeqCst, HasModification: true, Modification: 1},
+		{Thread: 2, Sequence: 0, Location: 5, Access: MemoryAccessRead, Atomic: true, Order: MemoryOrderSeqCst, HasReadsFrom: true, ReadsFrom: 0},
+	}}
+	workspace := memoryWorkspace(len(x.Events))
+	witness := SequentialConsistencyWitness{Order: []MemoryEventID{1, 2}}
+	if err := x.ValidateSequentialConsistency(witness, workspace); err == nil {
+		t.Fatal("SC read skipped SC-before write after its non-SC source")
+	}
+}
+
+func TestSeqCstInitialReadRejectsVisibleWrite(t *testing.T) {
+	x := MemoryExecution{Events: []MemoryEvent{
+		{Thread: 0, Sequence: 0, Location: 3, Access: MemoryAccessWrite, Atomic: true, Order: MemoryOrderSeqCst, HasModification: true, Modification: 0},
+		{Thread: 1, Sequence: 0, Location: 3, Access: MemoryAccessRead, Atomic: true, Order: MemoryOrderSeqCst},
+	}}
+	workspace := memoryWorkspace(len(x.Events))
+	witness := SequentialConsistencyWitness{Order: []MemoryEventID{0, 1}}
+	if err := x.ValidateSequentialConsistency(witness, workspace); err == nil {
+		t.Fatal("SC read of initial value after SC-before write unexpectedly validated")
+	}
+}
+
+func TestSeqCstInitialReadAllowedWithoutVisibleWrite(t *testing.T) {
+	x := MemoryExecution{Events: []MemoryEvent{
+		{Thread: 0, Sequence: 0, Location: 3, Access: MemoryAccessRead, Atomic: true, Order: MemoryOrderSeqCst},
+	}}
+	workspace := memoryWorkspace(len(x.Events))
+	witness := SequentialConsistencyWitness{Order: []MemoryEventID{0}}
+	if err := x.ValidateSequentialConsistency(witness, workspace); err != nil {
+		t.Fatalf("initial SC read with no visible write rejected: %v", err)
+	}
+}
+
+func TestSeqCstWitnessMustContainEverySCEventExactlyOnce(t *testing.T) {
+	x := seqCstPublicationExecution()
+	workspace := memoryWorkspace(len(x.Events))
+	for name, witness := range map[string]SequentialConsistencyWitness{
+		"missing":   {Order: []MemoryEventID{1}},
+		"duplicate": {Order: []MemoryEventID{1, 1}},
+		"non-sc":    {Order: []MemoryEventID{1, 3}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := x.ValidateSequentialConsistency(witness, workspace); err == nil {
+				t.Fatalf("invalid %s SC witness unexpectedly validated", name)
+			}
+		})
+	}
+}
+
+func TestSeqCstValidationRequiresCallerWorkspace(t *testing.T) {
+	x := seqCstPublicationExecution()
+	witness := SequentialConsistencyWitness{Order: []MemoryEventID{1, 2}}
+	if err := x.ValidateSequentialConsistency(witness, MemoryWorkspace{}); err != ErrMemoryWorkspaceTooSmall {
+		t.Fatalf("SC workspace error = %v, want %v", err, ErrMemoryWorkspaceTooSmall)
+	}
+}
+
+func TestSeqCstValidationAllocatesNothing(t *testing.T) {
+	x := seqCstPublicationExecution()
+	workspace := memoryWorkspace(len(x.Events))
+	witness := SequentialConsistencyWitness{Order: []MemoryEventID{1, 2}}
+	if err := x.ValidateSequentialConsistency(witness, workspace); err != nil {
+		t.Fatalf("execution rejected before allocation test: %v", err)
+	}
+	allocs := testing.AllocsPerRun(1000, func() {
+		if err := x.ValidateSequentialConsistency(witness, workspace); err != nil {
+			panic("unexpected SC validation failure")
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("SC validation allocated %.2f objects per run; want zero", allocs)
+	}
+}

--- a/spec/lean/Oak.lean
+++ b/spec/lean/Oak.lean
@@ -2,6 +2,7 @@ import Oak.TypeLattice
 import Oak.Effects
 import Oak.MemoryOrder
 import Oak.HappensBefore
+import Oak.SequentialConsistency
 import Oak.Borrowing
 import Oak.BorrowRegions
 import Oak.Reborrow

--- a/spec/lean/Oak/SequentialConsistency.lean
+++ b/spec/lean/Oak/SequentialConsistency.lean
@@ -1,0 +1,138 @@
+import Oak.HappensBefore
+
+namespace Oak.SequentialConsistency
+
+universe u
+
+/-- A strict total order restricted to events classified as seq-cst. The
+    executable witness represents this relation by position in a caller-owned
+    list; this abstract form states the mathematical contract. -/
+structure SCOrder {Event : Type u} (isSC : Event -> Prop) where
+  before : Event -> Event -> Prop
+  irreflexive : ∀ event, ¬ before event event
+  transitive : ∀ {a b c}, before a b -> before b c -> before a c
+  total : ∀ {a b}, isSC a -> isSC b -> a ≠ b -> before a b ∨ before b a
+
+/-- The global SC order must preserve happens-before between seq-cst events. -/
+def ConsistentWithHB {Event : Type u} {isSC : Event -> Prop}
+    (order : SCOrder isSC) (hb : Event -> Event -> Prop) : Prop :=
+  ∀ {a b}, isSC a -> isSC b -> hb a b -> order.before a b
+
+/-- The global SC order must preserve per-location modification order between
+    seq-cst writes/RMWs. -/
+def ConsistentWithModification {Event : Type u} {isSC : Event -> Prop}
+    (order : SCOrder isSC)
+    (isSCWrite : Event -> Prop)
+    (modificationBefore : Event -> Event -> Prop) : Prop :=
+  ∀ {a b}, isSCWrite a -> isSCWrite b ->
+    modificationBefore a b -> order.before a b
+
+/-- An SC read that observes `source` may not skip a later modification already
+    visible before the read through happens-before or through SC order. If the
+    source itself is SC, it must precede the read in SC order. -/
+def VisibleSource {Event : Type u} {isSC : Event -> Prop}
+    (order : SCOrder isSC)
+    (hb modificationBefore : Event -> Event -> Prop)
+    (isWrite : Event -> Prop)
+    (source read : Event) : Prop :=
+  (isSC source -> order.before source read) ∧
+  ∀ later, isWrite later -> modificationBefore source later ->
+    (¬ hb later read) ∧ ¬ (isSC later ∧ order.before later read)
+
+/-- Reading the implicit initialized value is allowed only when no represented
+    write is already visible before the SC read through HB or SC order. -/
+def InitialValueAllowed {Event : Type u} {isSC : Event -> Prop}
+    (order : SCOrder isSC)
+    (hb : Event -> Event -> Prop)
+    (isWrite : Event -> Prop)
+    (read : Event) : Prop :=
+  ∀ write, isWrite write ->
+    (¬ hb write read) ∧ ¬ (isSC write ∧ order.before write read)
+
+/-- If SC order respects HB, an HB edge between SC events can never be reversed
+    in SC order. -/
+theorem hb_consistency_excludes_reverse
+    {Event : Type u} {isSC : Event -> Prop}
+    {order : SCOrder isSC} {hb : Event -> Event -> Prop}
+    {a b : Event}
+    (hConsistent : ConsistentWithHB order hb)
+    (hA : isSC a) (hB : isSC b)
+    (hHB : hb a b) :
+    ¬ order.before b a := by
+  intro hReverse
+  have hForward : order.before a b := hConsistent hA hB hHB
+  have hCycle : order.before a a := order.transitive hForward hReverse
+  exact order.irreflexive a hCycle
+
+/-- Likewise, SC order cannot reverse modification order between SC writes. -/
+theorem modification_consistency_excludes_reverse
+    {Event : Type u} {isSC : Event -> Prop}
+    {order : SCOrder isSC}
+    {isSCWrite : Event -> Prop}
+    {modificationBefore : Event -> Event -> Prop}
+    {a b : Event}
+    (hConsistent : ConsistentWithModification order isSCWrite modificationBefore)
+    (hA : isSCWrite a) (hB : isSCWrite b)
+    (hMO : modificationBefore a b) :
+    ¬ order.before b a := by
+  intro hReverse
+  have hForward : order.before a b := hConsistent hA hB hMO
+  have hCycle : order.before a a := order.transitive hForward hReverse
+  exact order.irreflexive a hCycle
+
+/-- A source visibility witness directly excludes skipping any later write that
+    happens-before the SC read. -/
+theorem visible_source_does_not_skip_hb_write
+    {Event : Type u} {isSC : Event -> Prop}
+    {order : SCOrder isSC}
+    {hb modificationBefore : Event -> Event -> Prop}
+    {isWrite : Event -> Prop}
+    {source read later : Event}
+    (hVisible : VisibleSource order hb modificationBefore isWrite source read)
+    (hWrite : isWrite later)
+    (hLater : modificationBefore source later) :
+    ¬ hb later read := by
+  exact (hVisible.2 later hWrite hLater).1
+
+/-- Nor can it skip a later seq-cst write already SC-before the read. -/
+theorem visible_source_does_not_skip_sc_write
+    {Event : Type u} {isSC : Event -> Prop}
+    {order : SCOrder isSC}
+    {hb modificationBefore : Event -> Event -> Prop}
+    {isWrite : Event -> Prop}
+    {source read later : Event}
+    (hVisible : VisibleSource order hb modificationBefore isWrite source read)
+    (hWrite : isWrite later)
+    (hLater : modificationBefore source later)
+    (hSC : isSC later) :
+    ¬ order.before later read := by
+  intro hBefore
+  exact (hVisible.2 later hWrite hLater).2 ⟨hSC, hBefore⟩
+
+/-- If an SC source is observed, the source must be globally SC-before the read. -/
+theorem sc_source_precedes_sc_read
+    {Event : Type u} {isSC : Event -> Prop}
+    {order : SCOrder isSC}
+    {hb modificationBefore : Event -> Event -> Prop}
+    {isWrite : Event -> Prop}
+    {source read : Event}
+    (hVisible : VisibleSource order hb modificationBefore isWrite source read)
+    (hSourceSC : isSC source) :
+    order.before source read :=
+  hVisible.1 hSourceSC
+
+/-- An SC read of the implicit initial value cannot have an SC write before it. -/
+theorem initial_value_excludes_prior_sc_write
+    {Event : Type u} {isSC : Event -> Prop}
+    {order : SCOrder isSC}
+    {hb : Event -> Event -> Prop}
+    {isWrite : Event -> Prop}
+    {write read : Event}
+    (hInitial : InitialValueAllowed order hb isWrite read)
+    (hWrite : isWrite write)
+    (hSC : isSC write) :
+    ¬ order.before write read := by
+  intro hBefore
+  exact (hInitial write hWrite).2 ⟨hSC, hBefore⟩
+
+end Oak.SequentialConsistency


### PR DESCRIPTION
Closes Oak's language-level memory model through sequential consistency.

Design:
- Sequential consistency is a separate caller-owned witness `S = [event...]`, not another field conflated with program order or modification order.
- The witness must contain every and only seq-cst event exactly once; list position is global SC rank.
- Global S must respect happens-before between seq-cst events.
- Global S must respect per-location modification order between seq-cst writes/RMWs.
- Seq-cst reads/RMWs carry value constraints: an SC source must be SC-before the read, and a read may not skip a later modification already visible before it through HB or SC order.
- An SC read of the implicit initial value is rejected if a represented write is already visible before it.
- SC reads may still observe concurrent non-SC writes when no later write is already visible; seq-cst is not modeled as an isolated universe.

Performance/boundedness:
- SC order storage is caller-owned.
- HB scratch is caller-owned and reused.
- Membership/position use bounded linear scans; no hidden map/tree/worklist allocation.
- Reference validation intentionally favors a tiny auditable bounded implementation over verification-time asymptotic complexity.
- Valid SC verification is regression-tested at zero internal allocations.

Formal verification:
- New `Oak.SequentialConsistency` models a strict total SC order.
- Formalizes consistency with HB and modification order.
- Formalizes SC-source visibility and implicit-initial visibility.
- Proves HB-consistent SC cannot reverse HB.
- Proves modification-consistent SC cannot reverse per-location modification order.
- Proves visible-source rules exclude skipping later HB-visible and SC-before writes.

Executable tests:
- valid seq-cst publication;
- HB reversal rejected;
- modification-order reversal rejected;
- stale SC source past later SC write rejected;
- concurrent non-SC source accepted when legal;
- stale non-SC source past later SC write rejected;
- initial-value visibility positive/negative cases;
- exact witness membership failures;
- caller-workspace requirement;
- zero-allocation valid validation.

Docs:
- New normative `68-sequential-consistency.md`.
- Chapters 65–67 updated to mark the language-level memory relation set explicit through seq-cst.

Still open by design: Go-to-Lean refinement, generated-C weak-memory refinement, AArch64 assembly/litmus validation, and target-specific lock-free admission.