### PR TITLE
Add AArch64 event and interrupt control surface

### DIFF
--- a/codegen/aarch64_event_control_test.go
+++ b/codegen/aarch64_event_control_test.go
@@ -1,0 +1,106 @@
+package codegen
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const aarch64EventControlSource = `
+package main
+fn mask_irq() -> ()
+  arm64.daifset_irq()
+fn unmask_irq() -> ()
+  arm64.daifclr_irq()
+fn wait_irq() -> ()
+  arm64.wfi()
+fn wait_event() -> ()
+  arm64.wfe()
+fn send_event() -> ()
+  arm64.sev()
+`
+
+func compileEventControlAArch64Assembly(t *testing.T) (generated, assembly string) {
+	t.Helper()
+	clang := requireAArch64Clang(t)
+	generated = generateSourceC(t, aarch64EventControlSource)
+	for _, forbidden := range []string{"malloc(", "calloc(", "realloc(", "free("} {
+		if strings.Contains(generated, forbidden) {
+			t.Fatalf("event-control path unexpectedly references heap primitive %q", forbidden)
+		}
+	}
+	dir := t.TempDir()
+	cPath := filepath.Join(dir, "event_control.c")
+	sPath := filepath.Join(dir, "event_control.s")
+	if err := os.WriteFile(cPath, []byte(generated), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(clang,
+		"--target=aarch64-none-elf", "-march=armv8-a",
+		"-std=c11", "-O2", "-ffreestanding",
+		"-Wall", "-Wextra", "-Werror", "-Wno-unused-function",
+		"-S", cPath, "-o", sPath,
+	)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("cross-compile event-control C: %v\n%s\n--- C ---\n%s", err, output, generated)
+	}
+	bytes, err := os.ReadFile(sPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return generated, strings.ToLower(string(bytes))
+}
+
+func TestAArch64EventControlInstructionRefinement(t *testing.T) {
+	_, assembly := compileEventControlAArch64Assembly(t)
+	cases := []struct {
+		fn   string
+		want string
+	}{
+		{"mask_irq", "msr\tdaifset, #2"},
+		{"unmask_irq", "msr\tdaifclr, #2"},
+		{"wait_irq", "wfi"},
+		{"wait_event", "wfe"},
+		{"send_event", "sev"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.fn, func(t *testing.T) {
+			body := aarch64FunctionBody(t, assembly, tc.fn)
+			if !strings.Contains(body, tc.want) && !strings.Contains(body, strings.ReplaceAll(tc.want, "\t", " ")) {
+				t.Fatalf("%s lacks %q:\n%s", tc.fn, tc.want, body)
+			}
+			for _, forbidden := range []string{"dmb", "dsb", "isb"} {
+				if hasInstruction(body, forbidden) {
+					t.Fatalf("%s unexpectedly contains hidden %s:\n%s", tc.fn, forbidden, body)
+				}
+			}
+		})
+	}
+}
+
+func TestAArch64EventControlGeneratedCFailsClosedOnHost(t *testing.T) {
+	cc, err := exec.LookPath("cc")
+	if err != nil {
+		t.Skip("host C compiler is not available")
+	}
+	generated := generateSourceC(t, `
+package main
+fn wait() -> ()
+  arm64.wfi()
+`)
+	dir := t.TempDir()
+	cPath := filepath.Join(dir, "event_control.c")
+	oPath := filepath.Join(dir, "event_control.o")
+	if err := os.WriteFile(cPath, []byte(generated), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	output, err := exec.Command(cc, "-std=c11", "-O2", "-c", cPath, "-o", oPath).CombinedOutput()
+	if err == nil {
+		t.Fatal("host compilation of architectural event control unexpectedly succeeded")
+	}
+	if !strings.Contains(string(output), "arm64.wfi requires an AArch64 target") {
+		t.Fatalf("host failure did not explain AArch64 requirement:\n%s", output)
+	}
+}

--- a/codegen/event_control.go
+++ b/codegen/event_control.go
@@ -1,0 +1,27 @@
+package codegen
+
+import (
+	"fmt"
+
+	"github.com/SCKelemen/oak/semir"
+)
+
+// Event-control operations are compile-time-selected, pay-for-use helpers.
+// They carry no runtime opcode and inject no barriers beyond the named
+// architectural instruction itself.
+func init() {
+	for _, member := range semir.Arm64EventControlMembers() {
+		spec, ok := semir.LookupArm64EventControl(member)
+		if !ok {
+			continue
+		}
+		arm64HelperSources[member] = fmt.Sprintf(`static inline void oak_arm64_%s( void ) {
+#if defined(__aarch64__) && !defined(OAK_PORTABLE_INTRINSICS)
+  __asm__ volatile("%s" ::: "memory");
+#else
+#error "arm64.%s requires an AArch64 target"
+#endif
+}
+`, member, spec.Instruction, member)
+	}
+}

--- a/docs/spec/98-aarch64-event-control.md
+++ b/docs/spec/98-aarch64-event-control.md
@@ -1,0 +1,64 @@
+# 98 - AArch64 Event and Interrupt Control
+
+Status: normative bootstrap machine surface.
+
+## 1. Scope
+
+Oak exposes a deliberately small set of AArch64 event and interrupt-control instructions needed by low-level runtime and hypervisor code:
+
+- `arm64.daifset_irq()` -> `MSR DAIFSet, #2`
+- `arm64.daifclr_irq()` -> `MSR DAIFClr, #2`
+- `arm64.wfi()` -> `WFI`
+- `arm64.wfe()` -> `WFE`
+- `arm64.sev()` -> `SEV`
+
+All operations are nullary and return Unit. The instruction choice and any immediate are encoded by the source member itself; there is no runtime opcode, enum, string lookup, callback, or dispatch.
+
+## 2. Authority and semantics
+
+`daifset_irq` masks the IRQ bit in PSTATE. `daifclr_irq` unmasks that bit. These functions intentionally expose IRQ masking only; broader DAIF manipulation is not part of this v1 surface.
+
+`wfi` and `wfe` may suspend forward execution according to AArch64 architectural event/interrupt rules. They are therefore explicit machine effects and must never be introduced by an optimizer as an ordinary power hint.
+
+`sev` sends an architectural event. It does not by itself publish ordinary memory under Oak's language memory model.
+
+## 3. Ordering boundary
+
+None of these operations is an Oak memory barrier.
+
+In particular:
+
+- `WFI`, `WFE`, and `SEV` do not silently add `DMB`, `DSB`, or `ISB`;
+- DAIF mask changes do not silently add `ISB`;
+- a C compiler `memory` clobber in the bootstrap backend prevents compiler motion across the inline assembly but is not an AArch64 hardware memory barrier.
+
+When a protocol requires ordering, completion, or instruction synchronization, Oak source must spell the corresponding `arm64.dmb_*`, `arm64.dsb_*`, or `arm64.isb()` operation explicitly.
+
+## 4. Representation and cost
+
+These are pay-for-use helper functions in the bootstrap C backend. A used operation lowers to exactly the named architectural instruction, plus ordinary call/inlining mechanics eliminated by optimization. No allocation or runtime dispatch is permitted.
+
+Host/non-AArch64 code generation fails closed. The sequential evaluator also fails closed rather than pretending to suspend, change PSTATE, or send an architectural event.
+
+## 5. Verification obligations
+
+The implementation is guarded by:
+
+1. zero-allocation SemIR lookup tests;
+2. typechecker tests for nullary Unit signatures;
+3. freestanding AArch64 assembly tests requiring exact `MSR DAIFSet, #2`, `MSR DAIFClr, #2`, `WFI`, `WFE`, and `SEV` instruction shapes;
+4. negative assembly checks forbidding hidden `DMB`, `DSB`, or `ISB`;
+5. Lean `Oak.AArch64EventControl` facts separating IRQ-mask, wait, event-send, and memory-ordering capabilities.
+
+## 6. Non-goals
+
+This surface does not yet define:
+
+- `ERET` or other non-local control transfer;
+- full DAIF read/write or FIQ/SError/debug-mask policy;
+- scheduler semantics for sleeping vCPUs;
+- proof that a particular wait/wakeup protocol has no lost wakeup;
+- interrupt-controller acknowledgement/EOI semantics;
+- a full Arm axiomatic model for architectural events.
+
+Those require higher-level protocols rather than being hidden inside these instruction primitives.

--- a/evaluator/event_control_test.go
+++ b/evaluator/event_control_test.go
@@ -1,0 +1,22 @@
+package evaluator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/SCKelemen/oak/object"
+	"github.com/SCKelemen/oak/parser"
+	"github.com/SCKelemen/oak/scanner"
+)
+
+func TestEventControlEvaluatorFailsClosed(t *testing.T) {
+	p := parser.New(scanner.New(`arm64.wfi()`))
+	program := p.ParseProgram()
+	if errs := p.Errors(); len(errs) != 0 {
+		t.Fatalf("parser errors: %v", errs)
+	}
+	result := Eval(program, object.NewEnvironment())
+	if result == nil || !strings.Contains(result.Inspect(), "requires the native AArch64 backend") {
+		t.Fatalf("expected fail-closed event-control error, got %v", result)
+	}
+}

--- a/evaluator/ffi.go
+++ b/evaluator/ffi.go
@@ -2,9 +2,10 @@ package evaluator
 
 // Interpreter semantics for the compiler-known foreign-interface libraries.
 // Portable arm64 value-transforming instruction functions execute natively in
-// the interpreter. Architectural barriers, MMIO, and system registers do not:
-// their machine semantics cannot be faithfully represented by the sequential
-// host evaluator, so execution fails explicitly rather than inventing state.
+// the interpreter. Architectural barriers, MMIO, system registers, and event
+// control do not: their machine semantics cannot be faithfully represented by
+// the sequential host evaluator, so execution fails explicitly rather than
+// inventing state.
 
 import (
 	"math/bits"
@@ -33,6 +34,12 @@ func evalLibraryCall(library, member string, args []ast.Expression, env *object.
 }
 
 func evalArm64Intrinsic(member string, args []ast.Expression, env *object.Environment) object.Object {
+	if _, eventControl := semir.LookupArm64EventControl(member); eventControl {
+		if len(args) != 0 {
+			return newError("arm64.%s takes exactly zero arguments", member)
+		}
+		return newError("arm64.%s is an event-control machine operation and requires the native AArch64 backend", member)
+	}
 	if _, sysreg, write := semir.LookupArm64SysRegMember(member); sysreg {
 		want := 0
 		if write {

--- a/semir/event_control.go
+++ b/semir/event_control.go
@@ -1,0 +1,70 @@
+package semir
+
+import "fmt"
+
+// EventControlOperation identifies the exact architectural instruction class.
+type EventControlOperation string
+
+const (
+	EventDAIFSet EventControlOperation = "daifset"
+	EventDAIFClr EventControlOperation = "daifclr"
+	EventWFI     EventControlOperation = "wfi"
+	EventWFE     EventControlOperation = "wfe"
+	EventSEV     EventControlOperation = "sev"
+)
+
+// Arm64EventControlSpec is a compile-time machine operation. Every member is
+// nullary and returns Unit; any DAIF immediate is part of source identity.
+type Arm64EventControlSpec struct {
+	Member      string
+	Operation   EventControlOperation
+	Instruction string
+}
+
+func (s Arm64EventControlSpec) Effect() Effect {
+	return Effect{Namespace: "Machine", Name: "EventControl", Parameters: []string{string(s.Operation), s.Instruction}}
+}
+
+func LookupArm64EventControl(member string) (Arm64EventControlSpec, bool) {
+	switch member {
+	case "daifset_irq":
+		return Arm64EventControlSpec{Member: member, Operation: EventDAIFSet, Instruction: "msr daifset, #2"}, true
+	case "daifclr_irq":
+		return Arm64EventControlSpec{Member: member, Operation: EventDAIFClr, Instruction: "msr daifclr, #2"}, true
+	case "wfi":
+		return Arm64EventControlSpec{Member: member, Operation: EventWFI, Instruction: "wfi"}, true
+	case "wfe":
+		return Arm64EventControlSpec{Member: member, Operation: EventWFE, Instruction: "wfe"}, true
+	case "sev":
+		return Arm64EventControlSpec{Member: member, Operation: EventSEV, Instruction: "sev"}, true
+	default:
+		return Arm64EventControlSpec{}, false
+	}
+}
+
+func Arm64EventControlMembers() [5]string {
+	return [5]string{"daifset_irq", "daifclr_irq", "wfi", "wfe", "sev"}
+}
+
+func ValidateArm64EventControl(spec Arm64EventControlSpec) error {
+	if spec.Member == "" || spec.Instruction == "" {
+		return fmt.Errorf("event-control member and instruction must be non-empty")
+	}
+	switch spec.Operation {
+	case EventDAIFSet:
+		if spec.Instruction != "msr daifset, #2" {
+			return fmt.Errorf("DAIFSet IRQ must encode immediate #2")
+		}
+	case EventDAIFClr:
+		if spec.Instruction != "msr daifclr, #2" {
+			return fmt.Errorf("DAIFClr IRQ must encode immediate #2")
+		}
+	case EventWFI, EventWFE, EventSEV:
+		if spec.Instruction != string(spec.Operation) {
+			return fmt.Errorf("event instruction %q does not match operation %q", spec.Instruction, spec.Operation)
+		}
+	default:
+		return fmt.Errorf("unknown event-control operation %q", spec.Operation)
+	}
+	return nil
+}

--- a/semir/event_control_test.go
+++ b/semir/event_control_test.go
@@ -1,0 +1,32 @@
+package semir
+
+import "testing"
+
+func TestArm64EventControlCatalogIsExact(t *testing.T) {
+	members := Arm64EventControlMembers()
+	seen := map[string]bool{}
+	for _, member := range members {
+		if seen[member] {
+			t.Fatalf("duplicate member %q", member)
+		}
+		seen[member] = true
+		spec, ok := LookupArm64EventControl(member)
+		if !ok {
+			t.Fatalf("member %q is not resolvable", member)
+		}
+		if err := ValidateArm64EventControl(spec); err != nil {
+			t.Fatalf("invalid %q: %v", member, err)
+		}
+		if spec.Effect().Namespace != "Machine" || spec.Effect().Name != "EventControl" {
+			t.Fatalf("%q has wrong effect: %+v", member, spec.Effect())
+		}
+	}
+}
+
+func TestArm64EventControlLookupAllocatesNothing(t *testing.T) {
+	if got := testing.AllocsPerRun(1000, func() {
+		_, _ = LookupArm64EventControl("wfi")
+	}); got != 0 {
+		t.Fatalf("lookup allocated: %f", got)
+	}
+}

--- a/spec/lean/Oak.lean
+++ b/spec/lean/Oak.lean
@@ -7,6 +7,7 @@ import Oak.AArch64Memory
 import Oak.AArch64Barrier
 import Oak.AArch64Mmio
 import Oak.AArch64SysReg
+import Oak.AArch64EventControl
 import Oak.Borrowing
 import Oak.BorrowRegions
 import Oak.Reborrow

--- a/spec/lean/Oak/AArch64EventControl.lean
+++ b/spec/lean/Oak/AArch64EventControl.lean
@@ -1,0 +1,44 @@
+namespace Oak.AArch64EventControl
+
+inductive Operation where
+  | daifSetIrq
+  | daifClrIrq
+  | wfi
+  | wfe
+  | sev
+  deriving DecidableEq, Repr
+
+structure Capability where
+  changesIrqMask : Bool
+  mayWait : Bool
+  sendsEvent : Bool
+  ordersMemory : Bool
+  completesMemory : Bool
+  instructionSync : Bool
+  deriving DecidableEq, Repr
+
+def capability : Operation -> Capability
+  | .daifSetIrq => ⟨true, false, false, false, false, false⟩
+  | .daifClrIrq => ⟨true, false, false, false, false, false⟩
+  | .wfi => ⟨false, true, false, false, false, false⟩
+  | .wfe => ⟨false, true, false, false, false, false⟩
+  | .sev => ⟨false, false, true, false, false, false⟩
+
+theorem daif_operations_only_change_irq_mask :
+    (capability .daifSetIrq).changesIrqMask = true ∧
+    (capability .daifClrIrq).changesIrqMask = true := by
+  decide
+
+theorem wait_operations_are_explicit :
+    (capability .wfi).mayWait = true ∧
+    (capability .wfe).mayWait = true ∧
+    (capability .sev).sendsEvent = true := by
+  decide
+
+theorem event_control_does_not_hide_barrier (op : Operation) :
+    (capability op).ordersMemory = false ∧
+    (capability op).completesMemory = false ∧
+    (capability op).instructionSync = false := by
+  cases op <;> decide
+
+end Oak.AArch64EventControl

--- a/typechecker/event_control.go
+++ b/typechecker/event_control.go
@@ -1,0 +1,13 @@
+package typechecker
+
+import "github.com/SCKelemen/oak/semir"
+
+// Register nullary machine-control operations in the existing arm64 catalog.
+func init() {
+	for _, member := range semir.Arm64EventControlMembers() {
+		arm64Intrinsics[member] = &FunctionType{
+			Parameters: []Type{},
+			ReturnType: &UnitType{},
+		}
+	}
+}

--- a/typechecker/event_control_test.go
+++ b/typechecker/event_control_test.go
@@ -1,0 +1,52 @@
+package typechecker
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/SCKelemen/oak/object"
+	"github.com/SCKelemen/oak/parser"
+	"github.com/SCKelemen/oak/scanner"
+)
+
+func checkEventControlSource(t *testing.T, source string) []string {
+	t.Helper()
+	p := parser.New(scanner.New(source))
+	program := p.ParseProgram()
+	if errs := p.Errors(); len(errs) != 0 {
+		t.Fatalf("parser errors: %v", errs)
+	}
+	tc := New(object.NewEnvironment())
+	tc.CheckProgram(program)
+	return tc.Errors()
+}
+
+func TestArm64EventControlOperationsAreNullaryUnit(t *testing.T) {
+	errs := checkEventControlSource(t, `
+package main
+fn control() -> () {
+  arm64.daifset_irq()
+  arm64.daifclr_irq()
+  arm64.wfi()
+  arm64.wfe()
+  arm64.sev()
+}
+`)
+	if len(errs) != 0 {
+		t.Fatalf("valid event-control program rejected: %v", errs)
+	}
+}
+
+func TestArm64EventControlRejectsOperands(t *testing.T) {
+	errs := checkEventControlSource(t, `
+package main
+fn bad(value: u64) -> ()
+  arm64.wfi(value)
+`)
+	for _, err := range errs {
+		if strings.Contains(err, "takes 0 argument(s), got 1") {
+			return
+		}
+	}
+	t.Fatalf("wrong failure: %v", errs)
+}


### PR DESCRIPTION
Adds the next explicit AArch64 machine-control slice needed by Oak's EL2 runtime path.

Surface:
- `arm64.daifset_irq()` -> `MSR DAIFSet, #2`
- `arm64.daifclr_irq()` -> `MSR DAIFClr, #2`
- `arm64.wfi()` -> `WFI`
- `arm64.wfe()` -> `WFE`
- `arm64.sev()` -> `SEV`

Design:
- source identity fixes the exact architectural instruction/immediate;
- nullary Unit operations, no runtime opcode/dispatch/allocation;
- explicit `Machine.EventControl[...]` effects;
- fail-closed host evaluator and non-AArch64 generated C;
- no hidden DMB/DSB/ISB or memory-model publication semantics;
- compiler memory clobber is documented as compiler ordering only, not a hardware barrier.

Verification:
- zero-allocation SemIR lookup test;
- typechecker nullary surface tests;
- freestanding AArch64 assembly checks for exact DAIFSet/DAIFClr/WFI/WFE/SEV forms;
- negative assembly checks for hidden barriers;
- Lean `Oak.AArch64EventControl` separates IRQ-mask, wait, event-send, and ordering capabilities;
- normative `docs/spec/98-aarch64-event-control.md`.

Intentionally separate: ERET/non-local control transfer, higher-level wait/wakeup protocol proofs, interrupt-controller ack/EOI, and full Arm event axioms.