### PR TITLE
Add path-sensitive resource flow joins

### DIFF
--- a/borrowchecker/resource_flow.go
+++ b/borrowchecker/resource_flow.go
@@ -6,141 +6,98 @@ import (
 
 	"github.com/SCKelemen/oak/ast"
 	"github.com/SCKelemen/oak/diagnostic"
+	"github.com/SCKelemen/oak/resourceflow"
 )
 
 // CodeResourceUsedAfterConsume is the stable diagnostic for a resource name
 // (including any alias in the same authority class) used after consumption.
 const CodeResourceUsedAfterConsume diagnostic.Code = "OAK-B0111"
 
-type resourceClassID uint64
-
-type resourceAliasInfo struct {
-	class  resourceClassID
-	parent string
-	origin ast.Node
-}
-
-type resourceConsumption struct {
-	name string
-	site ast.Node
-}
-
-type resourceClassState struct {
-	consumed *resourceConsumption
-}
-
-// ResourceFlow is the executable counterpart of Oak.ResourceFlow. It tracks
-// resource authority separately from temporary borrow state: a UniqueWrite
-// borrow can be released, while a consumed alias class never regains authority.
-//
-// Surface syntax is intentionally not part of this type. The semantic layer
-// should register resource-typed values/aliases and invoke Use/Consume after
-// type resolution, once Oak's consume spelling is frozen.
+// ResourceFlow is the borrow-checker projection of Oak's shared path-sensitive
+// resource authority state. Temporary borrow conflicts remain borrow-checker
+// policy; alias classes, consumption, snapshots, and joins live in resourceflow.
 type ResourceFlow struct {
-	checker   *BorrowChecker
-	nextClass resourceClassID
-	aliases   map[string]resourceAliasInfo
-	classes   map[resourceClassID]*resourceClassState
+	checker *BorrowChecker
+	flow    *resourceflow.Flow
 }
 
 // NewResourceFlow creates an empty resource-flow analysis associated with a
 // borrow checker. The association lets consumption reject any live view/span
 // whose backing owner belongs to the same resource alias class.
 func NewResourceFlow(checker *BorrowChecker) *ResourceFlow {
-	return &ResourceFlow{
-		checker: checker,
-		aliases: make(map[string]resourceAliasInfo),
-		classes: make(map[resourceClassID]*resourceClassState),
+	return &ResourceFlow{checker: checker, flow: resourceflow.New()}
+}
+
+// Clone creates an independent control-flow branch state.
+func (rf *ResourceFlow) Clone() *ResourceFlow {
+	if rf == nil {
+		return NewResourceFlow(nil)
 	}
+	return &ResourceFlow{checker: rf.checker, flow: rf.flow.Clone()}
+}
+
+// JoinResourceFlows joins reachable branch exits. Only authority definitely
+// live on every incoming path remains usable after the join.
+func JoinResourceFlows(flows ...*ResourceFlow) *ResourceFlow {
+	if len(flows) == 0 {
+		return NewResourceFlow(nil)
+	}
+	checker := flows[0].checker
+	cores := make([]*resourceflow.Flow, 0, len(flows))
+	for _, flow := range flows {
+		if flow == nil {
+			cores = append(cores, nil)
+			continue
+		}
+		cores = append(cores, flow.flow)
+	}
+	return &ResourceFlow{checker: checker, flow: resourceflow.Join(cores...)}
 }
 
 // Register introduces a new independently-owned resource authority class.
-// Duplicate registrations are rejected without mutating existing provenance.
 func (rf *ResourceFlow) Register(name string, origin ast.Node) bool {
-	if rf == nil || name == "" {
-		return false
-	}
-	if _, exists := rf.aliases[name]; exists {
-		return false
-	}
-
-	classID := rf.nextClass
-	rf.nextClass++
-	rf.aliases[name] = resourceAliasInfo{class: classID, origin: origin}
-	rf.classes[classID] = &resourceClassState{}
-	return true
+	return rf != nil && rf.flow != nil && rf.flow.Register(name, origin)
 }
 
 // Alias records that alias derives resource authority from source. Alias
-// creation itself uses source authority, so it is rejected if source was
-// already consumed. The parent edge is retained for programmer-facing
-// provenance diagnostics; authority remains class-wide.
+// creation itself uses source authority, so consumed/maybe-consumed sources
+// produce the same OAK-B0111 diagnostic as any later use.
 func (rf *ResourceFlow) Alias(alias, source string, origin ast.Node) bool {
-	if rf == nil || alias == "" || source == "" || alias == source {
-		return false
-	}
-	if _, exists := rf.aliases[alias]; exists {
-		return false
-	}
-	sourceInfo, exists := rf.aliases[source]
-	if !exists {
+	if rf == nil || rf.flow == nil || alias == "" || source == "" {
 		return false
 	}
 	if !rf.Use(source, origin) {
 		return false
 	}
-
-	rf.aliases[alias] = resourceAliasInfo{
-		class:  sourceInfo.class,
-		parent: source,
-		origin: origin,
-	}
-	return true
+	return rf.flow.Alias(alias, source, origin)
 }
 
 // Use validates one resource access. Non-resource names are ignored so the
-// caller can invoke this after ordinary identifier classification. A consumed
-// class produces OAK-B0111 with the original consume site and the shortest
-// available programmer-visible alias chain.
+// caller can invoke this after ordinary identifier classification.
 func (rf *ResourceFlow) Use(name string, node ast.Node) bool {
-	if rf == nil || name == "" {
+	if rf == nil || rf.flow == nil || name == "" || !rf.flow.Registered(name) {
 		return true
 	}
-	info, exists := rf.aliases[name]
-	if !exists {
+	if rf.flow.CanUse(name) {
 		return true
 	}
-	classState := rf.classes[info.class]
-	if classState == nil || classState.consumed == nil {
-		return true
-	}
-
-	rf.reportConsumedUse(name, node, classState.consumed)
+	rf.reportUnavailableUse(name, node)
 	return false
 }
 
-// Consume permanently removes authority from name's entire alias class.
-// Consumption is rejected while any live borrow depends on a class member.
-// A second consume is itself a use-after-consume and therefore reports
-// OAK-B0111.
+// Consume permanently removes authority from name's entire alias class on the
+// current path. Consumption is rejected while a dependent temporary borrow is
+// live, and also when authority is already consumed or only maybe live.
 func (rf *ResourceFlow) Consume(name string, site ast.Node) bool {
-	if rf == nil || name == "" {
+	if rf == nil || rf.flow == nil || name == "" || !rf.flow.Registered(name) {
 		return false
 	}
-	info, exists := rf.aliases[name]
-	if !exists {
-		return false
-	}
-	classState := rf.classes[info.class]
-	if classState == nil {
-		return false
-	}
-	if classState.consumed != nil {
-		rf.reportConsumedUse(name, site, classState.consumed)
+	if !rf.flow.CanUse(name) {
+		rf.reportUnavailableUse(name, site)
 		return false
 	}
 
-	if borrowName, borrow, ok := rf.firstDependentBorrow(info.class); ok {
+	if borrowName, borrow, ok := rf.firstDependentBorrow(name); ok {
 		if rf.checker != nil {
 			d := rf.checker.reportBorrow(site, CodeBorrowGeneric,
 				fmt.Sprintf("resource %q cannot be consumed while borrow %q is live", name, borrowName))
@@ -151,62 +108,70 @@ func (rf *ResourceFlow) Consume(name string, site ast.Node) bool {
 		}
 		return false
 	}
-
-	classState.consumed = &resourceConsumption{name: name, site: site}
-	return true
+	return rf.flow.Consume(name, site)
 }
 
-// Consumed reports whether name is a registered resource whose alias class has
-// already lost authority. It is primarily useful to semantic pipeline tests
-// and later control-flow joining.
+// Authority reports the path summary for a registered resource.
+func (rf *ResourceFlow) Authority(name string) (resourceflow.Authority, bool) {
+	if rf == nil || rf.flow == nil {
+		return resourceflow.AuthorityInvalid, false
+	}
+	return rf.flow.AuthorityOf(name)
+}
+
+// Consumed is true only when every incoming path has consumed the authority.
+// Maybe-consumed remains unavailable, but is not definitely consumed.
 func (rf *ResourceFlow) Consumed(name string) bool {
-	if rf == nil {
-		return false
-	}
-	info, exists := rf.aliases[name]
-	if !exists {
-		return false
-	}
-	classState := rf.classes[info.class]
-	return classState != nil && classState.consumed != nil
+	authority, exists := rf.Authority(name)
+	return exists && authority == resourceflow.AuthorityConsumed
 }
 
-func (rf *ResourceFlow) reportConsumedUse(name string, node ast.Node, consumed *resourceConsumption) {
-	if rf == nil || rf.checker == nil || consumed == nil {
+func (rf *ResourceFlow) reportUnavailableUse(name string, node ast.Node) {
+	if rf == nil || rf.flow == nil || rf.checker == nil {
+		return
+	}
+	authority, exists := rf.flow.AuthorityOf(name)
+	if !exists || authority == resourceflow.AuthorityLive {
 		return
 	}
 
-	d := rf.checker.reportBorrow(node, CodeResourceUsedAfterConsume,
-		fmt.Sprintf("resource %q cannot be used after its authority was consumed", name))
-	if consumed.site != nil {
-		d.AddSecondary(diagnostic.NodeToRange(consumed.site),
-			fmt.Sprintf("resource authority was consumed here through %q", consumed.name))
-	} else {
-		d.AddNote(fmt.Sprintf("resource authority was previously consumed through %q", consumed.name))
+	title := fmt.Sprintf("resource %q cannot be used after its authority was consumed", name)
+	if authority == resourceflow.AuthorityMaybeConsumed {
+		title = fmt.Sprintf("resource %q cannot be used because its authority may have been consumed", name)
 	}
+	d := rf.checker.reportBorrow(node, CodeResourceUsedAfterConsume, title)
 
-	path := rf.aliasPath(consumed.name, name)
-	for i := 0; i+1 < len(path); i++ {
-		left, right := path[i], path[i+1]
-		child, parent, origin, ok := rf.aliasEdge(left, right)
-		if !ok {
-			continue
-		}
-		message := fmt.Sprintf("resource alias %q derives authority from %q", child, parent)
-		if origin != nil {
-			d.AddSecondary(diagnostic.NodeToRange(origin), message)
+	consumptions := rf.flow.Consumptions(name)
+	for _, consumed := range consumptions {
+		if consumed.Site != nil {
+			message := fmt.Sprintf("resource authority was consumed on this path through %q", consumed.Name)
+			if authority == resourceflow.AuthorityConsumed && len(consumptions) == 1 {
+				message = fmt.Sprintf("resource authority was consumed here through %q", consumed.Name)
+			}
+			d.AddSecondary(diagnostic.NodeToRange(consumed.Site), message)
 		} else {
-			d.AddNote(message)
+			d.AddNote(fmt.Sprintf("resource authority was consumed through %q on an incoming path", consumed.Name))
 		}
+
+		for _, edge := range rf.flow.AliasPath(consumed.Name, name) {
+			message := fmt.Sprintf("resource alias %q derives authority from %q", edge.Child, edge.Parent)
+			if edge.Origin != nil {
+				d.AddSecondary(diagnostic.NodeToRange(edge.Origin), message)
+			} else {
+				d.AddNote(message)
+			}
+		}
+	}
+	if authority == resourceflow.AuthorityMaybeConsumed {
+		d.AddNote("the control-flow join includes both a live path and a consumed path; authority must be live on every path")
 	}
 	d.AddHelp("use the resource value returned by the consuming operation, if it transfers authority back")
 }
 
 // firstDependentBorrow finds the earliest source-causal live borrow whose
-// owner belongs to classID. Sorting makes diagnostics independent of Go map
-// iteration order.
-func (rf *ResourceFlow) firstDependentBorrow(classID resourceClassID) (string, borrowInfo, bool) {
-	if rf == nil || rf.checker == nil {
+// owner aliases resourceName. Sorting keeps diagnostics deterministic.
+func (rf *ResourceFlow) firstDependentBorrow(resourceName string) (string, borrowInfo, bool) {
+	if rf == nil || rf.flow == nil || rf.checker == nil {
 		return "", borrowInfo{}, false
 	}
 	type candidate struct {
@@ -215,8 +180,7 @@ func (rf *ResourceFlow) firstDependentBorrow(classID resourceClassID) (string, b
 	}
 	candidates := make([]candidate, 0)
 	for borrowName, info := range rf.checker.activeBorrows {
-		ownerInfo, ok := rf.aliases[info.owner]
-		if !ok || ownerInfo.class != classID {
+		if !rf.flow.Aliases(info.owner, resourceName) {
 			continue
 		}
 		candidates = append(candidates, candidate{name: borrowName, info: info})
@@ -244,73 +208,4 @@ func (rf *ResourceFlow) firstDependentBorrow(classID resourceClassID) (string, b
 		return left.name < right.name
 	})
 	return candidates[0].name, candidates[0].info, true
-}
-
-// aliasPath returns the deterministic shortest path between two names in one
-// alias class. Alias registration forms a tree today, but BFS deliberately
-// treats the graph generically so future provenance edges do not change the
-// diagnostic contract.
-func (rf *ResourceFlow) aliasPath(from, to string) []string {
-	if rf == nil || from == "" || to == "" {
-		return nil
-	}
-	if from == to {
-		return []string{from}
-	}
-	fromInfo, fromOK := rf.aliases[from]
-	toInfo, toOK := rf.aliases[to]
-	if !fromOK || !toOK || fromInfo.class != toInfo.class {
-		return nil
-	}
-
-	neighbors := make(map[string][]string)
-	for name, info := range rf.aliases {
-		if info.class != fromInfo.class || info.parent == "" {
-			continue
-		}
-		neighbors[name] = append(neighbors[name], info.parent)
-		neighbors[info.parent] = append(neighbors[info.parent], name)
-	}
-	for name := range neighbors {
-		sort.Strings(neighbors[name])
-	}
-
-	queue := []string{from}
-	seen := map[string]bool{from: true}
-	prev := make(map[string]string)
-	for len(queue) > 0 {
-		current := queue[0]
-		queue = queue[1:]
-		for _, next := range neighbors[current] {
-			if seen[next] {
-				continue
-			}
-			seen[next] = true
-			prev[next] = current
-			if next == to {
-				path := []string{to}
-				for cursor := to; cursor != from; {
-					cursor = prev[cursor]
-					path = append(path, cursor)
-				}
-				for i, j := 0, len(path)-1; i < j; i, j = i+1, j-1 {
-					path[i], path[j] = path[j], path[i]
-				}
-				return path
-			}
-			queue = append(queue, next)
-		}
-	}
-	return nil
-}
-
-// aliasEdge recovers the directed provenance edge between adjacent names.
-func (rf *ResourceFlow) aliasEdge(left, right string) (child, parent string, origin ast.Node, ok bool) {
-	if info, exists := rf.aliases[left]; exists && info.parent == right {
-		return left, right, info.origin, true
-	}
-	if info, exists := rf.aliases[right]; exists && info.parent == left {
-		return right, left, info.origin, true
-	}
-	return "", "", nil, false
 }

--- a/resourceflow/flow.go
+++ b/resourceflow/flow.go
@@ -1,0 +1,416 @@
+// Package resourceflow is Oak's checker-independent resource-authority core.
+//
+// It owns alias classes, consumption provenance, and path-state joins. The
+// borrow checker and type checker project diagnostics and local policy from
+// this one state machine rather than maintaining independent move models.
+package resourceflow
+
+import (
+	"sort"
+
+	"github.com/SCKelemen/oak/ast"
+)
+
+// Authority summarizes every control-flow path reaching a program point.
+// A resource is usable only when it is definitely Live on all incoming paths.
+type Authority uint8
+
+const (
+	AuthorityInvalid Authority = iota
+	AuthorityLive
+	AuthorityConsumed
+	AuthorityMaybeConsumed
+)
+
+func (a Authority) String() string {
+	switch a {
+	case AuthorityLive:
+		return "live"
+	case AuthorityConsumed:
+		return "consumed"
+	case AuthorityMaybeConsumed:
+		return "maybe-consumed"
+	default:
+		return "invalid"
+	}
+}
+
+// JoinAuthority is the path join. Live and Consumed represent singleton sets
+// of possible runtime states; MaybeConsumed represents {Live, Consumed}.
+func JoinAuthority(left, right Authority) Authority {
+	if left == AuthorityInvalid || right == AuthorityInvalid {
+		return AuthorityInvalid
+	}
+	if left == right {
+		return left
+	}
+	return AuthorityMaybeConsumed
+}
+
+// Consumption is one programmer-visible path that consumed an authority class.
+type Consumption struct {
+	Name string
+	Site ast.Node
+}
+
+type classID uint64
+
+type aliasInfo struct {
+	class  classID
+	parent string
+	origin ast.Node
+}
+
+type classState struct {
+	authority    Authority
+	consumptions []Consumption
+}
+
+// AliasEdge is a directed provenance edge: Child derives authority from Parent.
+type AliasEdge struct {
+	Child  string
+	Parent string
+	Origin ast.Node
+}
+
+// Flow is one path-sensitive resource environment.
+type Flow struct {
+	nextClass classID
+	aliases   map[string]aliasInfo
+	classes   map[classID]*classState
+}
+
+func New() *Flow {
+	return &Flow{
+		aliases: make(map[string]aliasInfo),
+		classes: make(map[classID]*classState),
+	}
+}
+
+// Clone creates an independent branch state while retaining immutable source
+// provenance. Later consumption in the clone does not mutate its parent path.
+func (f *Flow) Clone() *Flow {
+	if f == nil {
+		return New()
+	}
+	out := &Flow{
+		nextClass: f.nextClass,
+		aliases:   make(map[string]aliasInfo, len(f.aliases)),
+		classes:   make(map[classID]*classState, len(f.classes)),
+	}
+	for name, info := range f.aliases {
+		out.aliases[name] = info
+	}
+	for id, state := range f.classes {
+		if state == nil {
+			continue
+		}
+		copyState := &classState{authority: state.authority}
+		copyState.consumptions = append(copyState.consumptions, state.consumptions...)
+		out.classes[id] = copyState
+	}
+	return out
+}
+
+// Register introduces a new independent resource authority class.
+func (f *Flow) Register(name string, origin ast.Node) bool {
+	if f == nil || name == "" {
+		return false
+	}
+	if _, exists := f.aliases[name]; exists {
+		return false
+	}
+	id := f.nextClass
+	f.nextClass++
+	f.aliases[name] = aliasInfo{class: id, origin: origin}
+	f.classes[id] = &classState{authority: AuthorityLive}
+	return true
+}
+
+// Alias records that alias derives authority from source. Alias creation
+// requires source to be definitely live at this program point.
+func (f *Flow) Alias(alias, source string, origin ast.Node) bool {
+	if f == nil || alias == "" || source == "" || alias == source {
+		return false
+	}
+	if _, exists := f.aliases[alias]; exists {
+		return false
+	}
+	sourceInfo, exists := f.aliases[source]
+	if !exists || !f.CanUse(source) {
+		return false
+	}
+	f.aliases[alias] = aliasInfo{class: sourceInfo.class, parent: source, origin: origin}
+	return true
+}
+
+// AuthorityOf reports the current path summary for a registered resource name.
+func (f *Flow) AuthorityOf(name string) (Authority, bool) {
+	if f == nil {
+		return AuthorityInvalid, false
+	}
+	info, exists := f.aliases[name]
+	if !exists {
+		return AuthorityInvalid, false
+	}
+	state := f.classes[info.class]
+	if state == nil {
+		return AuthorityInvalid, false
+	}
+	return state.authority, true
+}
+
+func (f *Flow) Registered(name string) bool {
+	_, ok := f.AuthorityOf(name)
+	return ok
+}
+
+// CanUse is deliberately strict: conditional authority is not authority.
+func (f *Flow) CanUse(name string) bool {
+	authority, exists := f.AuthorityOf(name)
+	return exists && authority == AuthorityLive
+}
+
+// Consume permanently consumes a definitely-live alias class on this path.
+// MaybeConsumed is rejected because the operation would double-consume on some
+// incoming path.
+func (f *Flow) Consume(name string, site ast.Node) bool {
+	if f == nil {
+		return false
+	}
+	info, exists := f.aliases[name]
+	if !exists {
+		return false
+	}
+	state := f.classes[info.class]
+	if state == nil || state.authority != AuthorityLive {
+		return false
+	}
+	state.authority = AuthorityConsumed
+	state.consumptions = []Consumption{{Name: name, Site: site}}
+	return true
+}
+
+// Consumptions returns deterministic programmer-visible consume provenance for
+// a name's class. MaybeConsumed states retain the consuming incoming paths.
+func (f *Flow) Consumptions(name string) []Consumption {
+	if f == nil {
+		return nil
+	}
+	info, exists := f.aliases[name]
+	if !exists {
+		return nil
+	}
+	state := f.classes[info.class]
+	if state == nil {
+		return nil
+	}
+	out := append([]Consumption(nil), state.consumptions...)
+	sort.SliceStable(out, func(i, j int) bool {
+		li, lj := nodeOrder(out[i].Site), nodeOrder(out[j].Site)
+		if li.line != lj.line {
+			return li.line < lj.line
+		}
+		if li.column != lj.column {
+			return li.column < lj.column
+		}
+		return out[i].Name < out[j].Name
+	})
+	return dedupeConsumptions(out)
+}
+
+// Aliases reports whether two registered names carry authority from one class.
+func (f *Flow) Aliases(left, right string) bool {
+	if f == nil {
+		return false
+	}
+	li, lok := f.aliases[left]
+	ri, rok := f.aliases[right]
+	return lok && rok && li.class == ri.class
+}
+
+// AliasPath returns the deterministic shortest programmer-visible provenance
+// path between two aliases in one authority class.
+func (f *Flow) AliasPath(from, to string) []AliasEdge {
+	if f == nil || from == "" || to == "" || from == to || !f.Aliases(from, to) {
+		return nil
+	}
+	class := f.aliases[from].class
+	neighbors := make(map[string][]string)
+	for name, info := range f.aliases {
+		if info.class != class || info.parent == "" {
+			continue
+		}
+		neighbors[name] = append(neighbors[name], info.parent)
+		neighbors[info.parent] = append(neighbors[info.parent], name)
+	}
+	for name := range neighbors {
+		sort.Strings(neighbors[name])
+	}
+
+	queue := []string{from}
+	seen := map[string]bool{from: true}
+	prev := make(map[string]string)
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		for _, next := range neighbors[current] {
+			if seen[next] {
+				continue
+			}
+			seen[next] = true
+			prev[next] = current
+			if next == to {
+				names := []string{to}
+				for cursor := to; cursor != from; {
+					cursor = prev[cursor]
+					names = append(names, cursor)
+				}
+				for i, j := 0, len(names)-1; i < j; i, j = i+1, j-1 {
+					names[i], names[j] = names[j], names[i]
+				}
+				edges := make([]AliasEdge, 0, len(names)-1)
+				for i := 0; i+1 < len(names); i++ {
+					if edge, ok := f.aliasEdge(names[i], names[i+1]); ok {
+						edges = append(edges, edge)
+					}
+				}
+				return edges
+			}
+			queue = append(queue, next)
+		}
+	}
+	return nil
+}
+
+func (f *Flow) aliasEdge(left, right string) (AliasEdge, bool) {
+	if info, exists := f.aliases[left]; exists && info.parent == right {
+		return AliasEdge{Child: left, Parent: right, Origin: info.origin}, true
+	}
+	if info, exists := f.aliases[right]; exists && info.parent == left {
+		return AliasEdge{Child: right, Parent: left, Origin: info.origin}, true
+	}
+	return AliasEdge{}, false
+}
+
+// Join merges reachable branch exits. Branches are expected to be clones of a
+// common predecessor. Names introduced on only some paths do not escape the
+// join; incompatible provenance also fails closed by dropping that name.
+func Join(flows ...*Flow) *Flow {
+	if len(flows) == 0 {
+		return New()
+	}
+	var first *Flow
+	for _, flow := range flows {
+		if flow != nil {
+			first = flow
+			break
+		}
+	}
+	if first == nil {
+		return New()
+	}
+	out := first.Clone()
+
+	for name, info := range out.aliases {
+		compatible := true
+		for _, flow := range flows {
+			if flow == nil {
+				compatible = false
+				break
+			}
+			other, exists := flow.aliases[name]
+			if !exists || other.class != info.class || other.parent != info.parent {
+				compatible = false
+				break
+			}
+		}
+		if !compatible {
+			delete(out.aliases, name)
+		}
+	}
+
+	for id, state := range out.classes {
+		if state == nil {
+			continue
+		}
+		authority := state.authority
+		consumptions := append([]Consumption(nil), state.consumptions...)
+		valid := true
+		for i := 1; i < len(flows); i++ {
+			if flows[i] == nil || flows[i].classes[id] == nil {
+				valid = false
+				break
+			}
+			other := flows[i].classes[id]
+			authority = JoinAuthority(authority, other.authority)
+			consumptions = append(consumptions, other.consumptions...)
+		}
+		if !valid {
+			delete(out.classes, id)
+			continue
+		}
+		state.authority = authority
+		state.consumptions = dedupeConsumptions(consumptions)
+	}
+
+	// Remove any alias whose class did not survive structural compatibility.
+	for name, info := range out.aliases {
+		if _, exists := out.classes[info.class]; !exists {
+			delete(out.aliases, name)
+		}
+	}
+	return out
+}
+
+type orderKey struct {
+	line, column int
+}
+
+func nodeOrder(node ast.Node) orderKey {
+	if node == nil {
+		return orderKey{line: int(^uint(0) >> 1), column: int(^uint(0) >> 1)}
+	}
+	pos := node.Pos()
+	return orderKey{line: pos.Line, column: pos.Column}
+}
+
+func dedupeConsumptions(in []Consumption) []Consumption {
+	out := make([]Consumption, 0, len(in))
+	seen := make(map[string]bool)
+	for _, item := range in {
+		key := item.Name
+		if item.Site != nil {
+			pos := item.Site.Pos()
+			key += "@" + positionKey(pos.Line, pos.Column)
+		}
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, item)
+	}
+	return out
+}
+
+func positionKey(line, column int) string {
+	// Decimal formatting without fmt keeps this core dependency-light.
+	return itoa(line) + ":" + itoa(column)
+}
+
+func itoa(value int) string {
+	if value == 0 {
+		return "0"
+	}
+	if value < 0 {
+		return "-" + itoa(-value)
+	}
+	var digits [24]byte
+	i := len(digits)
+	for value > 0 {
+		i--
+		digits[i] = byte('0' + value%10)
+		value /= 10
+	}
+	return string(digits[i:])
+}

--- a/resourceflow/flow.go
+++ b/resourceflow/flow.go
@@ -6,9 +6,11 @@
 package resourceflow
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/SCKelemen/oak/ast"
+	"github.com/SCKelemen/oak/diagnostic"
 )
 
 // Authority summarizes every control-flow path reaching a program point.
@@ -297,28 +299,19 @@ func (f *Flow) aliasEdge(left, right string) (AliasEdge, bool) {
 // common predecessor. Names introduced on only some paths do not escape the
 // join; incompatible provenance also fails closed by dropping that name.
 func Join(flows ...*Flow) *Flow {
-	if len(flows) == 0 {
+	if len(flows) == 0 || flows[0] == nil {
 		return New()
 	}
-	var first *Flow
 	for _, flow := range flows {
-		if flow != nil {
-			first = flow
-			break
+		if flow == nil {
+			return New()
 		}
 	}
-	if first == nil {
-		return New()
-	}
-	out := first.Clone()
+	out := flows[0].Clone()
 
 	for name, info := range out.aliases {
 		compatible := true
-		for _, flow := range flows {
-			if flow == nil {
-				compatible = false
-				break
-			}
+		for _, flow := range flows[1:] {
 			other, exists := flow.aliases[name]
 			if !exists || other.class != info.class || other.parent != info.parent {
 				compatible = false
@@ -337,12 +330,12 @@ func Join(flows ...*Flow) *Flow {
 		authority := state.authority
 		consumptions := append([]Consumption(nil), state.consumptions...)
 		valid := true
-		for i := 1; i < len(flows); i++ {
-			if flows[i] == nil || flows[i].classes[id] == nil {
+		for _, flow := range flows[1:] {
+			other := flow.classes[id]
+			if other == nil {
 				valid = false
 				break
 			}
-			other := flows[i].classes[id]
 			authority = JoinAuthority(authority, other.authority)
 			consumptions = append(consumptions, other.consumptions...)
 		}
@@ -354,10 +347,17 @@ func Join(flows ...*Flow) *Flow {
 		state.consumptions = dedupeConsumptions(consumptions)
 	}
 
-	// Remove any alias whose class did not survive structural compatibility.
+	usedClasses := make(map[classID]bool)
 	for name, info := range out.aliases {
 		if _, exists := out.classes[info.class]; !exists {
 			delete(out.aliases, name)
+			continue
+		}
+		usedClasses[info.class] = true
+	}
+	for id := range out.classes {
+		if !usedClasses[id] {
+			delete(out.classes, id)
 		}
 	}
 	return out
@@ -369,10 +369,11 @@ type orderKey struct {
 
 func nodeOrder(node ast.Node) orderKey {
 	if node == nil {
-		return orderKey{line: int(^uint(0) >> 1), column: int(^uint(0) >> 1)}
+		max := int(^uint(0) >> 1)
+		return orderKey{line: max, column: max}
 	}
-	pos := node.Pos()
-	return orderKey{line: pos.Line, column: pos.Column}
+	start := diagnostic.NodeToRange(node).Start
+	return orderKey{line: start.Line, column: start.Character}
 }
 
 func dedupeConsumptions(in []Consumption) []Consumption {
@@ -381,8 +382,8 @@ func dedupeConsumptions(in []Consumption) []Consumption {
 	for _, item := range in {
 		key := item.Name
 		if item.Site != nil {
-			pos := item.Site.Pos()
-			key += "@" + positionKey(pos.Line, pos.Column)
+			start := diagnostic.NodeToRange(item.Site).Start
+			key += fmt.Sprintf("@%d:%d", start.Line, start.Character)
 		}
 		if seen[key] {
 			continue
@@ -391,26 +392,4 @@ func dedupeConsumptions(in []Consumption) []Consumption {
 		out = append(out, item)
 	}
 	return out
-}
-
-func positionKey(line, column int) string {
-	// Decimal formatting without fmt keeps this core dependency-light.
-	return itoa(line) + ":" + itoa(column)
-}
-
-func itoa(value int) string {
-	if value == 0 {
-		return "0"
-	}
-	if value < 0 {
-		return "-" + itoa(-value)
-	}
-	var digits [24]byte
-	i := len(digits)
-	for value > 0 {
-		i--
-		digits[i] = byte('0' + value%10)
-		value /= 10
-	}
-	return string(digits[i:])
 }

--- a/resourceflow/flow_test.go
+++ b/resourceflow/flow_test.go
@@ -1,0 +1,108 @@
+package resourceflow
+
+import "testing"
+
+func TestJoinAuthorityLaws(t *testing.T) {
+	values := []Authority{AuthorityLive, AuthorityConsumed, AuthorityMaybeConsumed}
+	for _, a := range values {
+		if got := JoinAuthority(a, a); got != a {
+			t.Fatalf("idempotence: join(%v, %v) = %v", a, a, got)
+		}
+		for _, b := range values {
+			if left, right := JoinAuthority(a, b), JoinAuthority(b, a); left != right {
+				t.Fatalf("commutativity: join(%v, %v)=%v, reverse=%v", a, b, left, right)
+			}
+			for _, c := range values {
+				left := JoinAuthority(JoinAuthority(a, b), c)
+				right := JoinAuthority(a, JoinAuthority(b, c))
+				if left != right {
+					t.Fatalf("associativity failed for %v, %v, %v: %v != %v", a, b, c, left, right)
+				}
+			}
+		}
+	}
+}
+
+func TestBranchCloneDoesNotMutateIncomingState(t *testing.T) {
+	incoming := New()
+	if !incoming.Register("socket", nil) {
+		t.Fatal("registration failed")
+	}
+	branch := incoming.Clone()
+	if !branch.Consume("socket", nil) {
+		t.Fatal("branch consume failed")
+	}
+	if !incoming.CanUse("socket") {
+		t.Fatal("mutating a branch must not mutate its predecessor")
+	}
+}
+
+func TestJoinLiveAndConsumedBecomesMaybeConsumed(t *testing.T) {
+	incoming := New()
+	incoming.Register("socket", nil)
+	live := incoming.Clone()
+	consumed := incoming.Clone()
+	consumed.Consume("socket", nil)
+
+	joined := Join(live, consumed)
+	got, ok := joined.AuthorityOf("socket")
+	if !ok || got != AuthorityMaybeConsumed {
+		t.Fatalf("expected maybe-consumed join, got %v, exists=%v", got, ok)
+	}
+	if joined.CanUse("socket") {
+		t.Fatal("conditional authority must not be usable after a join")
+	}
+	if joined.Consume("socket", nil) {
+		t.Fatal("conditional authority must not be consumable again")
+	}
+}
+
+func TestJoinConsumedOnAllPathsIsDefinitelyConsumed(t *testing.T) {
+	incoming := New()
+	incoming.Register("socket", nil)
+	left := incoming.Clone()
+	right := incoming.Clone()
+	left.Consume("socket", nil)
+	right.Consume("socket", nil)
+
+	joined := Join(left, right)
+	got, ok := joined.AuthorityOf("socket")
+	if !ok || got != AuthorityConsumed {
+		t.Fatalf("expected definitely consumed, got %v, exists=%v", got, ok)
+	}
+}
+
+func TestAliasClassSharesJoinedAuthority(t *testing.T) {
+	incoming := New()
+	incoming.Register("buffer", nil)
+	if !incoming.Alias("payload", "buffer", nil) {
+		t.Fatal("alias failed")
+	}
+	left := incoming.Clone()
+	right := incoming.Clone()
+	left.Consume("payload", nil)
+
+	joined := Join(left, right)
+	for _, name := range []string{"buffer", "payload"} {
+		got, ok := joined.AuthorityOf(name)
+		if !ok || got != AuthorityMaybeConsumed {
+			t.Fatalf("%s: expected maybe-consumed alias class, got %v, exists=%v", name, got, ok)
+		}
+	}
+}
+
+func TestBranchLocalNamesDoNotEscapeJoin(t *testing.T) {
+	incoming := New()
+	incoming.Register("root", nil)
+	left := incoming.Clone()
+	right := incoming.Clone()
+	left.Register("leftOnly", nil)
+
+	joined := Join(left, right)
+	if joined.Registered("leftOnly") {
+		t.Fatal("name introduced on one branch must not escape the join")
+	}
+	if !joined.CanUse("root") {
+		t.Fatal("common live authority should survive branch-local declarations")
+	}
+}

--- a/semir/ir.go
+++ b/semir/ir.go
@@ -130,9 +130,10 @@ type TagLayout struct {
 }
 
 // Authority describes what code holding a value may do with it. Ownership,
-// capabilities, and effects are semantic facts, not comments or tags.
+// resource liveness, capabilities, and effects are independent semantic facts.
 type Authority struct {
 	Ownership        Ownership
+	Resource         ResourceAuthority
 	Capabilities     []Capability
 	RequiredEffects  []Effect
 	ForbiddenEffects []Effect
@@ -148,6 +149,18 @@ const (
 	OwnershipUniqueWrite Ownership = "unique-write"
 	OwnershipMoved       Ownership = "moved"
 	OwnershipExternal    Ownership = "external"
+)
+
+// ResourceAuthority is the path-sensitive authority summary projected by
+// semantic resource-flow analysis. It is deliberately separate from Ownership:
+// a UniqueWrite borrow can end, while consumed resource authority never returns.
+type ResourceAuthority string
+
+const (
+	ResourceAuthorityUnspecified   ResourceAuthority = ""
+	ResourceAuthorityLive          ResourceAuthority = "live"
+	ResourceAuthorityConsumed      ResourceAuthority = "consumed"
+	ResourceAuthorityMaybeConsumed ResourceAuthority = "maybe-consumed"
 )
 
 type Capability struct {
@@ -224,73 +237,41 @@ const (
 	OpMod Operator = "mod"
 )
 
-func Ref(name string) Expr { return Expr{Kind: ExprRef, Ref: name} }
-func Int(value int64) Expr { return Expr{Kind: ExprInt, Int: value} }
-func Bool(value bool) Expr { return Expr{Kind: ExprBool, Bool: value} }
-func Apply(op Operator, args ...Expr) Expr {
-	return Expr{Kind: ExprApply, Op: op, Args: args}
-}
-
-// Protocol describes legal state evolution. Local typestate, temporal-model
-// projection, generated DST actions, and debugger state diagrams should all use
-// the same transition vocabulary.
+// Protocol describes legal state transitions independently of representation.
 type Protocol struct {
 	Name        string
-	States      []State
-	Initial     string
+	States      []string
 	Transitions []Transition
-	Invariants  []Proposition
-	Assumptions []TemporalProperty
-	Guarantees  []TemporalProperty
-}
-
-type State struct {
-	Name string
 }
 
 type Transition struct {
-	Name     string
-	From     string
-	To       string
-	Requires []Proposition
-	Effects  []Effect
+	Name          string
+	From          string
+	To            string
+	Requires      []Proposition
+	Effects       []Effect
+	ConsumesInput bool
+	ReturnsFresh  bool
 }
 
-type TemporalProperty struct {
-	Name    string
-	Formula TemporalExpr
+// Allocator captures the contract required by a pluggable allocator. Region
+// and lifetime facts are semantic constraints, not runtime allocation policy.
+type Allocator struct {
+	Name          string
+	Allocate      string
+	Deallocate    string
+	Region        string
+	Lifetime      string
+	ThreadSafe    bool
+	Required      []Effect
+	Forbidden     []Effect
+	Propositions  []Proposition
 }
 
-type TemporalExpr struct {
-	Kind TemporalKind
-	Atom string
-	Args []TemporalExpr
-}
-
-type TemporalKind string
-
-const (
-	TemporalInvalid    TemporalKind = ""
-	TemporalAtom       TemporalKind = "atom"
-	TemporalNot        TemporalKind = "not"
-	TemporalAnd        TemporalKind = "and"
-	TemporalOr         TemporalKind = "or"
-	TemporalAlways     TemporalKind = "always"
-	TemporalEventually TemporalKind = "eventually"
-	TemporalNext       TemporalKind = "next"
-	TemporalUntil      TemporalKind = "until"
-	TemporalImplies    TemporalKind = "implies"
-)
-
-func Atom(name string) TemporalExpr { return TemporalExpr{Kind: TemporalAtom, Atom: name} }
-func Temporal(kind TemporalKind, args ...TemporalExpr) TemporalExpr {
-	return TemporalExpr{Kind: kind, Args: args}
-}
-
-// Attribute is extensible metadata. Correctness-critical semantics belong in
-// the typed axes above rather than in this escape hatch.
+// Attribute is structured metadata that does not change value type or
+// representation unless a specific semantic rule says otherwise.
 type Attribute struct {
-	Namespace string
-	Name      string
-	Value     string
+	Namespace  string
+	Name       string
+	Parameters []string
 }

--- a/semir/ir.go
+++ b/semir/ir.go
@@ -130,7 +130,7 @@ type TagLayout struct {
 }
 
 // Authority describes what code holding a value may do with it. Ownership,
-// resource liveness, capabilities, and effects are independent semantic facts.
+// resource liveness, capabilities, and effects are semantic facts, not comments.
 type Authority struct {
 	Ownership        Ownership
 	Resource         ResourceAuthority
@@ -151,9 +151,9 @@ const (
 	OwnershipExternal    Ownership = "external"
 )
 
-// ResourceAuthority is the path-sensitive authority summary projected by
-// semantic resource-flow analysis. It is deliberately separate from Ownership:
-// a UniqueWrite borrow can end, while consumed resource authority never returns.
+// ResourceAuthority is the path-sensitive resource-flow summary. It is
+// orthogonal to Ownership: temporary UniqueWrite may be released, while
+// consumed resource authority never returns to the old value.
 type ResourceAuthority string
 
 const (
@@ -237,41 +237,73 @@ const (
 	OpMod Operator = "mod"
 )
 
-// Protocol describes legal state transitions independently of representation.
+func Ref(name string) Expr { return Expr{Kind: ExprRef, Ref: name} }
+func Int(value int64) Expr { return Expr{Kind: ExprInt, Int: value} }
+func Bool(value bool) Expr { return Expr{Kind: ExprBool, Bool: value} }
+func Apply(op Operator, args ...Expr) Expr {
+	return Expr{Kind: ExprApply, Op: op, Args: args}
+}
+
+// Protocol describes legal state evolution. Local typestate, temporal-model
+// projection, generated DST actions, and debugger state diagrams should all use
+// the same transition vocabulary.
 type Protocol struct {
 	Name        string
-	States      []string
+	States      []State
+	Initial     string
 	Transitions []Transition
+	Invariants  []Proposition
+	Assumptions []TemporalProperty
+	Guarantees  []TemporalProperty
+}
+
+type State struct {
+	Name string
 }
 
 type Transition struct {
-	Name          string
-	From          string
-	To            string
-	Requires      []Proposition
-	Effects       []Effect
-	ConsumesInput bool
-	ReturnsFresh  bool
+	Name     string
+	From     string
+	To       string
+	Requires []Proposition
+	Effects  []Effect
 }
 
-// Allocator captures the contract required by a pluggable allocator. Region
-// and lifetime facts are semantic constraints, not runtime allocation policy.
-type Allocator struct {
-	Name          string
-	Allocate      string
-	Deallocate    string
-	Region        string
-	Lifetime      string
-	ThreadSafe    bool
-	Required      []Effect
-	Forbidden     []Effect
-	Propositions  []Proposition
+type TemporalProperty struct {
+	Name    string
+	Formula TemporalExpr
 }
 
-// Attribute is structured metadata that does not change value type or
-// representation unless a specific semantic rule says otherwise.
+type TemporalExpr struct {
+	Kind TemporalKind
+	Atom string
+	Args []TemporalExpr
+}
+
+type TemporalKind string
+
+const (
+	TemporalInvalid    TemporalKind = ""
+	TemporalAtom       TemporalKind = "atom"
+	TemporalNot        TemporalKind = "not"
+	TemporalAnd        TemporalKind = "and"
+	TemporalOr         TemporalKind = "or"
+	TemporalAlways     TemporalKind = "always"
+	TemporalEventually TemporalKind = "eventually"
+	TemporalNext       TemporalKind = "next"
+	TemporalUntil      TemporalKind = "until"
+	TemporalImplies    TemporalKind = "implies"
+)
+
+func Atom(name string) TemporalExpr { return TemporalExpr{Kind: TemporalAtom, Atom: name} }
+func Temporal(kind TemporalKind, args ...TemporalExpr) TemporalExpr {
+	return TemporalExpr{Kind: kind, Args: args}
+}
+
+// Attribute is extensible metadata. Correctness-critical semantics belong in
+// the typed axes above rather than in this escape hatch.
 type Attribute struct {
-	Namespace  string
-	Name       string
-	Parameters []string
+	Namespace string
+	Name      string
+	Value     string
 }

--- a/spec/lean/Oak/ResourceFlow.lean
+++ b/spec/lean/Oak/ResourceFlow.lean
@@ -146,4 +146,63 @@ theorem consumed_authority_cannot_be_consumed (borrow : Oak.Borrowing.State) :
     ¬ CanConsume borrow .consumed := by
   simp [CanConsume]
 
+/-- A control-flow summary represents all reachable incoming paths. `maybeConsumed`
+is the conservative join of a path where authority is live and one where it has
+been consumed. It carries no usable authority. -/
+inductive Summary where
+  | live
+  | consumed
+  | maybeConsumed
+  deriving DecidableEq, Repr
+
+/-- Path join is set union over the concrete states {live} and {consumed}.
+`maybeConsumed` therefore absorbs either concrete state. -/
+def joinSummary : Summary → Summary → Summary
+  | .live, .live => .live
+  | .consumed, .consumed => .consumed
+  | _, _ => .maybeConsumed
+
+/-- Only authority proven live on every incoming path is usable after a join. -/
+def SummaryUsable : Summary → Prop
+  | .live => True
+  | .consumed => False
+  | .maybeConsumed => False
+
+/-- The summary reached by one straight-line concrete state. -/
+def summarize : Authority → Summary
+  | .live => .live
+  | .consumed => .consumed
+
+theorem joinSummary_idem (a : Summary) : joinSummary a a = a := by
+  cases a <;> rfl
+
+theorem joinSummary_comm (a b : Summary) :
+    joinSummary a b = joinSummary b a := by
+  cases a <;> cases b <;> rfl
+
+theorem joinSummary_assoc (a b c : Summary) :
+    joinSummary (joinSummary a b) c = joinSummary a (joinSummary b c) := by
+  cases a <;> cases b <;> cases c <;> rfl
+
+/-- The canonical conditional-consume case is unavailable after the join. -/
+theorem live_join_consumed_is_maybe :
+    joinSummary .live .consumed = .maybeConsumed := by
+  rfl
+
+theorem live_join_consumed_not_usable :
+    ¬ SummaryUsable (joinSummary .live .consumed) := by
+  simp [SummaryUsable, joinSummary]
+
+/-- A join is usable exactly when both incoming summaries are definitely live.
+This is the fail-closed rule implemented by the executable checker. -/
+theorem join_usable_iff (a b : Summary) :
+    SummaryUsable (joinSummary a b) ↔
+      SummaryUsable a ∧ SummaryUsable b := by
+  cases a <;> cases b <;> simp [SummaryUsable, joinSummary]
+
+/-- Joining a state with itself loses no authority information. -/
+theorem summarize_join_self (a : Authority) :
+    joinSummary (summarize a) (summarize a) = summarize a := by
+  cases a <;> rfl
+
 end Oak.ResourceFlow

--- a/typechecker/resource_diagnostics.go
+++ b/typechecker/resource_diagnostics.go
@@ -1,0 +1,20 @@
+package typechecker
+
+import (
+	"github.com/SCKelemen/oak/ast"
+	"github.com/SCKelemen/oak/diagnostic"
+	"github.com/SCKelemen/oak/lsp"
+)
+
+// addResourceDiagnostic keeps OAK-B0111 in the borrow/resource diagnostic
+// category even though typed resource analysis is hosted by typechecker.
+func (tc *TypeChecker) addResourceDiagnostic(node ast.Node, title string) *diagnostic.Diagnostic {
+	var d *diagnostic.Diagnostic
+	if node != nil {
+		d = diagnostic.NewDiagnosticFromNodeWithCode(node, "borrow", CodeResourceUsedAfterConsume, title)
+	} else {
+		d = diagnostic.NewDiagnosticWithCode(lsp.Range{}, "borrow", CodeResourceUsedAfterConsume, title)
+	}
+	tc.diagnostics.AddDiagnostic(d)
+	return d
+}

--- a/typechecker/resource_flow.go
+++ b/typechecker/resource_flow.go
@@ -18,7 +18,7 @@ const CodeResourceUsedAfterConsume = "OAK-B0111"
 // no source syntax: frontends/protocol lowering can mark which arguments lose
 // old authority, and whether the result denotes fresh authority.
 type ResourceOperation struct {
-	Consumes    []int
+	Consumes     []int
 	ReturnsFresh bool
 }
 
@@ -374,7 +374,7 @@ func (a *typedResourceAnalysis) use(name string, node ast.Node) {
 	if authority == resourceflow.AuthorityMaybeConsumed {
 		title = fmt.Sprintf("resource %q cannot be used because its authority may have been consumed", name)
 	}
-	d := a.tc.addTypeDiagnostic(node, CodeResourceUsedAfterConsume, title)
+	d := a.tc.addResourceDiagnostic(node, title)
 	consumptions := a.flow.Consumptions(name)
 	for _, consumed := range consumptions {
 		if consumed.Site != nil {

--- a/typechecker/resource_flow.go
+++ b/typechecker/resource_flow.go
@@ -1,0 +1,397 @@
+package typechecker
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/SCKelemen/oak/ast"
+	"github.com/SCKelemen/oak/diagnostic"
+	"github.com/SCKelemen/oak/resourceflow"
+)
+
+// CodeResourceUsedAfterConsume is shared semantically with the borrow checker.
+// It lives here too because typechecker must not import borrowchecker (the
+// borrow checker already depends on typechecker).
+const CodeResourceUsedAfterConsume = "OAK-B0111"
+
+// ResourceOperation is internal semantic metadata for a callable. It freezes
+// no source syntax: frontends/protocol lowering can mark which arguments lose
+// old authority, and whether the result denotes fresh authority.
+type ResourceOperation struct {
+	Consumes    []int
+	ReturnsFresh bool
+}
+
+// ResourceModel is the syntax-independent bridge from resolved types/callables
+// to resource-flow analysis. ResourceTypes contains nominal source type names;
+// Operations contains semantic consuming operations by resolved callable name.
+type ResourceModel struct {
+	ResourceTypes map[string]bool
+	Operations    map[string]ResourceOperation
+}
+
+func NewResourceModel() ResourceModel {
+	return ResourceModel{
+		ResourceTypes: make(map[string]bool),
+		Operations:    make(map[string]ResourceOperation),
+	}
+}
+
+func (m *ResourceModel) MarkResourceType(name string) {
+	if m.ResourceTypes == nil {
+		m.ResourceTypes = make(map[string]bool)
+	}
+	m.ResourceTypes[name] = true
+}
+
+func (m *ResourceModel) MarkOperation(name string, operation ResourceOperation) {
+	if m.Operations == nil {
+		m.Operations = make(map[string]ResourceOperation)
+	}
+	copyOperation := operation
+	copyOperation.Consumes = append([]int(nil), operation.Consumes...)
+	m.Operations[name] = copyOperation
+}
+
+// CheckProgramWithResources is the integrated typed-program entrypoint for the
+// internal resource protocol model. Existing CheckProgram remains unchanged
+// until Oak freezes how source declarations opt into resource semantics.
+func (tc *TypeChecker) CheckProgramWithResources(program *ast.Program, model ResourceModel) {
+	tc.CheckProgram(program)
+	tc.CheckResourceFlow(program, model)
+}
+
+// CheckResourceFlow runs path-sensitive authority analysis over an already
+// typed AST. Each function has independent authority; no resource state leaks
+// between function bodies.
+func (tc *TypeChecker) CheckResourceFlow(program *ast.Program, model ResourceModel) {
+	if tc == nil || program == nil {
+		return
+	}
+	for _, statement := range program.Statements {
+		fn, ok := statement.(*ast.FunctionStatement)
+		if !ok || fn == nil || fn.ExternSymbol != "" {
+			continue
+		}
+		analysis := &typedResourceAnalysis{
+			tc:       tc,
+			model:    model,
+			flow:     resourceflow.New(),
+			reported: make(map[string]bool),
+		}
+		if fn.Receiver != nil && fn.Receiver.Name != nil && model.isResourceType(fn.Receiver.Type) {
+			analysis.flow.Register(fn.Receiver.Name.Value, fn.Receiver.Name)
+		}
+		for _, parameter := range fn.Parameters {
+			if parameter != nil && parameter.Name != nil && model.isResourceType(parameter.Type) {
+				analysis.flow.Register(parameter.Name.Value, parameter.Name)
+			}
+		}
+		analysis.expression(fn.Body)
+	}
+}
+
+type typedResourceAnalysis struct {
+	tc       *TypeChecker
+	model    ResourceModel
+	flow     *resourceflow.Flow
+	reported map[string]bool
+}
+
+func (m ResourceModel) isResourceType(expr ast.Expression) bool {
+	if expr == nil {
+		return false
+	}
+	switch t := expr.(type) {
+	case *ast.Identifier:
+		return m.ResourceTypes[t.Value]
+	case *ast.IndexExpression:
+		// Generic nominal applications retain the nominal base in Left.
+		if ident, ok := t.Left.(*ast.Identifier); ok {
+			return m.ResourceTypes[ident.Value]
+		}
+	}
+	return m.ResourceTypes[expr.String()]
+}
+
+func (m ResourceModel) operation(expr ast.Expression) (ResourceOperation, bool) {
+	ident, ok := expr.(*ast.Identifier)
+	if !ok || ident == nil {
+		return ResourceOperation{}, false
+	}
+	op, exists := m.Operations[ident.Value]
+	return op, exists
+}
+
+func (a *typedResourceAnalysis) statement(stmt ast.Statement) {
+	if stmt == nil {
+		return
+	}
+	switch s := stmt.(type) {
+	case *ast.VariableDeclaration:
+		a.variable(s)
+	case *ast.AssignmentStatement:
+		a.expression(s.Value)
+	case *ast.IndexAssignmentStatement:
+		if s.Target != nil {
+			a.expression(s.Target.Left)
+			if !s.Target.Dot {
+				a.expression(s.Target.Index)
+			}
+		}
+		a.expression(s.Value)
+	case *ast.ExpressionStatement:
+		a.expression(s.Expression)
+	case *ast.BlockStatement:
+		a.block(s)
+	case *ast.IfStatement:
+		a.ifStatement(s)
+	case *ast.WhileStatement:
+		a.whileStatement(s)
+	}
+}
+
+func (a *typedResourceAnalysis) block(block *ast.BlockStatement) {
+	if block == nil {
+		return
+	}
+	for _, stmt := range block.Statements {
+		a.statement(stmt)
+	}
+}
+
+func (a *typedResourceAnalysis) variable(stmt *ast.VariableDeclaration) {
+	if stmt == nil || stmt.Name == nil {
+		return
+	}
+	if stmt.Value != nil {
+		a.expression(stmt.Value)
+	}
+	isResource := a.model.isResourceType(stmt.Type)
+	if !isResource {
+		if call, ok := stmt.Value.(*ast.InvocationExpression); ok {
+			if op, exists := a.model.operation(call.Function); exists && op.ReturnsFresh {
+				isResource = true
+			}
+		}
+	}
+	if !isResource {
+		return
+	}
+	if source, ok := stmt.Value.(*ast.Identifier); ok && a.flow.Registered(source.Value) {
+		if a.flow.CanUse(source.Value) {
+			a.flow.Alias(stmt.Name.Value, source.Value, stmt.Name)
+		}
+		return
+	}
+	// A resource-returning transition/constructor creates a new authority
+	// class. This is never revival of the consumed input binding.
+	a.flow.Register(stmt.Name.Value, stmt.Name)
+}
+
+func (a *typedResourceAnalysis) ifStatement(stmt *ast.IfStatement) {
+	if stmt == nil {
+		return
+	}
+	a.expression(stmt.Condition)
+	incoming := a.flow.Clone()
+
+	a.flow = incoming.Clone()
+	a.block(stmt.Consequence)
+	consequence := a.flow.Clone()
+
+	a.flow = incoming.Clone()
+	switch alternative := stmt.Alternative.(type) {
+	case nil:
+	case *ast.IfStatement:
+		a.ifStatement(alternative)
+	case *ast.BlockStatement:
+		a.block(alternative)
+	}
+	alternative := a.flow.Clone()
+	a.flow = resourceflow.Join(consequence, alternative)
+}
+
+func (a *typedResourceAnalysis) whileStatement(stmt *ast.WhileStatement) {
+	if stmt == nil {
+		return
+	}
+	// A loop may execute zero times, so its incoming state participates in
+	// the loop-head fixed point. The lattice has height three; probing a
+	// second iteration is enough to expose re-use/double-consume from a
+	// first-iteration consumption and reaches the conservative fixed point.
+	incoming := a.flow.Clone()
+
+	a.flow = incoming.Clone()
+	a.expression(stmt.Condition)
+	a.block(stmt.Body)
+	oneIteration := a.flow.Clone()
+
+	invariant := resourceflow.Join(incoming, oneIteration)
+	a.flow = invariant.Clone()
+	a.expression(stmt.Condition)
+	a.block(stmt.Body)
+	twoIterations := a.flow.Clone()
+
+	a.flow = resourceflow.Join(incoming, oneIteration, twoIterations)
+}
+
+func (a *typedResourceAnalysis) expression(expr ast.Expression) {
+	if expr == nil {
+		return
+	}
+	switch e := expr.(type) {
+	case *ast.Identifier:
+		a.use(e.Value, e)
+	case *ast.PrefixExpression:
+		a.expression(e.Right)
+	case *ast.InfixExpression:
+		a.expression(e.Left)
+		if e.Operator == "&&" || e.Operator == "||" {
+			incoming := a.flow.Clone()
+			a.flow = incoming.Clone()
+			a.expression(e.Right)
+			rightEvaluated := a.flow.Clone()
+			a.flow = resourceflow.Join(incoming, rightEvaluated)
+			return
+		}
+		a.expression(e.Right)
+	case *ast.InvocationExpression:
+		a.invocation(e)
+	case *ast.IndexExpression:
+		a.expression(e.Left)
+		if !e.Dot {
+			a.expression(e.Index)
+		}
+	case *ast.SliceExpression:
+		a.expression(e.Seq)
+		a.expression(e.Low)
+		a.expression(e.High)
+	case *ast.BlockExpression:
+		a.block(e.Block)
+	case *ast.RecordLiteral:
+		if len(e.FieldOrder) > 0 {
+			for _, field := range e.FieldOrder {
+				a.expression(field.Value)
+			}
+		} else {
+			names := make([]string, 0, len(e.Fields))
+			for name := range e.Fields {
+				names = append(names, name)
+			}
+			sort.Strings(names)
+			for _, name := range names {
+				a.expression(e.Fields[name])
+			}
+		}
+	case *ast.ArrayLiteral:
+		for _, element := range e.Elements {
+			a.expression(element)
+		}
+	case *ast.MatchExpression:
+		a.match(e)
+	case *ast.VariantExpression:
+		a.expression(e.Payload)
+	case *ast.FunctionLiteral:
+		// Capturing resource closures are rejected by the existing closure
+		// discipline. Analyze the body independently so local resource uses
+		// are still checked without lending outer authority to the closure.
+		outer := a.flow
+		a.flow = resourceflow.New()
+		a.block(e.Body)
+		a.flow = outer
+	}
+}
+
+func (a *typedResourceAnalysis) invocation(expr *ast.InvocationExpression) {
+	if expr == nil {
+		return
+	}
+	// The callee identifier is not a resource value. Non-identifier callees
+	// may themselves evaluate expressions, so preserve their effects.
+	if _, simple := expr.Function.(*ast.Identifier); !simple {
+		a.expression(expr.Function)
+	}
+	for _, argument := range expr.Arguments {
+		a.expression(argument)
+	}
+
+	op, consuming := a.model.operation(expr.Function)
+	if !consuming {
+		return
+	}
+	for _, index := range op.Consumes {
+		if index < 0 || index >= len(expr.Arguments) {
+			continue
+		}
+		ident, ok := expr.Arguments[index].(*ast.Identifier)
+		if !ok || ident == nil || !a.flow.Registered(ident.Value) {
+			continue
+		}
+		// Argument evaluation already performed the ordinary Use check. If it
+		// failed, do not emit a second diagnostic for the consuming action.
+		if a.flow.CanUse(ident.Value) {
+			a.flow.Consume(ident.Value, expr)
+		}
+	}
+}
+
+func (a *typedResourceAnalysis) match(expr *ast.MatchExpression) {
+	if expr == nil {
+		return
+	}
+	a.expression(expr.Scrutinee)
+	incoming := a.flow.Clone()
+	branches := make([]*resourceflow.Flow, 0, len(expr.Arms))
+	for _, arm := range expr.Arms {
+		if arm == nil {
+			continue
+		}
+		a.flow = incoming.Clone()
+		a.expression(arm.Body)
+		branches = append(branches, a.flow.Clone())
+	}
+	if len(branches) == 0 {
+		a.flow = incoming
+		return
+	}
+	a.flow = resourceflow.Join(branches...)
+}
+
+func (a *typedResourceAnalysis) use(name string, node ast.Node) {
+	if a == nil || a.flow == nil || name == "" || !a.flow.Registered(name) || a.flow.CanUse(name) {
+		return
+	}
+	range_ := diagnostic.NodeToRange(node)
+	key := fmt.Sprintf("%s@%d:%d", name, range_.Start.Line, range_.Start.Character)
+	if a.reported[key] {
+		return
+	}
+	a.reported[key] = true
+
+	authority, _ := a.flow.AuthorityOf(name)
+	title := fmt.Sprintf("resource %q cannot be used after its authority was consumed", name)
+	if authority == resourceflow.AuthorityMaybeConsumed {
+		title = fmt.Sprintf("resource %q cannot be used because its authority may have been consumed", name)
+	}
+	d := a.tc.addTypeDiagnostic(node, CodeResourceUsedAfterConsume, title)
+	consumptions := a.flow.Consumptions(name)
+	for _, consumed := range consumptions {
+		if consumed.Site != nil {
+			d.AddSecondary(diagnostic.NodeToRange(consumed.Site),
+				fmt.Sprintf("resource authority was consumed on an incoming path through %q", consumed.Name))
+		}
+		for _, edge := range a.flow.AliasPath(consumed.Name, name) {
+			message := fmt.Sprintf("resource alias %q derives authority from %q", edge.Child, edge.Parent)
+			if edge.Origin != nil {
+				d.AddSecondary(diagnostic.NodeToRange(edge.Origin), message)
+			} else {
+				d.AddNote(message)
+			}
+		}
+	}
+	if authority == resourceflow.AuthorityMaybeConsumed {
+		d.AddNote("authority is unavailable after this control-flow join because at least one reachable path consumed it")
+	}
+	d.AddHelp("use the fresh resource value returned by the consuming operation, if the protocol returns one")
+}

--- a/typechecker/resource_flow_test.go
+++ b/typechecker/resource_flow_test.go
@@ -1,0 +1,152 @@
+package typechecker
+
+import (
+	"strings"
+	"testing"
+)
+
+func resourceTestModel() ResourceModel {
+	model := NewResourceModel()
+	model.MarkResourceType("Handle")
+	model.MarkOperation("close", ResourceOperation{Consumes: []int{0}})
+	model.MarkOperation("renew", ResourceOperation{Consumes: []int{0}, ReturnsFresh: true})
+	return model
+}
+
+func resourceDiagnostics(tc *TypeChecker) []string {
+	out := []string{}
+	for _, d := range tc.Diagnostics() {
+		if d.Code == CodeResourceUsedAfterConsume {
+			out = append(out, d.PlainText())
+		}
+	}
+	return out
+}
+
+func TestTypedResourceDirectUseAfterConsumingCall(t *testing.T) {
+	input := `
+Handle: type = struct { id: u32 }
+close: (h: Handle): () = {}
+f: (h: Handle): u32 {
+  close(h)
+  h.id
+}`
+	tc := setupTypeChecker(input)
+	program := parseProgram(input)
+	tc.CheckProgramWithResources(program, resourceTestModel())
+
+	got := resourceDiagnostics(tc)
+	if len(got) != 1 {
+		t.Fatalf("expected one OAK-B0111 diagnostic, got %v (all errors: %v)", got, tc.Errors())
+	}
+	if !strings.Contains(got[0], "cannot be used after") {
+		t.Fatalf("expected direct consumed-authority explanation, got %q", got[0])
+	}
+}
+
+func TestTypedResourceConditionalConsumeJoinsToMaybeConsumed(t *testing.T) {
+	input := `
+Handle: type = struct { id: u32 }
+close: (h: Handle): () = {}
+f: (h: Handle, take: Bool): u32 {
+  take ? {
+    close(h)
+  } | {}
+  h.id
+}`
+	tc := setupTypeChecker(input)
+	program := parseProgram(input)
+	tc.CheckProgramWithResources(program, resourceTestModel())
+
+	got := resourceDiagnostics(tc)
+	if len(got) != 1 {
+		t.Fatalf("expected one joined OAK-B0111 diagnostic, got %v (all errors: %v)", got, tc.Errors())
+	}
+	if !strings.Contains(got[0], "may have been consumed") || !strings.Contains(got[0], "control-flow join") {
+		t.Fatalf("expected maybe-consumed join explanation, got %q", got[0])
+	}
+}
+
+func TestTypedResourceBothBranchesConsumeIsDefinitelyConsumed(t *testing.T) {
+	input := `
+Handle: type = struct { id: u32 }
+close: (h: Handle): () = {}
+f: (h: Handle, take: Bool): u32 {
+  take ? {
+    close(h)
+  } | {
+    close(h)
+  }
+  h.id
+}`
+	tc := setupTypeChecker(input)
+	program := parseProgram(input)
+	tc.CheckProgramWithResources(program, resourceTestModel())
+
+	got := resourceDiagnostics(tc)
+	if len(got) != 1 {
+		t.Fatalf("expected one OAK-B0111 diagnostic, got %v (all errors: %v)", got, tc.Errors())
+	}
+	if strings.Contains(got[0], "may have been consumed") {
+		t.Fatalf("both consuming paths should join to definitely consumed, got %q", got[0])
+	}
+}
+
+func TestTypedResourceAliasClassInvalidatesTogether(t *testing.T) {
+	input := `
+Handle: type = struct { id: u32 }
+close: (h: Handle): () = {}
+f: (h: Handle): u32 {
+  alias: Handle = h
+  close(alias)
+  h.id
+}`
+	tc := setupTypeChecker(input)
+	program := parseProgram(input)
+	tc.CheckProgramWithResources(program, resourceTestModel())
+
+	got := resourceDiagnostics(tc)
+	if len(got) != 1 {
+		t.Fatalf("expected alias-class OAK-B0111, got %v (all errors: %v)", got, tc.Errors())
+	}
+	if !strings.Contains(got[0], `alias "alias" derives authority from "h"`) {
+		t.Fatalf("expected programmer-visible alias provenance, got %q", got[0])
+	}
+}
+
+func TestTypedResourceFreshReturnDoesNotReviveOldBinding(t *testing.T) {
+	input := `
+Handle: type = struct { id: u32 }
+renew: (h: Handle): Handle = h
+f: (h: Handle): u32 {
+  next: Handle = renew(h)
+  next.id
+}`
+	tc := setupTypeChecker(input)
+	program := parseProgram(input)
+	tc.CheckProgramWithResources(program, resourceTestModel())
+
+	if got := resourceDiagnostics(tc); len(got) != 0 {
+		t.Fatalf("fresh returned resource should be usable: %v", got)
+	}
+}
+
+func TestTypedResourceShortCircuitConsumeIsConditional(t *testing.T) {
+	input := `
+Handle: type = struct { id: u32 }
+close_bool: (h: Handle): Bool = true
+f: (h: Handle, gate: Bool): u32 {
+  gate && close_bool(h)
+  h.id
+}`
+	model := resourceTestModel()
+	model.MarkOperation("close_bool", ResourceOperation{Consumes: []int{0}})
+	tc := setupTypeChecker(input)
+	program := parseProgram(input)
+	tc.CheckProgramWithResources(program, model)
+
+	got := resourceDiagnostics(tc)
+	if len(got) != 1 || !strings.Contains(got[0], "may have been consumed") {
+		t.Fatalf("short-circuit RHS should join live and consumed paths, got %v (all errors: %v)", got, tc.Errors())
+	}
+}


### PR DESCRIPTION
Extends the proof-backed resource authority model with path-sensitive live/consumed/maybe-consumed joins, extracts a checker-neutral `resourceflow` core, preserves borrow/resource `OAK-B0111` diagnostics, exposes resource authority in SemIR, and adds an internal typed-AST resource protocol analysis without freezing consume syntax.

Highlights:
- Lean proves join idempotence, commutativity, associativity, the live+consumed => maybe-consumed case, and `join_usable_iff` (joined authority is usable exactly when both incoming authorities are usable).
- `resourceflow.Flow` owns alias classes, consumption provenance, snapshots, and joins; borrowchecker adds temporary-borrow conflict policy on top.
- SemIR gains an orthogonal `ResourceAuthority` axis (`live`, `consumed`, `maybe-consumed`) distinct from temporary ownership/borrowing.
- Typechecker has an opt-in `ResourceModel` / `ResourceOperation` bridge for real typed Oak programs. It handles branches, match arms, short-circuit RHS paths, alias classes, fresh-return transitions, and a conservative loop fixed point.
- Typed-program tests exercise direct use-after-consume, conditional joins, all-path consumption, alias invalidation, fresh return authority, and short-circuit consumption.

Surface resource declarations and consume spelling remain deliberately unfrozen. The current `specification` base's unrelated codegen/verification updates are included by GitHub's synthetic merge validation.