### PR TITLE
Add cold EL2 guest preparation protocol

### DIFF
--- a/codegen/aarch64_el2_cold_prepare_test.go
+++ b/codegen/aarch64_el2_cold_prepare_test.go
@@ -1,0 +1,69 @@
+package codegen
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAArch64EL2ColdPrepareInstructionSequence(t *testing.T) {
+	clang := requireAArch64Clang(t)
+	sourcePath := filepath.Join("..", "examples", "hypervisor", "el2_cold_prepare.oak")
+	source, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	generated := generateSourceC(t, string(source))
+	for _, forbidden := range []string{"malloc(", "calloc(", "realloc(", "free("} {
+		if strings.Contains(generated, forbidden) {
+			t.Fatalf("cold-entry path unexpectedly references heap primitive %q", forbidden)
+		}
+	}
+
+	dir := t.TempDir()
+	cPath := filepath.Join(dir, "el2_cold_prepare.c")
+	sPath := filepath.Join(dir, "el2_cold_prepare.s")
+	if err := os.WriteFile(cPath, []byte(generated), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(clang,
+		"--target=aarch64-none-elf", "-march=armv8-a",
+		"-std=c11", "-O2", "-ffreestanding",
+		"-Wall", "-Wextra", "-Werror", "-Wno-unused-function",
+		"-S", cPath, "-o", sPath,
+	)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("cross-compile cold EL2 preparation: %v\n%s\n--- C ---\n%s", err, output, generated)
+	}
+	assemblyBytes, err := os.ReadFile(sPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assembly := strings.ToLower(string(assemblyBytes))
+	body := aarch64FunctionBody(t, assembly, "hypervisor_el2_cold_prepare")
+	flat := strings.Join(strings.Fields(body), " ")
+
+	ordered := []string{
+		"msr daifset, #2",
+		"msr hcr_el2,",
+		"msr vttbr_el2,",
+		"msr vtcr_el2,",
+		"msr cnthctl_el2,",
+		"msr cntvoff_el2,",
+		"msr sp_el1,",
+		"msr elr_el2,",
+		"msr spsr_el2,",
+		"isb",
+	}
+	cursor := 0
+	for _, want := range ordered {
+		rel := strings.Index(flat[cursor:], want)
+		if rel < 0 {
+			t.Fatalf("cold-entry body lacks ordered instruction %q after offset %d:\n%s", want, cursor, body)
+		}
+		cursor += rel + len(want)
+	}
+	forbidInstruction(t, body, "dmb", "dsb", "wfi", "wfe", "sev")
+}

--- a/docs/spec/99-el2-cold-guest-prepare.md
+++ b/docs/spec/99-el2-cold-guest-prepare.md
@@ -1,0 +1,57 @@
+# 99 - Cold EL2 Guest Preparation
+
+Status: normative bootstrap protocol for a vCPU that has not yet executed.
+
+## 1. Purpose
+
+This protocol is the first whole hypervisor-shaped Oak program built from the machine primitives in specs 96-98. It installs the initial EL2/EL1 guest execution context before the vCPU has entered EL1.
+
+The reference implementation is `examples/hypervisor/el2_cold_prepare.oak`.
+
+## 2. Preconditions
+
+The protocol is valid only for cold initialization of a vCPU whose stage-2 translation context has not previously been active.
+
+In particular, it does **not** authorize changing VTTBR_EL2 or VTCR_EL2 underneath a live or previously active translation context without the required invalidation/completion protocol. Live stage-2 reconfiguration requires explicit TLBI and DSB machinery that is outside this specification.
+
+## 3. Ordered machine sequence
+
+The reference sequence is:
+
+1. mask IRQ delivery with `arm64.daifset_irq()`;
+2. write `HCR_EL2`;
+3. write `VTTBR_EL2`;
+4. write `VTCR_EL2`;
+5. write `CNTHCTL_EL2`;
+6. write `CNTVOFF_EL2`;
+7. write guest `SP_EL1`;
+8. write `ELR_EL2` (guest PC);
+9. write `SPSR_EL2` (guest PSTATE restore state);
+10. issue explicit `arm64.isb()`.
+
+The final transfer with `ERET` is intentionally absent until Oak can represent a non-returning machine control transfer faithfully as `never`.
+
+## 4. Invariants
+
+- IRQs remain masked throughout preparation.
+- Every machine register is selected statically by source identity; there is no runtime register dispatch.
+- No heap allocation is introduced by the protocol or its machine helpers.
+- No DMB or DSB is silently inserted. This protocol is cold initialization, not live translation reconfiguration.
+- No wait/event operation occurs during preparation.
+- The ISB is explicit and visible in source.
+- This function returns to its EL2 caller; it does not enter the guest.
+
+## 5. Verification
+
+`codegen/aarch64_el2_cold_prepare_test.go` cross-compiles the reference Oak source for freestanding ARMv8-A and checks the emitted assembly for the complete ordered instruction sequence. The test also rejects hidden DMB, DSB, WFI, WFE, or SEV instructions and heap dependencies.
+
+The constituent authority/order facts remain covered by the Lean models for AArch64 system registers, barriers, MMIO, and event control. A later guest-entry state-machine model should compose these facts with `ERET`, stage-2 invalidation, and vCPU lifecycle state.
+
+## 6. Next protocol layers
+
+1. correct bottom-type (`never`) control-flow composition;
+2. `ERET` as a non-returning AArch64 control transfer;
+3. cold prepare + ERET guest entry;
+4. TLBI/DSB primitives and live stage-2 reconfiguration protocol;
+5. virtual interrupt/timer entry/exit integration;
+6. QEMU EL2 smoke test driven by generated Oak code.

--- a/examples/hypervisor/el2_cold_prepare.oak
+++ b/examples/hypervisor/el2_cold_prepare.oak
@@ -1,0 +1,25 @@
+package hypervisor
+
+// Initial guest-context installation before this vCPU has executed.
+// Live stage-2 reconfiguration requires a separate TLBI/DSB protocol.
+fn el2_cold_prepare(
+  hcr: u64,
+  vttbr: u64,
+  vtcr: u64,
+  cnthctl: u64,
+  cntvoff: u64,
+  guest_sp: u64,
+  guest_pc: u64,
+  guest_pstate: u64
+) -> () {
+  arm64.daifset_irq()
+  arm64.write_hcr_el2(hcr)
+  arm64.write_vttbr_el2(vttbr)
+  arm64.write_vtcr_el2(vtcr)
+  arm64.write_cnthctl_el2(cnthctl)
+  arm64.write_cntvoff_el2(cntvoff)
+  arm64.write_sp_el1(guest_sp)
+  arm64.write_elr_el2(guest_pc)
+  arm64.write_spsr_el2(guest_pstate)
+  arm64.isb()
+}


### PR DESCRIPTION
Adds the first whole hypervisor-shaped Oak program built from the AArch64 machine surface.

Reference protocol:
- mask IRQs;
- write HCR_EL2;
- install initial VTTBR_EL2/VTCR_EL2;
- configure CNTHCTL_EL2/CNTVOFF_EL2;
- install guest SP_EL1, ELR_EL2, SPSR_EL2;
- finish with explicit ISB.

Scope is deliberately cold-entry only: the vCPU must not have previously used the stage-2 context. Live VTTBR/VTCR reconfiguration remains blocked on explicit TLBI/DSB protocol work.

Verification:
- freestanding ARMv8-A cross-compile of `examples/hypervisor/el2_cold_prepare.oak`;
- assembly test checks the complete ordered machine sequence;
- rejects hidden DMB/DSB/WFI/WFE/SEV;
- rejects heap dependencies;
- normative `docs/spec/99-el2-cold-guest-prepare.md` records preconditions, invariants, and the pending ERET/bottom-type work.

This function intentionally returns to EL2. It does not fake ERET as a Unit-returning intrinsic; guest control transfer remains a separate correctness slice.