### PR TITLE
Specify aggregate record representations

### DIFF
--- a/docs/spec/45-representations.md
+++ b/docs/spec/45-representations.md
@@ -151,6 +151,61 @@ relation is preserved.
 This lets Oak support aggressive systems representations without weakening the
 semantic type system.
 
+## 7.1 Aggregate representations: AoS, SoA, and AoSoA
+
+Array-of-structs and structure-of-arrays are representations of a **sequence of
+semantic record values**, not different record meanings.
+
+For a semantic element shape:
+
+```oak
+Particle: type = {
+  x: f32
+  y: f32
+  mass: f32
+}
+```
+
+the abstract value of an `N`-element collection is the same indexed sequence
+of `Particle` values under each of these layouts:
+
+```text
+AoS:   [x0 y0 mass0] [x1 y1 mass1] ...
+SoA:   [x0 x1 ...] [y0 y1 ...] [mass0 mass1 ...]
+AoSoA: [x0..xL] [y0..yL] [mass0..massL] ...
+```
+
+This diagram is specification notation, not Oak surface syntax.
+
+The current `[N]Stored` form, where `Stored` is a concrete struct, retains
+its ordinary contiguous array-of-structs representation. A future SoA or AoSoA
+form must be selected explicitly on the collection representation axis. The
+compiler must not infer such a transformation merely from use, optimization
+level, target SIMD width, or field order.
+
+Every aggregate representation must establish an abstraction relation
+`element(storage, i)` such that, for each in-range index `i`:
+
+- the logical element has exactly the semantic fields and field types required
+  by the element record;
+- reading `elements[i].field` denotes the corresponding field at `i`;
+- writing through authorized mutable access changes that field and no other
+  semantic element;
+- collection length and element order are preserved;
+- borrowing/provenance rules apply to the actual projected storage regions;
+- conversion or materialization never introduces hidden unbounded copying.
+
+A SoA representation does not contain a contiguous struct object for each
+logical element. Therefore it must not manufacture `&elements[i]` as a
+pointer to such an object. An element view may instead be a checked logical
+projection; the exact source form is intentionally not frozen here.
+
+SIMD width, column alignment, cache-line separation, tiling, and prefetch stride
+are representation parameters. They may change physical placement and access
+cost, but they cannot change record-shape satisfaction. AoS, SoA, and AoSoA
+realizations of `Particle` all satisfy the same `Particle` field
+requirements.
+
 ## 8. Representation and ABI visibility
 
 A private representation may change without changing the semantic module API,

--- a/typechecker/records_shapes_test.go
+++ b/typechecker/records_shapes_test.go
@@ -35,6 +35,34 @@ both: (x: AB, y: BA): u8 = sum(x) + sum(y)
 	}
 }
 
+// Layout policy is not part of semantic shape identity. Natural, packed,
+// aggregate-aligned, per-field-aligned, and reordered structs over the same
+// members all satisfy the same record requirement.
+func TestRecordShapeSatisfactionIgnoresConcreteLayoutPolicy(t *testing.T) {
+	input := `
+u8_ab: type = { a, b: u8 }
+
+Natural: type = struct { a: u8, b: u8 }
+Packed: type = struct(packed) { b: u8, a: u8 }
+Aligned: type = struct(align: 16) { a: u8, b: u8 }
+FieldAligned: type = struct {
+  b(align: 16): u8
+  a: u8
+}
+
+sum: (v: u8_ab): u8 = v.a + v.b
+
+all: (n: Natural, p: Packed, a: Aligned, f: FieldAligned): u8 =
+  sum(n) + sum(p) + sum(a) + sum(f)
+`
+	tc := setupTypeChecker(input)
+	program := parseProgram(input)
+	tc.CheckProgram(program)
+	if len(tc.Errors()) > 0 {
+		t.Fatalf("layout policy must not affect record-shape satisfaction: %v", tc.Errors())
+	}
+}
+
 // Named structs stay nominal islands even when a shape would match:
 // ordered representation is identity, and BA is not AB.
 func TestOrderedStructsRemainNominal(t *testing.T) {


### PR DESCRIPTION
## Summary

- specify AoS, SoA, and AoSoA as representations of the same semantic sequence of record values
- preserve the existing `[N]Stored` array-of-structs behavior
- require future transformed layouts to be explicit and to establish element/field, mutation, borrowing, order, and cost obligations
- make SIMD width, column alignment, cache-line separation, and tiling representation parameters
- add a type-checker regression showing natural, packed, aggregate-aligned, per-field-aligned, and reordered structs all satisfy the same record shape

## Scope

This does not freeze new Oak surface syntax or claim SoA lowering is implemented. It establishes the semantic contract that a future layout implementation must satisfy.