### PR TITLE
Restore implicit generic inference

### DIFF
--- a/typechecker/typechecker.go
+++ b/typechecker/typechecker.go
@@ -677,6 +677,7 @@ func typeParamsConstrained(params []*ast.TypeParameter) bool {
 }
 
 func (tc *TypeChecker) CheckProgram(program *ast.Program) {
+<<<<<<< Updated upstream
 	// Resolve declared types before caching function signatures. Otherwise a
 	// span of a named record can retain an unresolved type variable.
 	for _, stmt := range program.Statements {
@@ -685,9 +686,11 @@ func (tc *TypeChecker) CheckProgram(program *ast.Program) {
 			tc.checkStatement(stmt)
 		}
 	}
+=======
 	// The global scope is the closure of top-level declarations; template
 	// instantiations check against it, never a caller's local scope.
 	tc.globalEnv = tc.env
+>>>>>>> Stashed changes
 	// Pre-declare top-level non-generic function signatures so functions can
 	// reference one another regardless of declaration order (mutual
 	// recursion included); each signature is finalized when its declaration


### PR DESCRIPTION
Closed without merge. Subsequent `specification` commits moved past the earlier generic-function failures: on current head the stdlib workflow's compiler/test step passes and the remaining failure is formatting in concurrent verification-poc work. The attempted whole-file restoration was also invalid because the parent blob contained unresolved merge markers. No repair from this PR should be merged.