### PR TITLE
Derive resource flow from SemIR protocols

### DIFF
--- a/semir/ir.go
+++ b/semir/ir.go
@@ -262,7 +262,11 @@ type State struct {
 }
 
 type Transition struct {
-	Name     string
+	Name string
+	// Callable is the resolved semantic callable implementing this transition.
+	// It is deliberately distinct from Name: transition labels are protocol-local,
+	// while callable identities are what executable semantic analyses consume.
+	Callable string
 	From     string
 	To       string
 	Requires []Proposition

--- a/semir/resource_effects.go
+++ b/semir/resource_effects.go
@@ -10,8 +10,8 @@ import (
 const (
 	// ResourceEffectNamespace owns semantic effects that change resource
 	// authority. These are SemIR facts, not source syntax.
-	ResourceEffectNamespace = "resource"
-	ResourceEffectConsume   = "consume"
+	ResourceEffectNamespace   = "resource"
+	ResourceEffectConsume     = "consume"
 	ResourceEffectReturnFresh = "return-fresh"
 )
 

--- a/semir/resource_effects.go
+++ b/semir/resource_effects.go
@@ -1,0 +1,115 @@
+package semir
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const (
+	// ResourceEffectNamespace owns semantic effects that change resource
+	// authority. These are SemIR facts, not source syntax.
+	ResourceEffectNamespace = "resource"
+	ResourceEffectConsume   = "consume"
+	ResourceEffectReturnFresh = "return-fresh"
+)
+
+// ResourceTransitionSemantics is the resource-authority projection of one
+// protocol transition. Consumes contains zero-based callable argument indices;
+// ReturnsFresh means the transition's result carries new live authority rather
+// than reviving any consumed input value.
+type ResourceTransitionSemantics struct {
+	Consumes     []int
+	ReturnsFresh bool
+}
+
+// ResourceConsumeArgument constructs the canonical semantic effect for a
+// consuming parameter. Negative indices are retained so validation can reject
+// malformed generated SemIR instead of silently rewriting it.
+func ResourceConsumeArgument(index int) Effect {
+	return Effect{
+		Namespace:  ResourceEffectNamespace,
+		Name:       ResourceEffectConsume,
+		Parameters: []string{"arg:" + strconv.Itoa(index)},
+	}
+}
+
+// ResourceReturnFresh constructs the canonical semantic effect for a
+// transition that returns a new resource authority class.
+func ResourceReturnFresh() Effect {
+	return Effect{Namespace: ResourceEffectNamespace, Name: ResourceEffectReturnFresh}
+}
+
+// ResourceSemantics decodes structured resource effects from a transition.
+// Effects outside the resource namespace are ignored. Unknown/malformed
+// resource effects are rejected so typos cannot silently weaken consumption.
+func (t Transition) ResourceSemantics() (ResourceTransitionSemantics, bool, error) {
+	result := ResourceTransitionSemantics{}
+	seenConsume := make(map[int]bool)
+	seenFresh := false
+	present := false
+
+	for _, effect := range t.Effects {
+		if effect.Namespace != ResourceEffectNamespace {
+			continue
+		}
+		present = true
+		switch effect.Name {
+		case ResourceEffectConsume:
+			if len(effect.Parameters) != 1 {
+				return ResourceTransitionSemantics{}, true,
+					fmt.Errorf("resource.consume expects exactly one arg:<index> parameter")
+			}
+			parameter := effect.Parameters[0]
+			if !strings.HasPrefix(parameter, "arg:") {
+				return ResourceTransitionSemantics{}, true,
+					fmt.Errorf("resource.consume parameter %q must be arg:<index>", parameter)
+			}
+			index, err := strconv.Atoi(strings.TrimPrefix(parameter, "arg:"))
+			if err != nil || index < 0 {
+				return ResourceTransitionSemantics{}, true,
+					fmt.Errorf("resource.consume parameter %q has invalid argument index", parameter)
+			}
+			if seenConsume[index] {
+				return ResourceTransitionSemantics{}, true,
+					fmt.Errorf("resource.consume duplicates argument %d", index)
+			}
+			seenConsume[index] = true
+			result.Consumes = append(result.Consumes, index)
+
+		case ResourceEffectReturnFresh:
+			if len(effect.Parameters) != 0 {
+				return ResourceTransitionSemantics{}, true,
+					fmt.Errorf("resource.return-fresh does not accept parameters")
+			}
+			if seenFresh {
+				return ResourceTransitionSemantics{}, true,
+					fmt.Errorf("resource.return-fresh is duplicated")
+			}
+			seenFresh = true
+			result.ReturnsFresh = true
+
+		default:
+			return ResourceTransitionSemantics{}, true,
+				fmt.Errorf("unknown resource effect %q", effect.Name)
+		}
+	}
+
+	sort.Ints(result.Consumes)
+	return result, present, nil
+}
+
+// ValidateResourceSemantics validates every resource-specific transition fact
+// in the module. Module.Validate owns the generic SemIR schema; this method is
+// the resource protocol refinement consumed by resource-aware frontends.
+func (m Module) ValidateResourceSemantics() error {
+	for _, protocol := range m.Protocols {
+		for _, transition := range protocol.Transitions {
+			if _, _, err := transition.ResourceSemantics(); err != nil {
+				return fmt.Errorf("protocol %q transition %q: %w", protocol.Name, transition.Name, err)
+			}
+		}
+	}
+	return nil
+}

--- a/semir/resource_effects.go
+++ b/semir/resource_effects.go
@@ -101,13 +101,22 @@ func (t Transition) ResourceSemantics() (ResourceTransitionSemantics, bool, erro
 }
 
 // ValidateResourceSemantics validates every resource-specific transition fact
-// in the module. Module.Validate owns the generic SemIR schema; this method is
-// the resource protocol refinement consumed by resource-aware frontends.
+// in the module. Resource effects require an explicit resolved Callable so a
+// protocol-local transition label cannot accidentally affect an unrelated
+// source callable with the same spelling.
 func (m Module) ValidateResourceSemantics() error {
 	for _, protocol := range m.Protocols {
 		for _, transition := range protocol.Transitions {
-			if _, _, err := transition.ResourceSemantics(); err != nil {
+			_, present, err := transition.ResourceSemantics()
+			if err != nil {
 				return fmt.Errorf("protocol %q transition %q: %w", protocol.Name, transition.Name, err)
+			}
+			if present && transition.Callable == "" {
+				return fmt.Errorf(
+					"protocol %q transition %q has resource effects but no resolved callable",
+					protocol.Name,
+					transition.Name,
+				)
 			}
 		}
 	}

--- a/semir/resource_effects_test.go
+++ b/semir/resource_effects_test.go
@@ -58,6 +58,27 @@ func TestResourceTransitionSemanticsRejectsMalformedConsume(t *testing.T) {
 	}
 }
 
+func TestValidateResourceSemanticsRequiresResolvedCallable(t *testing.T) {
+	module := Module{
+		Protocols: []Protocol{{
+			Name:    "HandleLifecycle",
+			Initial: "Open",
+			States:  []State{{Name: "Open"}, {Name: "Closed"}},
+			Transitions: []Transition{{
+				Name:    "CloseTransition",
+				From:    "Open",
+				To:      "Closed",
+				Effects: []Effect{ResourceConsumeArgument(0)},
+			}},
+		}},
+	}
+
+	err := module.ValidateResourceSemantics()
+	if err == nil || !strings.Contains(err.Error(), "no resolved callable") {
+		t.Fatalf("expected resource transition callable requirement, got %v", err)
+	}
+}
+
 func TestValidateResourceSemanticsQualifiesProtocolAndTransition(t *testing.T) {
 	module := Module{
 		Protocols: []Protocol{{
@@ -65,9 +86,10 @@ func TestValidateResourceSemanticsQualifiesProtocolAndTransition(t *testing.T) {
 			Initial: "Open",
 			States:  []State{{Name: "Open"}, {Name: "Closed"}},
 			Transitions: []Transition{{
-				Name: "close",
-				From: "Open",
-				To:   "Closed",
+				Name:     "CloseTransition",
+				Callable: "close",
+				From:     "Open",
+				To:       "Closed",
 				Effects: []Effect{{
 					Namespace: ResourceEffectNamespace,
 					Name:      "typo",
@@ -77,7 +99,7 @@ func TestValidateResourceSemanticsQualifiesProtocolAndTransition(t *testing.T) {
 	}
 
 	err := module.ValidateResourceSemantics()
-	if err == nil || !strings.Contains(err.Error(), `protocol "HandleLifecycle" transition "close"`) {
+	if err == nil || !strings.Contains(err.Error(), `protocol "HandleLifecycle" transition "CloseTransition"`) {
 		t.Fatalf("expected qualified resource semantic error, got %v", err)
 	}
 }

--- a/semir/resource_effects_test.go
+++ b/semir/resource_effects_test.go
@@ -1,0 +1,83 @@
+package semir
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResourceTransitionSemanticsDecodesStructuredEffects(t *testing.T) {
+	transition := Transition{
+		Name: "renew",
+		Effects: []Effect{
+			ResourceConsumeArgument(2),
+			{Namespace: "memory", Name: "write"},
+			ResourceConsumeArgument(0),
+			ResourceReturnFresh(),
+		},
+	}
+
+	semantics, present, err := transition.ResourceSemantics()
+	if err != nil {
+		t.Fatalf("resource semantics rejected: %v", err)
+	}
+	if !present {
+		t.Fatal("expected resource semantics to be present")
+	}
+	if len(semantics.Consumes) != 2 || semantics.Consumes[0] != 0 || semantics.Consumes[1] != 2 {
+		t.Fatalf("expected sorted consumed arguments [0 2], got %v", semantics.Consumes)
+	}
+	if !semantics.ReturnsFresh {
+		t.Fatal("expected fresh-return semantic fact")
+	}
+}
+
+func TestResourceTransitionSemanticsIgnoresUnrelatedEffects(t *testing.T) {
+	transition := Transition{Effects: []Effect{{Namespace: "memory", Name: "allocate"}}}
+	semantics, present, err := transition.ResourceSemantics()
+	if err != nil {
+		t.Fatalf("unrelated effect rejected: %v", err)
+	}
+	if present || len(semantics.Consumes) != 0 || semantics.ReturnsFresh {
+		t.Fatalf("unrelated effects must not invent resource semantics: %#v", semantics)
+	}
+}
+
+func TestResourceTransitionSemanticsRejectsMalformedConsume(t *testing.T) {
+	transition := Transition{
+		Name: "close",
+		Effects: []Effect{{
+			Namespace:  ResourceEffectNamespace,
+			Name:       ResourceEffectConsume,
+			Parameters: []string{"arg:not-a-number"},
+		}},
+	}
+
+	_, present, err := transition.ResourceSemantics()
+	if !present || err == nil || !strings.Contains(err.Error(), "invalid argument index") {
+		t.Fatalf("expected malformed consume rejection, got present=%v err=%v", present, err)
+	}
+}
+
+func TestValidateResourceSemanticsQualifiesProtocolAndTransition(t *testing.T) {
+	module := Module{
+		Protocols: []Protocol{{
+			Name:    "HandleLifecycle",
+			Initial: "Open",
+			States:  []State{{Name: "Open"}, {Name: "Closed"}},
+			Transitions: []Transition{{
+				Name: "close",
+				From: "Open",
+				To:   "Closed",
+				Effects: []Effect{{
+					Namespace: ResourceEffectNamespace,
+					Name:      "typo",
+				}},
+			}},
+		}},
+	}
+
+	err := module.ValidateResourceSemantics()
+	if err == nil || !strings.Contains(err.Error(), `protocol "HandleLifecycle" transition "close"`) {
+		t.Fatalf("expected qualified resource semantic error, got %v", err)
+	}
+}

--- a/typechecker/resource_semir.go
+++ b/typechecker/resource_semir.go
@@ -1,0 +1,97 @@
+package typechecker
+
+import (
+	"fmt"
+
+	"github.com/SCKelemen/oak/ast"
+	"github.com/SCKelemen/oak/semir"
+)
+
+// ResourceModelFromSemIR derives the typechecker's executable resource model
+// from checked semantic facts. Resource-bearing definitions are identified by
+// their Authority.Resource axis; consuming/fresh-return operations come from
+// structured resource effects on protocol transitions.
+func ResourceModelFromSemIR(module semir.Module) (ResourceModel, error) {
+	if err := module.Validate(); err != nil {
+		return ResourceModel{}, fmt.Errorf("invalid semantic module: %w", err)
+	}
+	if err := module.ValidateResourceSemantics(); err != nil {
+		return ResourceModel{}, err
+	}
+
+	model := NewResourceModel()
+	for _, definition := range module.Definitions {
+		switch definition.Authority.Resource {
+		case semir.ResourceAuthorityUnspecified:
+			continue
+		case semir.ResourceAuthorityLive,
+			semir.ResourceAuthorityConsumed,
+			semir.ResourceAuthorityMaybeConsumed:
+			model.MarkResourceType(definition.Name)
+		default:
+			return ResourceModel{}, fmt.Errorf(
+				"definition %q has invalid resource authority %q",
+				definition.Name,
+				definition.Authority.Resource,
+			)
+		}
+	}
+
+	for _, protocol := range module.Protocols {
+		for _, transition := range protocol.Transitions {
+			semantics, present, err := transition.ResourceSemantics()
+			if err != nil {
+				return ResourceModel{}, fmt.Errorf(
+					"protocol %q transition %q: %w",
+					protocol.Name,
+					transition.Name,
+					err,
+				)
+			}
+			if !present {
+				continue
+			}
+
+			operation := ResourceOperation{
+				Consumes:     append([]int(nil), semantics.Consumes...),
+				ReturnsFresh: semantics.ReturnsFresh,
+			}
+			if existing, exists := model.Operations[transition.Name]; exists {
+				if !sameResourceOperation(existing, operation) {
+					return ResourceModel{}, fmt.Errorf(
+						"resource operation %q has conflicting semantics across protocols",
+						transition.Name,
+					)
+				}
+				continue
+			}
+			model.MarkOperation(transition.Name, operation)
+		}
+	}
+
+	return model, nil
+}
+
+// CheckProgramWithSemIR is the semantic-pipeline resource-checking entrypoint.
+// Callers provide the already resolved SemIR module; no manual ResourceModel
+// registration is required, and no source-level consume spelling is assumed.
+func (tc *TypeChecker) CheckProgramWithSemIR(program *ast.Program, module semir.Module) error {
+	model, err := ResourceModelFromSemIR(module)
+	if err != nil {
+		return err
+	}
+	tc.CheckProgramWithResources(program, model)
+	return nil
+}
+
+func sameResourceOperation(left, right ResourceOperation) bool {
+	if left.ReturnsFresh != right.ReturnsFresh || len(left.Consumes) != len(right.Consumes) {
+		return false
+	}
+	for i := range left.Consumes {
+		if left.Consumes[i] != right.Consumes[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/typechecker/resource_semir.go
+++ b/typechecker/resource_semir.go
@@ -10,7 +10,7 @@ import (
 // ResourceModelFromSemIR derives the typechecker's executable resource model
 // from checked semantic facts. Resource-bearing definitions are identified by
 // their Authority.Resource axis; consuming/fresh-return operations come from
-// structured resource effects on protocol transitions.
+// structured resource effects bound to resolved protocol callables.
 func ResourceModelFromSemIR(module semir.Module) (ResourceModel, error) {
 	if err := module.Validate(); err != nil {
 		return ResourceModel{}, fmt.Errorf("invalid semantic module: %w", err)
@@ -56,16 +56,17 @@ func ResourceModelFromSemIR(module semir.Module) (ResourceModel, error) {
 				Consumes:     append([]int(nil), semantics.Consumes...),
 				ReturnsFresh: semantics.ReturnsFresh,
 			}
-			if existing, exists := model.Operations[transition.Name]; exists {
+			callable := transition.Callable
+			if existing, exists := model.Operations[callable]; exists {
 				if !sameResourceOperation(existing, operation) {
 					return ResourceModel{}, fmt.Errorf(
-						"resource operation %q has conflicting semantics across protocols",
-						transition.Name,
+						"resource callable %q has conflicting semantics across protocols",
+						callable,
 					)
 				}
 				continue
 			}
-			model.MarkOperation(transition.Name, operation)
+			model.MarkOperation(callable, operation)
 		}
 	}
 

--- a/typechecker/resource_semir_test.go
+++ b/typechecker/resource_semir_test.go
@@ -1,0 +1,179 @@
+package typechecker
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/SCKelemen/oak/semir"
+)
+
+func resourceSemanticModule() semir.Module {
+	return semir.Module{
+		Definitions: []semir.Definition{
+			{
+				Name:     "Handle",
+				Type:     semir.Type{Kind: semir.TypeRecord},
+				Protocol: "HandleLifecycle",
+				Authority: semir.Authority{
+					Ownership: semir.OwnershipOwned,
+					Resource:  semir.ResourceAuthorityLive,
+				},
+			},
+			{
+				Name:     "PlainState",
+				Type:     semir.Type{Kind: semir.TypeRecord},
+				Protocol: "PlainLifecycle",
+				Authority: semir.Authority{
+					Ownership: semir.OwnershipOwned,
+				},
+			},
+		},
+		Protocols: []semir.Protocol{
+			{
+				Name:    "HandleLifecycle",
+				Initial: "Open",
+				States:  []semir.State{{Name: "Open"}, {Name: "Closed"}},
+				Transitions: []semir.Transition{
+					{
+						Name:    "close",
+						From:    "Open",
+						To:      "Closed",
+						Effects: []semir.Effect{semir.ResourceConsumeArgument(0)},
+					},
+					{
+						Name: "renew",
+						From: "Open",
+						To:   "Open",
+						Effects: []semir.Effect{
+							semir.ResourceConsumeArgument(0),
+							semir.ResourceReturnFresh(),
+						},
+					},
+				},
+			},
+			{
+				Name:    "PlainLifecycle",
+				Initial: "Idle",
+				States:  []semir.State{{Name: "Idle"}},
+				Transitions: []semir.Transition{
+					{
+						Name:    "tick",
+						From:    "Idle",
+						To:      "Idle",
+						Effects: []semir.Effect{{Namespace: "time", Name: "observe"}},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestResourceModelFromSemIRDerivesTypesAndOperations(t *testing.T) {
+	model, err := ResourceModelFromSemIR(resourceSemanticModule())
+	if err != nil {
+		t.Fatalf("resource model derivation failed: %v", err)
+	}
+	if !model.ResourceTypes["Handle"] {
+		t.Fatal("resource-bearing semantic definition should become a resource type")
+	}
+	if model.ResourceTypes["PlainState"] {
+		t.Fatal("protocol membership alone must not invent resource authority")
+	}
+	closeOp, ok := model.Operations["close"]
+	if !ok || len(closeOp.Consumes) != 1 || closeOp.Consumes[0] != 0 || closeOp.ReturnsFresh {
+		t.Fatalf("unexpected close resource operation: %#v", closeOp)
+	}
+	renewOp, ok := model.Operations["renew"]
+	if !ok || len(renewOp.Consumes) != 1 || renewOp.Consumes[0] != 0 || !renewOp.ReturnsFresh {
+		t.Fatalf("unexpected renew resource operation: %#v", renewOp)
+	}
+	if _, ok := model.Operations["tick"]; ok {
+		t.Fatal("non-resource protocol effects must not become resource operations")
+	}
+}
+
+func TestCheckProgramWithSemIRAutomaticallyRejectsUseAfterConsume(t *testing.T) {
+	input := `
+Handle: type = struct { id: u32 }
+close: (h: Handle): () = {}
+f: (h: Handle): u32 {
+  close(h)
+  h.id
+}`
+	tc := setupTypeChecker(input)
+	program := parseProgram(input)
+	if err := tc.CheckProgramWithSemIR(program, resourceSemanticModule()); err != nil {
+		t.Fatalf("semantic resource checking failed: %v", err)
+	}
+
+	got := resourceDiagnostics(tc)
+	if len(got) != 1 || !strings.Contains(got[0], "cannot be used after") {
+		t.Fatalf("expected automatic OAK-B0111, got %v (all errors: %v)", got, tc.Errors())
+	}
+}
+
+func TestCheckProgramWithSemIRDerivesFreshReturnAuthority(t *testing.T) {
+	input := `
+Handle: type = struct { id: u32 }
+renew: (h: Handle): Handle = h
+f: (h: Handle): u32 {
+  next: Handle = renew(h)
+  next.id
+}`
+	tc := setupTypeChecker(input)
+	program := parseProgram(input)
+	if err := tc.CheckProgramWithSemIR(program, resourceSemanticModule()); err != nil {
+		t.Fatalf("semantic resource checking failed: %v", err)
+	}
+	if got := resourceDiagnostics(tc); len(got) != 0 {
+		t.Fatalf("fresh returned authority should be usable: %v", got)
+	}
+}
+
+func TestResourceModelFromSemIRRejectsConflictingCallableSemantics(t *testing.T) {
+	module := semir.Module{
+		Protocols: []semir.Protocol{
+			{
+				Name:    "Left",
+				Initial: "S",
+				States:  []semir.State{{Name: "S"}},
+				Transitions: []semir.Transition{{
+					Name:    "close",
+					From:    "S",
+					To:      "S",
+					Effects: []semir.Effect{semir.ResourceConsumeArgument(0)},
+				}},
+			},
+			{
+				Name:    "Right",
+				Initial: "S",
+				States:  []semir.State{{Name: "S"}},
+				Transitions: []semir.Transition{{
+					Name:    "close",
+					From:    "S",
+					To:      "S",
+					Effects: []semir.Effect{semir.ResourceConsumeArgument(1)},
+				}},
+			},
+		},
+	}
+
+	_, err := ResourceModelFromSemIR(module)
+	if err == nil || !strings.Contains(err.Error(), "conflicting semantics") {
+		t.Fatalf("expected conflicting callable semantics rejection, got %v", err)
+	}
+}
+
+func TestResourceModelFromSemIRRejectsMalformedResourceEffect(t *testing.T) {
+	module := resourceSemanticModule()
+	module.Protocols[0].Transitions[0].Effects = []semir.Effect{{
+		Namespace:  semir.ResourceEffectNamespace,
+		Name:       semir.ResourceEffectConsume,
+		Parameters: []string{"arg:bad"},
+	}}
+
+	_, err := ResourceModelFromSemIR(module)
+	if err == nil || !strings.Contains(err.Error(), "invalid argument index") {
+		t.Fatalf("expected malformed semantic resource effect rejection, got %v", err)
+	}
+}

--- a/typechecker/resource_semir_test.go
+++ b/typechecker/resource_semir_test.go
@@ -35,15 +35,17 @@ func resourceSemanticModule() semir.Module {
 				States:  []semir.State{{Name: "Open"}, {Name: "Closed"}},
 				Transitions: []semir.Transition{
 					{
-						Name:    "close",
-						From:    "Open",
-						To:      "Closed",
-						Effects: []semir.Effect{semir.ResourceConsumeArgument(0)},
+						Name:     "CloseTransition",
+						Callable: "close",
+						From:     "Open",
+						To:       "Closed",
+						Effects:  []semir.Effect{semir.ResourceConsumeArgument(0)},
 					},
 					{
-						Name: "renew",
-						From: "Open",
-						To:   "Open",
+						Name:     "RenewTransition",
+						Callable: "renew",
+						From:     "Open",
+						To:       "Open",
 						Effects: []semir.Effect{
 							semir.ResourceConsumeArgument(0),
 							semir.ResourceReturnFresh(),
@@ -57,7 +59,7 @@ func resourceSemanticModule() semir.Module {
 				States:  []semir.State{{Name: "Idle"}},
 				Transitions: []semir.Transition{
 					{
-						Name:    "tick",
+						Name:    "TickTransition",
 						From:    "Idle",
 						To:      "Idle",
 						Effects: []semir.Effect{{Namespace: "time", Name: "observe"}},
@@ -68,7 +70,7 @@ func resourceSemanticModule() semir.Module {
 	}
 }
 
-func TestResourceModelFromSemIRDerivesTypesAndOperations(t *testing.T) {
+func TestResourceModelFromSemIRDerivesTypesAndResolvedCallables(t *testing.T) {
 	model, err := ResourceModelFromSemIR(resourceSemanticModule())
 	if err != nil {
 		t.Fatalf("resource model derivation failed: %v", err)
@@ -87,7 +89,10 @@ func TestResourceModelFromSemIRDerivesTypesAndOperations(t *testing.T) {
 	if !ok || len(renewOp.Consumes) != 1 || renewOp.Consumes[0] != 0 || !renewOp.ReturnsFresh {
 		t.Fatalf("unexpected renew resource operation: %#v", renewOp)
 	}
-	if _, ok := model.Operations["tick"]; ok {
+	if _, ok := model.Operations["CloseTransition"]; ok {
+		t.Fatal("protocol-local transition labels must not be treated as callable identities")
+	}
+	if _, ok := model.Operations["TickTransition"]; ok {
 		t.Fatal("non-resource protocol effects must not become resource operations")
 	}
 }
@@ -138,10 +143,11 @@ func TestResourceModelFromSemIRRejectsConflictingCallableSemantics(t *testing.T)
 				Initial: "S",
 				States:  []semir.State{{Name: "S"}},
 				Transitions: []semir.Transition{{
-					Name:    "close",
-					From:    "S",
-					To:      "S",
-					Effects: []semir.Effect{semir.ResourceConsumeArgument(0)},
+					Name:     "LeftClose",
+					Callable: "close",
+					From:     "S",
+					To:       "S",
+					Effects:  []semir.Effect{semir.ResourceConsumeArgument(0)},
 				}},
 			},
 			{
@@ -149,10 +155,11 @@ func TestResourceModelFromSemIRRejectsConflictingCallableSemantics(t *testing.T)
 				Initial: "S",
 				States:  []semir.State{{Name: "S"}},
 				Transitions: []semir.Transition{{
-					Name:    "close",
-					From:    "S",
-					To:      "S",
-					Effects: []semir.Effect{semir.ResourceConsumeArgument(1)},
+					Name:     "RightClose",
+					Callable: "close",
+					From:     "S",
+					To:       "S",
+					Effects:  []semir.Effect{semir.ResourceConsumeArgument(1)},
 				}},
 			},
 		},


### PR DESCRIPTION
Derives the typechecker resource model from SemIR instead of requiring manual resource registration.

- Adds canonical structured resource effects for consumed arguments and fresh resource returns.
- Validates malformed/unknown resource effects so semantic typos cannot weaken authority checks.
- Derives resource-bearing types from `Definition.Authority.Resource`.
- Adds `Transition.Callable` as the resolved semantic callable identity, distinct from a protocol-local transition label.
- Requires resource-bearing transitions to bind a resolved callable, preventing unrelated same-spelling functions from inheriting resource semantics.
- Derives consuming/fresh-return operations from those callable-bound protocol transition effects, with conflict detection across protocols.
- Adds `CheckProgramWithSemIR` so typed resource checking runs from resolved semantic facts without freezing source-level consume syntax.
- Adds SemIR and typed integration tests for derivation, use-after-consume, fresh return authority, malformed effects, missing callable bindings, and conflicting callable semantics.

Surface resource declarations and consume syntax remain deliberately unfrozen.