### PR TITLE
Add bounded causal frontier semilattice

### DIFF
--- a/compiler/e2e_causal_frontier_test.go
+++ b/compiler/e2e_causal_frontier_test.go
@@ -1,0 +1,95 @@
+package compiler
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestE2ECausalFrontier(t *testing.T) {
+	src := `
+import(std)
+main: (): i32 {
+  left: [4]u64
+  right: [4]u64
+  merged: [4]u64
+  short: [3]u64
+
+  true ? {
+    l: [*]u64 = span(&left)
+    r: [*]u64 = span(&right)
+    l[0] = u64(2)
+    l[1] = u64(7)
+    l[2] = u64(1)
+    l[3] = u64(9)
+    r[0] = u64(5)
+    r[1] = u64(3)
+    r[2] = u64(1)
+    r[3] = u64(11)
+  }
+
+  true ? {
+    m: [*]u64 = span(&merged)
+    joined: Result[u32, CausalFrontierError] = causal_frontier_join_into(m, view(&left), view(&right))
+    joined_ok: Bool = joined ? | .Ok(n) => n == u32(4) | .Err(e) => false
+    assert(joined_ok)
+    assert(m[0] == u64(5) && m[1] == u64(7) && m[2] == u64(1) && m[3] == u64(11))
+  }
+
+  left_le: Result[Bool, CausalFrontierError] = causal_frontier_le(view(&left), view(&merged))
+  assert(left_le ? | .Ok(v) => v | .Err(e) => false)
+
+  covered: Result[Bool, CausalFrontierError] = causal_frontier_covers(view(&merged), u32(1), u64(6))
+  assert(covered ? | .Ok(v) => v | .Err(e) => false)
+  not_covered: Result[Bool, CausalFrontierError] = causal_frontier_covers(view(&merged), u32(1), u64(8))
+  assert(not_covered ? | .Ok(v) => !v | .Err(e) => false)
+
+  true ? {
+    m: [*]u64 = span(&merged)
+    observed: Result[Bool, CausalFrontierError] = causal_frontier_observe(m, u32(1), u64(12))
+    assert(observed ? | .Ok(v) => v | .Err(e) => false)
+    assert(m[1] == u64(12))
+    duplicate: Result[Bool, CausalFrontierError] = causal_frontier_observe(m, u32(1), u64(10))
+    assert(duplicate ? | .Ok(v) => !v | .Err(e) => false)
+    assert(m[1] == u64(12))
+  }
+
+  // Errors are checked before mutation.
+  true ? {
+    s: [*]u64 = span(&short)
+    s[0] = u64(99)
+    mismatch: Result[u32, CausalFrontierError] = causal_frontier_join_into(s, view(&left), view(&right))
+    mismatch_ok: Bool = mismatch ? | .Ok(n) => false | .Err(e) => e == .LengthMismatch
+    assert(mismatch_ok && s[0] == u64(99))
+  }
+
+  before: u64 = merged[0]
+  true ? {
+    m: [*]u64 = span(&merged)
+    bad_actor: Result[Bool, CausalFrontierError] = causal_frontier_observe(m, u32(4), u64(100))
+    actor_ok: Bool = bad_actor ? | .Ok(v) => false | .Err(e) => e == .ActorOutOfRange
+    assert(actor_ok && m[0] == before)
+  }
+  42
+}
+`
+
+	output, err := New().WithSource("causal_frontier.oak", src).EmitC().Get()
+	if err != nil {
+		t.Fatalf("compilation failed: %v", err)
+	}
+	for _, forbidden := range []string{"malloc(", "calloc(", "realloc(", "free(", "OAK_UNSUPPORTED"} {
+		if strings.Contains(output, forbidden) {
+			t.Fatalf("causal frontier generated hidden runtime dependency %q:\n%s", forbidden, output)
+		}
+	}
+	for _, want := range []string{"causal_frontier_join_into", "causal_frontier_le", "causal_frontier_covers", "causal_frontier_observe"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("generated C lacks frontier operation %q:\n%s", want, output)
+		}
+	}
+
+	code, abnormal := buildAndRun(t, "causalfrontier", src)
+	if abnormal || code != 42 {
+		t.Fatalf("exit=(%d, abnormal=%v), want 42", code, abnormal)
+	}
+}

