### PR TITLE
Add non-returning AArch64 ERET surface

### DIFF
--- a/codegen/aarch64_eret_test.go
+++ b/codegen/aarch64_eret_test.go
@@ -1,0 +1,43 @@
+package codegen
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const aarch64EretSource = `
+package main
+fn enter() -> never
+  arm64.eret()
+`
+
+func TestAArch64EretIsExactNonReturningControlTransfer(t *testing.T) {
+	clang := requireAArch64Clang(t)
+	generated := generateSourceC(t, aarch64EretSource)
+	if strings.Contains(generated, "malloc(") || strings.Contains(generated, "calloc(") || strings.Contains(generated, "realloc(") || strings.Contains(generated, "free(") {
+		t.Fatalf("ERET lowering acquired a heap dependency:\n%s", generated)
+	}
+
+	dir := t.TempDir()
+	cPath := filepath.Join(dir, "eret.c")
+	sPath := filepath.Join(dir, "eret.s")
+	if err := os.WriteFile(cPath, []byte(generated), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(clang,
+		"--target=aarch64-none-elf", "-march=armv8-a", "-std=c11", "-O2", "-ffreestanding",
+		"-Wall", "-Wextra", "-Werror", "-Wno-unused-function", "-S", cPath, "-o", sPath)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("cross-compile ERET: %v\n%s\n--- C ---\n%s", err, output, generated)
+	}
+	assemblyBytes, err := os.ReadFile(sPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := aarch64FunctionBody(t, strings.ToLower(string(assemblyBytes)), "enter")
+	requireInstruction(t, body, "eret")
+	forbidInstruction(t, body, "ret", "dmb", "dsb", "isb", "wfi", "wfe", "sev")
+}

--- a/codegen/eret.go
+++ b/codegen/eret.go
@@ -2,16 +2,23 @@ package codegen
 
 import "github.com/SCKelemen/oak/semir"
 
-// ERET is emitted as a pay-for-use noreturn helper.  __builtin_unreachable is
-// compiler control-flow metadata after the architectural transfer; it emits no
-// runtime instruction and prevents a synthetic C return path after ERET.
+// ERET is emitted as a pay-for-use noreturn helper. The C bootstrap backend
+// needs a syntactic carrier for Oak's uninhabited `never` type because the
+// generic expression emitter writes `return eret()`. `oak_never` is therefore
+// an ABI spelling only: the helper is noreturn and can never produce a value of
+// that carrier. No source-level value constructor exists.
+//
+// __builtin_unreachable is compiler control-flow metadata after the
+// architectural transfer; it emits no runtime instruction and prevents a
+// synthetic C return path after ERET.
 func init() {
 	for _, member := range semir.Arm64ControlTransferMembers() {
 		spec, ok := semir.LookupArm64ControlTransfer(member)
 		if !ok {
 			continue
 		}
-		arm64HelperSources[member] = `__attribute__((noreturn)) static inline void oak_arm64_eret( void ) {
+		arm64HelperSources[member] = `typedef u8 oak_never; /* uninhabited in Oak; no value is ever produced */
+__attribute__((noreturn)) static inline oak_never oak_arm64_eret( void ) {
 #if defined(__aarch64__) && !defined(OAK_PORTABLE_INTRINSICS)
   __asm__ volatile("` + spec.Instruction + `" ::: "memory");
   __builtin_unreachable();

--- a/codegen/eret.go
+++ b/codegen/eret.go
@@ -1,0 +1,24 @@
+package codegen
+
+import "github.com/SCKelemen/oak/semir"
+
+// ERET is emitted as a pay-for-use noreturn helper.  __builtin_unreachable is
+// compiler control-flow metadata after the architectural transfer; it emits no
+// runtime instruction and prevents a synthetic C return path after ERET.
+func init() {
+	for _, member := range semir.Arm64ControlTransferMembers() {
+		spec, ok := semir.LookupArm64ControlTransfer(member)
+		if !ok {
+			continue
+		}
+		arm64HelperSources[member] = `__attribute__((noreturn)) static inline void oak_arm64_eret( void ) {
+#if defined(__aarch64__) && !defined(OAK_PORTABLE_INTRINSICS)
+  __asm__ volatile("` + spec.Instruction + `" ::: "memory");
+  __builtin_unreachable();
+#else
+#error "arm64.eret requires an AArch64 target"
+#endif
+}
+`
+	}
+}

--- a/docs/spec/100-aarch64-control-transfer.md
+++ b/docs/spec/100-aarch64-control-transfer.md
@@ -1,0 +1,78 @@
+# AArch64 control transfer
+
+Status: executable language contract for the first non-returning privileged control transfer.
+
+## Scope
+
+Oak exposes AArch64 exception return as:
+
+```oak
+arm64.eret() -> never
+```
+
+`ERET` is not an ordinary function return, an event-control operation, or a memory barrier. It consumes architectural exception-return state such as `ELR_EL2` and `SPSR_EL2` and transfers control according to the AArch64 architecture.
+
+The initial surface contains exactly one control transfer: `eret`.
+
+## Type and control-flow contract
+
+The source result type is `never`, Oak's existing bottom type. Oak must not type `ERET` as `()` merely to accommodate a backend ABI: that would falsely permit ordinary continuation after an operation that never returns to its caller.
+
+A function whose final expression is `arm64.eret()` may therefore be declared `-> never` today. The semantic type lattice already specifies and proves `never` as bottom. General expected-position use of `never <: T` is separate checker-integration work; this chapter does not claim that every expression consumer already uses the lattice relation.
+
+## Effects
+
+`ERET` contributes:
+
+```text
+Machine.ControlTransfer[eret]
+```
+
+It does not itself establish:
+
+- memory ordering;
+- memory completion;
+- instruction synchronization;
+- interrupt-controller acknowledgement;
+- a scheduler handoff.
+
+Any required `DMB`, `DSB`, `ISB`, system-register writes, or interrupt masking must remain explicit in the surrounding Oak protocol.
+
+## Backend contract
+
+The AArch64 C bootstrap backend lowers the operation to an inline `ERET` instruction in a `noreturn` helper. Compiler control-flow metadata may mark the path unreachable after that instruction, but it must not emit a runtime return, heap allocation, dispatch table, opcode switch, or hidden barrier.
+
+Non-AArch64 compilation fails closed rather than emulating exception return. The host evaluator likewise fails closed and never fabricates a new exception level or program counter.
+
+## Performance contract
+
+The operation is pay-for-use and allocation-free:
+
+- semantic lookup allocates zero objects;
+- register/instruction identity is fixed at compile time;
+- there is no runtime opcode or callback dispatch;
+- generated machine code contains the architectural control transfer directly.
+
+## Verification
+
+The acceptance surface includes:
+
+1. SemIR tests for the exact one-member catalog and zero-allocation lookup.
+2. Typechecker tests that `arm64.eret()` is nullary and has type `never`.
+3. Host-evaluator tests that execution fails closed.
+4. Freestanding AArch64 assembly tests requiring `ERET` and rejecting an ordinary `RET` path, hidden barriers, wait/event instructions, and heap dependencies.
+5. Lean `Oak.AArch64ControlTransfer` proofs that ERET is non-returning, is an exception-context transfer, and supplies no hidden barrier capability.
+
+These facts prove the declared abstraction and test its implementation/refinement boundary. They do not by themselves prove that arbitrary values written to `ELR_EL2`/`SPSR_EL2` form a valid guest context. That obligation belongs to the higher-level EL2 guest-entry protocol.
+
+## Next protocol
+
+The cold guest-preparation sequence in `99-el2-cold-guest-prepare.md` may be extended with this primitive to form an actual cold guest-entry operation:
+
+```text
+prepare EL2/EL1 state
+    -> explicit ISB
+    -> ERET
+```
+
+Live stage-2 reconfiguration remains separate and requires the appropriate TLBI/DSB protocol before guest re-entry.

--- a/evaluator/eret_test.go
+++ b/evaluator/eret_test.go
@@ -1,0 +1,29 @@
+package evaluator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/SCKelemen/oak/object"
+	"github.com/SCKelemen/oak/parser"
+	"github.com/SCKelemen/oak/scanner"
+)
+
+func TestEretEvaluatorFailsClosed(t *testing.T) {
+	p := parser.New(scanner.New(`
+package main
+fn enter() -> never
+  arm64.eret()
+`))
+	program := p.ParseProgram()
+	if errs := p.Errors(); len(errs) != 0 {
+		t.Fatalf("parser errors: %v", errs)
+	}
+	result := Eval(program, object.NewEnvironment())
+	if result == nil {
+		t.Fatal("host evaluator must not pretend ERET executed")
+	}
+	if !strings.Contains(result.Inspect(), "non-returning control-transfer") {
+		t.Fatalf("unexpected ERET evaluator result: %s", result.Inspect())
+	}
+}

--- a/evaluator/eret_test.go
+++ b/evaluator/eret_test.go
@@ -10,11 +10,7 @@ import (
 )
 
 func TestEretEvaluatorFailsClosed(t *testing.T) {
-	p := parser.New(scanner.New(`
-package main
-fn enter() -> never
-  arm64.eret()
-`))
+	p := parser.New(scanner.New(`arm64.eret()`))
 	program := p.ParseProgram()
 	if errs := p.Errors(); len(errs) != 0 {
 		t.Fatalf("parser errors: %v", errs)

--- a/evaluator/ffi.go
+++ b/evaluator/ffi.go
@@ -2,10 +2,10 @@ package evaluator
 
 // Interpreter semantics for the compiler-known foreign-interface libraries.
 // Portable arm64 value-transforming instruction functions execute natively in
-// the interpreter. Architectural barriers, MMIO, system registers, and event
-// control do not: their machine semantics cannot be faithfully represented by
-// the sequential host evaluator, so execution fails explicitly rather than
-// inventing state.
+// the interpreter. Architectural barriers, MMIO, system registers, event
+// control, and non-returning control transfers do not: their machine semantics
+// cannot be faithfully represented by the sequential host evaluator, so
+// execution fails explicitly rather than inventing state or control flow.
 
 import (
 	"math/bits"
@@ -34,6 +34,12 @@ func evalLibraryCall(library, member string, args []ast.Expression, env *object.
 }
 
 func evalArm64Intrinsic(member string, args []ast.Expression, env *object.Environment) object.Object {
+	if _, controlTransfer := semir.LookupArm64ControlTransfer(member); controlTransfer {
+		if len(args) != 0 {
+			return newError("arm64.%s takes exactly zero arguments", member)
+		}
+		return newError("arm64.%s is a non-returning control-transfer machine operation and requires the native AArch64 backend", member)
+	}
 	if _, eventControl := semir.LookupArm64EventControl(member); eventControl {
 		if len(args) != 0 {
 			return newError("arm64.%s takes exactly zero arguments", member)
@@ -123,14 +129,13 @@ func evalArm64VectorIntrinsic(member string, args []ast.Expression, env *object.
 				max = lane
 			}
 		}
-		return &object.Integer{Value: int64(max)}
+		return &object.Integer{Value: max}
 	case "uminv_u8x16":
 		min := byte(255)
 		for _, lane := range vec.Bytes {
 			if lane < min {
 				min = lane
 			}
-		}
 		return &object.Integer{Value: int64(min)}
 	case "cnt_u8x16":
 		result := &object.Vector{VectorKind: "U8x16"}

--- a/evaluator/ffi.go
+++ b/evaluator/ffi.go
@@ -129,13 +129,14 @@ func evalArm64VectorIntrinsic(member string, args []ast.Expression, env *object.
 				max = lane
 			}
 		}
-		return &object.Integer{Value: max}
+		return &object.Integer{Value: int64(max)}
 	case "uminv_u8x16":
 		min := byte(255)
 		for _, lane := range vec.Bytes {
 			if lane < min {
 				min = lane
 			}
+		}
 		return &object.Integer{Value: int64(min)}
 	case "cnt_u8x16":
 		result := &object.Vector{VectorKind: "U8x16"}

--- a/semir/control_transfer.go
+++ b/semir/control_transfer.go
@@ -1,0 +1,28 @@
+package semir
+
+// Arm64ControlTransferSpec describes an architectural control transfer that
+// does not return to its Oak caller.  It is deliberately separate from event
+// control and barriers: changing PC/exception level is neither waiting nor a
+// memory-ordering operation.
+type Arm64ControlTransferSpec struct {
+	Member      string
+	Instruction string
+}
+
+func (s Arm64ControlTransferSpec) Effect() Effect {
+	return Effect{Namespace: "Machine", Name: "ControlTransfer", Parameters: []string{s.Member}}
+}
+
+// LookupArm64ControlTransfer is intentionally tiny in v1.  ERET consumes the
+// architectural ELR_EL2/SPSR_EL2 state already installed by explicit sysreg
+// operations and transfers control according to the Arm architecture.
+func LookupArm64ControlTransfer(member string) (Arm64ControlTransferSpec, bool) {
+	if member == "eret" {
+		return Arm64ControlTransferSpec{Member: "eret", Instruction: "eret"}, true
+	}
+	return Arm64ControlTransferSpec{}, false
+}
+
+func Arm64ControlTransferMembers() [1]string {
+	return [1]string{"eret"}
+}

--- a/semir/control_transfer_test.go
+++ b/semir/control_transfer_test.go
@@ -1,0 +1,28 @@
+package semir
+
+import "testing"
+
+func TestArm64ControlTransferCatalogIsExact(t *testing.T) {
+	members := Arm64ControlTransferMembers()
+	if members != [1]string{"eret"} {
+		t.Fatalf("unexpected control-transfer surface: %v", members)
+	}
+	spec, ok := LookupArm64ControlTransfer("eret")
+	if !ok || spec.Instruction != "eret" {
+		t.Fatalf("ERET semantic descriptor missing or wrong: %#v %v", spec, ok)
+	}
+	if _, ok := LookupArm64ControlTransfer("ret"); ok {
+		t.Fatal("ordinary RET must not be part of the privileged control-transfer surface")
+	}
+}
+
+func TestArm64ControlTransferLookupAllocatesNothing(t *testing.T) {
+	allocs := testing.AllocsPerRun(1000, func() {
+		if _, ok := LookupArm64ControlTransfer("eret"); !ok {
+			panic("missing eret")
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("control-transfer lookup allocated: %f", allocs)
+	}
+}

--- a/spec/lean/Oak.lean
+++ b/spec/lean/Oak.lean
@@ -8,6 +8,7 @@ import Oak.AArch64Barrier
 import Oak.AArch64Mmio
 import Oak.AArch64SysReg
 import Oak.AArch64EventControl
+import Oak.AArch64ControlTransfer
 import Oak.Borrowing
 import Oak.BorrowRegions
 import Oak.Reborrow

--- a/spec/lean/Oak/AArch64ControlTransfer.lean
+++ b/spec/lean/Oak/AArch64ControlTransfer.lean
@@ -1,0 +1,37 @@
+namespace Oak.AArch64ControlTransfer
+
+inductive Operation where
+  | eret
+  deriving DecidableEq, Repr
+
+structure Capability where
+  returnsToCaller : Bool
+  transfersExceptionLevel : Bool
+  ordersMemory : Bool
+  completesMemory : Bool
+  instructionSync : Bool
+  deriving DecidableEq, Repr
+
+def capability : Operation -> Capability
+  | .eret => ⟨false, true, false, false, false⟩
+
+/-- ERET is semantically non-returning from the Oak caller. -/
+theorem eret_does_not_return :
+    (capability .eret).returnsToCaller = false := by
+  decide
+
+/-- The transfer changes architectural exception context rather than acting as
+    an ordinary call/return operation. -/
+theorem eret_is_exception_return :
+    (capability .eret).transfersExceptionLevel = true := by
+  decide
+
+/-- ERET itself must not be used as a substitute for explicit barrier
+    operations required by the surrounding architectural protocol. -/
+theorem eret_does_not_hide_barrier :
+    (capability .eret).ordersMemory = false ∧
+    (capability .eret).completesMemory = false ∧
+    (capability .eret).instructionSync = false := by
+  decide
+
+end Oak.AArch64ControlTransfer

--- a/typechecker/eret.go
+++ b/typechecker/eret.go
@@ -1,0 +1,17 @@
+package typechecker
+
+import "github.com/SCKelemen/oak/semir"
+
+// ERET is a genuine non-returning machine operation.  It is not typed as Unit
+// merely to fit C: the source type is () -> never, matching Oak's existing
+// bottom type.  Functions that end in ERET should therefore declare `never`
+// until general expected-position bottom coercion is wired through all checker
+// paths.
+func init() {
+	for _, member := range semir.Arm64ControlTransferMembers() {
+		arm64Intrinsics[member] = &FunctionType{
+			Parameters: []Type{},
+			ReturnType: &NeverType{},
+		}
+	}
+}

--- a/typechecker/eret_test.go
+++ b/typechecker/eret_test.go
@@ -1,0 +1,51 @@
+package typechecker
+
+import (
+	"testing"
+
+	"github.com/SCKelemen/oak/object"
+	"github.com/SCKelemen/oak/parser"
+	"github.com/SCKelemen/oak/scanner"
+)
+
+func TestEretIsNullaryAndReturnsNever(t *testing.T) {
+	p := parser.New(scanner.New(`
+package main
+fn enter() -> never
+  arm64.eret()
+`))
+	program := p.ParseProgram()
+	if errs := p.Errors(); len(errs) != 0 {
+		t.Fatalf("parser errors: %v", errs)
+	}
+	tc := New(object.NewEnvironment())
+	tc.CheckProgram(program)
+	if errs := tc.Errors(); len(errs) != 0 {
+		t.Fatalf("valid ERET function rejected: %v", errs)
+	}
+	fn, ok := tc.Env().GetType("enter")
+	if !ok {
+		t.Fatal("enter missing from type environment")
+	}
+	ft, ok := fn.(*FunctionType)
+	if !ok {
+		t.Fatalf("enter has non-function type %T", fn)
+	}
+	if _, ok := ft.ReturnType.(*NeverType); !ok {
+		t.Fatalf("ERET function return type = %T, want NeverType", ft.ReturnType)
+	}
+}
+
+func TestEretRejectsOperands(t *testing.T) {
+	p := parser.New(scanner.New(`
+package main
+fn bad(x: u64) -> never
+  arm64.eret(x)
+`))
+	program := p.ParseProgram()
+	tc := New(object.NewEnvironment())
+	tc.CheckProgram(program)
+	if len(tc.Errors()) == 0 {
+		t.Fatal("ERET with an operand must be rejected")
+	}
+}


### PR DESCRIPTION
Adds the first explicit non-returning AArch64 control-transfer primitive.

Surface:
- `arm64.eret() -> never`

Semantics:
- ERET is `Machine.ControlTransfer[eret]`, not Unit, event control, or a barrier.
- Source type uses Oak's existing `never` bottom type; this PR does not fake continuation after exception return.
- No hidden DMB/DSB/ISB or memory-model publication semantics.
- No runtime opcode, allocation, callback, or dispatch.

Backend/evaluator:
- pay-for-use AArch64 `noreturn` helper emits exact `ERET` then compiler-only `__builtin_unreachable()` metadata;
- non-AArch64 compilation fails closed;
- host evaluator fails closed instead of fabricating exception-level state.

Verification:
- exact SemIR catalog + zero-allocation lookup;
- typechecker proves the public operation is nullary and returns `never`;
- Lean `Oak.AArch64ControlTransfer` proves non-returning exception-context transfer and no hidden barrier capability;
- freestanding ARMv8-A assembly test requires `ERET`, rejects ordinary `RET`, hidden barriers/event instructions, and heap dependencies;
- normative `docs/spec/100-aarch64-control-transfer.md`.

Known separate integration debt: the type lattice already proves `never` is bottom, but general expected-position checker consumers still need to consistently use semantic subtyping. This PR only relies on the honest `fn ... -> never` path.