### PR TITLE
Add AArch64 system-register surface

### DIFF
--- a/codegen/aarch64_sysreg_test.go
+++ b/codegen/aarch64_sysreg_test.go
@@ -1,0 +1,114 @@
+package codegen
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const aarch64SysRegSource = `
+package main
+
+fn sysreg_read_hcr() -> u64
+  arm64.read_hcr_el2()
+fn sysreg_write_hcr(value: u64) -> ()
+  arm64.write_hcr_el2(value)
+fn sysreg_read_esr() -> u64
+  arm64.read_esr_el2()
+fn sysreg_read_counter() -> u64
+  arm64.read_cntvct_el0()
+fn sysreg_write_vttbr(value: u64) -> ()
+  arm64.write_vttbr_el2(value)
+fn sysreg_write_vtcr(value: u64) -> ()
+  arm64.write_vtcr_el2(value)
+`
+
+func compileSysRegAArch64Assembly(t *testing.T) (generated, assembly string) {
+	t.Helper()
+	clang := requireAArch64Clang(t)
+	generated = generateSourceC(t, aarch64SysRegSource)
+	for _, forbidden := range []string{"malloc(", "calloc(", "realloc(", "free("} {
+		if strings.Contains(generated, forbidden) {
+			t.Fatalf("generated sysreg path unexpectedly references heap primitive %q:\n%s", forbidden, generated)
+		}
+	}
+
+	dir := t.TempDir()
+	cPath := filepath.Join(dir, "sysreg.c")
+	sPath := filepath.Join(dir, "sysreg.s")
+	if err := os.WriteFile(cPath, []byte(generated), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(clang,
+		"--target=aarch64-none-elf", "-march=armv8-a",
+		"-std=c11", "-O2", "-ffreestanding",
+		"-Wall", "-Wextra", "-Werror", "-Wno-unused-function",
+		"-S", cPath, "-o", sPath,
+	)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("cross-compile generated system-register C: %v\n%s\n--- C ---\n%s", err, output, generated)
+	}
+	bytes, err := os.ReadFile(sPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return generated, strings.ToLower(string(bytes))
+}
+
+func TestAArch64SystemRegisterInstructionRefinement(t *testing.T) {
+	_, assembly := compileSysRegAArch64Assembly(t)
+	cases := []struct {
+		fn       string
+		mnemonic string
+		reg      string
+	}{
+		{"sysreg_read_hcr", "mrs", "hcr_el2"},
+		{"sysreg_write_hcr", "msr", "hcr_el2"},
+		{"sysreg_read_esr", "mrs", "esr_el2"},
+		{"sysreg_read_counter", "mrs", "cntvct_el0"},
+		{"sysreg_write_vttbr", "msr", "vttbr_el2"},
+		{"sysreg_write_vtcr", "msr", "vtcr_el2"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.fn, func(t *testing.T) {
+			body := aarch64FunctionBody(t, assembly, tc.fn)
+			requireInstruction(t, body, tc.mnemonic)
+			if !strings.Contains(body, tc.reg) {
+				t.Fatalf("%s lacks exact system register %s:\n%s", tc.fn, tc.reg, body)
+			}
+			for _, barrier := range []string{"dmb", "dsb", "isb"} {
+				if hasInstruction(body, barrier) {
+					t.Fatalf("%s acquired hidden %s barrier:\n%s", tc.fn, barrier, body)
+				}
+			}
+		})
+	}
+}
+
+func TestAArch64SystemRegisterGeneratedCFailsClosedOnHost(t *testing.T) {
+	cc, err := exec.LookPath("cc")
+	if err != nil {
+		t.Skip("host C compiler is not available")
+	}
+	generated := generateSourceC(t, `
+package main
+fn read() -> u64
+  arm64.read_hcr_el2()
+`)
+	dir := t.TempDir()
+	cPath := filepath.Join(dir, "sysreg.c")
+	oPath := filepath.Join(dir, "sysreg.o")
+	if err := os.WriteFile(cPath, []byte(generated), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(cc, "-std=c11", "-O2", "-c", cPath, "-o", oPath)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("host compilation of system-register operation unexpectedly succeeded")
+	}
+	if !strings.Contains(string(output), "requires an AArch64 target") {
+		t.Fatalf("host failure did not explain AArch64 system-register requirement:\n%s\n--- C ---\n%s", output, generated)
+	}
+}

--- a/codegen/sysreg.go
+++ b/codegen/sysreg.go
@@ -1,0 +1,38 @@
+package codegen
+
+import (
+	"fmt"
+
+	"github.com/SCKelemen/oak/semir"
+)
+
+// Install pay-for-use AArch64 MRS/MSR helpers into the existing machine-library
+// catalog. Register identity is compile-time source identity: generated code
+// carries no string/enum lookup, allocation, callback, or runtime dispatch.
+func init() {
+	for _, spec := range semir.Arm64SysRegs() {
+		readName := spec.ReadMember()
+		arm64HelperSources[readName] = fmt.Sprintf(`static inline u64 oak_arm64_%s( void ) {
+#if defined(__aarch64__) && !defined(OAK_PORTABLE_INTRINSICS)
+  u64 value;
+  __asm__ volatile("mrs %%0, %s" : "=r"(value) :: "memory");
+  return value;
+#else
+#error "arm64.%s requires an AArch64 target"
+#endif
+}
+`, readName, spec.Asm, readName)
+
+		if spec.Access.CanWrite() {
+			writeName := spec.WriteMember()
+			arm64HelperSources[writeName] = fmt.Sprintf(`static inline void oak_arm64_%s( u64 value ) {
+#if defined(__aarch64__) && !defined(OAK_PORTABLE_INTRINSICS)
+  __asm__ volatile("msr %s, %%0" :: "r"(value) : "memory");
+#else
+#error "arm64.%s requires an AArch64 target"
+#endif
+}
+`, writeName, spec.Asm, writeName)
+		}
+	}
+}

--- a/docs/spec/97-aarch64-system-registers.md
+++ b/docs/spec/97-aarch64-system-registers.md
@@ -1,0 +1,170 @@
+# AArch64 system-register operations
+
+This chapter specifies Oak's initial system-register surface for the EL2/EL1
+bootstrap path. Register identity is compile-time source identity: callers do
+not pass a register number, string, enum, or descriptor at runtime.
+
+The governing rule is:
+
+> Machine control must stay explicit enough that the source shows both the
+> register being changed and every required synchronization operation.
+
+## 1. Source surface
+
+Readable registers expose a nullary function:
+
+```text
+arm64.read_hcr_el2() -> u64
+arm64.read_esr_el2() -> u64
+```
+
+Writable registers additionally expose:
+
+```text
+arm64.write_hcr_el2(value: u64) -> ()
+```
+
+The v1 catalog is deliberately small and OS-driven.
+
+Read-only:
+
+- `CurrentEL`;
+- `ESR_EL2`;
+- `FAR_EL2`;
+- `HPFAR_EL2`;
+- `CNTVCT_EL0`.
+
+Read/write:
+
+- `HCR_EL2`, `VTTBR_EL2`, `VTCR_EL2`;
+- `CNTHCTL_EL2`, `CNTVOFF_EL2`;
+- `ELR_EL2`, `SPSR_EL2`;
+- `CNTV_CTL_EL0`, `CNTV_CVAL_EL0`;
+- `SP_EL1`, `SCTLR_EL1`, `TTBR0_EL1`, `TCR_EL1`, `VBAR_EL1`.
+
+Adding a register is a language change. Its architectural access direction,
+privilege assumptions, source spelling, effect, and backend spelling must be
+reviewed together.
+
+## 2. Effects
+
+Reads project to:
+
+```text
+Machine.SysRegRead[register]
+```
+
+Writes project to:
+
+```text
+Machine.SysRegWrite[register]
+```
+
+These operations are machine effects. They are not pure integer functions even
+when a read returns a `u64`.
+
+## 3. Runtime and allocation contract
+
+Register identity is encoded in the source member name and Semantic-IR catalog.
+Generated code contains no:
+
+- heap allocation;
+- register enum/string argument;
+- runtime register lookup;
+- virtual dispatch or callback;
+- generic system-register wrapper.
+
+The compiler semantic lookup is bounded and regression-tested at zero
+allocations. The C bootstrap backend emits a pay-for-use static-inline helper
+containing the exact `MRS` or `MSR` operation.
+
+## 4. Ordering and context synchronization
+
+A system-register read/write does **not** implicitly emit `DMB`, `DSB`, or
+`ISB`.
+
+This is essential because AArch64 architectural requirements differ by register
+and by transition. For example, control-register changes often require an
+explicit context-synchronization sequence, while adding an `ISB` to every
+system-register write would be both semantically misleading and expensive.
+
+Required sequences therefore stay visible:
+
+```text
+arm64.write_hcr_el2(value)
+arm64.isb()
+```
+
+when the architecture/protocol requires that sequence.
+
+The bootstrap C inline assembly uses `volatile` plus a compiler `memory`
+clobber so the C compiler does not move ordinary memory operations across the
+machine-state effect. This compiler-ordering constraint is **not** an AArch64
+hardware memory barrier and does not satisfy an architectural `DMB`, `DSB`, or
+`ISB` requirement.
+
+## 5. Backend refinement
+
+On AArch64, a read lowers to the semantic equivalent of:
+
+```asm
+mrs xN, HCR_EL2
+```
+
+and a write to:
+
+```asm
+msr HCR_EL2, xN
+```
+
+The generated helper fails compilation on non-AArch64 targets. The host
+interpreter also fails explicitly rather than manufacturing synthetic system
+state.
+
+Freestanding cross-compilation tests inspect optimized AArch64 assembly and
+require the exact `MRS`/`MSR` register name while rejecting hidden `DMB`, `DSB`,
+or `ISB` instructions in that operation's function body.
+
+## 6. Formal verification
+
+`spec/lean/Oak/AArch64SysReg.lean` mirrors the exact v1 register set and proves:
+
+- all catalog registers are readable;
+- `CurrentEL`, `ESR_EL2`, `FAR_EL2`, `HPFAR_EL2`, and `CNTVCT_EL0` are not
+  writable through the language surface;
+- any legal write is to a register classified writable;
+- system-register operations themselves provide no memory-ordering,
+  completion, or instruction-synchronization capability.
+
+These are language/catalog properties. They are not a proof that an arbitrary
+sequence of register writes satisfies the Arm Architecture Reference Manual.
+Protocol-specific ordering obligations remain separate specifications and tests.
+
+## 7. Verification status
+
+| Layer | Status |
+| --- | --- |
+| exact register catalog | implemented + tested |
+| read/write authority | implemented + Lean-modeled |
+| zero-allocation semantic lookup | tested |
+| source type signatures | implemented + tested |
+| host evaluator | fail-closed + tested |
+| C bootstrap lowering | implemented |
+| exact `MRS`/`MSR` register selection | AArch64 assembly-refinement tested |
+| hidden hardware barriers | absence assembly-tested + Lean capability theorem |
+| runtime allocation/dispatch | absent by construction |
+| protocol-specific register sequencing | not globally proved |
+| full Arm axiomatic system-register refinement | not proved |
+
+## 8. Next work
+
+This catalog is sufficient to start expressing the existing hypervisor's pure
+EL2 control path in Oak. The next pieces should be:
+
+1. structured unsafe/assumption tracking around privileged machine setup;
+2. explicit exception-entry/return and special-instruction contracts (`ERET`,
+   interrupt masking, wait/event primitives) rather than treating them as
+   ordinary calls;
+3. device-memory mapping/MAIR semantics for MMIO;
+4. compile a small Oak EL2 register/timer adapter and link it into the existing
+   Zig/QEMU OS harness.

--- a/evaluator/ffi.go
+++ b/evaluator/ffi.go
@@ -2,10 +2,9 @@ package evaluator
 
 // Interpreter semantics for the compiler-known foreign-interface libraries.
 // Portable arm64 value-transforming instruction functions execute natively in
-// the interpreter. Architectural barriers and MMIO do not: their machine
-// ordering/device-access semantics cannot be faithfully represented by the
-// sequential host evaluator, so execution fails explicitly rather than
-// pretending they are no-ops or ordinary host memory accesses.
+// the interpreter. Architectural barriers, MMIO, and system registers do not:
+// their machine semantics cannot be faithfully represented by the sequential
+// host evaluator, so execution fails explicitly rather than inventing state.
 
 import (
 	"math/bits"
@@ -34,6 +33,16 @@ func evalLibraryCall(library, member string, args []ast.Expression, env *object.
 }
 
 func evalArm64Intrinsic(member string, args []ast.Expression, env *object.Environment) object.Object {
+	if _, sysreg, write := semir.LookupArm64SysRegMember(member); sysreg {
+		want := 0
+		if write {
+			want = 1
+		}
+		if len(args) != want {
+			return newError("arm64.%s takes exactly %d argument(s)", member, want)
+		}
+		return newError("arm64.%s is a system-register machine operation and requires the native AArch64 backend", member)
+	}
 	if spec, mmio := semir.LookupArm64Mmio(member); mmio {
 		if len(args) != int(spec.Arity) {
 			return newError("arm64.%s takes exactly %d argument(s)", member, spec.Arity)

--- a/evaluator/sysreg_test.go
+++ b/evaluator/sysreg_test.go
@@ -1,0 +1,31 @@
+package evaluator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/SCKelemen/oak/object"
+	"github.com/SCKelemen/oak/parser"
+	"github.com/SCKelemen/oak/scanner"
+)
+
+func TestSystemRegisterEvaluatorFailsClosed(t *testing.T) {
+	for _, input := range []string{
+		"package main\narm64.read_hcr_el2()\n",
+		"package main\narm64.write_hcr_el2(u64(1))\n",
+	} {
+		p := parser.New(scanner.New(input))
+		program := p.ParseProgram()
+		if errs := p.Errors(); len(errs) != 0 {
+			t.Fatalf("parser errors: %v", errs)
+		}
+		result := Eval(program, object.NewEnvironment())
+		err, ok := result.(*object.Error)
+		if !ok {
+			t.Fatalf("system-register evaluation produced %T, want error", result)
+		}
+		if !strings.Contains(err.Message, "requires the native AArch64 backend") {
+			t.Fatalf("system-register evaluator failure is not explicit: %s", err.Message)
+		}
+	}
+}

--- a/semir/sysreg.go
+++ b/semir/sysreg.go
@@ -1,0 +1,89 @@
+package semir
+
+import "fmt"
+
+// SysRegAccess is the architectural access direction Oak exposes for a system
+// register. It is static catalog data; generated code contains no access tag.
+type SysRegAccess uint8
+
+const (
+	SysRegReadOnly SysRegAccess = iota + 1
+	SysRegReadWrite
+)
+
+func (a SysRegAccess) CanRead() bool { return a == SysRegReadOnly || a == SysRegReadWrite }
+func (a SysRegAccess) CanWrite() bool { return a == SysRegReadWrite }
+
+// SysRegSpec is one AArch64 system-register contract. v1 deliberately admits
+// only 64-bit register transfers used by the EL2/EL1 bootstrap path.
+type SysRegSpec struct {
+	Name   string
+	Asm    string
+	Access SysRegAccess
+}
+
+func (s SysRegSpec) Legal() bool {
+	return s.Name != "" && s.Asm != "" && s.Access.CanRead()
+}
+
+func (s SysRegSpec) ReadMember() string  { return "read_" + s.Name }
+func (s SysRegSpec) WriteMember() string { return "write_" + s.Name }
+
+func (s SysRegSpec) ReadEffect() (Effect, error) {
+	if !s.Legal() || !s.Access.CanRead() {
+		return Effect{}, fmt.Errorf("system register %q is not readable", s.Name)
+	}
+	return Effect{Namespace: "Machine", Name: "SysRegRead", Parameters: []string{s.Name}}, nil
+}
+
+func (s SysRegSpec) WriteEffect() (Effect, error) {
+	if !s.Legal() || !s.Access.CanWrite() {
+		return Effect{}, fmt.Errorf("system register %q is not writable", s.Name)
+	}
+	return Effect{Namespace: "Machine", Name: "SysRegWrite", Parameters: []string{s.Name}}, nil
+}
+
+// Keep this catalog intentionally small and explicit. Adding a register is a
+// language change: its privilege/access semantics and backend spelling must be
+// reviewed together.
+var arm64SysRegs = [...]SysRegSpec{
+	{Name: "currentel", Asm: "CurrentEL", Access: SysRegReadOnly},
+	{Name: "esr_el2", Asm: "ESR_EL2", Access: SysRegReadOnly},
+	{Name: "far_el2", Asm: "FAR_EL2", Access: SysRegReadOnly},
+	{Name: "hpfar_el2", Asm: "HPFAR_EL2", Access: SysRegReadOnly},
+	{Name: "cntvct_el0", Asm: "CNTVCT_EL0", Access: SysRegReadOnly},
+
+	{Name: "hcr_el2", Asm: "HCR_EL2", Access: SysRegReadWrite},
+	{Name: "vttbr_el2", Asm: "VTTBR_EL2", Access: SysRegReadWrite},
+	{Name: "vtcr_el2", Asm: "VTCR_EL2", Access: SysRegReadWrite},
+	{Name: "cnthctl_el2", Asm: "CNTHCTL_EL2", Access: SysRegReadWrite},
+	{Name: "cntvoff_el2", Asm: "CNTVOFF_EL2", Access: SysRegReadWrite},
+	{Name: "elr_el2", Asm: "ELR_EL2", Access: SysRegReadWrite},
+	{Name: "spsr_el2", Asm: "SPSR_EL2", Access: SysRegReadWrite},
+
+	{Name: "cntv_ctl_el0", Asm: "CNTV_CTL_EL0", Access: SysRegReadWrite},
+	{Name: "cntv_cval_el0", Asm: "CNTV_CVAL_EL0", Access: SysRegReadWrite},
+	{Name: "sp_el1", Asm: "SP_EL1", Access: SysRegReadWrite},
+	{Name: "sctlr_el1", Asm: "SCTLR_EL1", Access: SysRegReadWrite},
+	{Name: "ttbr0_el1", Asm: "TTBR0_EL1", Access: SysRegReadWrite},
+	{Name: "tcr_el1", Asm: "TCR_EL1", Access: SysRegReadWrite},
+	{Name: "vbar_el1", Asm: "VBAR_EL1", Access: SysRegReadWrite},
+}
+
+// Arm64SysRegs returns the fixed catalog by value. Callers cannot mutate the
+// authoritative table and no heap allocation is required to enumerate it.
+func Arm64SysRegs() [len(arm64SysRegs)]SysRegSpec { return arm64SysRegs }
+
+func LookupArm64SysRegMember(member string) (SysRegSpec, bool, bool) {
+	// returns (spec, found, write)
+	for i := range arm64SysRegs {
+		s := arm64SysRegs[i]
+		if member == s.ReadMember() {
+			return s, true, false
+		}
+		if s.Access.CanWrite() && member == s.WriteMember() {
+			return s, true, true
+		}
+	}
+	return SysRegSpec{}, false, false
+}

--- a/semir/sysreg_test.go
+++ b/semir/sysreg_test.go
@@ -1,0 +1,60 @@
+package semir
+
+import "testing"
+
+func TestArm64SysRegCatalogIsLegalAndUnique(t *testing.T) {
+	regs := Arm64SysRegs()
+	if len(regs) != 19 {
+		t.Fatalf("system-register catalog has %d entries, want 19", len(regs))
+	}
+	seenReg := map[string]bool{}
+	seenMember := map[string]bool{}
+	for _, reg := range regs {
+		if !reg.Legal() {
+			t.Fatalf("illegal system-register spec: %+v", reg)
+		}
+		if seenReg[reg.Name] {
+			t.Fatalf("duplicate system-register identity %q", reg.Name)
+		}
+		seenReg[reg.Name] = true
+		if seenMember[reg.ReadMember()] {
+			t.Fatalf("duplicate read member %q", reg.ReadMember())
+		}
+		seenMember[reg.ReadMember()] = true
+		if _, err := reg.ReadEffect(); err != nil {
+			t.Fatalf("read effect for %q: %v", reg.Name, err)
+		}
+		if reg.Access.CanWrite() {
+			if seenMember[reg.WriteMember()] {
+				t.Fatalf("duplicate write member %q", reg.WriteMember())
+			}
+			seenMember[reg.WriteMember()] = true
+			if _, err := reg.WriteEffect(); err != nil {
+				t.Fatalf("write effect for %q: %v", reg.Name, err)
+			}
+		}
+	}
+}
+
+func TestReadOnlySysRegsHaveNoWriteSurface(t *testing.T) {
+	for _, name := range []string{"currentel", "esr_el2", "far_el2", "hpfar_el2", "cntvct_el0"} {
+		if _, found, _ := LookupArm64SysRegMember("write_" + name); found {
+			t.Fatalf("read-only register %s unexpectedly exposes a write member", name)
+		}
+		if _, found, write := LookupArm64SysRegMember("read_" + name); !found || write {
+			t.Fatalf("read member for %s missing or misclassified", name)
+		}
+	}
+}
+
+func TestSysRegLookupAllocatesNothing(t *testing.T) {
+	allocs := testing.AllocsPerRun(1000, func() {
+		reg, found, write := LookupArm64SysRegMember("write_hcr_el2")
+		if !found || !write || reg.Name != "hcr_el2" {
+			panic("lookup failed")
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("system-register lookup allocated %.2f objects per call; want zero", allocs)
+	}
+}

--- a/spec/lean/Oak.lean
+++ b/spec/lean/Oak.lean
@@ -6,6 +6,7 @@ import Oak.SequentialConsistency
 import Oak.AArch64Memory
 import Oak.AArch64Barrier
 import Oak.AArch64Mmio
+import Oak.AArch64SysReg
 import Oak.Borrowing
 import Oak.BorrowRegions
 import Oak.Reborrow

--- a/spec/lean/Oak/AArch64SysReg.lean
+++ b/spec/lean/Oak/AArch64SysReg.lean
@@ -1,0 +1,60 @@
+namespace Oak.AArch64SysReg
+
+inductive Reg where
+  | currentel | esrEl2 | farEl2 | hpfarEl2 | cntvctEl0
+  | hcrEl2 | vttbrEl2 | vtcrEl2 | cnthctlEl2 | cntvoffEl2
+  | elrEl2 | spsrEl2 | cntvCtlEl0 | cntvCvalEl0
+  | spEl1 | sctlrEl1 | ttbr0El1 | tcrEl1 | vbarEl1
+  deriving DecidableEq, Repr
+
+def writable : Reg -> Bool
+  | .currentel | .esrEl2 | .farEl2 | .hpfarEl2 | .cntvctEl0 => false
+  | _ => true
+
+inductive Operation where
+  | read
+  | write
+  deriving DecidableEq, Repr
+
+def legal : Operation -> Reg -> Bool
+  | .read, _ => true
+  | .write, reg => writable reg
+
+theorem currentel_read_only : legal .write .currentel = false := rfl
+theorem esr_el2_read_only : legal .write .esrEl2 = false := rfl
+theorem far_el2_read_only : legal .write .farEl2 = false := rfl
+theorem hpfar_el2_read_only : legal .write .hpfarEl2 = false := rfl
+theorem cntvct_el0_read_only : legal .write .cntvctEl0 = false := rfl
+
+theorem every_register_readable (reg : Reg) : legal .read reg = true := rfl
+
+theorem legal_write_is_writable (reg : Reg)
+    (h : legal .write reg = true) : writable reg = true := by
+  simpa [legal] using h
+
+/-- A system-register access is a machine-state effect. It is not an
+    architectural memory barrier or context-synchronization event. -/
+structure Capability where
+  readsSystemState : Bool
+  writesSystemState : Bool
+  ordersMemory : Bool
+  completesMemory : Bool
+  instructionSync : Bool
+  deriving DecidableEq, Repr
+
+def capability : Operation -> Capability
+  | .read => ⟨true, false, false, false, false⟩
+  | .write => ⟨false, true, false, false, false⟩
+
+theorem sysreg_does_not_hide_barrier (op : Operation) :
+    (capability op).ordersMemory = false ∧
+    (capability op).completesMemory = false ∧
+    (capability op).instructionSync = false := by
+  cases op <;> simp [capability]
+
+theorem write_requires_separate_instruction_sync (reg : Reg)
+    (h : legal .write reg = true) :
+    (capability .write).instructionSync = false := by
+  simp [capability]
+
+end Oak.AArch64SysReg

--- a/typechecker/sysreg.go
+++ b/typechecker/sysreg.go
@@ -1,0 +1,21 @@
+package typechecker
+
+import "github.com/SCKelemen/oak/semir"
+
+// System-register operations are ordinary compiler-known arm64 functions at
+// the source level. Register identity and access direction live in SemIR; the
+// source never carries a runtime register enum.
+func init() {
+	for _, spec := range semir.Arm64SysRegs() {
+		arm64Intrinsics[spec.ReadMember()] = &FunctionType{
+			Parameters: nil,
+			ReturnType: &PrimitiveType{Name: "u64"},
+		}
+		if spec.Access.CanWrite() {
+			arm64Intrinsics[spec.WriteMember()] = &FunctionType{
+				Parameters: []Type{&PrimitiveType{Name: "u64"}},
+				ReturnType: &UnitType{},
+			}
+		}
+	}
+}

--- a/typechecker/sysreg_test.go
+++ b/typechecker/sysreg_test.go
@@ -1,0 +1,72 @@
+package typechecker
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/SCKelemen/oak/object"
+	"github.com/SCKelemen/oak/parser"
+	"github.com/SCKelemen/oak/scanner"
+)
+
+func checkSysRegSource(t *testing.T, source string) []string {
+	t.Helper()
+	p := parser.New(scanner.New(source))
+	program := p.ParseProgram()
+	if errs := p.Errors(); len(errs) != 0 {
+		t.Fatalf("parser errors: %v", errs)
+	}
+	tc := New(object.NewEnvironment())
+	tc.CheckProgram(program)
+	return tc.Errors()
+}
+
+func requireSysRegError(t *testing.T, errs []string, fragment string) {
+	t.Helper()
+	for _, err := range errs {
+		if strings.Contains(err, fragment) {
+			return
+		}
+	}
+	t.Fatalf("errors %v do not contain %q", errs, fragment)
+}
+
+func TestSysRegReadWriteSurfaceTypes(t *testing.T) {
+	errs := checkSysRegSource(t, `
+package main
+fn configure(value: u64) -> u64 {
+  arm64.write_hcr_el2(value)
+  arm64.read_hcr_el2()
+}
+`)
+	if len(errs) != 0 {
+		t.Fatalf("valid system-register program rejected: %v", errs)
+	}
+}
+
+func TestSysRegReadOnlyRegisterHasNoWriteMember(t *testing.T) {
+	errs := checkSysRegSource(t, `
+package main
+fn bad(value: u64) -> ()
+  arm64.write_esr_el2(value)
+`)
+	requireSysRegError(t, errs, "no member write_esr_el2")
+}
+
+func TestSysRegWriteRequiresU64(t *testing.T) {
+	errs := checkSysRegSource(t, `
+package main
+fn bad(value: u32) -> ()
+  arm64.write_hcr_el2(value)
+`)
+	requireSysRegError(t, errs, "expects u64")
+}
+
+func TestSysRegReadIsNullary(t *testing.T) {
+	errs := checkSysRegSource(t, `
+package main
+fn bad(value: u64) -> u64
+  arm64.read_hcr_el2(value)
+`)
+	requireSysRegError(t, errs, "expects 0 argument")
+}

--- a/typechecker/sysreg_test.go
+++ b/typechecker/sysreg_test.go
@@ -50,7 +50,7 @@ package main
 fn bad(value: u64) -> ()
   arm64.write_esr_el2(value)
 `)
-	requireSysRegError(t, errs, "no member write_esr_el2")
+	requireSysRegError(t, errs, "no instruction function arm64.write_esr_el2")
 }
 
 func TestSysRegWriteRequiresU64(t *testing.T) {
@@ -68,5 +68,5 @@ package main
 fn bad(value: u64) -> u64
   arm64.read_hcr_el2(value)
 `)
-	requireSysRegError(t, errs, "expects 0 argument")
+	requireSysRegError(t, errs, "takes 0 argument(s), got 1")
 }


### PR DESCRIPTION
Adds the first explicit AArch64 system-register surface needed by Oak's EL2/EL1 OS path.

Highlights:
- SemIR-owned fixed catalog of 19 reviewed registers.
- Read-only: CurrentEL, ESR_EL2, FAR_EL2, HPFAR_EL2, CNTVCT_EL0.
- Read/write: HCR_EL2, VTTBR_EL2, VTCR_EL2, CNTHCTL_EL2, CNTVOFF_EL2, ELR_EL2, SPSR_EL2, CNTV_CTL_EL0, CNTV_CVAL_EL0, SP_EL1, SCTLR_EL1, TTBR0_EL1, TCR_EL1, VBAR_EL1.
- Source identity encodes the register: `arm64.read_hcr_el2()` / `arm64.write_hcr_el2(value)`; no runtime register enum/string/dispatch.
- Effects: `Machine.SysRegRead[reg]` / `Machine.SysRegWrite[reg]`.
- C bootstrap lowers pay-for-use helpers to exact volatile MRS/MSR inline assembly and fails closed off AArch64.
- No hidden DMB/DSB/ISB; required architectural synchronization stays explicit in Oak source.
- Compiler memory clobber prevents C reordering across the machine-state effect but is documented as not being a hardware barrier.
- Evaluator fails closed instead of synthesizing system state.
- Zero-allocation semantic lookup regression.
- AArch64 freestanding assembly tests require exact register names and reject hidden barriers.
- Lean `Oak.AArch64SysReg` proves read-only/writable authority and that sysreg operations themselves supply no ordering/completion/instruction-sync capability.
- Normative `docs/spec/97-aarch64-system-registers.md` documents the catalog and trust boundary.

Still intentionally separate: structured unsafe context tracking, protocol-specific register sequencing proofs, ERET/DAIF/WFI/WFE/SEV contracts, MAIR/device-memory mapping semantics, and full Arm axiomatic refinement.