### PR TITLE
Formalize and implement resource consumption

### DIFF
--- a/borrowchecker/resource_flow.go
+++ b/borrowchecker/resource_flow.go
@@ -1,0 +1,316 @@
+package borrowchecker
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/SCKelemen/oak/ast"
+	"github.com/SCKelemen/oak/diagnostic"
+)
+
+// CodeResourceUsedAfterConsume is the stable diagnostic for a resource name
+// (including any alias in the same authority class) used after consumption.
+const CodeResourceUsedAfterConsume diagnostic.Code = "OAK-B0111"
+
+type resourceClassID uint64
+
+type resourceAliasInfo struct {
+	class  resourceClassID
+	parent string
+	origin ast.Node
+}
+
+type resourceConsumption struct {
+	name string
+	site ast.Node
+}
+
+type resourceClassState struct {
+	consumed *resourceConsumption
+}
+
+// ResourceFlow is the executable counterpart of Oak.ResourceFlow. It tracks
+// resource authority separately from temporary borrow state: a UniqueWrite
+// borrow can be released, while a consumed alias class never regains authority.
+//
+// Surface syntax is intentionally not part of this type. The semantic layer
+// should register resource-typed values/aliases and invoke Use/Consume after
+// type resolution, once Oak's consume spelling is frozen.
+type ResourceFlow struct {
+	checker   *BorrowChecker
+	nextClass resourceClassID
+	aliases   map[string]resourceAliasInfo
+	classes   map[resourceClassID]*resourceClassState
+}
+
+// NewResourceFlow creates an empty resource-flow analysis associated with a
+// borrow checker. The association lets consumption reject any live view/span
+// whose backing owner belongs to the same resource alias class.
+func NewResourceFlow(checker *BorrowChecker) *ResourceFlow {
+	return &ResourceFlow{
+		checker: checker,
+		aliases: make(map[string]resourceAliasInfo),
+		classes: make(map[resourceClassID]*resourceClassState),
+	}
+}
+
+// Register introduces a new independently-owned resource authority class.
+// Duplicate registrations are rejected without mutating existing provenance.
+func (rf *ResourceFlow) Register(name string, origin ast.Node) bool {
+	if rf == nil || name == "" {
+		return false
+	}
+	if _, exists := rf.aliases[name]; exists {
+		return false
+	}
+
+	classID := rf.nextClass
+	rf.nextClass++
+	rf.aliases[name] = resourceAliasInfo{class: classID, origin: origin}
+	rf.classes[classID] = &resourceClassState{}
+	return true
+}
+
+// Alias records that alias derives resource authority from source. Alias
+// creation itself uses source authority, so it is rejected if source was
+// already consumed. The parent edge is retained for programmer-facing
+// provenance diagnostics; authority remains class-wide.
+func (rf *ResourceFlow) Alias(alias, source string, origin ast.Node) bool {
+	if rf == nil || alias == "" || source == "" || alias == source {
+		return false
+	}
+	if _, exists := rf.aliases[alias]; exists {
+		return false
+	}
+	sourceInfo, exists := rf.aliases[source]
+	if !exists {
+		return false
+	}
+	if !rf.Use(source, origin) {
+		return false
+	}
+
+	rf.aliases[alias] = resourceAliasInfo{
+		class:  sourceInfo.class,
+		parent: source,
+		origin: origin,
+	}
+	return true
+}
+
+// Use validates one resource access. Non-resource names are ignored so the
+// caller can invoke this after ordinary identifier classification. A consumed
+// class produces OAK-B0111 with the original consume site and the shortest
+// available programmer-visible alias chain.
+func (rf *ResourceFlow) Use(name string, node ast.Node) bool {
+	if rf == nil || name == "" {
+		return true
+	}
+	info, exists := rf.aliases[name]
+	if !exists {
+		return true
+	}
+	classState := rf.classes[info.class]
+	if classState == nil || classState.consumed == nil {
+		return true
+	}
+
+	rf.reportConsumedUse(name, node, classState.consumed)
+	return false
+}
+
+// Consume permanently removes authority from name's entire alias class.
+// Consumption is rejected while any live borrow depends on a class member.
+// A second consume is itself a use-after-consume and therefore reports
+// OAK-B0111.
+func (rf *ResourceFlow) Consume(name string, site ast.Node) bool {
+	if rf == nil || name == "" {
+		return false
+	}
+	info, exists := rf.aliases[name]
+	if !exists {
+		return false
+	}
+	classState := rf.classes[info.class]
+	if classState == nil {
+		return false
+	}
+	if classState.consumed != nil {
+		rf.reportConsumedUse(name, site, classState.consumed)
+		return false
+	}
+
+	if borrowName, borrow, ok := rf.firstDependentBorrow(info.class); ok {
+		if rf.checker != nil {
+			d := rf.checker.reportBorrow(site, CodeBorrowGeneric,
+				fmt.Sprintf("resource %q cannot be consumed while borrow %q is live", name, borrowName))
+			rf.checker.addBorrowContext(d, borrowName, borrow,
+				fmt.Sprintf("borrow %q still depends on this resource authority", borrowName))
+			d.AddNote("consumption is permanent; Oak requires dependent temporary borrows to end first")
+			d.AddHelp("let the view/span leave scope before consuming the resource")
+		}
+		return false
+	}
+
+	classState.consumed = &resourceConsumption{name: name, site: site}
+	return true
+}
+
+// Consumed reports whether name is a registered resource whose alias class has
+// already lost authority. It is primarily useful to semantic pipeline tests
+// and later control-flow joining.
+func (rf *ResourceFlow) Consumed(name string) bool {
+	if rf == nil {
+		return false
+	}
+	info, exists := rf.aliases[name]
+	if !exists {
+		return false
+	}
+	classState := rf.classes[info.class]
+	return classState != nil && classState.consumed != nil
+}
+
+func (rf *ResourceFlow) reportConsumedUse(name string, node ast.Node, consumed *resourceConsumption) {
+	if rf == nil || rf.checker == nil || consumed == nil {
+		return
+	}
+
+	d := rf.checker.reportBorrow(node, CodeResourceUsedAfterConsume,
+		fmt.Sprintf("resource %q cannot be used after its authority was consumed", name))
+	if consumed.site != nil {
+		d.AddSecondary(diagnostic.NodeToRange(consumed.site),
+			fmt.Sprintf("resource authority was consumed here through %q", consumed.name))
+	} else {
+		d.AddNote(fmt.Sprintf("resource authority was previously consumed through %q", consumed.name))
+	}
+
+	path := rf.aliasPath(consumed.name, name)
+	for i := 0; i+1 < len(path); i++ {
+		left, right := path[i], path[i+1]
+		child, parent, origin, ok := rf.aliasEdge(left, right)
+		if !ok {
+			continue
+		}
+		message := fmt.Sprintf("resource alias %q derives authority from %q", child, parent)
+		if origin != nil {
+			d.AddSecondary(diagnostic.NodeToRange(origin), message)
+		} else {
+			d.AddNote(message)
+		}
+	}
+	d.AddHelp("use the resource value returned by the consuming operation, if it transfers authority back")
+}
+
+// firstDependentBorrow finds the earliest source-causal live borrow whose
+// owner belongs to classID. Sorting makes diagnostics independent of Go map
+// iteration order.
+func (rf *ResourceFlow) firstDependentBorrow(classID resourceClassID) (string, borrowInfo, bool) {
+	if rf == nil || rf.checker == nil {
+		return "", borrowInfo{}, false
+	}
+	type candidate struct {
+		name string
+		info borrowInfo
+	}
+	candidates := make([]candidate, 0)
+	for borrowName, info := range rf.checker.activeBorrows {
+		ownerInfo, ok := rf.aliases[info.owner]
+		if !ok || ownerInfo.class != classID {
+			continue
+		}
+		candidates = append(candidates, candidate{name: borrowName, info: info})
+	}
+	if len(candidates) == 0 {
+		return "", borrowInfo{}, false
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		left, right := candidates[i], candidates[j]
+		if left.info.origin != nil && right.info.origin != nil {
+			lr := diagnostic.NodeToRange(left.info.origin).Start
+			rr := diagnostic.NodeToRange(right.info.origin).Start
+			if lr.Line != rr.Line {
+				return lr.Line < rr.Line
+			}
+			if lr.Character != rr.Character {
+				return lr.Character < rr.Character
+			}
+		} else if left.info.origin != nil {
+			return true
+		} else if right.info.origin != nil {
+			return false
+		}
+		return left.name < right.name
+	})
+	return candidates[0].name, candidates[0].info, true
+}
+
+// aliasPath returns the deterministic shortest path between two names in one
+// alias class. Alias registration forms a tree today, but BFS deliberately
+// treats the graph generically so future provenance edges do not change the
+// diagnostic contract.
+func (rf *ResourceFlow) aliasPath(from, to string) []string {
+	if rf == nil || from == "" || to == "" {
+		return nil
+	}
+	if from == to {
+		return []string{from}
+	}
+	fromInfo, fromOK := rf.aliases[from]
+	toInfo, toOK := rf.aliases[to]
+	if !fromOK || !toOK || fromInfo.class != toInfo.class {
+		return nil
+	}
+
+	neighbors := make(map[string][]string)
+	for name, info := range rf.aliases {
+		if info.class != fromInfo.class || info.parent == "" {
+			continue
+		}
+		neighbors[name] = append(neighbors[name], info.parent)
+		neighbors[info.parent] = append(neighbors[info.parent], name)
+	}
+	for name := range neighbors {
+		sort.Strings(neighbors[name])
+	}
+
+	queue := []string{from}
+	seen := map[string]bool{from: true}
+	prev := make(map[string]string)
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		for _, next := range neighbors[current] {
+			if seen[next] {
+				continue
+			}
+			seen[next] = true
+			prev[next] = current
+			if next == to {
+				path := []string{to}
+				for cursor := to; cursor != from; {
+					cursor = prev[cursor]
+					path = append(path, cursor)
+				}
+				for i, j := 0, len(path)-1; i < j; i, j = i+1, j-1 {
+					path[i], path[j] = path[j], path[i]
+				}
+				return path
+			}
+			queue = append(queue, next)
+		}
+	}
+	return nil
+}
+
+// aliasEdge recovers the directed provenance edge between adjacent names.
+func (rf *ResourceFlow) aliasEdge(left, right string) (child, parent string, origin ast.Node, ok bool) {
+	if info, exists := rf.aliases[left]; exists && info.parent == right {
+		return left, right, info.origin, true
+	}
+	if info, exists := rf.aliases[right]; exists && info.parent == left {
+		return right, left, info.origin, true
+	}
+	return "", "", nil, false
+}

