### PR TITLE
Add typed AArch64 MMIO surface

### DIFF
--- a/codegen/aarch64_mmio_test.go
+++ b/codegen/aarch64_mmio_test.go
@@ -1,0 +1,120 @@
+package codegen
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const aarch64MmioSource = `
+package main
+
+fn mmio_load8(addr: u64) -> u8
+  arm64.mmio_read_rw_u8(arm64.mmio_unsafe_rw_u8(addr))
+fn mmio_load16(addr: u64) -> u16
+  arm64.mmio_read_rw_u16(arm64.mmio_unsafe_rw_u16(addr))
+fn mmio_load32(addr: u64) -> u32
+  arm64.mmio_read_rw_u32(arm64.mmio_unsafe_rw_u32(addr))
+fn mmio_load64(addr: u64) -> u64
+  arm64.mmio_read_rw_u64(arm64.mmio_unsafe_rw_u64(addr))
+
+fn mmio_store8(addr: u64, value: u8) -> ()
+  arm64.mmio_write_rw_u8(arm64.mmio_unsafe_rw_u8(addr), value)
+fn mmio_store16(addr: u64, value: u16) -> ()
+  arm64.mmio_write_rw_u16(arm64.mmio_unsafe_rw_u16(addr), value)
+fn mmio_store32(addr: u64, value: u32) -> ()
+  arm64.mmio_write_rw_u32(arm64.mmio_unsafe_rw_u32(addr), value)
+fn mmio_store64(addr: u64, value: u64) -> ()
+  arm64.mmio_write_rw_u64(arm64.mmio_unsafe_rw_u64(addr), value)
+`
+
+func compileMmioAArch64Assembly(t *testing.T) (generated, assembly string) {
+	t.Helper()
+	clang := requireAArch64Clang(t)
+	generated = generateSourceC(t, aarch64MmioSource)
+	for _, forbidden := range []string{"malloc(", "calloc(", "realloc(", "free("} {
+		if strings.Contains(generated, forbidden) {
+			t.Fatalf("generated MMIO path unexpectedly references heap primitive %q:\n%s", forbidden, generated)
+		}
+	}
+	if strings.Contains(generated, "atomic_thread_fence") {
+		t.Fatalf("MMIO lowering acquired hidden C atomic fence:\n%s", generated)
+	}
+
+	dir := t.TempDir()
+	cPath := filepath.Join(dir, "mmio.c")
+	sPath := filepath.Join(dir, "mmio.s")
+	if err := os.WriteFile(cPath, []byte(generated), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(clang,
+		"--target=aarch64-none-elf", "-march=armv8-a",
+		"-std=c11", "-O2", "-ffreestanding",
+		"-Wall", "-Wextra", "-Werror", "-Wno-unused-function",
+		"-S", cPath, "-o", sPath,
+	)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("cross-compile generated MMIO C: %v\n%s\n--- C ---\n%s", err, output, generated)
+	}
+	bytes, err := os.ReadFile(sPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return generated, strings.ToLower(string(bytes))
+}
+
+func TestAArch64MmioExactAccessWidthAndNoHiddenBarrier(t *testing.T) {
+	_, assembly := compileMmioAArch64Assembly(t)
+	cases := []struct {
+		fn       string
+		mnemonic string
+	}{
+		{"mmio_load8", "ldrb"},
+		{"mmio_load16", "ldrh"},
+		{"mmio_load32", "ldr"},
+		{"mmio_load64", "ldr"},
+		{"mmio_store8", "strb"},
+		{"mmio_store16", "strh"},
+		{"mmio_store32", "str"},
+		{"mmio_store64", "str"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.fn, func(t *testing.T) {
+			body := aarch64FunctionBody(t, assembly, tc.fn)
+			requireInstruction(t, body, tc.mnemonic)
+			for _, barrier := range []string{"dmb", "dsb", "isb"} {
+				if hasInstruction(body, barrier) {
+					t.Fatalf("%s acquired hidden %s barrier:\n%s", tc.fn, barrier, body)
+				}
+			}
+		})
+	}
+}
+
+func TestAArch64MmioGeneratedCFailsClosedOnHost(t *testing.T) {
+	cc, err := exec.LookPath("cc")
+	if err != nil {
+		t.Skip("host C compiler is not available")
+	}
+	generated := generateSourceC(t, `
+package main
+fn load(addr: u64) -> u32
+  arm64.mmio_read_rw_u32(arm64.mmio_unsafe_rw_u32(addr))
+`)
+	dir := t.TempDir()
+	cPath := filepath.Join(dir, "mmio.c")
+	oPath := filepath.Join(dir, "mmio.o")
+	if err := os.WriteFile(cPath, []byte(generated), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(cc, "-std=c11", "-O2", "-c", cPath, "-o", oPath)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("host compilation of architectural MMIO unexpectedly succeeded")
+	}
+	if !strings.Contains(string(output), "arm64 MMIO") {
+		t.Fatalf("host failure did not explain AArch64 MMIO requirement:\n%s\n--- C ---\n%s", output, generated)
+	}
+}

--- a/codegen/mmio.go
+++ b/codegen/mmio.go
@@ -1,0 +1,62 @@
+package codegen
+
+import (
+	"fmt"
+
+	"github.com/SCKelemen/oak/semir"
+)
+
+func mmioAccessName(access semir.MmioAccess) string {
+	switch access {
+	case semir.MmioReadOnly:
+		return "ro"
+	case semir.MmioWriteOnly:
+		return "wo"
+	case semir.MmioReadWrite:
+		return "rw"
+	default:
+		return "invalid"
+	}
+}
+
+// init installs exact helper source for every SemIR-owned MMIO member into the
+// existing pay-for-use arm64 helper catalog. Runtime representation of a typed
+// register handle is exactly u64 address bits; width/access tags are erased
+// after type checking and never consume storage or dispatch cycles.
+func init() {
+	for _, spec := range semir.Arm64MmioMembers() {
+		carrier := spec.Width.Carrier()
+		name := "oak_arm64_" + spec.Member
+		switch spec.Operation {
+		case semir.MmioConstruct:
+			mask := spec.Width.Bytes() - 1
+			arm64HelperSources[spec.Member] = fmt.Sprintf(`static inline u64 %s( u64 address ) {
+#if defined(__aarch64__) && !defined(OAK_PORTABLE_INTRINSICS)
+  if ((address & %dULL) != 0ULL) { __builtin_trap(); }
+  return address;
+#else
+#error "arm64 MMIO register construction requires an AArch64 target"
+#endif
+}
+`, name, mask)
+		case semir.MmioRead:
+			arm64HelperSources[spec.Member] = fmt.Sprintf(`static inline %s %s( u64 address ) {
+#if defined(__aarch64__) && !defined(OAK_PORTABLE_INTRINSICS)
+  return *(volatile %s *)(uintptr_t)address;
+#else
+#error "arm64 MMIO read requires an AArch64 target"
+#endif
+}
+`, carrier, name, carrier)
+		case semir.MmioWrite:
+			arm64HelperSources[spec.Member] = fmt.Sprintf(`static inline void %s( u64 address, %s value ) {
+#if defined(__aarch64__) && !defined(OAK_PORTABLE_INTRINSICS)
+  *(volatile %s *)(uintptr_t)address = value;
+#else
+#error "arm64 MMIO write requires an AArch64 target"
+#endif
+}
+`, name, carrier, carrier)
+		}
+	}
+}

--- a/docs/spec/96-aarch64-mmio.md
+++ b/docs/spec/96-aarch64-mmio.md
@@ -1,0 +1,215 @@
+# AArch64 typed MMIO
+
+This chapter specifies Oak's first executable memory-mapped I/O surface. It is
+an architecture-specific bootstrap surface under `arm64`; a future extensible
+machine-library mechanism may lift the same nominal register types into a
+portable `mmio` namespace without changing their semantics.
+
+The governing rules are:
+
+> A register address is typed authority, not an integer convention.
+
+> One MMIO source access means exactly one volatile-width machine access and no
+> hidden barrier.
+
+## 1. Register identity
+
+A typed register handle has two static dimensions:
+
+- width: `u8`, `u16`, `u32`, or `u64`;
+- access authority: read-only, write-only, or read-write.
+
+The typechecker represents these as nominal
+`arm64.MMIO[carrier,access]` types. Different widths and authorities do not
+implicitly convert.
+
+The current source surface keeps register handles expression-local because Oak
+has not yet exposed these compiler-owned nominal machine types in type position.
+They are nevertheless real checked types: constructor results can only flow to
+operations accepting the exact same width/authority. Exposing annotations such
+as `mmio.Reg[u32,ReadWrite]` is a later surface-language refinement, not a
+change to the machine semantics.
+
+## 2. Assumption-bearing construction
+
+Construction is deliberately named `unsafe`:
+
+```text
+arm64.mmio_unsafe_ro_u32(address: u64)
+arm64.mmio_unsafe_wo_u32(address: u64)
+arm64.mmio_unsafe_rw_u32(address: u64)
+```
+
+with the same three constructors for `u8`, `u16`, and `u64`.
+
+Construction asserts facts Oak cannot derive from address bits alone:
+
+- the address refers to the intended device register;
+- the current translation regime maps it with suitable device-memory
+  attributes;
+- the caller has authority to access that device;
+- the register's hardware semantics match its declared access direction.
+
+Oak does check the machine fact it can enforce locally: the address is naturally
+aligned to the declared access width. Misaligned construction traps before an
+MMIO access is issued.
+
+The current `unsafe_` spelling records the assumption at the operation itself.
+A later language revision should require these constructors to occur inside the
+same structured `unsafe` assumption blocks used elsewhere, once the typechecker
+tracks unsafe context for compiler-known machine calls.
+
+## 3. Read/write surface
+
+For each readable handle:
+
+```text
+arm64.mmio_read_ro_u32(reg) -> u32
+arm64.mmio_read_rw_u32(reg) -> u32
+```
+
+For each writable handle:
+
+```text
+arm64.mmio_write_wo_u32(reg, value) -> ()
+arm64.mmio_write_rw_u32(reg, value) -> ()
+```
+
+and equivalently for `u8`, `u16`, and `u64`.
+
+There is intentionally no read operation for write-only handles and no write
+operation for read-only handles. The source catalog contains no such members,
+and the typechecker rejects attempts to substitute a handle of the wrong width
+or authority.
+
+## 4. Effects
+
+Construction projects to:
+
+```text
+Machine.AssumeMmioRegister[carrier, access]
+```
+
+Reads and writes project to:
+
+```text
+Memory.MMIORead[carrier]
+Memory.MMIOWrite[carrier]
+```
+
+None of these effects implies allocation, blocking, a syscall, scheduler
+interaction, an atomic synchronization edge, or a barrier.
+
+## 5. Runtime representation and allocation
+
+A checked MMIO register handle erases to exactly the `u64` address bits. Width
+and access authority are compile-time facts and consume no runtime tag,
+wrapper, heap object, vtable, callback, or dispatch branch.
+
+The compiler-side semantic lookup is regression-tested at zero allocations.
+The generated runtime path contains no Oak allocation. Constructor alignment
+checking is a bounded integer mask/test; a read/write then lowers directly to
+one volatile access of the declared carrier width.
+
+## 6. AArch64 bootstrap backend
+
+The C bootstrap backend lowers a read to the semantic equivalent of:
+
+```c
+*(volatile u32 *)(uintptr_t)address
+```
+
+and a write to:
+
+```c
+*(volatile u32 *)(uintptr_t)address = value
+```
+
+using the exact declared width.
+
+The generated helper fails compilation off AArch64. The host evaluator also
+fails explicitly rather than dereferencing host process memory or simulating a
+device register.
+
+Freestanding cross-compilation tests inspect optimized AArch64 assembly and
+require the corresponding access-width instruction (`LDRB/LDRH/LDR` and
+`STRB/STRH/STR`). The same function body is checked to contain no hidden
+`DMB`, `DSB`, or `ISB`.
+
+## 7. Volatile is not memory type
+
+The volatile source operation guarantees an observable access of the requested
+width. It does **not** configure the translation regime.
+
+Correct physical MMIO on AArch64 additionally depends on page-table attributes,
+MAIR configuration, shareability, device type (for example Device-nGnRnE vs
+other Device forms), and platform-specific interconnect/device requirements.
+Those are OS/hypervisor mapping facts and must be established independently.
+Oak must not claim that a C volatile pointer magically creates Device memory.
+
+## 8. Barriers are explicit composition
+
+No MMIO operation inserts an architecture barrier. Ordering/completion is
+composed explicitly using the barrier surface from `95-aarch64-barriers.md`:
+
+```text
+arm64.mmio_write_rw_u32(...)
+arm64.dsb_sy()
+```
+
+when that is what the device/architecture protocol requires.
+
+This separation is intentional: automatically surrounding every device access
+with a full barrier would be both semantically wrong for many protocols and a
+major performance regression.
+
+`Oak.AArch64Mmio` proves that the abstract capability of MMIO read/write has no
+hidden ordering, completion, or instruction-synchronization capability.
+
+## 9. Formal verification
+
+`spec/lean/Oak/AArch64Mmio.lean` proves:
+
+- write-only authority cannot perform a read;
+- read-only authority cannot perform a write;
+- read-write authority admits both operations;
+- every legal read/write carries the corresponding static authority;
+- `u32` construction means alignment modulo 4;
+- `u64` construction means alignment modulo 8;
+- MMIO access itself provides no memory-ordering, completion, or instruction
+  synchronization capability.
+
+These are language/source-surface facts. They do not constitute a formal model
+of the full Arm memory system, page-table attributes, or a specific device.
+
+## 10. Verification status
+
+| Layer | Status |
+| --- | --- |
+| width/access semantic catalog | implemented + tested |
+| nominal width/access type identity | implemented + tested |
+| forbidden RO/WO operations | absent from source catalog + tested |
+| natural alignment predicate | implemented + tested |
+| access/alignment laws | proved in Lean |
+| no-hidden-barrier capability | proved in Lean |
+| evaluator behavior | fail-closed + tested |
+| C bootstrap lowering | implemented |
+| generated runtime allocation | none by construction; source checked for heap primitives |
+| AArch64 exact access width | assembly-refinement tested |
+| hidden barrier absence | assembly-refinement tested |
+| actual device-memory attributes | external OS mapping obligation |
+| full Arm axiomatic refinement | not proved |
+| structured `unsafe {}` enforcement for constructor | pending |
+| user-spellable architecture-neutral register type | pending |
+
+## 11. Next work
+
+The next machine layers are:
+
+1. expose the nominal register type in ordinary type position without losing
+   the zero-runtime representation;
+2. connect unsafe MMIO construction to structured assumption tracking;
+3. specify page-table/MAIR device-memory attributes as typed mapping facts;
+4. add system-register instruction functions needed to configure EL2/EL1;
+5. exercise the resulting surface from the Oak IRQ/timer experiment and the
+   existing Zig hypervisor harness.

--- a/evaluator/ffi.go
+++ b/evaluator/ffi.go
@@ -2,10 +2,10 @@ package evaluator
 
 // Interpreter semantics for the compiler-known foreign-interface libraries.
 // Portable arm64 value-transforming instruction functions execute natively in
-// the interpreter. Architectural barriers do not: DMB/DSB/ISB have machine
-// ordering/completion semantics that cannot be faithfully represented by the
+// the interpreter. Architectural barriers and MMIO do not: their machine
+// ordering/device-access semantics cannot be faithfully represented by the
 // sequential host evaluator, so execution fails explicitly rather than
-// pretending they are no-ops.
+// pretending they are no-ops or ordinary host memory accesses.
 
 import (
 	"math/bits"
@@ -34,6 +34,12 @@ func evalLibraryCall(library, member string, args []ast.Expression, env *object.
 }
 
 func evalArm64Intrinsic(member string, args []ast.Expression, env *object.Environment) object.Object {
+	if spec, mmio := semir.LookupArm64Mmio(member); mmio {
+		if len(args) != int(spec.Arity) {
+			return newError("arm64.%s takes exactly %d argument(s)", member, spec.Arity)
+		}
+		return newError("arm64.%s is an MMIO machine operation and requires the native AArch64 backend", member)
+	}
 	if _, barrier := semir.LookupArm64Barrier(member); barrier {
 		if len(args) != 0 {
 			return newError("arm64.%s takes exactly zero arguments", member)

--- a/evaluator/mmio_test.go
+++ b/evaluator/mmio_test.go
@@ -1,0 +1,30 @@
+package evaluator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/SCKelemen/oak/object"
+	"github.com/SCKelemen/oak/parser"
+	"github.com/SCKelemen/oak/scanner"
+)
+
+func TestMmioEvaluatorFailsClosed(t *testing.T) {
+	input := `
+package main
+arm64.mmio_read_rw_u32(arm64.mmio_unsafe_rw_u32(u64(4096)))
+`
+	p := parser.New(scanner.New(input))
+	program := p.ParseProgram()
+	if errs := p.Errors(); len(errs) != 0 {
+		t.Fatalf("parser errors: %v", errs)
+	}
+	result := Eval(program, object.NewEnvironment())
+	err, ok := result.(*object.Error)
+	if !ok {
+		t.Fatalf("MMIO evaluation produced %T, want error", result)
+	}
+	if !strings.Contains(err.Message, "requires the native AArch64 backend") {
+		t.Fatalf("MMIO evaluator failure is not explicit: %s", err.Message)
+	}
+}

--- a/semir/mmio.go
+++ b/semir/mmio.go
@@ -1,0 +1,157 @@
+package semir
+
+import "fmt"
+
+// MmioAccess is the static authority carried by an MMIO register handle.
+// There is deliberately no dynamic access-mode field on the runtime path.
+type MmioAccess string
+
+const (
+	MmioReadOnly  MmioAccess = "read-only"
+	MmioWriteOnly MmioAccess = "write-only"
+	MmioReadWrite MmioAccess = "read-write"
+)
+
+func (a MmioAccess) CanRead() bool {
+	return a == MmioReadOnly || a == MmioReadWrite
+}
+
+func (a MmioAccess) CanWrite() bool {
+	return a == MmioWriteOnly || a == MmioReadWrite
+}
+
+// MmioWidth is the exact observable machine access width.
+type MmioWidth uint8
+
+const (
+	Mmio8  MmioWidth = 8
+	Mmio16 MmioWidth = 16
+	Mmio32 MmioWidth = 32
+	Mmio64 MmioWidth = 64
+)
+
+func (w MmioWidth) Bytes() uint64 { return uint64(w) / 8 }
+
+func (w MmioWidth) Carrier() string {
+	switch w {
+	case Mmio8:
+		return "u8"
+	case Mmio16:
+		return "u16"
+	case Mmio32:
+		return "u32"
+	case Mmio64:
+		return "u64"
+	default:
+		return ""
+	}
+}
+
+func (w MmioWidth) Valid() bool { return w.Carrier() != "" }
+
+// MmioAddressAligned is the v1 constructor proof obligation. Device-memory
+// attributes and mapping authority are separate assumptions; this predicate
+// proves only that an access of the declared width is naturally aligned.
+func MmioAddressAligned(address uint64, width MmioWidth) bool {
+	return width.Valid() && address%width.Bytes() == 0
+}
+
+type MmioOperation string
+
+const (
+	MmioConstruct MmioOperation = "construct"
+	MmioRead      MmioOperation = "read"
+	MmioWrite     MmioOperation = "write"
+)
+
+// MmioSpec is the one semantic catalog row shared by type checking, effects,
+// code generation, tests, and documentation projections.
+type MmioSpec struct {
+	Member    string
+	Operation MmioOperation
+	Width     MmioWidth
+	Access    MmioAccess
+	Arity     uint8
+}
+
+func (s MmioSpec) Legal() bool {
+	if !s.Width.Valid() {
+		return false
+	}
+	switch s.Operation {
+	case MmioConstruct:
+		return s.Arity == 1
+	case MmioRead:
+		return s.Arity == 1 && s.Access.CanRead()
+	case MmioWrite:
+		return s.Arity == 2 && s.Access.CanWrite()
+	default:
+		return false
+	}
+}
+
+func (s MmioSpec) Effect() (Effect, error) {
+	if !s.Legal() {
+		return Effect{}, fmt.Errorf("illegal MMIO specification %q", s.Member)
+	}
+	switch s.Operation {
+	case MmioConstruct:
+		return Effect{Namespace: "Machine", Name: "AssumeMmioRegister", Parameters: []string{s.Width.Carrier(), string(s.Access)}}, nil
+	case MmioRead:
+		return Effect{Namespace: "Memory", Name: "MMIORead", Parameters: []string{s.Width.Carrier()}}, nil
+	case MmioWrite:
+		return Effect{Namespace: "Memory", Name: "MMIOWrite", Parameters: []string{s.Width.Carrier()}}, nil
+	default:
+		return Effect{}, fmt.Errorf("unknown MMIO operation %q", s.Operation)
+	}
+}
+
+func mmioMember(op string, access MmioAccess, carrier string) string {
+	accessName := ""
+	switch access {
+	case MmioReadOnly:
+		accessName = "ro"
+	case MmioWriteOnly:
+		accessName = "wo"
+	case MmioReadWrite:
+		accessName = "rw"
+	}
+	return "mmio_" + op + "_" + accessName + "_" + carrier
+}
+
+var mmioCatalog = func() []MmioSpec {
+	widths := []MmioWidth{Mmio8, Mmio16, Mmio32, Mmio64}
+	accesses := []MmioAccess{MmioReadOnly, MmioWriteOnly, MmioReadWrite}
+	out := make([]MmioSpec, 0, 28)
+	for _, width := range widths {
+		carrier := width.Carrier()
+		for _, access := range accesses {
+			out = append(out, MmioSpec{Member: "mmio_unsafe_" + string(map[MmioAccess]string{MmioReadOnly: "ro", MmioWriteOnly: "wo", MmioReadWrite: "rw"}[access]) + "_" + carrier, Operation: MmioConstruct, Width: width, Access: access, Arity: 1})
+			if access.CanRead() {
+				out = append(out, MmioSpec{Member: mmioMember("read", access, carrier), Operation: MmioRead, Width: width, Access: access, Arity: 1})
+			}
+			if access.CanWrite() {
+				out = append(out, MmioSpec{Member: mmioMember("write", access, carrier), Operation: MmioWrite, Width: width, Access: access, Arity: 2})
+			}
+		}
+	}
+	return out
+}()
+
+// Arm64MmioMembers returns a copy so callers cannot mutate the language catalog.
+func Arm64MmioMembers() []MmioSpec {
+	out := make([]MmioSpec, len(mmioCatalog))
+	copy(out, mmioCatalog)
+	return out
+}
+
+// LookupArm64Mmio uses a bounded scan of a compile-time-sized catalog. This is
+// compiler-side only; generated MMIO operations contain no lookup/dispatch.
+func LookupArm64Mmio(member string) (MmioSpec, bool) {
+	for i := range mmioCatalog {
+		if mmioCatalog[i].Member == member {
+			return mmioCatalog[i], true
+		}
+	}
+	return MmioSpec{}, false
+}

--- a/semir/mmio_test.go
+++ b/semir/mmio_test.go
@@ -1,0 +1,73 @@
+package semir
+
+import "testing"
+
+func TestMmioCatalogIsExactAndLegal(t *testing.T) {
+	specs := Arm64MmioMembers()
+	if len(specs) != 28 {
+		t.Fatalf("MMIO catalog has %d members, want 28", len(specs))
+	}
+	seen := map[string]bool{}
+	for _, spec := range specs {
+		if seen[spec.Member] {
+			t.Fatalf("duplicate MMIO member %q", spec.Member)
+		}
+		seen[spec.Member] = true
+		if !spec.Legal() {
+			t.Fatalf("catalog exposes illegal MMIO member %+v", spec)
+		}
+		if _, err := spec.Effect(); err != nil {
+			t.Fatalf("catalog member %q has no effect: %v", spec.Member, err)
+		}
+	}
+}
+
+func TestMmioAuthoritySurfaceRejectsForbiddenAccesses(t *testing.T) {
+	if _, ok := LookupArm64Mmio("mmio_read_wo_u32"); ok {
+		t.Fatal("write-only u32 register unexpectedly exposes read")
+	}
+	if _, ok := LookupArm64Mmio("mmio_write_ro_u32"); ok {
+		t.Fatal("read-only u32 register unexpectedly exposes write")
+	}
+	for _, name := range []string{
+		"mmio_read_ro_u32", "mmio_read_rw_u32",
+		"mmio_write_wo_u32", "mmio_write_rw_u32",
+	} {
+		if _, ok := LookupArm64Mmio(name); !ok {
+			t.Fatalf("required MMIO member %q missing", name)
+		}
+	}
+}
+
+func TestMmioNaturalAlignment(t *testing.T) {
+	cases := []struct {
+		address uint64
+		width   MmioWidth
+		want    bool
+	}{
+		{0x1000, Mmio8, true},
+		{0x1001, Mmio16, false},
+		{0x1002, Mmio16, true},
+		{0x1002, Mmio32, false},
+		{0x1004, Mmio32, true},
+		{0x1004, Mmio64, false},
+		{0x1008, Mmio64, true},
+	}
+	for _, tc := range cases {
+		if got := MmioAddressAligned(tc.address, tc.width); got != tc.want {
+			t.Fatalf("aligned(%#x,%d)=%v want %v", tc.address, tc.width, got, tc.want)
+		}
+	}
+}
+
+func TestMmioLookupAllocatesNothing(t *testing.T) {
+	allocs := testing.AllocsPerRun(1000, func() {
+		spec, ok := LookupArm64Mmio("mmio_read_rw_u32")
+		if !ok || spec.Operation != MmioRead || spec.Width != Mmio32 {
+			panic("lookup failed")
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("MMIO lookup allocated %.2f objects per call; want zero", allocs)
+	}
+}

--- a/spec/lean/Oak.lean
+++ b/spec/lean/Oak.lean
@@ -5,6 +5,7 @@ import Oak.HappensBefore
 import Oak.SequentialConsistency
 import Oak.AArch64Memory
 import Oak.AArch64Barrier
+import Oak.AArch64Mmio
 import Oak.Borrowing
 import Oak.BorrowRegions
 import Oak.Reborrow

--- a/spec/lean/Oak/AArch64Mmio.lean
+++ b/spec/lean/Oak/AArch64Mmio.lean
@@ -84,6 +84,6 @@ theorem mmio_does_not_hide_barrier (op : Operation) (access : Access) :
     (capability op access).ordersMemory = false ∧
     (capability op access).completesMemory = false ∧
     (capability op access).instructionSync = false := by
-  cases op <;> cases access <;> rfl
+  cases op <;> cases access <;> simp [capability]
 
 end Oak.AArch64Mmio

--- a/spec/lean/Oak/AArch64Mmio.lean
+++ b/spec/lean/Oak/AArch64Mmio.lean
@@ -1,0 +1,89 @@
+namespace Oak.AArch64Mmio
+
+inductive Access where
+  | readOnly
+  | writeOnly
+  | readWrite
+  deriving DecidableEq, Repr
+
+inductive Width where
+  | w8
+  | w16
+  | w32
+  | w64
+  deriving DecidableEq, Repr
+
+def canRead : Access -> Bool
+  | .readOnly | .readWrite => true
+  | .writeOnly => false
+
+def canWrite : Access -> Bool
+  | .writeOnly | .readWrite => true
+  | .readOnly => false
+
+def bytes : Width -> Nat
+  | .w8 => 1
+  | .w16 => 2
+  | .w32 => 4
+  | .w64 => 8
+
+def aligned (address : Nat) (width : Width) : Prop :=
+  address % bytes width = 0
+
+inductive Operation where
+  | construct
+  | read
+  | write
+  deriving DecidableEq, Repr
+
+/-- The source-level admission predicate. Construction records an assumption;
+    reads and writes are admitted solely by static access authority. -/
+def legal : Operation -> Access -> Bool
+  | .construct, _ => true
+  | .read, access => canRead access
+  | .write, access => canWrite access
+
+theorem writeOnly_cannot_read : legal .read .writeOnly = false := rfl
+theorem readOnly_cannot_write : legal .write .readOnly = false := rfl
+theorem readWrite_can_read : legal .read .readWrite = true := rfl
+theorem readWrite_can_write : legal .write .readWrite = true := rfl
+
+theorem legal_read_has_read_authority (access : Access)
+    (h : legal .read access = true) : canRead access = true := by
+  simpa [legal] using h
+
+theorem legal_write_has_write_authority (access : Access)
+    (h : legal .write access = true) : canWrite access = true := by
+  simpa [legal] using h
+
+/-- Width identity fixes the natural-alignment obligation exactly. -/
+theorem aligned32_means_mod4 (address : Nat) :
+    aligned address .w32 ↔ address % 4 = 0 := by
+  rfl
+
+theorem aligned64_means_mod8 (address : Nat) :
+    aligned address .w64 ↔ address % 8 = 0 := by
+  rfl
+
+/-- MMIO access itself carries no ordering/completion capability. Barriers are
+    a separate source operation and must be composed explicitly. -/
+structure Capability where
+  readsDevice : Bool
+  writesDevice : Bool
+  ordersMemory : Bool
+  completesMemory : Bool
+  instructionSync : Bool
+  deriving DecidableEq, Repr
+
+def capability : Operation -> Access -> Capability
+  | .construct, _ => ⟨false, false, false, false, false⟩
+  | .read, access => ⟨canRead access, false, false, false, false⟩
+  | .write, access => ⟨false, canWrite access, false, false, false⟩
+
+theorem mmio_does_not_hide_barrier (op : Operation) (access : Access) :
+    (capability op access).ordersMemory = false ∧
+    (capability op access).completesMemory = false ∧
+    (capability op access).instructionSync = false := by
+  cases op <;> cases access <;> rfl
+
+end Oak.AArch64Mmio

--- a/typechecker/mmio.go
+++ b/typechecker/mmio.go
@@ -1,0 +1,50 @@
+package typechecker
+
+import "github.com/SCKelemen/oak/semir"
+
+// MmioRegisterType is a nominal machine register-address capability. Width and
+// access authority are part of static identity; there are no implicit
+// conversions between RO/WO/RW handles or between access widths.
+type MmioRegisterType struct {
+	Width  semir.MmioWidth
+	Access semir.MmioAccess
+}
+
+func (t *MmioRegisterType) String() string {
+	if t == nil {
+		return "arm64.MMIO<?>"
+	}
+	return "arm64.MMIO[" + t.Width.Carrier() + "," + string(t.Access) + "]"
+}
+
+func (t *MmioRegisterType) Equals(other Type) bool {
+	o, ok := other.(*MmioRegisterType)
+	return ok && t != nil && o != nil && t.Width == o.Width && t.Access == o.Access
+}
+
+// Register the SemIR-owned MMIO catalog into the existing arm64 machine
+// library. The backend and evaluator resolve the same member names through
+// semir.LookupArm64Mmio; the typechecker contributes only exact source types.
+func init() {
+	for _, spec := range semir.Arm64MmioMembers() {
+		reg := &MmioRegisterType{Width: spec.Width, Access: spec.Access}
+		carrier := &PrimitiveType{Name: spec.Width.Carrier()}
+		switch spec.Operation {
+		case semir.MmioConstruct:
+			arm64Intrinsics[spec.Member] = &FunctionType{
+				Parameters: []Type{&PrimitiveType{Name: "u64"}},
+				ReturnType: reg,
+			}
+		case semir.MmioRead:
+			arm64Intrinsics[spec.Member] = &FunctionType{
+				Parameters: []Type{reg},
+				ReturnType: carrier,
+			}
+		case semir.MmioWrite:
+			arm64Intrinsics[spec.Member] = &FunctionType{
+				Parameters: []Type{reg, carrier},
+				ReturnType: &UnitType{},
+			}
+		}
+	}
+}

--- a/typechecker/mmio_test.go
+++ b/typechecker/mmio_test.go
@@ -1,0 +1,74 @@
+package typechecker
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/SCKelemen/oak/object"
+	"github.com/SCKelemen/oak/parser"
+	"github.com/SCKelemen/oak/scanner"
+)
+
+func checkMmioSource(t *testing.T, source string) []string {
+	t.Helper()
+	p := parser.New(scanner.New(source))
+	program := p.ParseProgram()
+	if errs := p.Errors(); len(errs) != 0 {
+		t.Fatalf("parser errors: %v", errs)
+	}
+	tc := New(object.NewEnvironment())
+	tc.CheckProgram(program)
+	return tc.Errors()
+}
+
+func requireMmioError(t *testing.T, errs []string, fragment string) {
+	t.Helper()
+	for _, err := range errs {
+		if strings.Contains(err, fragment) {
+			return
+		}
+	}
+	t.Fatalf("errors %v do not contain %q", errs, fragment)
+}
+
+func TestMmioTypedReadWriteSurface(t *testing.T) {
+	errs := checkMmioSource(t, `
+package main
+fn load(addr: u64) -> u32
+  arm64.mmio_read_rw_u32(arm64.mmio_unsafe_rw_u32(addr))
+fn store(addr: u64, value: u32) -> ()
+  arm64.mmio_write_rw_u32(arm64.mmio_unsafe_rw_u32(addr), value)
+`)
+	if len(errs) != 0 {
+		t.Fatalf("valid typed MMIO rejected: %v", errs)
+	}
+}
+
+func TestMmioRejectsWrongAuthority(t *testing.T) {
+	errs := checkMmioSource(t, `
+package main
+fn bad_read(addr: u64) -> u32
+  arm64.mmio_read_rw_u32(arm64.mmio_unsafe_wo_u32(addr))
+fn bad_write(addr: u64, value: u32) -> ()
+  arm64.mmio_write_rw_u32(arm64.mmio_unsafe_ro_u32(addr), value)
+`)
+	requireMmioError(t, errs, "expects arm64.MMIO[u32,read-write]")
+}
+
+func TestMmioRejectsWrongWidth(t *testing.T) {
+	errs := checkMmioSource(t, `
+package main
+fn bad(addr: u64) -> u32
+  arm64.mmio_read_rw_u32(arm64.mmio_unsafe_rw_u64(addr))
+`)
+	requireMmioError(t, errs, "expects arm64.MMIO[u32,read-write]")
+}
+
+func TestMmioWriteValueMustMatchWidth(t *testing.T) {
+	errs := checkMmioSource(t, `
+package main
+fn bad(addr: u64, value: u64) -> ()
+  arm64.mmio_write_rw_u32(arm64.mmio_unsafe_rw_u32(addr), value)
+`)
+	requireMmioError(t, errs, "expects u32")
+}


### PR DESCRIPTION
Adds Oak's first typed MMIO machine surface on top of the explicit AArch64 barrier layer.

Semantics/types:
- SemIR-owned 28-member catalog across u8/u16/u32/u64 and RO/WO/RW authority.
- Nominal `arm64.MMIO[carrier,access]` type identity in the checker; widths/authorities do not implicitly convert.
- Unsafe-named constructors accept u64 address bits and record `Machine.AssumeMmioRegister[...]`.
- Constructor lowers to a bounded natural-alignment check; register handle erases to exactly u64 address bits.
- Reads/writes carry `Memory.MMIORead/Write[carrier]`; forbidden RO writes / WO reads have no source member.

Backend/performance:
- Pay-for-use AArch64 helpers only.
- Exactly one volatile access of the requested width after alignment admission.
- No heap object, runtime access/width tag, callback, vtable, atomic fence, or hidden DMB/DSB/ISB.
- Generated MMIO fails closed off AArch64; evaluator also fails explicitly rather than pretending host memory is a device.
- Compiler semantic lookup is regression-tested at zero allocations.

Verification:
- Lean `Oak.AArch64Mmio` proves RO/WO/RW authority laws, u32/u64 alignment obligations, and that MMIO access itself contributes no ordering/completion/instruction-sync capability.
- AArch64 freestanding assembly tests require LDRB/LDRH/LDR and STRB/STRH/STR by width and reject hidden barriers.
- Host compilation is required to fail with an AArch64 MMIO diagnostic.
- Normative `docs/spec/96-aarch64-mmio.md` documents the trust boundary, including that volatile does not establish MAIR/device-memory attributes.

Deliberately pending:
- user-spellable architecture-neutral `mmio.Reg[T,Access]` type syntax;
- structured `unsafe {}` enforcement for constructor calls;
- page-table/MAIR device-memory attribute types;
- full Arm axiomatic MMIO refinement.