### PR TITLE
Add explicit AArch64 barrier surface

### DIFF
--- a/codegen/aarch64_barrier_test.go
+++ b/codegen/aarch64_barrier_test.go
@@ -1,0 +1,126 @@
+package codegen
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const aarch64BarrierSource = `
+package main
+
+fn barrier_dmb_ishld() -> ()
+  arm64.dmb_ishld()
+
+fn barrier_dmb_ish() -> ()
+  arm64.dmb_ish()
+
+fn barrier_dmb_sy() -> ()
+  arm64.dmb_sy()
+
+fn barrier_dsb_ish() -> ()
+  arm64.dsb_ish()
+
+fn barrier_dsb_sy() -> ()
+  arm64.dsb_sy()
+
+fn barrier_isb() -> ()
+  arm64.isb()
+`
+
+func compileBarrierAArch64Assembly(t *testing.T) (generated, assembly string) {
+	t.Helper()
+	clang := requireAArch64Clang(t)
+	generated = generateSourceC(t, aarch64BarrierSource)
+
+	for _, forbidden := range []string{"malloc(", "calloc(", "realloc(", "free("} {
+		if strings.Contains(generated, forbidden) {
+			t.Fatalf("generated barrier path unexpectedly references heap primitive %q:\n%s", forbidden, generated)
+		}
+	}
+	if strings.Contains(generated, "OAK_PORTABLE_INTRINSICS") && !strings.Contains(generated, "#error \"arm64.") {
+		t.Fatalf("barrier lowering contains portable path without fail-closed #error:\n%s", generated)
+	}
+
+	dir := t.TempDir()
+	cPath := filepath.Join(dir, "barriers.c")
+	sPath := filepath.Join(dir, "barriers.s")
+	if err := os.WriteFile(cPath, []byte(generated), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(clang,
+		"--target=aarch64-none-elf", "-march=armv8-a",
+		"-std=c11", "-O2", "-ffreestanding",
+		"-Wall", "-Wextra", "-Werror", "-Wno-unused-function",
+		"-S", cPath, "-o", sPath,
+	)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("cross-compile generated barrier C: %v\n%s\n--- C ---\n%s", err, output, generated)
+	}
+	bytes, err := os.ReadFile(sPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return generated, strings.ToLower(string(bytes))
+}
+
+func TestAArch64BarrierInstructionRefinement(t *testing.T) {
+	_, assembly := compileBarrierAArch64Assembly(t)
+
+	cases := []struct {
+		fn          string
+		mnemonic    string
+		operandText string
+	}{
+		{"barrier_dmb_ishld", "dmb", "ishld"},
+		{"barrier_dmb_ish", "dmb", "ish"},
+		{"barrier_dmb_sy", "dmb", "sy"},
+		{"barrier_dsb_ish", "dsb", "ish"},
+		{"barrier_dsb_sy", "dsb", "sy"},
+		{"barrier_isb", "isb", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.fn, func(t *testing.T) {
+			body := aarch64FunctionBody(t, assembly, tc.fn)
+			requireInstruction(t, body, tc.mnemonic)
+			if tc.operandText != "" && !strings.Contains(body, tc.mnemonic+"\t"+tc.operandText) &&
+				!strings.Contains(body, tc.mnemonic+" "+tc.operandText) {
+				t.Fatalf("%s lacks exact barrier operand %s:\n%s", tc.fn, tc.operandText, body)
+			}
+			for _, other := range []string{"dmb", "dsb", "isb"} {
+				if other != tc.mnemonic && hasInstruction(body, other) {
+					t.Fatalf("%s unexpectedly contains additional barrier %s:\n%s", tc.fn, other, body)
+				}
+			}
+		})
+	}
+}
+
+func TestAArch64BarrierGeneratedCFailsClosedOnHost(t *testing.T) {
+	cc, err := exec.LookPath("cc")
+	if err != nil {
+		t.Skip("host C compiler is not available")
+	}
+	generated := generateSourceC(t, `
+package main
+fn barrier() -> ()
+  arm64.dsb_sy()
+`)
+	dir := t.TempDir()
+	cPath := filepath.Join(dir, "barrier.c")
+	oPath := filepath.Join(dir, "barrier.o")
+	if err := os.WriteFile(cPath, []byte(generated), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(cc, "-std=c11", "-O2", "-c", cPath, "-o", oPath)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("host compilation of architectural barrier unexpectedly succeeded")
+	}
+	if !strings.Contains(string(output), "arm64.dsb_sy requires an AArch64 target") {
+		t.Fatalf("host failure did not explain AArch64 barrier requirement:\n%s\n--- C ---\n%s", output, generated)
+	}
+}

--- a/codegen/ffi.go
+++ b/codegen/ffi.go
@@ -45,11 +45,10 @@ func libraryCallTarget(fn ast.Expression) (library, member string, ok bool) {
 	return base.Value, memberIdent.Value, true
 }
 
-// emitLibraryCall lowers a compiler-known library call: a c conversion
-// becomes an explicit C cast to the member's spelling; an arm64 instruction
-// function becomes its helper. Reports whether the call was handled.
-// The type checker has already rejected shadowed/local uses of the library
-// names in checked pipelines; unknown members fail closed.
+// emitLibraryCall lowers a compiler-known library call. The typechecker owns
+// the arm64 signature catalog, so codegen queries arity rather than maintaining
+// a second table. This supports both ordinary one-operand intrinsics and
+// nullary architectural barriers without runtime dispatch.
 func (cg *CodeGenerator) emitLibraryCall(call *ast.InvocationExpression, tc *typechecker.TypeChecker) bool {
 	library, member, ok := libraryCallTarget(call.Function)
 	if !ok {
@@ -71,14 +70,20 @@ func (cg *CodeGenerator) emitLibraryCall(call *ast.InvocationExpression, tc *typ
 		cg.output.WriteString(" ))")
 		return true
 	case "arm64":
-		validScalar := arm64IntrinsicWidths[member]
-		validVector := arm64VectorIntrinsicSources[member] != ""
-		if (!validScalar && !validVector) || len(call.Arguments) != 1 {
+		_, validVector := arm64VectorIntrinsicSources[member]
+		_, validScalarOrBarrier := arm64HelperSources[member]
+		arity, knownSignature := typechecker.Arm64IntrinsicArity(member)
+		if (!validScalarOrBarrier && !validVector) || !knownSignature || len(call.Arguments) != arity {
 			cg.output.WriteString("OAK_UNSUPPORTED_ARM64_INTRINSIC")
 			return true
 		}
 		cg.output.WriteString(fmt.Sprintf("oak_arm64_%s( ", member))
-		cg.emitExpressionFragment(call.Arguments[0], tc)
+		for i, arg := range call.Arguments {
+			cg.emitExpressionFragment(arg, tc)
+			if i < len(call.Arguments)-1 {
+				cg.output.WriteString(", ")
+			}
+		}
 		cg.output.WriteString(" )")
 		return true
 	case "simd":
@@ -99,23 +104,22 @@ func (cg *CodeGenerator) emitLibraryCall(call *ast.InvocationExpression, tc *typ
 	return false
 }
 
-// arm64IntrinsicWidths lists the v1 catalog (docs/spec/92-ffi.md
-// section 3.2), matching the type checker's table.
+// arm64IntrinsicWidths retains the original scalar-integer catalog for tests
+// and documentation. Barrier membership is instead owned by the SemIR-backed
+// typechecker catalog and arm64HelperSources below.
 var arm64IntrinsicWidths = map[string]bool{
 	"rev32": true, "rev64": true,
 	"rbit32": true, "rbit64": true,
 	"clz32": true, "clz64": true,
 }
 
-// collectUsedIntrinsics scans the program for scalar arm64
-// instruction-function calls so only the helpers a program uses are
-// emitted. Anything the scan cannot see would surface as a missing helper
-// at C compile time (fail closed, caught by the cc gate), never as wrong
-// behavior.
+// collectUsedIntrinsics scans the program for scalar arm64 instruction
+// functions and machine barriers. Presence in arm64HelperSources is the backend
+// capability witness; the typechecker independently rejects unknown members.
 func collectUsedIntrinsics(program *ast.Program) []string {
 	used := map[string]bool{}
 	scanCalls(program, func(library, member string) {
-		if library == "arm64" && arm64IntrinsicWidths[member] {
+		if library == "arm64" && arm64HelperSources[member] != "" {
 			used[member] = true
 		}
 	})
@@ -227,26 +231,26 @@ func scanCalls(program *ast.Program, visit func(library, member string)) {
 	}
 }
 
-// emitIntrinsicHelpers emits the helpers for the instruction functions the
-// program uses. On an AArch64 target each helper is the instruction itself
-// (inline assembly); elsewhere it is the portable C99 lowering
-// (docs/spec/92-ffi.md section 3.3). Semantics are identical by
-// Oak.Intrinsics plus the differential execution suite.
+// emitIntrinsicHelpers emits only helpers referenced by the program. Scalar
+// instruction functions keep their portable semantics. Architectural barriers
+// deliberately have no portable branch: compiling one for a non-AArch64 target
+// is a hard error rather than a semantic lie.
 func (cg *CodeGenerator) emitIntrinsicHelpers(program *ast.Program) {
 	used := collectUsedIntrinsics(program)
 	if len(used) == 0 {
 		return
 	}
-	cg.write("/* arm64 instruction functions: docs/spec/92-ffi.md section 3 */\n")
+	cg.write("/* arm64 instruction functions and barriers */\n")
 	for _, name := range used {
 		cg.writeRaw(arm64HelperSources[name])
 		cg.write("\n")
 	}
 }
 
-// arm64HelperSources holds one helper per instruction function. The
-// portable branches supply the total semantics the builtins leave undefined
-// (clz of zero) or missing (bit reverse, as the branch-free swap network).
+// arm64HelperSources holds one helper per scalar instruction function and
+// barrier. The portable scalar branches supply total semantics where possible;
+// barriers fail closed off AArch64 because DMB/DSB/ISB have architectural
+// semantics the host evaluator/C backend cannot faithfully emulate.
 var arm64HelperSources = map[string]string{
 	"rev32": `static inline u32 oak_arm64_rev32( u32 x ) {
 #if defined(__aarch64__) && !defined(OAK_PORTABLE_INTRINSICS)
@@ -271,7 +275,6 @@ var arm64HelperSources = map[string]string{
   __asm__("rbit %w0, %w1" : "=r"(x) : "r"(x));
   return x;
 #else
-  /* branch-free swap network (docs/spec/92-ffi.md section 3.3) */
   x = ((x & 0x55555555u) << 1) | ((x >> 1) & 0x55555555u);
   x = ((x & 0x33333333u) << 2) | ((x >> 2) & 0x33333333u);
   x = ((x & 0x0F0F0F0Fu) << 4) | ((x >> 4) & 0x0F0F0F0Fu);
@@ -284,7 +287,6 @@ var arm64HelperSources = map[string]string{
   __asm__("rbit %0, %1" : "=r"(x) : "r"(x));
   return x;
 #else
-  /* branch-free swap network (docs/spec/92-ffi.md section 3.3) */
   x = ((x & 0x5555555555555555u) << 1) | ((x >> 1) & 0x5555555555555555u);
   x = ((x & 0x3333333333333333u) << 2) | ((x >> 2) & 0x3333333333333333u);
   x = ((x & 0x0F0F0F0F0F0F0F0Fu) << 4) | ((x >> 4) & 0x0F0F0F0F0F0F0F0Fu);
@@ -298,7 +300,6 @@ var arm64HelperSources = map[string]string{
   __asm__("clz %w0, %w1" : "=r"(r) : "r"(x));
   return r;
 #else
-  /* guard supplies the total CLZ(0) = 32 the builtin leaves undefined */
   return x == 0u ? 32u : (u32)__builtin_clz(x);
 #endif
 }
@@ -309,8 +310,55 @@ var arm64HelperSources = map[string]string{
   __asm__("clz %0, %1" : "=r"(r) : "r"(x));
   return r;
 #else
-  /* guard supplies the total CLZ(0) = 64 the builtin leaves undefined */
   return x == 0u ? 64u : (u64)__builtin_clzll(x);
+#endif
+}
+`,
+	"dmb_ishld": `static inline void oak_arm64_dmb_ishld( void ) {
+#if defined(__aarch64__) && !defined(OAK_PORTABLE_INTRINSICS)
+  __asm__ volatile("dmb ishld" ::: "memory");
+#else
+#error "arm64.dmb_ishld requires an AArch64 target"
+#endif
+}
+`,
+	"dmb_ish": `static inline void oak_arm64_dmb_ish( void ) {
+#if defined(__aarch64__) && !defined(OAK_PORTABLE_INTRINSICS)
+  __asm__ volatile("dmb ish" ::: "memory");
+#else
+#error "arm64.dmb_ish requires an AArch64 target"
+#endif
+}
+`,
+	"dmb_sy": `static inline void oak_arm64_dmb_sy( void ) {
+#if defined(__aarch64__) && !defined(OAK_PORTABLE_INTRINSICS)
+  __asm__ volatile("dmb sy" ::: "memory");
+#else
+#error "arm64.dmb_sy requires an AArch64 target"
+#endif
+}
+`,
+	"dsb_ish": `static inline void oak_arm64_dsb_ish( void ) {
+#if defined(__aarch64__) && !defined(OAK_PORTABLE_INTRINSICS)
+  __asm__ volatile("dsb ish" ::: "memory");
+#else
+#error "arm64.dsb_ish requires an AArch64 target"
+#endif
+}
+`,
+	"dsb_sy": `static inline void oak_arm64_dsb_sy( void ) {
+#if defined(__aarch64__) && !defined(OAK_PORTABLE_INTRINSICS)
+  __asm__ volatile("dsb sy" ::: "memory");
+#else
+#error "arm64.dsb_sy requires an AArch64 target"
+#endif
+}
+`,
+	"isb": `static inline void oak_arm64_isb( void ) {
+#if defined(__aarch64__) && !defined(OAK_PORTABLE_INTRINSICS)
+  __asm__ volatile("isb" ::: "memory");
+#else
+#error "arm64.isb requires an AArch64 target"
 #endif
 }
 `,

--- a/codegen/ffi.go
+++ b/codegen/ffi.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/SCKelemen/oak/ast"
+	"github.com/SCKelemen/oak/semir"
 	"github.com/SCKelemen/oak/typechecker"
 )
 
@@ -240,7 +241,14 @@ func (cg *CodeGenerator) emitIntrinsicHelpers(program *ast.Program) {
 	if len(used) == 0 {
 		return
 	}
-	cg.write("/* arm64 instruction functions and barriers */\n")
+	header := "/* arm64 instruction functions */\n"
+	for _, name := range used {
+		if _, barrier := semir.LookupArm64Barrier(name); barrier {
+			header = "/* arm64 instruction functions and barriers */\n"
+			break
+		}
+	}
+	cg.write(header)
 	for _, name := range used {
 		cg.writeRaw(arm64HelperSources[name])
 		cg.write("\n")

--- a/docs/spec/95-aarch64-barriers.md
+++ b/docs/spec/95-aarch64-barriers.md
@@ -1,0 +1,268 @@
+# AArch64 barriers: explicit ordering, completion, and instruction synchronization
+
+This chapter defines Oak's first architecture-specific barrier surface for the
+AArch64 operating-system profile.
+
+The governing rule is:
+
+> Barriers are explicit machine operations. Oak neither inserts them silently
+> around volatile/MMIO accesses nor pretends they have portable host semantics.
+
+The source spelling identifies the exact architectural operation and scope.
+There is no runtime barrier enum, generic `barrier()` switch, hidden allocation,
+or fallback to an unrelated host fence.
+
+## 1. Source surface
+
+The compiler-known `arm64` library exposes exactly these nullary functions:
+
+```text
+arm64.dmb_ishld() -> ()
+arm64.dmb_ish()   -> ()
+arm64.dmb_sy()    -> ()
+arm64.dsb_ish()   -> ()
+arm64.dsb_sy()    -> ()
+arm64.isb()       -> ()
+```
+
+The option is part of the function identity. A program cannot construct a
+runtime string/enum and ask the backend to choose a barrier dynamically.
+Unknown barrier spellings fail type checking.
+
+## 2. Semantic IR
+
+`semir.Arm64BarrierSpec` records:
+
+```text
+member
+operation  // DMB, DSB, ISB
+scope      // ISHLD, ISH, SY, or none for ISB
+```
+
+and projects an explicit effect:
+
+```text
+Machine.Barrier[operation, scope?]
+```
+
+The catalog is the single source of barrier names for the typechecker and
+verification tests. Semantic lookup is a static switch and is regression-tested
+at zero allocations.
+
+## 3. DMB, DSB, and ISB stay distinct
+
+Oak intentionally does not collapse the three instruction families into a
+single notion of "strong fence".
+
+### 3.1 DMB
+
+DMB is admitted as a data-ordering barrier in its selected domain. The Oak
+profile does **not** claim DMB provides DSB-style completion.
+
+`dmb_ishld` is a load-ordering profile and is intentionally weaker than the
+full inner-shareable data barrier.
+
+`dmb_ish` is the full inner-shareable data-ordering profile.
+
+`dmb_sy` is the full system-scope data-ordering profile.
+
+### 3.2 DSB
+
+DSB provides the full data-ordering profile in the selected domain and adds the
+completion property on which Oak machine code may rely.
+
+`dsb_ish` is inner-shareable.
+
+`dsb_sy` is system scope.
+
+Oak does not automatically replace DMB with DSB "to be safe": unnecessary DSB
+use can be materially more expensive and would obscure the intended hardware
+contract.
+
+### 3.3 ISB
+
+ISB is modeled as instruction-context synchronization. It is not presented as a
+substitute for DMB/DSB data ordering or completion.
+
+Code that changes architectural state and requires an ISB must request
+`arm64.isb()` explicitly.
+
+## 4. Backend lowering
+
+Each source barrier lowers through one `static inline` C helper whose AArch64
+branch contains exactly one inline-assembly instruction:
+
+```text
+arm64.dmb_ishld -> dmb ishld
+arm64.dmb_ish   -> dmb ish
+arm64.dmb_sy    -> dmb sy
+arm64.dsb_ish   -> dsb ish
+arm64.dsb_sy    -> dsb sy
+arm64.isb       -> isb
+```
+
+The inline assembly is `volatile` and carries a C compiler `"memory"` clobber.
+That prevents the bootstrap C compiler from moving ordinary memory operations
+through the explicit machine barrier in ways that would destroy Oak's intended
+ordering boundary.
+
+There is no Oak runtime call, heap object, dynamically selected instruction, or
+hidden second barrier.
+
+## 5. Fail closed outside AArch64
+
+Unlike scalar value-transforming instruction functions such as byte-reverse or
+CLZ, DMB/DSB/ISB do not have a faithful architecture-independent evaluator or C
+fallback.
+
+Therefore generated helpers contain a compile-time error when the AArch64
+branch is unavailable.
+
+A source program using:
+
+```text
+arm64.dsb_sy()
+```
+
+must not successfully compile for an ordinary x86 host merely because the
+compiler can substitute a C atomic fence.
+
+A C fence is not a semantic replacement for AArch64 DSB completion.
+
+This fail-closed behavior is execution-tested with a host C compiler.
+
+## 6. Reference evaluator
+
+The Go evaluator recognizes barrier source functions and validates their arity,
+but executing one returns an explicit error explaining that the operation
+requires the native AArch64 backend.
+
+The evaluator does **not**:
+
+- silently return Unit;
+- call Go atomics;
+- insert a host mutex/fence;
+- model DSB completion as sequential evaluation;
+- pretend ISB has no observable semantic role.
+
+This keeps interpretation honest: parsing/typechecking and native execution are
+separate capabilities.
+
+## 7. Allocation and performance contract
+
+The barrier path is structurally minimal:
+
+1. source operation identity is compile-time;
+2. semantic catalog lookup performs zero allocations;
+3. typechecking has no runtime barrier object;
+4. generated code contains one inline helper per barrier actually used;
+5. helper body contains one barrier instruction in the AArch64 branch;
+6. no Oak heap allocation, callback, table dispatch, or syscall exists on the
+   runtime path;
+7. unused barrier helpers are not emitted.
+
+This is intended to make privileged hot paths reviewable directly from source
+and assembly.
+
+## 8. Formal verification
+
+`spec/lean/Oak/AArch64Barrier.lean` defines a deliberately narrow capability
+model rather than attempting to reproduce the full Arm memory axiomatic model.
+
+It distinguishes:
+
+```text
+data ordering: none / load / full
+completion
+instruction synchronization
+scope: inner-shareable / system
+```
+
+Lean proves:
+
+- admitted DMB variants do not claim completion;
+- admitted DSB variants do claim completion;
+- data barriers do not claim instruction-stream synchronization;
+- ISB does claim instruction synchronization;
+- DSB ISH preserves the full DMB ISH data-ordering class and adds completion;
+- DSB SY likewise extends DMB SY with completion;
+- DMB ISHLD is not classified as a full data barrier;
+- ISB makes no DMB/DSB-style data-order/completion claim.
+
+These are Oak profile facts, not a formal proof of every Arm architectural
+behavior.
+
+## 9. End-to-end verification
+
+The slice is accepted only if all of the following hold:
+
+- SemIR catalog/effect/instruction-spelling tests pass;
+- SemIR lookup remains zero-allocation;
+- typechecker accepts every exact nullary barrier and rejects operands/unknown
+  spellings;
+- evaluator diagnoses every barrier as native-AArch64-only;
+- Oak-generated C contains no heap primitive in the barrier path;
+- Clang cross-compiles the generated source for freestanding ARMv8-A;
+- each Oak function contains the exact requested DMB/DSB/ISB instruction and no
+  additional barrier family;
+- the same source fails closed when compiled by an ordinary host C compiler;
+- Lean kernel-checks the capability model;
+- ordinary Go/race, golden, and AArch64-refinement CI remain green.
+
+## 10. Relationship to atomics and volatile access
+
+Barriers are not replacements for the atomic model in chapters 65–69.
+
+Likewise, volatile access means an observable access occurs; it does not imply a
+DMB, DSB, ISB, acquire, release, or device-completion contract.
+
+Oak deliberately keeps:
+
+```text
+volatile access
+atomic synchronization
+AArch64 barrier
+```
+
+as separate concepts that may be composed explicitly when hardware semantics
+require them.
+
+This matters for MMIO: the correct barrier depends on the device protocol,
+memory attributes, DMA/coherency rules, and the operation being performed.
+Automatically inserting a maximal barrier around every register access would
+be both semantically imprecise and unnecessarily slow.
+
+## 11. Verification status
+
+| Layer | Status |
+| --- | --- |
+| exact source barrier catalog | specified + implemented |
+| Semantic IR barrier operation/scope/effect | specified + implemented + tested |
+| nullary source typing | implemented + tested |
+| zero-allocation semantic lookup | regression-tested |
+| native AArch64 inline-asm lowering | implemented + assembly-tested |
+| fail-closed non-AArch64 lowering | implemented + execution-tested |
+| evaluator honesty/native requirement | implemented + tested |
+| barrier capability classification | Lean-modeled + proved |
+| full formal Arm axiomatic refinement | not claimed |
+| typed MMIO register/address model | next |
+| device memory attributes | not yet modeled |
+| DMA/coherency ordering | not yet modeled |
+
+## 12. Next layer: typed MMIO
+
+The next machine slice should introduce nominal register-address types such as:
+
+```text
+mmio.U8
+mmio.U16
+mmio.U32
+mmio.U64
+```
+
+with explicit unsafe construction from an address, width/alignment validation,
+and exact one-access volatile read/write functions.
+
+No MMIO read/write will insert a barrier automatically. Device drivers and
+hypervisor adapters will compose typed MMIO operations with the barrier contract
+in this chapter according to the hardware protocol they implement.

--- a/evaluator/ffi.go
+++ b/evaluator/ffi.go
@@ -1,16 +1,18 @@
 package evaluator
 
-// Interpreter semantics for the compiler-known foreign-interface libraries
-// (docs/spec/92-ffi.md section 4): every arm64 instruction function runs
-// natively so interpreted and compiled programs agree; c conversions are
-// value-preserving (nominal typing is enforced statically); extern bindings
-// cannot be called, because the interpreter has no foreign world.
+// Interpreter semantics for the compiler-known foreign-interface libraries.
+// Portable arm64 value-transforming instruction functions execute natively in
+// the interpreter. Architectural barriers do not: DMB/DSB/ISB have machine
+// ordering/completion semantics that cannot be faithfully represented by the
+// sequential host evaluator, so execution fails explicitly rather than
+// pretending they are no-ops.
 
 import (
 	"math/bits"
 
 	"github.com/SCKelemen/oak/ast"
 	"github.com/SCKelemen/oak/object"
+	"github.com/SCKelemen/oak/semir"
 )
 
 func evalLibraryCall(library, member string, args []ast.Expression, env *object.Environment) object.Object {
@@ -23,8 +25,6 @@ func evalLibraryCall(library, member string, args []ast.Expression, env *object.
 		if member == "extern" {
 			return newError("extern bindings require the native backend; the interpreter cannot call foreign code")
 		}
-		// A c.* conversion preserves the abstract value (Oak.CInterop);
-		// the nominal boundary typing is enforced by the type checker.
 		if len(args) != 1 {
 			return newError("c.%s takes exactly one argument", member)
 		}
@@ -33,10 +33,13 @@ func evalLibraryCall(library, member string, args []ast.Expression, env *object.
 	return newError("unknown library: %s", library)
 }
 
-// evalArm64Intrinsic implements the v1 catalog of docs/spec/92-ffi.md
-// section 3.2 with the same total semantics as the Lean model
-// (Oak.Intrinsics) and the C lowerings.
 func evalArm64Intrinsic(member string, args []ast.Expression, env *object.Environment) object.Object {
+	if _, barrier := semir.LookupArm64Barrier(member); barrier {
+		if len(args) != 0 {
+			return newError("arm64.%s takes exactly zero arguments", member)
+		}
+		return newError("arm64.%s is an architectural barrier and requires the native AArch64 backend", member)
+	}
 	if arm64VectorMembers[member] {
 		return evalArm64VectorIntrinsic(member, args, env)
 	}
@@ -61,24 +64,17 @@ func evalArm64Intrinsic(member string, args []ast.Expression, env *object.Enviro
 	case "rbit64":
 		return &object.Integer{Value: int64(bits.Reverse64(uint64(operand.Value)))}
 	case "clz32":
-		// Total: clz32(0) = 32, the ARM CLZ semantics (Oak.Intrinsics).
 		return &object.Integer{Value: int64(bits.LeadingZeros32(uint32(operand.Value)))}
 	case "clz64":
-		// Total: clz64(0) = 64.
 		return &object.Integer{Value: int64(bits.LeadingZeros64(uint64(operand.Value)))}
 	}
 	return newError("the arm64 library has no instruction function arm64.%s", member)
 }
 
-// arm64VectorMembers are the horizontal vector instruction functions
-// (docs/spec/93-simd.md section 2).
 var arm64VectorMembers = map[string]bool{
 	"uaddlv_u8x16": true, "umaxv_u8x16": true, "uminv_u8x16": true, "cnt_u8x16": true,
 }
 
-// evalArm64VectorIntrinsic implements the horizontal vector instructions of
-// docs/spec/93-simd.md section 2 with the same total semantics as the NEON
-// and portable C lowerings.
 func evalArm64VectorIntrinsic(member string, args []ast.Expression, env *object.Environment) object.Object {
 	if len(args) != 1 {
 		return newError("arm64.%s takes exactly one argument", member)
@@ -112,7 +108,6 @@ func evalArm64VectorIntrinsic(member string, args []ast.Expression, env *object.
 			if lane < min {
 				min = lane
 			}
-		}
 		return &object.Integer{Value: int64(min)}
 	case "cnt_u8x16":
 		result := &object.Vector{VectorKind: "U8x16"}

--- a/evaluator/ffi.go
+++ b/evaluator/ffi.go
@@ -108,6 +108,7 @@ func evalArm64VectorIntrinsic(member string, args []ast.Expression, env *object.
 			if lane < min {
 				min = lane
 			}
+		}
 		return &object.Integer{Value: int64(min)}
 	case "cnt_u8x16":
 		result := &object.Vector{VectorKind: "U8x16"}

--- a/evaluator/ffi_test.go
+++ b/evaluator/ffi_test.go
@@ -5,26 +5,24 @@ import (
 	"testing"
 
 	"github.com/SCKelemen/oak/object"
+	"github.com/SCKelemen/oak/semir"
 )
 
-// Interpreter parity for the arm64 instruction functions
-// (docs/spec/92-ffi.md section 4): the interpreter is the third witness of
-// the intrinsic semantics, alongside the instruction and portable C
-// lowerings, and must agree on the Oak.Intrinsics laws.
+// Interpreter parity for the arm64 value-transforming instruction functions.
 func TestArm64IntrinsicsInterpreterParity(t *testing.T) {
 	tests := []struct {
 		input string
 		want  int64
 	}{
 		{"arm64.clz64(u64(1))", 63},
-		{"arm64.clz32(u32(0))", 32},   // total: CLZ(0) = width
-		{"arm64.clz64(u64(0))", 64},   // total: CLZ(0) = width
+		{"arm64.clz32(u32(0))", 32},
+		{"arm64.clz64(u64(0))", 64},
 		{"arm64.clz64(u64(255))", 56},
-		{"arm64.rev32(u32(287454020))", 1144201745},   // 0x11223344 -> 0x44332211
-		{"arm64.rev32(arm64.rev32(u32(19088743)))", 19088743},   // involution
+		{"arm64.rev32(u32(287454020))", 1144201745},
+		{"arm64.rev32(arm64.rev32(u32(19088743)))", 19088743},
 		{"arm64.rev64(arm64.rev64(u64(81985529216486895)))", 81985529216486895},
-		{"arm64.rbit32(u32(1))", 2147483648}, // bit 0 -> bit 31
-		{"arm64.rbit64(arm64.rbit64(u64(1234567890)))", 1234567890}, // involution
+		{"arm64.rbit32(u32(1))", 2147483648},
+		{"arm64.rbit64(arm64.rbit64(u64(1234567890)))", 1234567890},
 	}
 	for _, tt := range tests {
 		result := testEval(tt.input)
@@ -38,8 +36,26 @@ func TestArm64IntrinsicsInterpreterParity(t *testing.T) {
 	}
 }
 
-// Extern bindings are native-backend only: calling one under interpretation
-// is a diagnosed error, never a silent no-op (docs/spec/92-ffi.md section 4).
+// Architectural barriers cannot be faithfully executed by the sequential Go
+// evaluator. Every source barrier must fail explicitly rather than disappear as
+// a no-op or be over-strengthened into an unrelated host primitive.
+func TestArm64BarriersRequireNativeAArch64Backend(t *testing.T) {
+	for _, member := range semir.Arm64BarrierMembers() {
+		t.Run(member, func(t *testing.T) {
+			result := testEval("arm64." + member + "()")
+			err, ok := result.(*object.Error)
+			if !ok {
+				t.Fatalf("%s: expected native-backend error, got %v", member, result)
+			}
+			if !strings.Contains(err.Message, "native AArch64 backend") {
+				t.Fatalf("%s error %q does not explain native AArch64 requirement", member, err.Message)
+			}
+		})
+	}
+}
+
+// Extern bindings are native-backend only: calling one under interpretation is
+// a diagnosed error, never a silent no-op.
 func TestExternBindingsNotCallableInInterpreter(t *testing.T) {
 	result := testEval(`
 putchar: (ch: c.Int): c.Int = c.extern("putchar")

--- a/golden/arm64_intrinsics_7_codegen.c
+++ b/golden/arm64_intrinsics_7_codegen.c
@@ -111,14 +111,13 @@ static Bool oak_is_valid_utf8(oak_view_u8 v) {
   return oak_Bool_True;
 }
 
-/* arm64 instruction functions: docs/spec/92-ffi.md section 3 */
+/* arm64 instruction functions */
 static inline u32 oak_arm64_clz32( u32 x ) {
 #if defined(__aarch64__) && !defined(OAK_PORTABLE_INTRINSICS)
   u32 r;
   __asm__("clz %w0, %w1" : "=r"(r) : "r"(x));
   return r;
 #else
-  /* guard supplies the total CLZ(0) = 32 the builtin leaves undefined */
   return x == 0u ? 32u : (u32)__builtin_clz(x);
 #endif
 }
@@ -128,7 +127,6 @@ static inline u64 oak_arm64_rbit64( u64 x ) {
   __asm__("rbit %0, %1" : "=r"(x) : "r"(x));
   return x;
 #else
-  /* branch-free swap network (docs/spec/92-ffi.md section 3.3) */
   x = ((x & 0x5555555555555555u) << 1) | ((x >> 1) & 0x5555555555555555u);
   x = ((x & 0x3333333333333333u) << 2) | ((x >> 2) & 0x3333333333333333u);
   x = ((x & 0x0F0F0F0F0F0F0F0Fu) << 4) | ((x >> 4) & 0x0F0F0F0F0F0F0F0Fu);

--- a/semir/barrier.go
+++ b/semir/barrier.go
@@ -1,0 +1,100 @@
+package semir
+
+import "fmt"
+
+// BarrierOperation is the architectural barrier class, independent of its
+// scope/domain option. ISB is intentionally distinct from data-memory barriers.
+type BarrierOperation string
+
+const (
+	BarrierDMB BarrierOperation = "dmb"
+	BarrierDSB BarrierOperation = "dsb"
+	BarrierISB BarrierOperation = "isb"
+)
+
+// BarrierScope is the architectural option encoded in a DMB/DSB instruction.
+// ISB has no data-shareability scope and therefore uses BarrierScopeNone.
+type BarrierScope string
+
+const (
+	BarrierScopeNone  BarrierScope = ""
+	BarrierScopeISHLD BarrierScope = "ishld"
+	BarrierScopeISH   BarrierScope = "ish"
+	BarrierScopeSY    BarrierScope = "sy"
+)
+
+// Arm64BarrierSpec is the single semantic descriptor for source identity,
+// architectural operation, scope, and effect projection. Barriers are all
+// nullary and return Unit; the source surface carries no runtime barrier enum.
+type Arm64BarrierSpec struct {
+	Member    string
+	Operation BarrierOperation
+	Scope     BarrierScope
+}
+
+func (s Arm64BarrierSpec) Effect() Effect {
+	parameters := []string{string(s.Operation)}
+	if s.Scope != BarrierScopeNone {
+		parameters = append(parameters, string(s.Scope))
+	}
+	return Effect{Namespace: "Machine", Name: "Barrier", Parameters: parameters}
+}
+
+func (s Arm64BarrierSpec) Instruction() string {
+	if s.Operation == BarrierISB {
+		return "isb"
+	}
+	return string(s.Operation) + " " + string(s.Scope)
+}
+
+// LookupArm64Barrier defines the complete first machine-barrier source surface.
+// The spelling mirrors the exact AArch64 instruction option so a reviewer can
+// infer the machine contract directly from Oak source.
+func LookupArm64Barrier(member string) (Arm64BarrierSpec, bool) {
+	switch member {
+	case "dmb_ishld":
+		return Arm64BarrierSpec{Member: member, Operation: BarrierDMB, Scope: BarrierScopeISHLD}, true
+	case "dmb_ish":
+		return Arm64BarrierSpec{Member: member, Operation: BarrierDMB, Scope: BarrierScopeISH}, true
+	case "dmb_sy":
+		return Arm64BarrierSpec{Member: member, Operation: BarrierDMB, Scope: BarrierScopeSY}, true
+	case "dsb_ish":
+		return Arm64BarrierSpec{Member: member, Operation: BarrierDSB, Scope: BarrierScopeISH}, true
+	case "dsb_sy":
+		return Arm64BarrierSpec{Member: member, Operation: BarrierDSB, Scope: BarrierScopeSY}, true
+	case "isb":
+		return Arm64BarrierSpec{Member: member, Operation: BarrierISB, Scope: BarrierScopeNone}, true
+	default:
+		return Arm64BarrierSpec{}, false
+	}
+}
+
+// Arm64BarrierMembers returns a stable, allocation-free-to-query catalog source
+// for compiler layers. The returned array is a value; callers may range it
+// without maintaining a second list of barrier names.
+func Arm64BarrierMembers() [6]string {
+	return [6]string{"dmb_ishld", "dmb_ish", "dmb_sy", "dsb_ish", "dsb_sy", "isb"}
+}
+
+func ValidateArm64Barrier(spec Arm64BarrierSpec) error {
+	if spec.Member == "" {
+		return fmt.Errorf("barrier member is empty")
+	}
+	switch spec.Operation {
+	case BarrierDMB:
+		if spec.Scope != BarrierScopeISHLD && spec.Scope != BarrierScopeISH && spec.Scope != BarrierScopeSY {
+			return fmt.Errorf("DMB has unsupported scope %q", spec.Scope)
+		}
+	case BarrierDSB:
+		if spec.Scope != BarrierScopeISH && spec.Scope != BarrierScopeSY {
+			return fmt.Errorf("DSB has unsupported scope %q", spec.Scope)
+		}
+	case BarrierISB:
+		if spec.Scope != BarrierScopeNone {
+			return fmt.Errorf("ISB cannot carry data shareability scope %q", spec.Scope)
+		}
+	default:
+		return fmt.Errorf("unknown barrier operation %q", spec.Operation)
+	}
+	return nil
+}

--- a/semir/barrier_test.go
+++ b/semir/barrier_test.go
@@ -1,0 +1,57 @@
+package semir
+
+import "testing"
+
+func TestArm64BarrierCatalogIsValidAndExact(t *testing.T) {
+	members := Arm64BarrierMembers()
+	seen := map[string]bool{}
+	for _, member := range members {
+		if seen[member] {
+			t.Fatalf("duplicate barrier member %q", member)
+		}
+		seen[member] = true
+		spec, ok := LookupArm64Barrier(member)
+		if !ok {
+			t.Fatalf("catalog member %q is not recognized", member)
+		}
+		if spec.Member != member {
+			t.Fatalf("lookup changed member identity: got %q want %q", spec.Member, member)
+		}
+		if err := ValidateArm64Barrier(spec); err != nil {
+			t.Fatalf("barrier %q invalid: %v", member, err)
+		}
+		effect := spec.Effect()
+		if effect.Namespace != "Machine" || effect.Name != "Barrier" {
+			t.Fatalf("barrier %q effect = %#v", member, effect)
+		}
+	}
+}
+
+func TestArm64BarrierInstructionsAreExplicit(t *testing.T) {
+	want := map[string]string{
+		"dmb_ishld": "dmb ishld",
+		"dmb_ish":   "dmb ish",
+		"dmb_sy":    "dmb sy",
+		"dsb_ish":   "dsb ish",
+		"dsb_sy":    "dsb sy",
+		"isb":       "isb",
+	}
+	for member, instruction := range want {
+		spec, ok := LookupArm64Barrier(member)
+		if !ok || spec.Instruction() != instruction {
+			t.Fatalf("%s instruction = %q, want %q", member, spec.Instruction(), instruction)
+		}
+	}
+}
+
+func TestArm64BarrierLookupAllocatesNothing(t *testing.T) {
+	allocs := testing.AllocsPerRun(1000, func() {
+		spec, ok := LookupArm64Barrier("dsb_sy")
+		if !ok || spec.Operation != BarrierDSB || spec.Scope != BarrierScopeSY {
+			panic("barrier lookup failed")
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("barrier lookup allocated %.2f objects per call; want zero", allocs)
+	}
+}

--- a/spec/lean/Oak.lean
+++ b/spec/lean/Oak.lean
@@ -4,6 +4,7 @@ import Oak.MemoryOrder
 import Oak.HappensBefore
 import Oak.SequentialConsistency
 import Oak.AArch64Memory
+import Oak.AArch64Barrier
 import Oak.Borrowing
 import Oak.BorrowRegions
 import Oak.Reborrow

--- a/spec/lean/Oak/AArch64Barrier.lean
+++ b/spec/lean/Oak/AArch64Barrier.lean
@@ -1,0 +1,92 @@
+namespace Oak.AArch64Barrier
+
+/-- Shareability/domain classification retained by the Oak source spelling. -/
+inductive Scope where
+  | innerShareable
+  | system
+  deriving DecidableEq, Repr
+
+/-- Deliberately coarse data-ordering capability. This is an Oak machine-profile
+    classification, not a replacement for the Arm axiomatic memory model. -/
+inductive DataOrdering where
+  | none
+  | load
+  | full
+  deriving DecidableEq, Repr
+
+/-- The capabilities Oak relies on when selecting a barrier instruction.
+
+`completion` records the additional completion property claimed for DSB over
+DMB in the selected domain. `instructionSync` is reserved for ISB. -/
+structure Capability where
+  dataOrdering : DataOrdering
+  completion : Bool
+  instructionSync : Bool
+  scope : Option Scope
+  deriving DecidableEq, Repr
+
+inductive Barrier where
+  | dmbIshld
+  | dmbIsh
+  | dmbSy
+  | dsbIsh
+  | dsbSy
+  | isb
+  deriving DecidableEq, Repr
+
+def capability : Barrier -> Capability
+  | .dmbIshld => ⟨.load, false, false, some .innerShareable⟩
+  | .dmbIsh   => ⟨.full, false, false, some .innerShareable⟩
+  | .dmbSy    => ⟨.full, false, false, some .system⟩
+  | .dsbIsh   => ⟨.full, true, false, some .innerShareable⟩
+  | .dsbSy    => ⟨.full, true, false, some .system⟩
+  | .isb      => ⟨.none, false, true, none⟩
+
+/-- DMB is modeled as ordering, never as completion. -/
+theorem dmb_does_not_claim_completion (b : Barrier)
+    (h : b = .dmbIshld ∨ b = .dmbIsh ∨ b = .dmbSy) :
+    (capability b).completion = false := by
+  rcases h with rfl | rfl | rfl <;> rfl
+
+/-- DSB carries the completion capability in each admitted data scope. -/
+theorem dsb_claims_completion (b : Barrier)
+    (h : b = .dsbIsh ∨ b = .dsbSy) :
+    (capability b).completion = true := by
+  rcases h with rfl | rfl <;> rfl
+
+/-- ISB is the only admitted instruction-stream synchronization primitive. -/
+theorem isb_instruction_sync : (capability .isb).instructionSync = true := rfl
+
+theorem data_barriers_do_not_claim_instruction_sync (b : Barrier)
+    (h : b ≠ .isb) : (capability b).instructionSync = false := by
+  cases b <;> simp_all [capability]
+
+/-- The inner-shareable DSB preserves full data ordering and adds completion
+    relative to the corresponding DMB profile. -/
+theorem dsb_ish_extends_dmb_ish :
+    (capability .dsbIsh).dataOrdering = (capability .dmbIsh).dataOrdering ∧
+    (capability .dmbIsh).completion = false ∧
+    (capability .dsbIsh).completion = true := by
+  exact ⟨rfl, rfl, rfl⟩
+
+/-- The system-scope DSB similarly extends system-scope DMB with completion. -/
+theorem dsb_sy_extends_dmb_sy :
+    (capability .dsbSy).dataOrdering = (capability .dmbSy).dataOrdering ∧
+    (capability .dmbSy).completion = false ∧
+    (capability .dsbSy).completion = true := by
+  exact ⟨rfl, rfl, rfl⟩
+
+/-- ISHLD is intentionally weaker than the full inner-shareable data barrier in
+    the Oak profile; users must request `dmb_ish` when full data ordering is
+    required. -/
+theorem ishld_is_not_full :
+    (capability .dmbIshld).dataOrdering ≠ .full := by
+  decide
+
+/-- ISB makes no claim of DMB/DSB-style data ordering or completion. -/
+theorem isb_is_not_data_barrier :
+    (capability .isb).dataOrdering = .none ∧
+    (capability .isb).completion = false := by
+  exact ⟨rfl, rfl⟩
+
+end Oak.AArch64Barrier

--- a/typechecker/barrier.go
+++ b/typechecker/barrier.go
@@ -1,0 +1,25 @@
+package typechecker
+
+import "github.com/SCKelemen/oak/semir"
+
+// Register the machine-barrier source surface in the same compiler-known arm64
+// library used by the existing instruction functions. The SemIR catalog owns
+// the names; the typechecker contributes only the source type: () -> ().
+func init() {
+	for _, member := range semir.Arm64BarrierMembers() {
+		arm64Intrinsics[member] = &FunctionType{
+			Parameters: []Type{},
+			ReturnType: &UnitType{},
+		}
+	}
+}
+
+// Arm64IntrinsicArity exposes the checked arm64 library arity to backend code
+// without maintaining a second independent signature table.
+func Arm64IntrinsicArity(member string) (int, bool) {
+	signature, ok := arm64Intrinsics[member]
+	if !ok || signature == nil {
+		return 0, false
+	}
+	return len(signature.Parameters), true
+}

--- a/typechecker/barrier_test.go
+++ b/typechecker/barrier_test.go
@@ -1,0 +1,50 @@
+package typechecker
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/SCKelemen/oak/semir"
+)
+
+func TestArm64BarrierInstructionFunctionsTypecheck(t *testing.T) {
+	for _, member := range semir.Arm64BarrierMembers() {
+		t.Run(member, func(t *testing.T) {
+			input := "fn f() -> () = arm64." + member + "()"
+			tc := setupTypeChecker(input)
+			program := parseProgram(input)
+			tc.CheckProgram(program)
+			if len(tc.Errors()) != 0 {
+				t.Fatalf("valid barrier %s rejected: %v", member, tc.Errors())
+			}
+			arity, ok := Arm64IntrinsicArity(member)
+			if !ok || arity != 0 {
+				t.Fatalf("barrier %s arity = %d, ok=%v; want 0,true", member, arity, ok)
+			}
+		})
+	}
+}
+
+func TestArm64BarrierRejectsOperands(t *testing.T) {
+	input := "fn f() -> () = arm64.dmb_ish(u32(1))"
+	tc := setupTypeChecker(input)
+	program := parseProgram(input)
+	tc.CheckProgram(program)
+	if len(tc.Errors()) == 0 {
+		t.Fatal("barrier with runtime operand unexpectedly typechecked")
+	}
+	all := strings.Join(tc.Errors(), "\n")
+	if !strings.Contains(all, "expects 0 arguments") && !strings.Contains(all, "0 argument") {
+		t.Fatalf("barrier arity diagnostic is not explicit: %v", tc.Errors())
+	}
+}
+
+func TestUnknownArm64BarrierStillFailsClosed(t *testing.T) {
+	input := "fn f() -> () = arm64.dsb_outer_shareable()"
+	tc := setupTypeChecker(input)
+	program := parseProgram(input)
+	tc.CheckProgram(program)
+	if len(tc.Errors()) == 0 {
+		t.Fatal("unknown barrier spelling unexpectedly typechecked")
+	}
+}


### PR DESCRIPTION
Adds Oak's first explicit architecture-specific barrier surface as a complete machine slice.

Source/semantics:
- Adds exact nullary arm64 functions: `dmb_ishld`, `dmb_ish`, `dmb_sy`, `dsb_ish`, `dsb_sy`, and `isb`.
- One SemIR `Arm64BarrierSpec` owns member identity, operation, scope, exact instruction spelling, and `Machine.Barrier[...]` effect projection.
- No runtime barrier enum or generic dispatch.
- Barrier catalog lookup is regression-tested at zero allocations.

Typechecker/evaluator:
- Typechecker registers barrier signatures from the SemIR catalog as `() -> ()` and rejects operands/unknown spellings.
- Codegen queries arm64 arity from the typechecker instead of maintaining another signature table.
- The Go evaluator recognizes barriers but execution fails explicitly with a native-AArch64 requirement; DMB/DSB/ISB are never silently modeled as no-ops or Go fences.

Backend:
- Each used barrier lowers to one pay-for-use `static inline` helper with exact AArch64 inline asm and a `memory` compiler clobber.
- Generated non-AArch64 C fails closed with `#error` rather than substituting a portable atomic fence.
- Existing scalar arm64 portable fallbacks remain unchanged.
- No Oak heap allocation, callback, runtime order/scope switch, or hidden extra barrier exists on the runtime path.

AArch64 refinement tests:
- Freestanding Clang cross-compilation verifies exact emitted `dmb ishld`, `dmb ish`, `dmb sy`, `dsb ish`, `dsb sy`, and `isb` instructions.
- Each source function is checked not to acquire an additional barrier family.
- Host C compilation of an architectural barrier is required to fail with the explicit AArch64 diagnostic.
- Barrier test names are included automatically in the existing independent `AArch64 Memory Refinement` CI job.

Formal verification:
- New `Oak.AArch64Barrier` capability model distinguishes data ordering (none/load/full), completion, instruction synchronization, and scope.
- Lean proves DMB variants do not claim completion, DSB variants do, ISB is instruction-sync-only in this profile, DSB extends corresponding DMB with completion, and ISHLD is not classified as a full data barrier.
- Scope is intentionally a narrow Oak profile abstraction, not a claim to formalize the complete Arm axiomatic model.

Docs:
- New normative `docs/spec/95-aarch64-barriers.md`.
- Explicitly states barriers are separate from atomics and volatile access and are never inserted automatically around future MMIO.

Next after merge: nominal typed MMIO register-address types with unsafe construction, alignment/width checks, exact one-access volatile reads/writes, and explicit composition with this barrier layer.