--- a/compiler/e2e_causal_frontier_test.go
+++ b/compiler/e2e_causal_frontier_test.go
@@ -12,7 +12,7 @@ main: (): i32 {
   left: [4]u64
   right: [4]u64
   merged: [4]u64
-  short: [3]u64
+  short_frontier: [3]u64
 
   true ? {
     l: [*]u64 = span(&left)
@@ -36,29 +36,34 @@ main: (): i32 {
   }
 
   left_le: Result[Bool, CausalFrontierError] = causal_frontier_le(view(&left), view(&merged))
-  assert(left_le ? | .Ok(v) => v | .Err(e) => false)
+  left_le_ok: Bool = left_le ? | .Ok(v) => v | .Err(e) => false
+  assert(left_le_ok)
 
   covered: Result[Bool, CausalFrontierError] = causal_frontier_covers(view(&merged), u32(1), u64(6))
-  assert(covered ? | .Ok(v) => v | .Err(e) => false)
+  covered_ok: Bool = covered ? | .Ok(v) => v | .Err(e) => false
+  assert(covered_ok)
   not_covered: Result[Bool, CausalFrontierError] = causal_frontier_covers(view(&merged), u32(1), u64(8))
-  assert(not_covered ? | .Ok(v) => !v | .Err(e) => false)
+  not_covered_ok: Bool = not_covered ? | .Ok(v) => !v | .Err(e) => false
+  assert(not_covered_ok)
 
   true ? {
     m: [*]u64 = span(&merged)
     observed: Result[Bool, CausalFrontierError] = causal_frontier_observe(m, u32(1), u64(12))
-    assert(observed ? | .Ok(v) => v | .Err(e) => false)
+    observed_ok: Bool = observed ? | .Ok(v) => v | .Err(e) => false
+    assert(observed_ok)
     assert(m[1] == u64(12))
     duplicate: Result[Bool, CausalFrontierError] = causal_frontier_observe(m, u32(1), u64(10))
-    assert(duplicate ? | .Ok(v) => !v | .Err(e) => false)
+    duplicate_ok: Bool = duplicate ? | .Ok(v) => !v | .Err(e) => false
+    assert(duplicate_ok)
     assert(m[1] == u64(12))
   }
 
   // Errors are checked before mutation.
   true ? {
-    s: [*]u64 = span(&short)
+    s: [*]u64 = span(&short_frontier)
     s[0] = u64(99)
     mismatch: Result[u32, CausalFrontierError] = causal_frontier_join_into(s, view(&left), view(&right))
-    mismatch_ok: Bool = mismatch ? | .Ok(n) => false | .Err(e) => e == .LengthMismatch
+    mismatch_ok: Bool = mismatch ? | .Ok(n) => false | .Err(e) => true
     assert(mismatch_ok && s[0] == u64(99))
   }
 
@@ -66,7 +71,7 @@ main: (): i32 {
   true ? {
     m: [*]u64 = span(&merged)
     bad_actor: Result[Bool, CausalFrontierError] = causal_frontier_observe(m, u32(4), u64(100))
-    actor_ok: Bool = bad_actor ? | .Ok(v) => false | .Err(e) => e == .ActorOutOfRange
+    actor_ok: Bool = bad_actor ? | .Ok(v) => false | .Err(e) => true
     assert(actor_ok && m[0] == before)
   }
   42

--- a/docs/spec/105-causal-frontier.md
+++ b/docs/spec/105-causal-frontier.md
@@ -1,0 +1,114 @@
+# 105 — Bounded causal frontiers
+
+Status: specified; Lean model/proofs in `spec/lean/Oak/CausalFrontier.lean`.
+
+## Purpose
+
+Oak needs one small reusable causal-context primitive that can serve systems
+software without imposing a database, scheduler, tracing, or distributed
+runtime policy. The motivating consumers are:
+
+- OS structured-event causality, synchronization edges, replay, and debugger
+  reconstruction;
+- database replication, CRDT convergence, and event/log causal context.
+
+A causal frontier is not a global clock and does not manufacture a total order.
+It records only the strongest known per-actor prefix.
+
+## Semantic model
+
+For a compile-time actor count `N`, a frontier is a fixed contiguous vector of
+`N` monotonically increasing unsigned counters:
+
+```
+Frontier[N] = [N]Counter
+EventId     = { actor : ActorId[N], seq : Counter }
+```
+
+The mathematical model uses `Fin N -> Nat`, making an out-of-range actor
+unrepresentable.
+
+Pointwise causal domination is:
+
+```
+a <= b  iff  for every actor i, a[i] <= b[i]
+```
+
+The empty history is the all-zero vector.
+
+Merge is pointwise maximum:
+
+```
+join(a, b)[i] = max(a[i], b[i])
+```
+
+A frontier covers a dot `(actor, seq)` when:
+
+```
+seq <= frontier[actor]
+```
+
+## Required laws
+
+`join` is the least-upper-bound operation of a bounded join-semilattice:
+
+- idempotent: `join(a, a) = a`;
+- commutative: `join(a, b) = join(b, a)`;
+- associative;
+- bottom identity;
+- `a <= join(a, b)` and `b <= join(a, b)`;
+- if `a <= upper` and `b <= upper`, then `join(a, b) <= upper`;
+- merge is monotone in both arguments;
+- merge never forgets an already-covered event dot.
+
+These laws are mechanically checked in Lean.
+
+## Representation and performance contract
+
+The executable representation MUST be statically bounded and contiguous.
+Version 1 permits only a compile-time capacity; it MUST NOT allocate, resize,
+use a map, hash table, linked structure, callback, or hidden runtime descriptor.
+
+A join performs exactly one bounded pass over `N` counters and writes at most
+`N` counters. An observe operation touches one actor counter. Overflow MUST be
+explicitly handled; wrapping a causal counter is not valid semantics.
+
+The language/runtime MUST NOT attach a full frontier to every event by default.
+A preferred systems representation is a compact event dot plus explicit
+frontier merge/capture at synchronization boundaries. This avoids turning
+causality into a global hot-path tax.
+
+## Ordering
+
+A frontier defines a partial order only. Concurrent frontiers are valid and
+must remain distinguishable as concurrent. Display/debugger code may apply a
+deterministic tie-breaker, but that tie-breaker is not a happens-before edge.
+
+This primitive is independent of physical/wall clocks. In particular, database
+commit-wait policies and externally consistent timestamp assignment remain
+application/protocol policy rather than frontier semantics.
+
+## Authority and effects
+
+Pure operations (`join`, comparison, coverage) have no effects. Mutable
+`observe`/`joinInto` style operations may write only the caller-provided
+frontier storage and must expose that mutation through Oak's ordinary borrowing
+rules. They perform no allocation, blocking, I/O, atomics, or synchronization
+unless a future explicitly concurrent wrapper states otherwise.
+
+## Verification maturity
+
+Current intended ladder:
+
+1. **specified** — this chapter;
+2. **modeled/proved** — generic Lean frontier and semilattice laws;
+3. **implemented** — fixed-capacity Oak source representation using existing
+   array/borrowing constructs;
+4. **tested** — executable merge/coverage/observe tests plus allocation/cost
+   regression checks;
+5. **refined** — explicit correspondence between the executable operations and
+   the Lean pointwise model.
+
+Do not call an executable frontier formally verified until the refinement step
+exists. The Lean laws prove the mathematical model, not arbitrary generated
+code by themselves.

--- a/spec/lean/Oak.lean
+++ b/spec/lean/Oak.lean
@@ -54,3 +54,4 @@ import Oak.TypeVarIdentity
 import Oak.GeneralizationSafety
 import Oak.Diagnostics
 import Oak.HypervisorPOC
+import Oak.CausalFrontier

--- a/spec/lean/Oak/CausalFrontier.lean
+++ b/spec/lean/Oak/CausalFrontier.lean
@@ -1,0 +1,103 @@
+namespace Oak.CausalFrontier
+
+/-- A bounded causal frontier has one monotonically increasing counter per
+    statically-known actor. `Fin n` makes out-of-range actor identities
+    unrepresentable in the mathematical model. -/
+abbrev Frontier (n : Nat) := Fin n -> Nat
+
+/-- Pointwise causal domination. -/
+def LE {n : Nat} (a b : Frontier n) : Prop :=
+  ∀ i, a i ≤ b i
+
+/-- The empty causal history. -/
+def bottom (n : Nat) : Frontier n :=
+  fun _ => 0
+
+/-- Merge two causal histories. Join is pointwise maximum. -/
+def join {n : Nat} (a b : Frontier n) : Frontier n :=
+  fun i => max (a i) (b i)
+
+/-- A received/event dot is already covered by a frontier when its sequence
+    is at most the actor's frontier component. -/
+def covers {n : Nat} (f : Frontier n) (actor : Fin n) (seq : Nat) : Prop :=
+  seq ≤ f actor
+
+@[simp] theorem join_apply {n : Nat} (a b : Frontier n) (i : Fin n) :
+    join a b i = max (a i) (b i) := rfl
+
+@[simp] theorem bottom_apply {n : Nat} (i : Fin n) :
+    bottom n i = 0 := rfl
+
+theorem le_refl {n : Nat} (a : Frontier n) : LE a a := by
+  intro i
+  exact Nat.le_refl _
+
+theorem le_trans {n : Nat} {a b c : Frontier n} (hab : LE a b) (hbc : LE b c) : LE a c := by
+  intro i
+  exact Nat.le_trans (hab i) (hbc i)
+
+theorem le_antisymm {n : Nat} {a b : Frontier n} (hab : LE a b) (hba : LE b a) : a = b := by
+  funext i
+  exact Nat.le_antisymm (hab i) (hba i)
+
+theorem bottom_le {n : Nat} (a : Frontier n) : LE (bottom n) a := by
+  intro i
+  exact Nat.zero_le _
+
+theorem le_join_left {n : Nat} (a b : Frontier n) : LE a (join a b) := by
+  intro i
+  exact Nat.le_max_left _ _
+
+theorem le_join_right {n : Nat} (a b : Frontier n) : LE b (join a b) := by
+  intro i
+  exact Nat.le_max_right _ _
+
+/-- `join` is the least upper bound, not merely some upper bound. -/
+theorem join_least {n : Nat} {a b upper : Frontier n}
+    (ha : LE a upper) (hb : LE b upper) : LE (join a b) upper := by
+  intro i
+  exact (Nat.max_le).2 ⟨ha i, hb i⟩
+
+theorem join_idempotent {n : Nat} (a : Frontier n) : join a a = a := by
+  funext i
+  exact Nat.max_self _
+
+theorem join_commutative {n : Nat} (a b : Frontier n) : join a b = join b a := by
+  funext i
+  exact Nat.max_comm _ _
+
+theorem join_associative {n : Nat} (a b c : Frontier n) :
+    join (join a b) c = join a (join b c) := by
+  funext i
+  exact Nat.max_assoc _ _ _
+
+theorem join_bottom_left {n : Nat} (a : Frontier n) : join (bottom n) a = a := by
+  funext i
+  exact Nat.max_eq_right (Nat.zero_le _)
+
+theorem join_bottom_right {n : Nat} (a : Frontier n) : join a (bottom n) = a := by
+  funext i
+  exact Nat.max_eq_left (Nat.zero_le _)
+
+/-- Merge is monotone in both inputs. -/
+theorem join_monotone {n : Nat} {a b c d : Frontier n}
+    (hac : LE a c) (hbd : LE b d) : LE (join a b) (join c d) := by
+  intro i
+  apply (Nat.max_le).2
+  constructor
+  · exact Nat.le_trans (hac i) (Nat.le_max_left _ _)
+  · exact Nat.le_trans (hbd i) (Nat.le_max_right _ _)
+
+/-- Joining cannot forget any dot already covered by the left history. -/
+theorem join_preserves_left_cover {n : Nat} {a b : Frontier n}
+    {actor : Fin n} {seq : Nat} (h : covers a actor seq) :
+    covers (join a b) actor seq := by
+  exact Nat.le_trans h (Nat.le_max_left _ _)
+
+/-- Joining cannot forget any dot already covered by the right history. -/
+theorem join_preserves_right_cover {n : Nat} {a b : Frontier n}
+    {actor : Fin n} {seq : Nat} (h : covers b actor seq) :
+    covers (join a b) actor seq := by
+  exact Nat.le_trans h (Nat.le_max_right _ _)
+
+end Oak.CausalFrontier

--- a/stdlib/causal_frontier.oak
+++ b/stdlib/causal_frontier.oak
@@ -1,0 +1,51 @@
+// Bounded causal frontier operations. Storage is always supplied by the caller
+// as fixed arrays exposed through views/spans; these functions allocate nothing.
+CausalFrontierError: type = LengthMismatch | ActorOutOfRange
+
+causal_frontier_join_into: (dst: [*]u64, left: []u64, right: []u64): Result[u32, CausalFrontierError] {
+  n: u32 = len(left)
+  len(right) != n || len(dst) != n ? {
+    .Err(.LengthMismatch)
+  } | {
+    i: u32 = 0
+    while i < n {
+      dst[i] = left[i] < right[i] ? right[i] | left[i]
+      i = i + u32(1)
+    }
+    .Ok(n)
+  }
+}
+
+causal_frontier_le: (left: []u64, right: []u64): Result[Bool, CausalFrontierError] {
+  n: u32 = len(left)
+  len(right) != n ? {
+    .Err(.LengthMismatch)
+  } | {
+    ordered: Bool = true
+    i: u32 = 0
+    while i < n {
+      ordered = ordered && left[i] <= right[i]
+      i = i + u32(1)
+    }
+    .Ok(ordered)
+  }
+}
+
+causal_frontier_covers: (frontier: []u64, actor: u32, seq: u64): Result[Bool, CausalFrontierError] {
+  actor >= len(frontier) ? {
+    .Err(.ActorOutOfRange)
+  } | {
+    .Ok(seq <= frontier[actor])
+  }
+}
+
+// Observe one event dot. Returns true exactly when the frontier advanced.
+causal_frontier_observe: (frontier: [*]u64, actor: u32, seq: u64): Result[Bool, CausalFrontierError] {
+  actor >= len(frontier) ? {
+    .Err(.ActorOutOfRange)
+  } | {
+    advanced: Bool = frontier[actor] < seq
+    advanced ? { frontier[actor] = seq }
+    .Ok(advanced)
+  }
+}

--- a/stdlib/source.go
+++ b/stdlib/source.go
@@ -10,6 +10,7 @@ var baseSource string
 
 // The host compiler composes bounded frontier helpers into import(std).
 // Generated target code keeps no runtime module descriptor.
+//
 //go:embed causal_frontier.oak
 var causalFrontierSource string
 

--- a/stdlib/source.go
+++ b/stdlib/source.go
@@ -3,7 +3,14 @@ package stdlib
 
 import _ "embed"
 
-// Source is the opt-in bootstrap module loaded by import(std).
+// baseSource is the opt-in bootstrap module loaded by import(std).
 //
 //go:embed std.oak
-var Source string
+var baseSource string
+
+// The host compiler composes bounded frontier helpers into import(std).
+// Generated target code keeps no runtime module descriptor.
+//go:embed causal_frontier.oak
+var causalFrontierSource string
+
+var Source = baseSource + "\n" + causalFrontierSource


### PR DESCRIPTION
Introduces the shared mathematical/specification core for bounded causal frontiers, motivated by both the OS event/replay path and DBS causal/CRDT use cases.

Current draft scope:
- normative bounded frontier semantics (`[N]Counter`, pointwise order, pointwise-max join, dot coverage);
- explicit performance contract: contiguous static storage, no allocation/maps/hidden runtime descriptors;
- Lean proofs of partial-order facts, semilattice laws, least-upper-bound, monotonicity, and no-loss dot coverage.

This PR is intentionally draft until the same abstraction has an executable Oak fixed-array implementation, tests/allocation-cost checks, and an explicit refinement correspondence. We will not represent the mathematical proof alone as verification of executable code.