### PR TITLE
Add AArch64 atomic refinement and litmus gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,22 +10,50 @@ jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-latest
-    
+
     strategy:
       matrix:
         go-version: ['1.27.1']
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-    
+
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
-    
+
     - name: Verify dependencies
       run: go mod verify
-    
+
     - name: Run tests
       run: go test -v -race ./...
+
+  aarch64-memory-refinement:
+    name: AArch64 Memory Refinement
+    runs-on: ubuntu-24.04
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.27.1'
+
+    - name: Verify Clang cross-target support
+      run: |
+        clang --version
+        clang --target=aarch64-none-elf -ffreestanding -x c -S -o /tmp/oak-aarch64-smoke.s - <<'EOF'
+        _Atomic(unsigned long long) oak_atomic_smoke;
+        EOF
+
+    - name: Verify AArch64 atomic lowering
+      env:
+        OAK_REQUIRE_AARCH64_CLANG: '1'
+      run: go test -v ./codegen -run '^TestAArch64'
+
+    - name: Verify memory-model litmus outcomes
+      run: go test -v ./semir -run '^TestLitmus'

--- a/codegen/aarch64_memory_refinement_test.go
+++ b/codegen/aarch64_memory_refinement_test.go
@@ -22,13 +22,13 @@ fn load_acquire() -> u64
 fn load_seq_cst() -> u64
   atomic_load_seq_cst(cell)
 
-fn store_relaxed(value: u64) -> unit
+fn store_relaxed(value: u64) -> ()
   atomic_store_relaxed(cell, value)
 
-fn store_release(value: u64) -> unit
+fn store_release(value: u64) -> ()
   atomic_store_release(cell, value)
 
-fn store_seq_cst(value: u64) -> unit
+fn store_seq_cst(value: u64) -> ()
   atomic_store_seq_cst(cell, value)
 
 fn fetch_add_relaxed(value: u64) -> u64
@@ -49,16 +49,16 @@ fn cas_acq_rel(expected: u64, desired: u64) -> u64
 fn cas_seq_cst(expected: u64, desired: u64) -> u64
   atomic_compare_exchange_seq_cst_seq_cst(cell, expected, desired)
 
-fn fence_acquire() -> unit
+fn fence_acquire() -> ()
   atomic_fence_acquire()
 
-fn fence_release() -> unit
+fn fence_release() -> ()
   atomic_fence_release()
 
-fn fence_acq_rel() -> unit
+fn fence_acq_rel() -> ()
   atomic_fence_acq_rel()
 