--- a/borrowchecker/resource_flow_test.go
+++ b/borrowchecker/resource_flow_test.go
@@ -1,0 +1,210 @@
+package borrowchecker
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/SCKelemen/oak/diagnostic"
+)
+
+func TestResourceConsumeInvalidatesDirectUse(t *testing.T) {
+	bc := New()
+	rf := NewResourceFlow(bc)
+	if !rf.Register("file", diagnosticIdent("file", 1, 1)) {
+		t.Fatal("expected resource registration to succeed")
+	}
+	if !rf.Consume("file", diagnosticIdent("close", 2, 1)) {
+		t.Fatal("expected first consume to succeed")
+	}
+	if rf.Use("file", diagnosticIdent("file", 4, 1)) {
+		t.Fatal("consumed resource should not remain usable")
+	}
+
+	d := findBorrowDiagnostic(t, bc, CodeResourceUsedAfterConsume)
+	if d.Category != diagnostic.CategoryBorrow {
+		t.Fatalf("expected borrow category, got %q", d.Category)
+	}
+	if err := d.Validate(); err != nil {
+		t.Fatalf("diagnostic is not structurally valid: %v", err)
+	}
+	if len(d.Labels) != 2 {
+		t.Fatalf("expected invalid use plus consume site, got %#v", d.Labels)
+	}
+	if d.Labels[0].Style != diagnostic.LabelPrimary || d.Labels[1].Style != diagnostic.LabelSecondary {
+		t.Fatalf("expected primary use and secondary consume labels, got %#v", d.Labels)
+	}
+	if !strings.Contains(d.Labels[1].Message, "consumed here") {
+		t.Fatalf("consume-site label should explain lost authority, got %q", d.Labels[1].Message)
+	}
+}
+
+func TestResourceConsumeInvalidatesAliasClassAndExplainsChain(t *testing.T) {
+	bc := New()
+	rf := NewResourceFlow(bc)
+	rf.Register("buffer", diagnosticIdent("buffer", 1, 1))
+	if !rf.Alias("packet", "buffer", diagnosticIdent("packet", 2, 1)) {
+		t.Fatal("expected first resource alias to succeed")
+	}
+	if !rf.Alias("payload", "packet", diagnosticIdent("payload", 3, 1)) {
+		t.Fatal("expected second resource alias to succeed")
+	}
+	if !rf.Consume("buffer", diagnosticIdent("submit", 4, 1)) {
+		t.Fatal("expected consuming the root alias to succeed")
+	}
+	if rf.Use("payload", diagnosticIdent("payload", 6, 1)) {
+		t.Fatal("alias should lose authority when its class is consumed")
+	}
+
+	d := findBorrowDiagnostic(t, bc, CodeResourceUsedAfterConsume)
+	if len(d.Labels) != 4 {
+		t.Fatalf("expected use, consume, and two provenance edges, got %#v", d.Labels)
+	}
+	plain := d.PlainText()
+	if !strings.Contains(plain, `alias "packet" derives authority from "buffer"`) ||
+		!strings.Contains(plain, `alias "payload" derives authority from "packet"`) {
+		t.Fatalf("expected programmer-visible alias chain, got %q", plain)
+	}
+	if strings.Contains(plain, "classID") || strings.Contains(plain, "alias-set") {
+		t.Fatalf("diagnostic must not expose internal alias-class identifiers: %q", plain)
+	}
+}
+
+func TestResourceConsumePreservesUnrelatedClass(t *testing.T) {
+	bc := New()
+	rf := NewResourceFlow(bc)
+	rf.Register("left", diagnosticIdent("left", 1, 1))
+	rf.Register("right", diagnosticIdent("right", 2, 1))
+
+	if !rf.Consume("left", diagnosticIdent("take_left", 3, 1)) {
+		t.Fatal("expected left resource to be consumable")
+	}
+	if !rf.Use("right", diagnosticIdent("right", 4, 1)) {
+		t.Fatal("consuming one authority class must not affect another")
+	}
+	if rf.Consumed("right") {
+		t.Fatal("unrelated resource class should remain live")
+	}
+	if got := bc.Diagnostics(); len(got) != 0 {
+		t.Fatalf("unrelated use should not produce diagnostics: %#v", got)
+	}
+}
+
+func TestResourceCannotConsumeWhileDependentBorrowLives(t *testing.T) {
+	bc := New()
+	rf := NewResourceFlow(bc)
+	rf.Register("buf", diagnosticIdent("buf", 1, 1))
+	bc.ownerStates["buf"] = SharedRead
+	bc.activeBorrows["header"] = borrowInfo{
+		owner:  "buf",
+		kind:   BorrowView,
+		region: &Region{Offset: 0, Length: 4},
+		origin: diagnosticIdent("header", 2, 1),
+	}
+
+	if rf.Consume("buf", diagnosticIdent("submit", 4, 1)) {
+		t.Fatal("live dependent borrow must block permanent consumption")
+	}
+	if rf.Consumed("buf") {
+		t.Fatal("failed consume must not mutate resource authority")
+	}
+	if !rf.Use("buf", diagnosticIdent("buf", 5, 1)) {
+		t.Fatal("resource should remain live after rejected consume")
+	}
+
+	d := findBorrowDiagnostic(t, bc, CodeBorrowGeneric)
+	if !strings.Contains(d.Title, "cannot be consumed while borrow") {
+		t.Fatalf("expected consume-vs-borrow explanation, got %q", d.Title)
+	}
+	if len(d.Labels) != 2 || !strings.Contains(d.Labels[1].Message, "header") {
+		t.Fatalf("expected dependent borrow as secondary cause, got %#v", d.Labels)
+	}
+}
+
+func TestUniqueBorrowCanReleaseBeforePermanentConsume(t *testing.T) {
+	bc := New()
+	rf := NewResourceFlow(bc)
+	rf.Register("buf", diagnosticIdent("buf", 1, 1))
+	bc.ownerStates["buf"] = UniqueWrite
+	bc.activeBorrows["writer"] = borrowInfo{
+		owner:  "buf",
+		kind:   BorrowSpan,
+		region: &Region{Offset: 0, Length: 8},
+		origin: diagnosticIdent("writer", 2, 1),
+	}
+
+	if rf.Consume("buf", diagnosticIdent("submit", 3, 1)) {
+		t.Fatal("unique borrow should temporarily block consume")
+	}
+	bc.ClearErrors()
+	bc.dropBorrow("writer")
+	bc.recomputeOwnerStatesFromActiveBorrows()
+	if bc.ownerStates["buf"] != Free {
+		t.Fatalf("temporary unique borrow should release to Free, got %s", bc.ownerStates["buf"])
+	}
+	if !rf.Consume("buf", diagnosticIdent("submit", 5, 1)) {
+		t.Fatal("resource should become consumable after borrow release")
+	}
+	if !rf.Consumed("buf") {
+		t.Fatal("successful consume must permanently remove resource authority")
+	}
+	if rf.Use("buf", diagnosticIdent("buf", 6, 1)) {
+		t.Fatal("consumed resource must not become usable again after borrow release")
+	}
+	findBorrowDiagnostic(t, bc, CodeResourceUsedAfterConsume)
+}
+
+func TestSecondConsumeIsUseAfterConsume(t *testing.T) {
+	bc := New()
+	rf := NewResourceFlow(bc)
+	rf.Register("file", diagnosticIdent("file", 1, 1))
+	if !rf.Consume("file", diagnosticIdent("first_close", 2, 1)) {
+		t.Fatal("expected first consume to succeed")
+	}
+	if rf.Consume("file", diagnosticIdent("second_close", 3, 1)) {
+		t.Fatal("second consume must be rejected")
+	}
+
+	d := findBorrowDiagnostic(t, bc, CodeResourceUsedAfterConsume)
+	if len(d.Labels) != 2 || !strings.Contains(d.Labels[1].Message, "first_close") && !strings.Contains(d.PlainText(), "first_close") {
+		// The source range does not preserve token spelling in PlainText; the
+		// important structural contract is the original consume secondary label.
+		if len(d.Labels) != 2 || d.Labels[1].Style != diagnostic.LabelSecondary {
+			t.Fatalf("expected original consume as secondary cause, got %#v", d.Labels)
+		}
+	}
+}
+
+func TestAliasCreationAfterConsumeIsRejected(t *testing.T) {
+	bc := New()
+	rf := NewResourceFlow(bc)
+	rf.Register("handle", diagnosticIdent("handle", 1, 1))
+	rf.Consume("handle", diagnosticIdent("close", 2, 1))
+
+	if rf.Alias("late", "handle", diagnosticIdent("late", 3, 1)) {
+		t.Fatal("creating an alias requires live source authority")
+	}
+	if rf.Consumed("late") {
+		t.Fatal("failed alias registration must not create a new name")
+	}
+	findBorrowDiagnostic(t, bc, CodeResourceUsedAfterConsume)
+}
+
+func TestBorrowThroughResourceAliasBlocksClassConsume(t *testing.T) {
+	bc := New()
+	rf := NewResourceFlow(bc)
+	rf.Register("root", diagnosticIdent("root", 1, 1))
+	rf.Alias("mapped", "root", diagnosticIdent("mapped", 2, 1))
+	bc.activeBorrows["view"] = borrowInfo{
+		owner:  "mapped",
+		kind:   BorrowView,
+		region: &Region{Offset: 0, Length: 4},
+		origin: diagnosticIdent("view", 3, 1),
+	}
+
+	if rf.Consume("root", diagnosticIdent("consume", 5, 1)) {
+		t.Fatal("borrow through any class alias must block consume")
+	}
+	if rf.Consumed("root") || rf.Consumed("mapped") {
+		t.Fatal("rejected class consume must leave every alias live")
+	}
+}

