### PR TITLE
Add automatic package SemVer enforcement

### DIFF
--- a/cmd/oak-semver/main.go
+++ b/cmd/oak-semver/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/SCKelemen/oak/packageapi"
+)
+
+func readSnapshot(path string) (packageapi.Snapshot, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return packageapi.Snapshot{}, err
+	}
+	var snapshot packageapi.Snapshot
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		return packageapi.Snapshot{}, err
+	}
+	return snapshot, nil
+}
+
+func main() {
+	if len(os.Args) != 3 {
+		fmt.Fprintln(os.Stderr, "usage: oak-semver PREVIOUS_API.json CURRENT_API.json")
+		os.Exit(2)
+	}
+	previous, err := readSnapshot(os.Args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "previous snapshot: %v\n", err)
+		os.Exit(2)
+	}
+	current, err := readSnapshot(os.Args[2])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "current snapshot: %v\n", err)
+		os.Exit(2)
+	}
+	report, err := packageapi.Enforce(previous, current)
+	for _, change := range report.Changes {
+		fmt.Printf("%s: %s (%s)\n", change.Name, change.Level, change.Reason)
+	}
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fmt.Printf("version %s is valid for a %s API change\n", current.Version, report.Required)
+}

--- a/docs/spec/82-package-semver.md
+++ b/docs/spec/82-package-semver.md
@@ -1,0 +1,69 @@
+# Package API snapshots and automatic SemVer
+
+Status: normative for package publication; snapshot production is a compiler
+pipeline boundary.
+
+## 1. Checked public API
+
+A published Oak package carries a deterministic API snapshot produced after
+parsing, type checking, generic-constraint normalization, effect checking, and
+layout resolution. Each public export records:
+
+- its kind;
+- canonical semantic type, including parameters, results, row/shape constraints,
+  generic constraints, ownership, and effects;
+- canonical public ABI when representation is observable, including calling
+  convention, size, alignment, field order and offsets, tags, and carriers.
+
+Bodies, private declarations, source order without semantic meaning,
+documentation, and compiler-generated symbol names are excluded.
+
+## 2. Change classification
+
+| Change | Required release |
+|---|---|
+| No checked public API change | patch |
+| Add a public export | minor |
+| Remove or rename a public export | major |
+| Change an export kind or semantic type | major |
+| Strengthen an input constraint or effect requirement | major |
+| Weaken a promised result, shape, or effect | major |
+| Change an exposed struct/ABI layout | major |
+| Change only an unexposed semantic-record implementation layout | patch |
+
+The highest-severity individual change determines the package release.
+
+Before `1.0.0`, both additive and breaking public changes advance the minor
+component. Patch-only changes advance patch. At and after `1.0.0`, ordinary
+SemVer major/minor/patch rules apply.
+
+## 3. Enforcement
+
+Publishing compares the last published snapshot with the candidate snapshot.
+The declared candidate version must equal the exact next version implied by the
+table. A lower bump is unsafe; a larger bump is rejected as non-reproducible
+versioning. Package identity must not change between the two snapshots.
+
+The reference checker is:
+
+```sh
+go run ./cmd/oak-semver previous-api.json current-api.json
+```
+
+It exits nonzero for an invalid version and lists the public changes that caused
+the classification. Repositories can run this command in their publication CI
+using the last release snapshot and the compiler-produced candidate snapshot.
+
+## 4. Records and representation
+
+Adding a required field to an exported closed record shape or extensible-record
+constraint is major because callers may no longer satisfy it. Removing a
+required input field can be compatible only when the canonical function type
+proves the accepted domain widened; the initial conservative classifier treats
+any canonical type change as major.
+
+A concrete exported `struct` exposes ABI whenever foreign code, persisted data,
+or separately compiled Oak code can observe its representation. Reordering,
+packing, alignment, or carrier changes are then major. Choosing AoS, SoA, or
+AoSoA behind a semantic-record abstraction does not change the package API and
+is patch-compatible.