-fn fence_seq_cst() -> unit
+fn fence_seq_cst() -> ()
   atomic_fence_seq_cst()
 `
 

--- a/codegen/aarch64_memory_refinement_test.go
+++ b/codegen/aarch64_memory_refinement_test.go
@@ -1,0 +1,241 @@
+package codegen
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+const aarch64AtomicRefinementSource = `
+package main
+cell: Atomic[u64]
+
+fn load_relaxed() -> u64
+  atomic_load_relaxed(cell)
+
+fn load_acquire() -> u64
+  atomic_load_acquire(cell)
+
+fn load_seq_cst() -> u64
+  atomic_load_seq_cst(cell)
+
+fn store_relaxed(value: u64) -> unit
+  atomic_store_relaxed(cell, value)
+
+fn store_release(value: u64) -> unit
+  atomic_store_release(cell, value)
+
+fn store_seq_cst(value: u64) -> unit
+  atomic_store_seq_cst(cell, value)
+
+fn fetch_add_relaxed(value: u64) -> u64
+  atomic_fetch_add_relaxed(cell, value)
+
+fn fetch_add_acq_rel(value: u64) -> u64
+  atomic_fetch_add_acq_rel(cell, value)
+
+fn fetch_add_seq_cst(value: u64) -> u64
+  atomic_fetch_add_seq_cst(cell, value)
+
+fn cas_relaxed(expected: u64, desired: u64) -> u64
+  atomic_compare_exchange_relaxed_relaxed(cell, expected, desired)
+
+fn cas_acq_rel(expected: u64, desired: u64) -> u64
+  atomic_compare_exchange_acq_rel_acquire(cell, expected, desired)
+
+fn cas_seq_cst(expected: u64, desired: u64) -> u64
+  atomic_compare_exchange_seq_cst_seq_cst(cell, expected, desired)
+
+fn fence_acquire() -> unit
+  atomic_fence_acquire()
+
+fn fence_release() -> unit
+  atomic_fence_release()
+
+fn fence_acq_rel() -> unit
+  atomic_fence_acq_rel()
+
+fn fence_seq_cst() -> unit
+  atomic_fence_seq_cst()
+`
+
+func requireAArch64Clang(t *testing.T) string {
+	t.Helper()
+	clang, err := exec.LookPath("clang")
+	if err == nil {
+		return clang
+	}
+	if os.Getenv("OAK_REQUIRE_AARCH64_CLANG") == "1" {
+		t.Fatal("AArch64 memory refinement requires clang in CI")
+	}
+	t.Skip("clang is required for AArch64 memory refinement test")
+	return ""
+}
+
+func compileAArch64Assembly(t *testing.T, march string) string {
+	t.Helper()
+	clang := requireAArch64Clang(t)
+	generated := generateSourceC(t, aarch64AtomicRefinementSource)
+
+	// Admission assertions are target/compiler facts rather than language
+	// assumptions. Oak's fixed-width v1 carriers must be always lock-free on
+	// the AArch64 OS profile before hard-realtime code may depend on them.
+	admission := `
+_Static_assert(__atomic_always_lock_free(sizeof(u8), 0), "u8 atomics must be lock-free");
+_Static_assert(__atomic_always_lock_free(sizeof(u16), 0), "u16 atomics must be lock-free");
+_Static_assert(__atomic_always_lock_free(sizeof(u32), 0), "u32 atomics must be lock-free");
+_Static_assert(__atomic_always_lock_free(sizeof(u64), 0), "u64 atomics must be lock-free");
+`
+
+	dir := t.TempDir()
+	cPath := filepath.Join(dir, "oak_atomic_aarch64.c")
+	sPath := filepath.Join(dir, "oak_atomic_aarch64.s")
+	if err := os.WriteFile(cPath, []byte(generated+admission), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	args := []string{
+		"--target=aarch64-none-elf",
+		"-march=" + march,
+		"-std=c11", "-O2", "-ffreestanding",
+		"-Wall", "-Wextra", "-Werror", "-Wno-unused-function",
+		"-S", cPath, "-o", sPath,
+	}
+	cmd := exec.Command(clang, args...)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("cross-compile Oak-generated atomics for %s: %v\n%s\n--- C ---\n%s", march, err, output, generated+admission)
+	}
+	assembly, err := os.ReadFile(sPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return strings.ToLower(string(assembly))
+}
+
+func aarch64FunctionBody(t *testing.T, assembly, oakName string) string {
+	t.Helper()
+	label := "oak_" + oakName + ":"
+	start := strings.Index(assembly, label)
+	if start < 0 {
+		t.Fatalf("assembly does not contain %s\n%s", label, assembly)
+	}
+	rest := assembly[start+len(label):]
+	// Clang emits .Lfunc_endN on ELF AArch64. Fall back to the next global
+	// function if that spelling changes; either boundary is structural rather
+	// than tied to instruction scheduling.
+	end := strings.Index(rest, ".lfunc_end")
+	if end < 0 {
+		if next := strings.Index(rest, "\n\t.globl\t"); next >= 0 {
+			end = next
+		} else {
+			end = len(rest)
+		}
+	}
+	return rest[:end]
+}
+
+func hasInstruction(body, mnemonic string) bool {
+	// Match a mnemonic token at the start of an assembly instruction, allowing
+	// Clang's tabs/spaces but not substrings such as ldar matching ldapr.
+	re := regexp.MustCompile(`(?m)^\s*` + regexp.QuoteMeta(mnemonic) + `\s`)
+	return re.FindStringIndex(body) != nil
+}
+
+func requireInstruction(t *testing.T, body string, alternatives ...string) {
+	t.Helper()
+	for _, mnemonic := range alternatives {
+		if hasInstruction(body, mnemonic) {
+			return
+		}
+	}
+	t.Fatalf("function body lacks required instruction family %v:\n%s", alternatives, body)
+}
+
+func forbidInstruction(t *testing.T, body string, mnemonics ...string) {
+	t.Helper()
+	for _, mnemonic := range mnemonics {
+		if hasInstruction(body, mnemonic) {
+			t.Fatalf("function body unexpectedly contains %s:\n%s", mnemonic, body)
+		}
+	}
+}
+
+func TestAArch64BaseAtomicLoadStoreAndFenceRefinement(t *testing.T) {
+	assembly := compileAArch64Assembly(t, "armv8-a")
+
+	relaxedLoad := aarch64FunctionBody(t, assembly, "load_relaxed")
+	requireInstruction(t, relaxedLoad, "ldr")
+	forbidInstruction(t, relaxedLoad, "ldar", "ldapr", "dmb")
+
+	for _, name := range []string{"load_acquire", "load_seq_cst"} {
+		body := aarch64FunctionBody(t, assembly, name)
+		requireInstruction(t, body, "ldar")
+		// Oak's AArch64 OS profile deliberately requires RCsc acquire rather
+		// than accepting LDAPR/RCpc as an interchangeable projection.
+		forbidInstruction(t, body, "ldapr")
+	}
+
+	relaxedStore := aarch64FunctionBody(t, assembly, "store_relaxed")
+	requireInstruction(t, relaxedStore, "str")
+	forbidInstruction(t, relaxedStore, "stlr", "dmb")
+
+	for _, name := range []string{"store_release", "store_seq_cst"} {
+		body := aarch64FunctionBody(t, assembly, name)
+		requireInstruction(t, body, "stlr")
+	}
+
+	acquireFence := aarch64FunctionBody(t, assembly, "fence_acquire")
+	requireInstruction(t, acquireFence, "dmb")
+	if !strings.Contains(acquireFence, "ishld") {
+		t.Fatalf("acquire fence must use an acquire-capable DMB domain:\n%s", acquireFence)
+	}
+
+	for _, name := range []string{"fence_release", "fence_acq_rel", "fence_seq_cst"} {
+		body := aarch64FunctionBody(t, assembly, name)
+		requireInstruction(t, body, "dmb")
+		if !strings.Contains(body, "ish") {
+			t.Fatalf("%s must use inner-shareable DMB:\n%s", name, body)
+		}
+	}
+}
+
+func TestAArch64BaseAtomicRMWAndCASUseOrderedExclusivePairs(t *testing.T) {
+	assembly := compileAArch64Assembly(t, "armv8-a")
+
+	for _, name := range []string{"fetch_add_relaxed", "cas_relaxed"} {
+		body := aarch64FunctionBody(t, assembly, name)
+		requireInstruction(t, body, "ldxr")
+		requireInstruction(t, body, "stxr")
+		forbidInstruction(t, body, "ldaxr", "stlxr")
+	}
+
+	for _, name := range []string{"fetch_add_acq_rel", "fetch_add_seq_cst", "cas_acq_rel", "cas_seq_cst"} {
+		body := aarch64FunctionBody(t, assembly, name)
+		requireInstruction(t, body, "ldaxr")
+		requireInstruction(t, body, "stlxr")
+	}
+}
+
+func TestAArch64LSEAtomicRMWAndCASUseSingleInstructionForms(t *testing.T) {
+	assembly := compileAArch64Assembly(t, "armv8.1-a+lse")
+
+	relaxedAdd := aarch64FunctionBody(t, assembly, "fetch_add_relaxed")
+	requireInstruction(t, relaxedAdd, "ldadd")
+	forbidInstruction(t, relaxedAdd, "ldadda", "ldaddl", "ldaddal")
+
+	for _, name := range []string{"fetch_add_acq_rel", "fetch_add_seq_cst"} {
+		body := aarch64FunctionBody(t, assembly, name)
+		requireInstruction(t, body, "ldaddal")
+	}
+
+	relaxedCAS := aarch64FunctionBody(t, assembly, "cas_relaxed")
+	requireInstruction(t, relaxedCAS, "cas")
+	forbidInstruction(t, relaxedCAS, "casa", "casl", "casal")
+
+	for _, name := range []string{"cas_acq_rel", "cas_seq_cst"} {
+		body := aarch64FunctionBody(t, assembly, name)
+		requireInstruction(t, body, "casal")
+	}
+}

--- a/docs/spec/69-aarch64-memory-refinement.md
+++ b/docs/spec/69-aarch64-memory-refinement.md
@@ -1,0 +1,287 @@
+# AArch64 memory refinement: compiler and machine evidence
+
+This chapter begins the refinement from Oak's language-level memory model
+(chapters 65–68) to the AArch64 machine profile intended for the operating
+system.
+
+The governing rule is:
+
+> A correct source memory model is useful only if the compiler and target
+> preserve it.
+
+This layer deliberately uses **several independent forms of evidence** rather
+than treating one assembly snapshot as a proof of the entire Arm memory model.
+
+## 1. Evidence layers
+
+The current refinement stack is:
+
+```text
+Oak source atomics
+        |
+        v
+C11 explicit atomics             executable backend mapping
+        |
+        v
+Clang AArch64 assembly           implementation witness
+        |
+        +----> instruction-family admission checks
+        |
+Oak language execution model
+        +----> SB / MP / LB / IRIW small-state litmus checks
+        |
+Lean AArch64 local-order model
+        +----> kernel-checked instruction-class capability proofs
+```
+
+These layers make different claims.
+
+- C11 lowering verifies Oak emits the requested C memory order exactly.
+- Assembly inspection verifies the current compiler emits an admitted AArch64
+  instruction family for that C operation.
+- Lean proves the **abstract admitted instruction class** provides the local
+  acquire/release/RCsc capabilities Oak requires.
+- Litmus tests verify the language model permits and forbids the intended
+  outcomes.
+
+No one of these alone is called a complete C/LLVM/Arm axiomatic refinement
+proof.
+
+## 2. AArch64 OS-profile acquire semantics
+
+Oak's AArch64 OS profile requires RCsc acquire for ordinary acquire and seq-cst
+loads.
+
+The admitted scalar acquire load is:
+
+```text
+LDAR
+```
+
+`LDAPR` is **not** admitted as an interchangeable implementation of Oak acquire
+in this profile. LDAPR has RCpc/AcquirePC semantics rather than the RCsc acquire
+class tracked by Oak's machine contract.
+
+This deliberately gives the privileged OS profile a simple, reviewable ordering
+rule. A future weaker RCpc source operation can be added explicitly if there is
+a demonstrated performance need and a separate semantic contract.
+
+## 3. Baseline ARMv8-A scalar mapping
+
+The assembly gate cross-compiles Oak-generated C with:
+
+```text
+clang --target=aarch64-none-elf -march=armv8-a -ffreestanding -O2
+```
+
+The admitted scalar families are:
+
+| Oak operation | required baseline family |
+| --- | --- |
+| relaxed load | `LDR` |
+| acquire load | `LDAR` |
+| seq-cst load | `LDAR` |
+| relaxed store | `STR` |
+| release store | `STLR` |
+| seq-cst store | `STLR` |
+| acquire fence | `DMB ... ISHLD` |
+| release fence | `DMB ... ISH` |
+| acq-rel fence | `DMB ... ISH` |
+| seq-cst fence | `DMB ... ISH` |
+
+The gate rejects `LDAPR` for Oak acquire/seq-cst loads.
+
+Sequential consistency is **not** reduced to one local instruction property.
+The global SC relation and read-visibility constraints remain those of chapter
+68; the table above records only the target's local operation component.
+
+## 4. Baseline RMW and compare-exchange
+
+Without LSE, the admitted baseline implementation is an exclusive loop.
+
+Relaxed RMW/CAS must use the relaxed pair:
+
+```text
+LDXR
+STXR
+```
+
+Acquire-release and seq-cst RMW/CAS must use:
+
+```text
+LDAXR
+STLXR
+```
+
+The source CAS is strong. The generated loop therefore retries store-exclusive
+failure as needed rather than exposing architecture-level exclusive failure as
+an Oak CAS failure.
+
+CAS retry count remains potentially unbounded under contention. Nothing in this
+mapping changes the realtime rule that lock-free is not equivalent to bounded
+WCET.
+
+## 5. ARMv8.1-A + LSE performance profile
+
+The same Oak source is separately cross-compiled for:
+
+```text
+-march=armv8.1-a+lse
+```
+
+The performance profile expects the compiler to use the single-instruction LSE
+forms where available:
+
+| Oak operation | admitted LSE family |
+| --- | --- |
+| relaxed fetch-add | `LDADD` |
+| acq-rel / seq-cst fetch-add | `LDADDAL` |
+| relaxed strong CAS | `CAS` |
+| acq-rel / seq-cst strong CAS | `CASAL` |
+
+This is both a correctness and performance regression gate: an unexpected
+fallback to an out-of-line runtime or unnecessary generic dispatch is visible.
+
+The language semantics do not require LSE. Baseline LL/SC and LSE are two
+machine representations of the same Oak atomic operation.
+
+## 6. Target lock-free admission
+
+The cross-target compilation includes compile-time assertions that Oak's current
+v1 atomic carriers are always lock-free for the AArch64 target profile:
+
+```text
+u8
+u16
+u32
+u64
+```
+
+Signed carriers have the same widths/storage requirements.
+
+This converts lock-freedom from an assumption into a target admission check for
+the compiler/architecture tuple exercised by CI.
+
+It does not imply arbitrary aggregate or pointer atomics are lock-free, and it
+does not yet prove a cycle-level WCET bound.
+
+## 7. Litmus outcomes
+
+`semir/memory_litmus_test.go` exercises canonical small-state outcomes using the
+same execution/HB/MO/SC validators that define Oak's language model.
+
+### 7.1 Message passing (MP)
+
+Release/acquire publication establishes:
+
+```text
+payload write HB payload read
+```
+
+when the acquire observes the release flag publication.
+
+### 7.2 Store buffering (SB)
+
+For seq-cst stores followed by seq-cst loads, the both-zero outcome is forbidden.
+The test exhausts every candidate global SC order and verifies none satisfies
+the witness constraints.
+
+For all-relaxed atomics, the both-zero outcome remains allowed and data-race-free.
+This guards against accidentally making relaxed atomics stronger than specified.
+
+### 7.3 IRIW
+
+Two seq-cst readers cannot observe two seq-cst writers in contradictory orders.
+The test exhausts all candidate global SC orders for the six-event execution
+and verifies the split observation has no valid witness.
+
+### 7.4 Load buffering (LB)
+
+The seq-cst both-zero load-buffering outcome is allowed when both loads occur
+before both stores in one valid global order.
+
+This negative/positive pair matters: the checker must implement Oak's actual
+memory contract rather than merely rejecting every weak-looking outcome.
+
+## 8. Formal instruction-class model
+
+`spec/lean/Oak/AArch64Memory.lean` models local ordering capabilities:
+
+```text
+acquire
+release
+RCsc acquire
+```
+
+and instruction classes for:
+
+- `LDR`, `LDAR`, `LDAPR`;
+- `STR`, `STLR`;
+- `DMB ISHLD`, `DMB ISH`;
+- baseline exclusive load/store pairs;
+- LSE relaxed/acquire/release/acq-rel RMW classes.
+
+Lean proves:
+
+- baseline load mappings satisfy their required local order;
+- baseline store mappings satisfy their required local order;
+- baseline fence mappings satisfy their required local order;
+- every baseline RMW order maps to a sufficient exclusive pair;
+- every LSE RMW order maps to a sufficient LSE class;
+- `LDAR` satisfies Oak's RCsc acquire requirement;
+- `LDAPR` does **not** satisfy that profile requirement;
+- seq-cst load/store/fence select the intended local instruction classes.
+
+These proofs are intentionally local. `Oak.SequentialConsistency` remains the
+separate global-order proof layer.
+
+## 9. CI gate
+
+The main CI workflow has an independent:
+
+```text
+AArch64 Memory Refinement
+```
+
+job. It:
+
+1. requires Clang AArch64 freestanding cross-target support;
+2. runs the Oak source -> C -> AArch64 assembly checks;
+3. runs the memory-model litmus outcomes.
+
+The ordinary Go/race, Lean, and golden gates remain in place, so backend
+refinement cannot replace source/compiler/formal regression coverage.
+
+Local developers without Clang may skip the assembly tests. CI sets
+`OAK_REQUIRE_AARCH64_CLANG=1`, turning absence of the cross compiler into a hard
+failure rather than a skipped verification claim.
+
+## 10. What this does not yet prove
+
+This chapter does **not** claim:
+
+- a complete formal refinement of C11 through LLVM IR to the official Arm
+  axiomatic model;
+- exhaustive compiler-version correctness;
+- stochastic execution of weak-memory litmus tests on real AArch64 hardware;
+- cache/coherency/DMA/device-memory correctness;
+- cycle-level WCET for LL/SC retry loops;
+- MMIO/barrier correctness for device registers.
+
+The current result is stronger than source-only testing but deliberately weaker
+than a full verified compiler/ISA stack.
+
+## 11. Next steps
+
+The next machine-memory work should add:
+
+1. retained assembly artifacts/version metadata so failures are diagnosable;
+2. real AArch64 hardware litmus execution when a CI runner is available;
+3. MMIO address spaces and AArch64 `DMB`/`DSB`/`ISB` contracts;
+4. DMA/coherency and interrupt-boundary ordering;
+5. selective implementation-to-Lean refinement where the proof cost is
+   justified.
+
+Once this AArch64 refinement gate is stable, Oak has enough demonstrated
+shared-memory machinery to begin `SpscRing[T, N]` as the first higher-level
+lock-free proof consumer.

--- a/semir/memory_litmus_test.go
+++ b/semir/memory_litmus_test.go
@@ -1,0 +1,125 @@
+package semir
+
+import "testing"
+
+func allPermutations(ids []MemoryEventID, visit func([]MemoryEventID) bool) bool {
+	values := append([]MemoryEventID(nil), ids...)
+	var walk func(int) bool
+	walk = func(index int) bool {
+		if index == len(values) {
+			order := append([]MemoryEventID(nil), values...)
+			return visit(order)
+		}
+		for i := index; i < len(values); i++ {
+			values[index], values[i] = values[i], values[index]
+			if walk(index + 1) {
+				return true
+			}
+			values[index], values[i] = values[i], values[index]
+		}
+		return false
+	}
+	return walk(0)
+}
+
+func hasValidSCWitness(x MemoryExecution, ids []MemoryEventID) bool {
+	workspace := memoryWorkspace(len(x.Events))
+	return allPermutations(ids, func(order []MemoryEventID) bool {
+		return x.ValidateSequentialConsistency(SequentialConsistencyWitness{Order: order}, workspace) == nil
+	})
+}
+
+// SB: each thread stores then loads the other location. Under seq-cst, the
+// outcome r0=0 && r1=0 would require the cycle
+// Wx <S Ry <S Wy <S Rx <S Wx, so no global S can witness it.
+func TestLitmusStoreBufferingSeqCstBothZeroForbidden(t *testing.T) {
+	x := MemoryExecution{Events: []MemoryEvent{
+		// T0: x=1; r0=y(initial)
+		{Thread: 0, Sequence: 0, Location: 1, Access: MemoryAccessWrite, Atomic: true, Order: MemoryOrderSeqCst, HasModification: true, Modification: 0},
+		{Thread: 0, Sequence: 1, Location: 2, Access: MemoryAccessRead, Atomic: true, Order: MemoryOrderSeqCst},
+		// T1: y=1; r1=x(initial)
+		{Thread: 1, Sequence: 0, Location: 2, Access: MemoryAccessWrite, Atomic: true, Order: MemoryOrderSeqCst, HasModification: true, Modification: 0},
+		{Thread: 1, Sequence: 1, Location: 1, Access: MemoryAccessRead, Atomic: true, Order: MemoryOrderSeqCst},
+	}}
+	if err := x.Validate(); err != nil {
+		t.Fatalf("SB execution shape rejected: %v", err)
+	}
+	if hasValidSCWitness(x, []MemoryEventID{0, 1, 2, 3}) {
+		t.Fatal("seq-cst store-buffering both-zero outcome unexpectedly has a global SC witness")
+	}
+}
+
+// The same SB outcome is allowed by the language for all-relaxed atomics: all
+// accesses are atomic so there is no data race, and relaxed creates no SW edge.
+func TestLitmusStoreBufferingRelaxedBothZeroAllowed(t *testing.T) {
+	x := MemoryExecution{Events: []MemoryEvent{
+		{Thread: 0, Sequence: 0, Location: 1, Access: MemoryAccessWrite, Atomic: true, Order: MemoryOrderRelaxed, HasModification: true, Modification: 0},
+		{Thread: 0, Sequence: 1, Location: 2, Access: MemoryAccessRead, Atomic: true, Order: MemoryOrderRelaxed},
+		{Thread: 1, Sequence: 0, Location: 2, Access: MemoryAccessWrite, Atomic: true, Order: MemoryOrderRelaxed, HasModification: true, Modification: 0},
+		{Thread: 1, Sequence: 1, Location: 1, Access: MemoryAccessRead, Atomic: true, Order: MemoryOrderRelaxed},
+	}}
+	if err := x.Validate(); err != nil {
+		t.Fatalf("relaxed SB outcome should be a valid execution: %v", err)
+	}
+	workspace := memoryWorkspace(len(x.Events))
+	if a, b, race, err := x.FirstDataRace(workspace); err != nil || race {
+		t.Fatalf("all-atomic relaxed SB must remain data-race-free: (%d,%d) race=%v err=%v", a, b, race, err)
+	}
+}
+
+// MP: a release/acquire flag publishes an ordinary payload. The consumer
+// seeing the flag write necessarily orders the payload write before its read.
+func TestLitmusMessagePassingReleaseAcquirePublishesPayload(t *testing.T) {
+	x := releaseAcquirePublication()
+	if err := x.Validate(); err != nil {
+		t.Fatalf("MP execution rejected: %v", err)
+	}
+	workspace := memoryWorkspace(len(x.Events))
+	if hb, err := x.HappensBefore(0, 3, workspace); err != nil || !hb {
+		t.Fatalf("MP payload publication missing: hb=%v err=%v", hb, err)
+	}
+}
+
+// IRIW: two SC writers and two SC readers cannot disagree on writer order as
+// x=1,y=0 and y=1,x=0. Exhausting 6! candidate S orders provides an executable
+// small-state witness check rather than relying on one hand-picked ordering.
+func TestLitmusIRIWSeqCstSplitObservationForbidden(t *testing.T) {
+	x := MemoryExecution{
+		Events: []MemoryEvent{
+			{Thread: 0, Sequence: 0, Location: 1, Access: MemoryAccessWrite, Atomic: true, Order: MemoryOrderSeqCst, HasModification: true, Modification: 0}, // Wx
+			{Thread: 1, Sequence: 0, Location: 2, Access: MemoryAccessWrite, Atomic: true, Order: MemoryOrderSeqCst, HasModification: true, Modification: 0}, // Wy
+			{Thread: 2, Sequence: 0, Location: 1, Access: MemoryAccessRead, Atomic: true, Order: MemoryOrderSeqCst, HasReadsFrom: true, ReadsFrom: 0},          // Rx=1
+			{Thread: 2, Sequence: 1, Location: 2, Access: MemoryAccessRead, Atomic: true, Order: MemoryOrderSeqCst},                                     // Ry=0
+			{Thread: 3, Sequence: 0, Location: 2, Access: MemoryAccessRead, Atomic: true, Order: MemoryOrderSeqCst, HasReadsFrom: true, ReadsFrom: 1},          // Ry=1
+			{Thread: 3, Sequence: 1, Location: 1, Access: MemoryAccessRead, Atomic: true, Order: MemoryOrderSeqCst},                                     // Rx=0
+		},
+		Synchronizes: []MemorySyncEdge{
+			{From: 0, To: 2, Kind: MemorySyncReleaseAcquire},
+			{From: 1, To: 4, Kind: MemorySyncReleaseAcquire},
+		},
+	}
+	if err := x.Validate(); err != nil {
+		t.Fatalf("IRIW execution shape rejected: %v", err)
+	}
+	if hasValidSCWitness(x, []MemoryEventID{0, 1, 2, 3, 4, 5}) {
+		t.Fatal("seq-cst IRIW split observation unexpectedly has a global SC witness")
+	}
+}
+
+// LB: loads precede stores in both threads. Both initial reads are compatible
+// with a global SC order that places both loads before both stores. This test
+// guards against accidentally making Oak seq-cst stronger than its contract.
+func TestLitmusLoadBufferingSeqCstBothZeroAllowed(t *testing.T) {
+	x := MemoryExecution{Events: []MemoryEvent{
+		{Thread: 0, Sequence: 0, Location: 2, Access: MemoryAccessRead, Atomic: true, Order: MemoryOrderSeqCst},
+		{Thread: 0, Sequence: 1, Location: 1, Access: MemoryAccessWrite, Atomic: true, Order: MemoryOrderSeqCst, HasModification: true, Modification: 0},
+		{Thread: 1, Sequence: 0, Location: 1, Access: MemoryAccessRead, Atomic: true, Order: MemoryOrderSeqCst},
+		{Thread: 1, Sequence: 1, Location: 2, Access: MemoryAccessWrite, Atomic: true, Order: MemoryOrderSeqCst, HasModification: true, Modification: 0},
+	}}
+	if err := x.Validate(); err != nil {
+		t.Fatalf("LB execution shape rejected: %v", err)
+	}
+	if !hasValidSCWitness(x, []MemoryEventID{0, 1, 2, 3}) {
+		t.Fatal("seq-cst load-buffering both-zero outcome should have at least one valid global SC witness")
+	}
+}

--- a/spec/lean/Oak.lean
+++ b/spec/lean/Oak.lean
@@ -3,6 +3,7 @@ import Oak.Effects
 import Oak.MemoryOrder
 import Oak.HappensBefore
 import Oak.SequentialConsistency
+import Oak.AArch64Memory
 import Oak.Borrowing
 import Oak.BorrowRegions
 import Oak.Reborrow

--- a/spec/lean/Oak/AArch64Memory.lean
+++ b/spec/lean/Oak/AArch64Memory.lean
@@ -1,0 +1,196 @@
+import Oak.MemoryOrder
+
+namespace Oak.AArch64Memory
+
+open Oak.MemoryOrder
+
+/-- The local ordering capabilities required/provided by one machine operation.
+    RCsc acquire is tracked separately from acquire so LDAPR/RCpc cannot be
+    silently accepted where Oak's OS profile requires LDAR-style RCsc acquire. -/
+structure LocalOrdering where
+  acquire : Bool
+  release : Bool
+  rcscAcquire : Bool
+  deriving DecidableEq, Repr
+
+def none : LocalOrdering := ⟨false, false, false⟩
+def acquireRCsc : LocalOrdering := ⟨true, false, true⟩
+def releaseOnly : LocalOrdering := ⟨false, true, false⟩
+def acquireReleaseRCsc : LocalOrdering := ⟨true, true, true⟩
+
+/-- Required local ordering for a legal Oak load. Sequential consistency has
+    additional global constraints in Oak.SequentialConsistency; locally its load
+    requires RCsc acquire. -/
+def requiredLoad : Order -> Option LocalOrdering
+  | .relaxed => some none
+  | .acquire => some acquireRCsc
+  | .seqCst => some acquireRCsc
+  | .release | .acqRel => none
+
+/-- Required local ordering for a legal Oak store. -/
+def requiredStore : Order -> Option LocalOrdering
+  | .relaxed => some none
+  | .release => some releaseOnly
+  | .seqCst => some releaseOnly
+  | .acquire | .acqRel => none
+
+/-- Required local ordering for RMW. RCsc acquire is required whenever the RMW
+    has acquire semantics. -/
+def requiredRMW : Order -> LocalOrdering
+  | .relaxed => none
+  | .acquire => acquireRCsc
+  | .release => releaseOnly
+  | .acqRel | .seqCst => acquireReleaseRCsc
+
+/-- Required local ordering for fences. -/
+def requiredFence : Order -> Option LocalOrdering
+  | .acquire => some acquireRCsc
+  | .release => some releaseOnly
+  | .acqRel | .seqCst => some acquireReleaseRCsc
+  | .relaxed => none
+
+/-- A provided instruction class satisfies required local ordering when it
+    contains every requested capability. -/
+def satisfies (provided required : LocalOrdering) : Bool :=
+  (!required.acquire || provided.acquire) &&
+  (!required.release || provided.release) &&
+  (!required.rcscAcquire || provided.rcscAcquire)
+
+inductive LoadInstruction where
+  | ldr
+  | ldar
+  | ldapr
+  deriving DecidableEq, Repr
+
+def loadProvided : LoadInstruction -> LocalOrdering
+  | .ldr => none
+  | .ldar => acquireRCsc
+  | .ldapr => ⟨true, false, false⟩
+
+inductive StoreInstruction where
+  | str
+  | stlr
+  deriving DecidableEq, Repr
+
+def storeProvided : StoreInstruction -> LocalOrdering
+  | .str => none
+  | .stlr => releaseOnly
+
+inductive FenceInstruction where
+  | dmbIshld
+  | dmbIsh
+  deriving DecidableEq, Repr
+
+def fenceProvided : FenceInstruction -> LocalOrdering
+  | .dmbIshld => acquireRCsc
+  | .dmbIsh => acquireReleaseRCsc
+
+inductive ExclusivePair where
+  | ldxrStxr
+  | ldaxrStxr
+  | ldxrStlxr
+  | ldaxrStlxr
+  deriving DecidableEq, Repr
+
+def exclusiveProvided : ExclusivePair -> LocalOrdering
+  | .ldxrStxr => none
+  | .ldaxrStxr => acquireRCsc
+  | .ldxrStlxr => releaseOnly
+  | .ldaxrStlxr => acquireReleaseRCsc
+
+inductive LSEInstruction where
+  | relaxed
+  | acquire
+  | release
+  | acqRel
+  deriving DecidableEq, Repr
+
+def lseProvided : LSEInstruction -> LocalOrdering
+  | .relaxed => none
+  | .acquire => acquireRCsc
+  | .release => releaseOnly
+  | .acqRel => acquireReleaseRCsc
+
+/-- Baseline AArch64 load profile used by Oak's backend evidence gate. -/
+def baselineLoad : Order -> Option LoadInstruction
+  | .relaxed => some .ldr
+  | .acquire | .seqCst => some .ldar
+  | .release | .acqRel => none
+
+/-- Baseline AArch64 store profile. -/
+def baselineStore : Order -> Option StoreInstruction
+  | .relaxed => some .str
+  | .release | .seqCst => some .stlr
+  | .acquire | .acqRel => none
+
+/-- Baseline fences. -/
+def baselineFence : Order -> Option FenceInstruction
+  | .acquire => some .dmbIshld
+  | .release | .acqRel | .seqCst => some .dmbIsh
+  | .relaxed => none
+
+/-- The current base ARMv8 evidence gate checks relaxed and acquire-release/SC
+    RMW families explicitly. -/
+def baselineRMW : Order -> ExclusivePair
+  | .relaxed => .ldxrStxr
+  | .acquire => .ldaxrStxr
+  | .release => .ldxrStlxr
+  | .acqRel | .seqCst => .ldaxrStlxr
+
+/-- LSE profile: LDADD/CAS suffix classes encode the same four local strengths. -/
+def lseRMW : Order -> LSEInstruction
+  | .relaxed => .relaxed
+  | .acquire => .acquire
+  | .release => .release
+  | .acqRel | .seqCst => .acqRel
+
+theorem baseline_loads_satisfy_local_order (o : Order)
+    (required : LocalOrdering) (instruction : LoadInstruction)
+    (hRequired : requiredLoad o = some required)
+    (hInstruction : baselineLoad o = some instruction) :
+    satisfies (loadProvided instruction) required = true := by
+  cases o <;> simp_all [requiredLoad, baselineLoad, loadProvided, satisfies,
+    none, acquireRCsc]
+
+theorem baseline_stores_satisfy_local_order (o : Order)
+    (required : LocalOrdering) (instruction : StoreInstruction)
+    (hRequired : requiredStore o = some required)
+    (hInstruction : baselineStore o = some instruction) :
+    satisfies (storeProvided instruction) required = true := by
+  cases o <;> simp_all [requiredStore, baselineStore, storeProvided, satisfies,
+    none, releaseOnly]
+
+theorem baseline_fences_satisfy_local_order (o : Order)
+    (required : LocalOrdering) (instruction : FenceInstruction)
+    (hRequired : requiredFence o = some required)
+    (hInstruction : baselineFence o = some instruction) :
+    satisfies (fenceProvided instruction) required = true := by
+  cases o <;> simp_all [requiredFence, baselineFence, fenceProvided, satisfies,
+    acquireRCsc, releaseOnly, acquireReleaseRCsc]
+
+theorem baseline_rmw_satisfies_local_order (o : Order) :
+    satisfies (exclusiveProvided (baselineRMW o)) (requiredRMW o) = true := by
+  cases o <;> rfl
+
+theorem lse_rmw_satisfies_local_order (o : Order) :
+    satisfies (lseProvided (lseRMW o)) (requiredRMW o) = true := by
+  cases o <;> rfl
+
+/-- RCpc LDAPR has acquire semantics but is intentionally insufficient for the
+    Oak AArch64 OS profile's acquire requirement. -/
+theorem ldapr_does_not_satisfy_oak_acquire :
+    satisfies (loadProvided .ldapr) acquireRCsc = false := rfl
+
+theorem ldar_satisfies_oak_acquire :
+    satisfies (loadProvided .ldar) acquireRCsc = true := rfl
+
+/-- Seq-cst's global total-order/read-visibility obligations are not discharged
+    by this local instruction mapping. This theorem records only the local load
+    component; Oak.SequentialConsistency remains a separate proof obligation. -/
+theorem seqCst_load_uses_rcsc_acquire : baselineLoad .seqCst = some .ldar := rfl
+
+theorem seqCst_store_uses_release : baselineStore .seqCst = some .stlr := rfl
+
+theorem seqCst_fence_uses_full_dmb : baselineFence .seqCst = some .dmbIsh := rfl
+
+end Oak.AArch64Memory

--- a/spec/lean/Oak/AArch64Memory.lean
+++ b/spec/lean/Oak/AArch64Memory.lean
@@ -13,7 +13,7 @@ structure LocalOrdering where
   rcscAcquire : Bool
   deriving DecidableEq, Repr
 
-def none : LocalOrdering := ⟨false, false, false⟩
+def unordered : LocalOrdering := ⟨false, false, false⟩
 def acquireRCsc : LocalOrdering := ⟨true, false, true⟩
 def releaseOnly : LocalOrdering := ⟨false, true, false⟩
 def acquireReleaseRCsc : LocalOrdering := ⟨true, true, true⟩
@@ -22,22 +22,22 @@ def acquireReleaseRCsc : LocalOrdering := ⟨true, true, true⟩
     additional global constraints in Oak.SequentialConsistency; locally its load
     requires RCsc acquire. -/
 def requiredLoad : Order -> Option LocalOrdering
-  | .relaxed => some none
+  | .relaxed => some unordered
   | .acquire => some acquireRCsc
   | .seqCst => some acquireRCsc
-  | .release | .acqRel => none
+  | .release | .acqRel => Option.none
 
 /-- Required local ordering for a legal Oak store. -/
 def requiredStore : Order -> Option LocalOrdering
-  | .relaxed => some none
+  | .relaxed => some unordered
   | .release => some releaseOnly
   | .seqCst => some releaseOnly
-  | .acquire | .acqRel => none
+  | .acquire | .acqRel => Option.none
 
 /-- Required local ordering for RMW. RCsc acquire is required whenever the RMW
     has acquire semantics. -/
 def requiredRMW : Order -> LocalOrdering
-  | .relaxed => none
+  | .relaxed => unordered
   | .acquire => acquireRCsc
   | .release => releaseOnly
   | .acqRel | .seqCst => acquireReleaseRCsc
@@ -47,7 +47,7 @@ def requiredFence : Order -> Option LocalOrdering
   | .acquire => some acquireRCsc
   | .release => some releaseOnly
   | .acqRel | .seqCst => some acquireReleaseRCsc
-  | .relaxed => none
+  | .relaxed => Option.none
 
 /-- A provided instruction class satisfies required local ordering when it
     contains every requested capability. -/
@@ -63,7 +63,7 @@ inductive LoadInstruction where
   deriving DecidableEq, Repr
 
 def loadProvided : LoadInstruction -> LocalOrdering
-  | .ldr => none
+  | .ldr => unordered
   | .ldar => acquireRCsc
   | .ldapr => ⟨true, false, false⟩
 
@@ -73,7 +73,7 @@ inductive StoreInstruction where
   deriving DecidableEq, Repr
 
 def storeProvided : StoreInstruction -> LocalOrdering
-  | .str => none
+  | .str => unordered
   | .stlr => releaseOnly
 
 inductive FenceInstruction where
@@ -93,7 +93,7 @@ inductive ExclusivePair where
   deriving DecidableEq, Repr
 
 def exclusiveProvided : ExclusivePair -> LocalOrdering
-  | .ldxrStxr => none
+  | .ldxrStxr => unordered
   | .ldaxrStxr => acquireRCsc
   | .ldxrStlxr => releaseOnly
   | .ldaxrStlxr => acquireReleaseRCsc
@@ -106,7 +106,7 @@ inductive LSEInstruction where
   deriving DecidableEq, Repr
 
 def lseProvided : LSEInstruction -> LocalOrdering
-  | .relaxed => none
+  | .relaxed => unordered
   | .acquire => acquireRCsc
   | .release => releaseOnly
   | .acqRel => acquireReleaseRCsc
@@ -115,22 +115,21 @@ def lseProvided : LSEInstruction -> LocalOrdering
 def baselineLoad : Order -> Option LoadInstruction
   | .relaxed => some .ldr
   | .acquire | .seqCst => some .ldar
-  | .release | .acqRel => none
+  | .release | .acqRel => Option.none
 
 /-- Baseline AArch64 store profile. -/
 def baselineStore : Order -> Option StoreInstruction
   | .relaxed => some .str
   | .release | .seqCst => some .stlr
-  | .acquire | .acqRel => none
+  | .acquire | .acqRel => Option.none
 
 /-- Baseline fences. -/
 def baselineFence : Order -> Option FenceInstruction
   | .acquire => some .dmbIshld
   | .release | .acqRel | .seqCst => some .dmbIsh
-  | .relaxed => none
+  | .relaxed => Option.none
 
-/-- The current base ARMv8 evidence gate checks relaxed and acquire-release/SC
-    RMW families explicitly. -/
+/-- The base ARMv8 profile for all RMW order strengths. -/
 def baselineRMW : Order -> ExclusivePair
   | .relaxed => .ldxrStxr
   | .acquire => .ldaxrStxr
@@ -144,29 +143,39 @@ def lseRMW : Order -> LSEInstruction
   | .release => .release
   | .acqRel | .seqCst => .acqRel
 
-theorem baseline_loads_satisfy_local_order (o : Order)
-    (required : LocalOrdering) (instruction : LoadInstruction)
-    (hRequired : requiredLoad o = some required)
-    (hInstruction : baselineLoad o = some instruction) :
-    satisfies (loadProvided instruction) required = true := by
-  cases o <;> simp_all [requiredLoad, baselineLoad, loadProvided, satisfies,
-    none, acquireRCsc]
+/-- A total checker for the load profile. Illegal load orders are accepted only
+    when both the requirement and machine mapping are absent. -/
+def baselineLoadProfileValid (o : Order) : Bool :=
+  match requiredLoad o, baselineLoad o with
+  | some required, some instruction => satisfies (loadProvided instruction) required
+  | Option.none, Option.none => true
+  | _, _ => false
 
-theorem baseline_stores_satisfy_local_order (o : Order)
-    (required : LocalOrdering) (instruction : StoreInstruction)
-    (hRequired : requiredStore o = some required)
-    (hInstruction : baselineStore o = some instruction) :
-    satisfies (storeProvided instruction) required = true := by
-  cases o <;> simp_all [requiredStore, baselineStore, storeProvided, satisfies,
-    none, releaseOnly]
+/-- A total checker for the store profile. -/
+def baselineStoreProfileValid (o : Order) : Bool :=
+  match requiredStore o, baselineStore o with
+  | some required, some instruction => satisfies (storeProvided instruction) required
+  | Option.none, Option.none => true
+  | _, _ => false
 
-theorem baseline_fences_satisfy_local_order (o : Order)
-    (required : LocalOrdering) (instruction : FenceInstruction)
-    (hRequired : requiredFence o = some required)
-    (hInstruction : baselineFence o = some instruction) :
-    satisfies (fenceProvided instruction) required = true := by
-  cases o <;> simp_all [requiredFence, baselineFence, fenceProvided, satisfies,
-    acquireRCsc, releaseOnly, acquireReleaseRCsc]
+/-- A total checker for the fence profile. -/
+def baselineFenceProfileValid (o : Order) : Bool :=
+  match requiredFence o, baselineFence o with
+  | some required, some instruction => satisfies (fenceProvided instruction) required
+  | Option.none, Option.none => true
+  | _, _ => false
+
+theorem baseline_load_profile_valid (o : Order) :
+    baselineLoadProfileValid o = true := by
+  cases o <;> rfl
+
+theorem baseline_store_profile_valid (o : Order) :
+    baselineStoreProfileValid o = true := by
+  cases o <;> rfl
+
+theorem baseline_fence_profile_valid (o : Order) :
+    baselineFenceProfileValid o = true := by
+  cases o <;> rfl
 
 theorem baseline_rmw_satisfies_local_order (o : Order) :
     satisfies (exclusiveProvided (baselineRMW o)) (requiredRMW o) = true := by
@@ -185,8 +194,8 @@ theorem ldar_satisfies_oak_acquire :
     satisfies (loadProvided .ldar) acquireRCsc = true := rfl
 
 /-- Seq-cst's global total-order/read-visibility obligations are not discharged
-    by this local instruction mapping. This theorem records only the local load
-    component; Oak.SequentialConsistency remains a separate proof obligation. -/
+    by this local instruction mapping. These record only local components;
+    Oak.SequentialConsistency remains the separate global proof obligation. -/
 theorem seqCst_load_uses_rcsc_acquire : baselineLoad .seqCst = some .ldar := rfl
 
 theorem seqCst_store_uses_release : baselineStore .seqCst = some .stlr := rfl


### PR DESCRIPTION
Begins compiler/machine refinement for Oak's now-explicit language memory model.

AArch64 assembly evidence:
- Cross-compiles Oak-generated atomics with Clang `--target=aarch64-none-elf -ffreestanding -O2`.
- Baseline ARMv8-A checks:
  - relaxed load/store -> LDR/STR
  - acquire + seq-cst loads -> LDAR
  - release + seq-cst stores -> STLR
  - acquire fence -> DMB ISHLD
  - release/acq-rel/seq-cst fences -> DMB ISH
  - relaxed RMW/CAS -> LDXR/STXR
  - acq-rel/seq-cst RMW/CAS -> LDAXR/STLXR
- Oak's OS profile explicitly rejects LDAPR/RCpc as the acquire/seq-cst load projection; RCsc LDAR is required.
- ARMv8.1-A+LSE checks single-instruction performance forms:
  - relaxed fetch-add -> LDADD
  - acq-rel/seq-cst fetch-add -> LDADDAL
  - relaxed CAS -> CAS
  - acq-rel/seq-cst CAS -> CASAL
- Cross-target compile-time assertions require u8/u16/u32/u64 atomic widths to be always lock-free for the admitted AArch64 compiler/target tuple.

Litmus/source-model evidence:
- MP release/acquire publication establishes HB.
- SB both-zero is forbidden under seq-cst by exhausting all candidate SC witnesses.
- Relaxed SB both-zero remains allowed and data-race-free.
- IRIW contradictory seq-cst observations are forbidden by exhausting all 6! candidate SC orders.
- Seq-cst LB both-zero remains allowed, guarding against over-strengthening the model.

Formal evidence:
- New `Oak.AArch64Memory` models local acquire/release/RCsc capabilities and instruction classes.
- Lean proves the baseline load/store/fence and baseline/LSE RMW profiles satisfy Oak's required local ordering.
- Lean explicitly proves LDAR satisfies the OS profile and LDAPR does not.
- Claims remain narrow: global seq-cst stays in `Oak.SequentialConsistency`; this is not presented as a full LLVM/Arm axiomatic refinement proof.

CI:
- Adds independent `AArch64 Memory Refinement` job.
- Requires Clang cross-target support in CI (`OAK_REQUIRE_AARCH64_CLANG=1`).
- Runs assembly refinement tests and memory litmus outcomes independently of ordinary Go/race, Lean, and golden gates.

Docs:
- New normative `docs/spec/69-aarch64-memory-refinement.md` documenting admitted instruction families, lock-free admission, litmus coverage, proof scope, and remaining hardware/MMIO work.