--- a/spec/lean/Oak.lean
+++ b/spec/lean/Oak.lean
@@ -11,6 +11,7 @@ import Oak.AArch64EventControl
 import Oak.AArch64ControlTransfer
 import Oak.AArch64ColdEntry
 import Oak.Borrowing
+import Oak.ResourceFlow
 import Oak.BorrowRegions
 import Oak.Reborrow
 import Oak.ReborrowRefinement

--- a/spec/lean/Oak/ResourceFlow.lean
+++ b/spec/lean/Oak/ResourceFlow.lean
@@ -63,7 +63,8 @@ class, not merely the name passed to the consuming operation. -/
 theorem consume_invalidates_alias {s : State} {source alias : Name}
     (h : Aliases s source alias) :
     ¬ Usable (consume s source) alias := by
-  simp [Usable, consume, consumeClass, Aliases, h]
+  have halias : s.classOf alias = s.classOf source := h.symm
+  simp [Usable, consume, consumeClass, halias]
 
 /-- An unrelated alias class keeps exactly the authority it had before another
 class was consumed. -/

--- a/spec/lean/Oak/ResourceFlow.lean
+++ b/spec/lean/Oak/ResourceFlow.lean
@@ -1,0 +1,148 @@
+import Oak.Borrowing
+
+namespace Oak.ResourceFlow
+
+/-- Source-level resource names and alias classes are abstract identities here.
+The executable checker may use strings/integers; the proof only needs equality. -/
+abbrev Name := Nat
+abbrev ClassId := Nat
+
+/-- Resource authority is deliberately separate from Oak.Borrowing.State.
+A unique writable borrow is temporary; consumed authority never returns. -/
+inductive Authority where
+  | live
+  | consumed
+  deriving DecidableEq, Repr
+
+/-- `classOf` is provenance/alias membership. Authority belongs to the alias
+class, not to an individual spelling, so consuming one member invalidates all
+members of that class. -/
+structure State where
+  classOf : Name -> ClassId
+  authority : ClassId -> Authority
+
+/-- A name is usable exactly while its alias class still has live authority. -/
+def Usable (s : State) (name : Name) : Prop :=
+  s.authority (s.classOf name) = .live
+
+/-- Two names alias the same resource authority when they belong to one class. -/
+def Aliases (s : State) (left right : Name) : Prop :=
+  s.classOf left = s.classOf right
+
+/-- Consumption changes authority for exactly one alias class. Provenance is
+unchanged: aliases remain aliases, but the class no longer carries authority. -/
+def consumeClass (s : State) (classId : ClassId) : State :=
+  { s with
+    authority := fun candidate =>
+      if candidate = classId then .consumed else s.authority candidate }
+
+/-- Consuming a name consumes the authority of its entire alias class. -/
+def consume (s : State) (name : Name) : State :=
+  consumeClass s (s.classOf name)
+
+inductive Action where
+  | use : Name -> Action
+  | consume : Name -> Action
+  deriving Repr
+
+/-- The local resource-flow transition system. There is intentionally no
+transition that restores consumed authority. -/
+inductive Step : Action -> State -> State -> Prop where
+  | use {s : State} {name : Name} :
+      Usable s name -> Step (.use name) s s
+  | consume {s : State} {name : Name} :
+      Usable s name -> Step (.consume name) s (consume s name)
+
+/-- Consumption immediately invalidates the syntactic name that was consumed. -/
+theorem consume_invalidates_self (s : State) (name : Name) :
+    ¬ Usable (consume s name) name := by
+  simp [Usable, consume, consumeClass]
+
+/-- Consumption invalidates every alias whose authority belongs to the same
+class, not merely the name passed to the consuming operation. -/
+theorem consume_invalidates_alias {s : State} {source alias : Name}
+    (h : Aliases s source alias) :
+    ¬ Usable (consume s source) alias := by
+  simp [Usable, consume, consumeClass, Aliases, h]
+
+/-- An unrelated alias class keeps exactly the authority it had before another
+class was consumed. -/
+theorem consume_preserves_unrelated {s : State} {source other : Name}
+    (h : ¬ Aliases s source other) :
+    Usable (consume s source) other ↔ Usable s other := by
+  have hne : s.classOf other ≠ s.classOf source := by
+    intro heq
+    exact h heq.symm
+  simp [Usable, consume, consumeClass, hne]
+
+/-- Resource-flow steps never change provenance/alias-class membership. -/
+theorem step_preserves_class {action : Action} {before after : State}
+    (h : Step action before after) (name : Name) :
+    after.classOf name = before.classOf name := by
+  cases h <;> rfl
+
+/-- Therefore an alias relationship, once established for this local flow,
+remains the same across uses and consumption. -/
+theorem step_preserves_aliases {action : Action} {before after : State}
+    (hstep : Step action before after) {left right : Name}
+    (halias : Aliases before left right) :
+    Aliases after left right := by
+  unfold Aliases at halias ⊢
+  rw [step_preserves_class hstep left, step_preserves_class hstep right]
+  exact halias
+
+/-- Once an alias class is consumed, every later legal step preserves that
+fact. This is the core permanence property distinguishing consumption from a
+borrow that can later be released. -/
+theorem consumed_class_stays_consumed {action : Action} {before after : State}
+    {classId : ClassId}
+    (hconsumed : before.authority classId = .consumed)
+    (hstep : Step action before after) :
+    after.authority classId = .consumed := by
+  cases hstep with
+  | use _ =>
+      exact hconsumed
+  | consume _ =>
+      simp [consume, consumeClass, hconsumed]
+
+/-- A consumed name cannot be used. -/
+theorem consumed_cannot_use {s : State} {name : Name}
+    (hconsumed : s.authority (s.classOf name) = .consumed) :
+    ¬ Step (.use name) s s := by
+  intro hstep
+  cases hstep with
+  | use husable =>
+      simp [Usable, hconsumed] at husable
+
+/-- Consuming already-consumed authority is also rejected: a consuming call is
+itself a use of the old authority. -/
+theorem consumed_cannot_consume {s after : State} {name : Name}
+    (hconsumed : s.authority (s.classOf name) = .consumed) :
+    ¬ Step (.consume name) s after := by
+  intro hstep
+  cases hstep with
+  | consume husable =>
+      simp [Usable, hconsumed] at husable
+
+/-- Borrow admission and resource consumption are separate axes. Consumption is
+allowed only when the resource is live and no local borrow currently holds its
+access authority. -/
+def CanConsume (borrow : Oak.Borrowing.State) (authority : Authority) : Prop :=
+  borrow = .free ∧ authority = .live
+
+theorem free_live_can_consume : CanConsume .free .live := by
+  simp [CanConsume]
+
+theorem shared_borrow_blocks_consume (n : Nat) :
+    ¬ CanConsume (.shared (n + 1)) .live := by
+  simp [CanConsume]
+
+theorem unique_borrow_blocks_consume :
+    ¬ CanConsume .unique .live := by
+  simp [CanConsume]
+
+theorem consumed_authority_cannot_be_consumed (borrow : Oak.Borrowing.State) :
+    ¬ CanConsume borrow .consumed := by
+  simp [CanConsume]
+
+end Oak.ResourceFlow


### PR DESCRIPTION
## Summary

- add `Oak.ResourceFlow` Lean model for live/consumed resource authority and alias classes
- prove consumption invalidates all aliases, preserves unrelated classes, and is permanent across later legal steps
- prove temporary shared/unique borrowing blocks consumption without conflating borrow state with consumption
- add executable `borrowchecker.ResourceFlow` with alias provenance, permanent consumption, dependent-borrow rejection, and `OAK-B0111`
- add focused diagnostics/tests for direct use-after-consume, alias-chain invalidation, unrelated classes, second consume, and borrow-vs-consume behavior

## Deliberate scope

No Oak surface syntax is introduced. The semantic component is ready to be wired after resource typing and consume spelling are frozen.

## Verification

Final head `0f092d9639aa08288c61d45b94018c3956ec8c8a`, rebased onto current `specification`:

- Formal Verification: pass
- Golden File Verification: pass
- CI / `go test -race ./...`: pass
- Standard library: pass
- AArch64 Memory Refinement: pass

An earlier run exposed a pre-existing `experiments/verification-poc` failure on the then-current base; the subsequent base fix was incorporated before this final green matrix.