--- a/docs/spec/82-package-semver.md
+++ b/docs/spec/82-package-semver.md
@@ -44,6 +44,10 @@ The declared candidate version must equal the exact next version implied by the
 table. A lower bump is unsafe; a larger bump is rejected as non-reproducible
 versioning. Package identity must not change between the two snapshots.
 
+Oak source text is UTF-8. Package versions nevertheless use SemVer's lexical
+grammar: each `MAJOR`, `MINOR`, and `PATCH` component consists only of the ASCII
+digits `0` through `9`, without a leading zero unless the component is `0`.
+
 The reference checker is:
 
 ```sh

--- a/packageapi/semver.go
+++ b/packageapi/semver.go
@@ -48,8 +48,17 @@ func ParseVersion(text string) (Version, error) {
 		if part == "" || (len(part) > 1 && part[0] == '0') {
 			return Version{}, fmt.Errorf("version %q has a non-canonical component", text)
 		}
+		// Oak source is UTF-8, but SemVer numeric identifiers are defined by
+		// the ASCII digits 0-9. Validate the lexical grammar before Atoi so
+		// signs and other Unicode source characters cannot be normalized into
+		// a different package version.
+		for j := 0; j < len(part); j++ {
+			if part[j] < '0' || part[j] > '9' {
+				return Version{}, fmt.Errorf("version %q has an invalid component", text)
+			}
+		}
 		n, err := strconv.Atoi(part)
-		if err != nil || n < 0 {
+		if err != nil {
 			return Version{}, fmt.Errorf("version %q has an invalid component", text)
 		}
 		values[i] = n

--- a/packageapi/semver.go
+++ b/packageapi/semver.go
@@ -1,0 +1,164 @@
+// Package packageapi classifies public Oak package API changes and enforces
+// the version implied by them. Snapshots are produced after type checking, so
+// Type is canonical semantic identity and ABI is canonical representation.
+package packageapi
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type ChangeLevel uint8
+
+const (
+	Patch ChangeLevel = iota
+	Minor
+	Major
+)
+
+func (l ChangeLevel) String() string {
+	switch l {
+	case Major:
+		return "major"
+	case Minor:
+		return "minor"
+	default:
+		return "patch"
+	}
+}
+
+type Version struct {
+	Major int
+	Minor int
+	Patch int
+}
+
+func ParseVersion(text string) (Version, error) {
+	if strings.HasPrefix(text, "v") {
+		text = text[1:]
+	}
+	parts := strings.Split(text, ".")
+	if len(parts) != 3 {
+		return Version{}, fmt.Errorf("version %q must have form MAJOR.MINOR.PATCH", text)
+	}
+	values := [3]int{}
+	for i, part := range parts {
+		if part == "" || (len(part) > 1 && part[0] == '0') {
+			return Version{}, fmt.Errorf("version %q has a non-canonical component", text)
+		}
+		n, err := strconv.Atoi(part)
+		if err != nil || n < 0 {
+			return Version{}, fmt.Errorf("version %q has an invalid component", text)
+		}
+		values[i] = n
+	}
+	return Version{Major: values[0], Minor: values[1], Patch: values[2]}, nil
+}
+
+func (v Version) String() string {
+	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
+}
+
+// Export is one public name in a checked package API.
+//
+// Type is canonical semantic identity: parameter and result types, generic
+// constraints, effects, and record shapes. ABI is canonical representation:
+// calling convention, size/alignment, field offsets/order, tags and ownership.
+// Documentation and implementation bodies intentionally do not appear.
+type Export struct {
+	Kind string `json:"kind"`
+	Type string `json:"type"`
+	ABI  string `json:"abi,omitempty"`
+}
+
+type Snapshot struct {
+	Package string            `json:"package"`
+	Version string            `json:"version"`
+	Exports map[string]Export `json:"exports"`
+}
+
+type Change struct {
+	Name   string      `json:"name"`
+	Level  ChangeLevel `json:"level"`
+	Reason string      `json:"reason"`
+}
+
+type Report struct {
+	Required ChangeLevel `json:"required"`
+	Changes  []Change    `json:"changes"`
+}
+
+func Compare(previous, current Snapshot) Report {
+	report := Report{Required: Patch}
+	for name, old := range previous.Exports {
+		now, present := current.Exports[name]
+		switch {
+		case !present:
+			report.add(name, Major, "public export removed")
+		case old.Kind != now.Kind:
+			report.add(name, Major, "export kind changed")
+		case old.Type != now.Type:
+			report.add(name, Major, "semantic type changed")
+		case old.ABI != now.ABI:
+			report.add(name, Major, "public ABI or layout changed")
+		}
+	}
+	for name := range current.Exports {
+		if _, existed := previous.Exports[name]; !existed {
+			report.add(name, Minor, "public export added")
+		}
+	}
+	sort.Slice(report.Changes, func(i, j int) bool {
+		if report.Changes[i].Name != report.Changes[j].Name {
+			return report.Changes[i].Name < report.Changes[j].Name
+		}
+		return report.Changes[i].Reason < report.Changes[j].Reason
+	})
+	return report
+}
+
+func (r *Report) add(name string, level ChangeLevel, reason string) {
+	r.Changes = append(r.Changes, Change{Name: name, Level: level, Reason: reason})
+	if level > r.Required {
+		r.Required = level
+	}
+}
+
+func NextVersion(previous Version, level ChangeLevel) Version {
+	switch level {
+	case Major:
+		// Before 1.0, breaking and additive public changes both advance MINOR.
+		if previous.Major == 0 {
+			return Version{Minor: previous.Minor + 1}
+		}
+		return Version{Major: previous.Major + 1}
+	case Minor:
+		return Version{Major: previous.Major, Minor: previous.Minor + 1}
+	default:
+		return Version{Major: previous.Major, Minor: previous.Minor, Patch: previous.Patch + 1}
+	}
+}
+
+// Enforce requires the exact next version implied by Compare. Exactness avoids
+// accidental over-versioning and makes the rule reproducible by every client.
+func Enforce(previous, current Snapshot) (Report, error) {
+	report := Compare(previous, current)
+	if previous.Package == "" || current.Package == "" || previous.Package != current.Package {
+		return report, fmt.Errorf("package identity changed from %q to %q", previous.Package, current.Package)
+	}
+	oldVersion, err := ParseVersion(previous.Version)
+	if err != nil {
+		return report, fmt.Errorf("previous snapshot: %w", err)
+	}
+	newVersion, err := ParseVersion(current.Version)
+	if err != nil {
+		return report, fmt.Errorf("current snapshot: %w", err)
+	}
+	expected := NextVersion(oldVersion, report.Required)
+	if newVersion != expected {
+		return report, fmt.Errorf("%s API change requires version %s; declared %s", report.Required, expected, newVersion)
+	}
+	return report, nil
+}

--- a/packageapi/semver_test.go
+++ b/packageapi/semver_test.go
@@ -1,0 +1,74 @@
+package packageapi
+
+import (
+	"strings"
+	"testing"
+)
+
+func snap(version string, exports map[string]Export) Snapshot {
+	return Snapshot{Package: "example/net", Version: version, Exports: exports}
+}
+
+func TestCompareClassifiesPublicChanges(t *testing.T) {
+	base := snap("1.2.3", map[string]Export{
+		"read": {Kind: "function", Type: "fn([]u8)->u32"},
+		"Pair": {Kind: "struct", Type: "{a:u8,b:u8}", ABI: "size=2;align=1;a@0;b@1"},
+	})
+	tests := []struct {
+		name string
+		next Snapshot
+		want ChangeLevel
+	}{
+		{"body-only", snap("1.2.4", base.Exports), Patch},
+		{"addition", snap("1.3.0", map[string]Export{
+			"read": base.Exports["read"], "Pair": base.Exports["Pair"],
+			"write": {Kind: "function", Type: "fn([]u8)->u32"},
+		}), Minor},
+		{"removal", snap("2.0.0", map[string]Export{"read": base.Exports["read"]}), Major},
+		{"semantic type", snap("2.0.0", map[string]Export{
+			"read": {Kind: "function", Type: "fn([*]u8)->u32"}, "Pair": base.Exports["Pair"],
+		}), Major},
+		{"layout", snap("2.0.0", map[string]Export{
+			"read": base.Exports["read"],
+			"Pair": {Kind: "struct", Type: "{a:u8,b:u8}", ABI: "size=2;align=1;b@0;a@1"},
+		}), Major},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Compare(base, tt.next).Required; got != tt.want {
+				t.Fatalf("level = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEnforceRequiresExactAutomaticBump(t *testing.T) {
+	old := snap("1.2.3", map[string]Export{"read": {Kind: "function", Type: "fn()->u8"}})
+	added := snap("1.3.0", map[string]Export{
+		"read": old.Exports["read"],
+		"write": {Kind: "function", Type: "fn(u8)->()"},
+	})
+	if _, err := Enforce(old, added); err != nil {
+		t.Fatal(err)
+	}
+	added.Version = "1.2.4"
+	if _, err := Enforce(old, added); err == nil || !strings.Contains(err.Error(), "requires version 1.3.0") {
+		t.Fatalf("wanted required-version diagnostic, got %v", err)
+	}
+}
+
+func TestPreOneBreakingChangeAdvancesMinor(t *testing.T) {
+	old := snap("0.4.2", map[string]Export{"read": {Kind: "function", Type: "fn()->u8"}})
+	next := snap("0.5.0", map[string]Export{})
+	if _, err := Enforce(old, next); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestVersionParserRejectsNonCanonicalVersions(t *testing.T) {
+	for _, input := range []string{"1.2", "1.02.3", "1.2.-1", "1.2.3-alpha"} {
+		if _, err := ParseVersion(input); err == nil {
+			t.Fatalf("ParseVersion(%q) succeeded", input)
+		}
+	}
+}

--- a/packageapi/semver_test.go
+++ b/packageapi/semver_test.go
@@ -65,8 +65,23 @@ func TestPreOneBreakingChangeAdvancesMinor(t *testing.T) {
 	}
 }
 
-func TestVersionParserRejectsNonCanonicalVersions(t *testing.T) {
-	for _, input := range []string{"1.2", "1.02.3", "1.2.-1", "1.2.3-alpha"} {
+func TestVersionParserAcceptsCanonicalVersions(t *testing.T) {
+	for _, input := range []string{"0.0.0", "1.2.3", "v1.2.3"} {
+		if _, err := ParseVersion(input); err != nil {
+			t.Fatalf("ParseVersion(%q) failed: %v", input, err)
+		}
+	}
+}
+
+func TestVersionParserRejectsInvalidSemVerComponents(t *testing.T) {
+	for _, input := range []string{
+		"1.2", "1.2.3.4",
+		"01.2.3", "1.02.3", "1.2.03",
+		"+1.2.3", "-1.2.3", "1.+2.3", "1.-2.3", "1.2.+4", "1.2.+04", "1.2.-0", "1.2.-1",
+		"1.2.3-alpha", "1.2.3+build",
+		"1.2. 3", "1.2.\t3", "1.2.٣",
+		"V1.2.3", "vv1.2.3",
+	} {
 		if _, err := ParseVersion(input); err == nil {
 			t.Fatalf("ParseVersion(%q) succeeded", input)
 		}


### PR DESCRIPTION
## Summary

- define deterministic checked package API snapshots
- classify removals, semantic type changes, and exposed ABI/layout changes as major
- classify public additions as minor and implementation-only changes as patch
- enforce the exact next version, including a documented pre-1.0 policy
- add the `oak-semver` CI command and unit coverage
- specify how record shapes and concrete struct layouts affect compatibility

## Usage

```sh
go run ./cmd/oak-semver previous-api.json current-api.json
```

The command exits nonzero if the candidate package version does not match the API diff.