### PR TITLE
Add production resource SemIR emission

### DIFF
--- a/compiler/resource_semir.go
+++ b/compiler/resource_semir.go
@@ -1,0 +1,108 @@
+package compiler
+
+import (
+	"fmt"
+
+	"github.com/SCKelemen/oak/semir"
+	"github.com/SCKelemen/oak/typechecker"
+)
+
+// ResourceSemanticIR is the checked resource slice of Oak's semantic IR. The
+// compiler does not yet claim to project every language feature into SemIR;
+// this stage makes the resource authority path production-backed first.
+type ResourceSemanticIR struct {
+	Model     *SemanticModel
+	Module    semir.Module
+	Resources typechecker.ResolvedResourceProgram
+}
+
+// ResourceSemIR checks the program, resolves syntax-independent resource
+// declarations against the checked type environment, emits canonical SemIR,
+// and runs the path-sensitive resource checker from that emitted module.
+//
+// Resource declarations remain an internal semantic input until Oak freezes a
+// source or ABI spelling. The projection below is therefore reusable by either
+// future frontend without teaching the AST to guess ownership semantics.
+func (comp Compilation) ResourceSemIR(declarations []typechecker.ResourceProtocolDeclaration) Stage[*ResourceSemanticIR] {
+	return comp.Check().Then(func(model *SemanticModel) (*ResourceSemanticIR, error) {
+		resolved, err := model.TypeChecker.ResolveResourceDeclarations(declarations)
+		if err != nil {
+			return nil, fmt.Errorf("resource resolution failed: %w", err)
+		}
+
+		module, err := emitResourceSemIR(resolved)
+		if err != nil {
+			return nil, fmt.Errorf("resource SemIR emission failed: %w", err)
+		}
+
+		resourceModel, err := typechecker.ResourceModelFromSemIR(module)
+		if err != nil {
+			return nil, fmt.Errorf("resource SemIR projection failed: %w", err)
+		}
+		// Check() already performed ordinary type checking. Run only resource
+		// flow here so diagnostics are not duplicated by a second CheckProgram.
+		model.TypeChecker.CheckResourceFlow(model.Tree.Root, resourceModel)
+		if err := comp.gate("resource", model.TypeChecker.Diagnostics()); err != nil {
+			return nil, err
+		}
+
+		return &ResourceSemanticIR{
+			Model:     model,
+			Module:    module,
+			Resources: resolved,
+		}, nil
+	})
+}
+
+func emitResourceSemIR(resources typechecker.ResolvedResourceProgram) (semir.Module, error) {
+	module := semir.Module{}
+	for _, resourceType := range resources.Types {
+		// The resource projection asserts semantic identity/authority only. It
+		// intentionally leaves representation and detailed shape unspecified;
+		// those axes need their own production projection rather than guessed
+		// facts smuggled in with ownership metadata.
+		module.Definitions = append(module.Definitions, semir.Definition{
+			Name: resourceType.Name,
+			Type: semir.Type{Kind: semir.TypeOpaque},
+			Authority: semir.Authority{
+				Ownership: semir.OwnershipOwned,
+				Resource:  semir.ResourceAuthorityLive,
+			},
+			Protocol: resourceType.Protocol,
+		})
+	}
+
+	for _, resourceProtocol := range resources.Protocols {
+		protocol := semir.Protocol{
+			Name:    resourceProtocol.Name,
+			Initial: resourceProtocol.Initial,
+		}
+		for _, state := range resourceProtocol.States {
+			protocol.States = append(protocol.States, semir.State{Name: state})
+		}
+		for _, resourceTransition := range resourceProtocol.Transitions {
+			transition := semir.Transition{
+				Name:     resourceTransition.Name,
+				Callable: resourceTransition.Callable,
+				From:     resourceTransition.From,
+				To:       resourceTransition.To,
+			}
+			for _, index := range resourceTransition.Consumes {
+				transition.Effects = append(transition.Effects, semir.ResourceConsumeArgument(index))
+			}
+			if resourceTransition.ReturnsFresh {
+				transition.Effects = append(transition.Effects, semir.ResourceReturnFresh())
+			}
+			protocol.Transitions = append(protocol.Transitions, transition)
+		}
+		module.Protocols = append(module.Protocols, protocol)
+	}
+
+	if err := module.Validate(); err != nil {
+		return semir.Module{}, err
+	}
+	if err := module.ValidateResourceSemantics(); err != nil {
+		return semir.Module{}, err
+	}
+	return module, nil
+}

--- a/compiler/resource_semir.go
+++ b/compiler/resource_semir.go
@@ -57,16 +57,14 @@ func (comp Compilation) ResourceSemIR(declarations []typechecker.ResourceProtoco
 func emitResourceSemIR(resources typechecker.ResolvedResourceProgram) (semir.Module, error) {
 	module := semir.Module{}
 	for _, resourceType := range resources.Types {
-		// The resource projection asserts semantic identity/authority only. It
-		// intentionally leaves representation and detailed shape unspecified;
-		// those axes need their own production projection rather than guessed
-		// facts smuggled in with ownership metadata.
+		// This projection asserts only the axes established by resource
+		// resolution. Type shape, representation, and temporary ownership stay
+		// unspecified: permanent resource liveness is orthogonal to them.
 		module.Definitions = append(module.Definitions, semir.Definition{
 			Name: resourceType.Name,
 			Type: semir.Type{Kind: semir.TypeOpaque},
 			Authority: semir.Authority{
-				Ownership: semir.OwnershipOwned,
-				Resource:  semir.ResourceAuthorityLive,
+				Resource: semir.ResourceAuthorityLive,
 			},
 			Protocol: resourceType.Protocol,
 		})

--- a/compiler/resource_semir_integration_note.md
+++ b/compiler/resource_semir_integration_note.md
@@ -1,1 +1,0 @@
-Resource SemIR production tests live in `resource_semir_test.go`. This marker is intentionally temporary and should be removed before merge.

--- a/compiler/resource_semir_integration_note.md
+++ b/compiler/resource_semir_integration_note.md
@@ -1,0 +1,1 @@
+Resource SemIR production tests live in `resource_semir_test.go`. This marker is intentionally temporary and should be removed before merge.

--- a/compiler/resource_semir_test.go
+++ b/compiler/resource_semir_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/SCKelemen/oak/semir"
 	"github.com/SCKelemen/oak/typechecker"
 )
 
@@ -61,8 +62,14 @@ f: (h: Handle): u32 {
 	if definition.Name != "Handle" || definition.Protocol != "HandleLifecycle" {
 		t.Fatalf("unexpected resource definition: %#v", definition)
 	}
-	if definition.Authority.Resource != "live" || definition.Authority.Ownership != "owned" {
+	if definition.Type.Kind != semir.TypeOpaque {
+		t.Fatalf("resource-only projection must not invent detailed type shape: %#v", definition.Type)
+	}
+	if definition.Authority.Resource != semir.ResourceAuthorityLive {
 		t.Fatalf("resource authority was not emitted canonically: %#v", definition.Authority)
+	}
+	if definition.Authority.Ownership != semir.OwnershipUnspecified {
+		t.Fatalf("resource liveness must not invent temporary ownership authority: %#v", definition.Authority)
 	}
 	if len(result.Module.Protocols) != 1 || len(result.Module.Protocols[0].Transitions) != 2 {
 		t.Fatalf("unexpected emitted protocols: %#v", result.Module.Protocols)
@@ -111,7 +118,7 @@ f: (h: Handle): u32 {
 	}
 	found := false
 	for _, diagnostic := range diagnosticErr.Diagnostics {
-		if diagnostic != nil && string(diagnostic.Code) == typechecker.CodeResourceUsedAfterConsume {
+		if diagnostic != nil && diagnostic.Code == typechecker.CodeResourceUsedAfterConsume {
 			found = true
 			break
 		}

--- a/compiler/resource_semir_test.go
+++ b/compiler/resource_semir_test.go
@@ -1,0 +1,159 @@
+package compiler
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/SCKelemen/oak/typechecker"
+)
+
+func compilerResourceDeclarations() []typechecker.ResourceProtocolDeclaration {
+	return []typechecker.ResourceProtocolDeclaration{{
+		Name:          "HandleLifecycle",
+		ResourceTypes: []string{"Handle"},
+		States:        []string{"Open", "Closed"},
+		Initial:       "Open",
+		Transitions: []typechecker.ResourceTransitionDeclaration{
+			{
+				Name:     "close-transition",
+				Callable: "close",
+				From:     "Open",
+				To:       "Closed",
+				Consumes: []int{0},
+			},
+			{
+				Name:         "renew-transition",
+				Callable:     "renew",
+				From:         "Open",
+				To:           "Open",
+				Consumes:     []int{0},
+				ReturnsFresh: true,
+			},
+		},
+	}}
+}
+
+func TestResourceSemIREmitsResolvedAuthorityAndCallableEffects(t *testing.T) {
+	const source = `
+Handle: type = struct { id: u32 }
+close: (h: Handle): () = {}
+renew: (h: Handle): Handle = h
+f: (h: Handle): u32 {
+  next: Handle = renew(h)
+  next.id
+}
+`
+
+	result, err := New().
+		WithSource("resource.oak", source).
+		ResourceSemIR(compilerResourceDeclarations()).
+		Get()
+	if err != nil {
+		t.Fatalf("resource SemIR stage failed: %v", err)
+	}
+	if result == nil || result.Model == nil {
+		t.Fatal("expected checked semantic result")
+	}
+	if len(result.Module.Definitions) != 1 {
+		t.Fatalf("expected one resource definition, got %#v", result.Module.Definitions)
+	}
+	definition := result.Module.Definitions[0]
+	if definition.Name != "Handle" || definition.Protocol != "HandleLifecycle" {
+		t.Fatalf("unexpected resource definition: %#v", definition)
+	}
+	if definition.Authority.Resource != "live" || definition.Authority.Ownership != "owned" {
+		t.Fatalf("resource authority was not emitted canonically: %#v", definition.Authority)
+	}
+	if len(result.Module.Protocols) != 1 || len(result.Module.Protocols[0].Transitions) != 2 {
+		t.Fatalf("unexpected emitted protocols: %#v", result.Module.Protocols)
+	}
+	closeTransition := result.Module.Protocols[0].Transitions[0]
+	if closeTransition.Name != "close-transition" || closeTransition.Callable != "close" {
+		t.Fatalf("protocol label must not replace resolved callable identity: %#v", closeTransition)
+	}
+	semantics, present, err := closeTransition.ResourceSemantics()
+	if err != nil || !present {
+		t.Fatalf("emitted close effects did not decode: present=%v err=%v", present, err)
+	}
+	if len(semantics.Consumes) != 1 || semantics.Consumes[0] != 0 || semantics.ReturnsFresh {
+		t.Fatalf("unexpected emitted close semantics: %#v", semantics)
+	}
+	renewSemantics, present, err := result.Module.Protocols[0].Transitions[1].ResourceSemantics()
+	if err != nil || !present || !renewSemantics.ReturnsFresh {
+		t.Fatalf("expected canonical fresh-return effect, got present=%v semantics=%#v err=%v", present, renewSemantics, err)
+	}
+}
+
+func TestResourceSemIRFeedsEmittedModuleIntoPathSensitiveChecking(t *testing.T) {
+	const source = `
+Handle: type = struct { id: u32 }
+close: (h: Handle): () = {}
+renew: (h: Handle): Handle = h
+f: (h: Handle): u32 {
+  close(h)
+  h.id
+}
+`
+
+	_, err := New().
+		WithSource("consumed.oak", source).
+		ResourceSemIR(compilerResourceDeclarations()).
+		Get()
+	if err == nil {
+		t.Fatal("expected resource use-after-consume rejection")
+	}
+	var diagnosticErr *DiagnosticError
+	if !errors.As(err, &diagnosticErr) {
+		t.Fatalf("expected first-class DiagnosticError, got %T: %v", err, err)
+	}
+	if diagnosticErr.Phase != "resource" {
+		t.Fatalf("expected resource phase rejection, got %q", diagnosticErr.Phase)
+	}
+	found := false
+	for _, diagnostic := range diagnosticErr.Diagnostics {
+		if diagnostic != nil && string(diagnostic.Code) == typechecker.CodeResourceUsedAfterConsume {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected %s in resource diagnostics: %#v", typechecker.CodeResourceUsedAfterConsume, diagnosticErr.Diagnostics)
+	}
+}
+
+func TestResourceSemIRFreshReturnCarriesNewAuthority(t *testing.T) {
+	const source = `
+Handle: type = struct { id: u32 }
+close: (h: Handle): () = {}
+renew: (h: Handle): Handle = h
+f: (h: Handle): u32 {
+  next: Handle = renew(h)
+  next.id
+}
+`
+
+	if _, err := New().
+		WithSource("fresh.oak", source).
+		ResourceSemIR(compilerResourceDeclarations()).
+		Get(); err != nil {
+		t.Fatalf("fresh returned resource should remain usable: %v", err)
+	}
+}
+
+func TestResourceSemIRRejectsUnresolvedSemanticInputBeforeEmission(t *testing.T) {
+	const source = `
+Handle: type = struct { id: u32 }
+close: (h: Handle): () = {}
+`
+	declarations := compilerResourceDeclarations()
+	declarations[0].Transitions = declarations[0].Transitions[:1]
+	declarations[0].Transitions[0].Callable = ""
+
+	_, err := New().
+		WithSource("unresolved.oak", source).
+		ResourceSemIR(declarations).
+		Get()
+	if err == nil {
+		t.Fatal("expected unresolved resource declaration rejection")
+	}
+}

--- a/typechecker/resource_resolution.go
+++ b/typechecker/resource_resolution.go
@@ -98,7 +98,7 @@ func (tc *TypeChecker) ResolveResourceDeclarations(declarations []ResourceProtoc
 				return ResolvedResourceProgram{}, fmt.Errorf("resource protocol %q references unknown type %q", declaration.Name, name)
 			}
 			if nominalTypeName(typ) != name {
-				return ResolvedResourceProgram{}, fmt.Errorf("resource type %q must resolve to a nominal Oak type, got %s", name, typ)
+				return ResolvedResourceProgram{}, fmt.Errorf("resource type %q must resolve to a concrete nominal Oak type, got %s", name, typ)
 			}
 			if previous, exists := resourceProtocols[name]; exists {
 				return ResolvedResourceProgram{}, fmt.Errorf("resource type %q is bound to both protocols %q and %q", name, previous, declaration.Name)
@@ -213,9 +213,16 @@ func (tc *TypeChecker) ResolveResourceDeclarations(declarations []ResourceProtoc
 	return resolved, nil
 }
 
+// nominalTypeName returns the authority-bearing nominal base. Structural
+// records and interface contracts deliberately return empty: letting either opt
+// into non-duplicable resource semantics would allow structural compatibility
+// or dynamic abstraction to bypass the authority class model.
 func nominalTypeName(typ Type) string {
 	switch t := typ.(type) {
 	case *RecordType:
+		if !t.Struct {
+			return ""
+		}
 		return t.Name
 	case *ADTType:
 		return t.Name
@@ -223,8 +230,6 @@ func nominalTypeName(typ Type) string {
 		return t.Name
 	case *NarrowedADTVariantType:
 		return t.ADTName
-	case *InterfaceType:
-		return t.Name
 	default:
 		return ""
 	}

--- a/typechecker/resource_resolution.go
+++ b/typechecker/resource_resolution.go
@@ -1,0 +1,231 @@
+package typechecker
+
+import (
+	"fmt"
+	"sort"
+)
+
+// ResourceProtocolDeclaration is syntax-independent resource protocol input to
+// semantic resolution. It is deliberately not an AST node: future source, ABI,
+// or generated metadata can all project into this shape without making any one
+// surface spelling authoritative.
+type ResourceProtocolDeclaration struct {
+	Name          string
+	ResourceTypes []string
+	States        []string
+	Initial       string
+	Transitions   []ResourceTransitionDeclaration
+}
+
+// ResourceTransitionDeclaration binds one protocol-local transition label to
+// an explicit callable identity. Callable is never inferred from Name.
+type ResourceTransitionDeclaration struct {
+	Name         string
+	Callable     string
+	From         string
+	To           string
+	Consumes     []int
+	ReturnsFresh bool
+}
+
+// ResolvedResourceProgram contains only resource facts that have been checked
+// against Oak's semantic type environment.
+type ResolvedResourceProgram struct {
+	Types     []ResolvedResourceType
+	Protocols []ResolvedResourceProtocol
+}
+
+type ResolvedResourceType struct {
+	Name     string
+	Protocol string
+}
+
+type ResolvedResourceProtocol struct {
+	Name        string
+	States      []string
+	Initial     string
+	Transitions []ResolvedResourceTransition
+}
+
+type ResolvedResourceTransition struct {
+	Name         string
+	Callable     string
+	From         string
+	To           string
+	Consumes     []int
+	ReturnsFresh bool
+}
+
+// ResolveResourceDeclarations resolves internal protocol facts against the
+// already checked Oak environment. It never guesses resource authority from a
+// function name or type-state-shaped signature.
+func (tc *TypeChecker) ResolveResourceDeclarations(declarations []ResourceProtocolDeclaration) (ResolvedResourceProgram, error) {
+	if tc == nil || tc.env == nil {
+		return ResolvedResourceProgram{}, fmt.Errorf("resource resolution requires a checked type environment")
+	}
+
+	resolved := ResolvedResourceProgram{}
+	protocolNames := make(map[string]bool, len(declarations))
+	resourceProtocols := make(map[string]string)
+	resourceTypes := make(map[string]bool)
+
+	// Resolve resource-bearing nominal types first so transition validation may
+	// refer across protocols without depending on declaration order.
+	for _, declaration := range declarations {
+		if declaration.Name == "" {
+			return ResolvedResourceProgram{}, fmt.Errorf("resource protocol has empty name")
+		}
+		if protocolNames[declaration.Name] {
+			return ResolvedResourceProgram{}, fmt.Errorf("duplicate resource protocol %q", declaration.Name)
+		}
+		protocolNames[declaration.Name] = true
+		if len(declaration.ResourceTypes) == 0 {
+			return ResolvedResourceProgram{}, fmt.Errorf("resource protocol %q has no resource types", declaration.Name)
+		}
+
+		localTypes := make(map[string]bool, len(declaration.ResourceTypes))
+		for _, name := range declaration.ResourceTypes {
+			if name == "" {
+				return ResolvedResourceProgram{}, fmt.Errorf("resource protocol %q has an empty resource type", declaration.Name)
+			}
+			if localTypes[name] {
+				return ResolvedResourceProgram{}, fmt.Errorf("resource protocol %q duplicates resource type %q", declaration.Name, name)
+			}
+			localTypes[name] = true
+
+			typ, exists := tc.env.GetType(name)
+			if !exists || typ == nil {
+				return ResolvedResourceProgram{}, fmt.Errorf("resource protocol %q references unknown type %q", declaration.Name, name)
+			}
+			if nominalTypeName(typ) != name {
+				return ResolvedResourceProgram{}, fmt.Errorf("resource type %q must resolve to a nominal Oak type, got %s", name, typ)
+			}
+			if previous, exists := resourceProtocols[name]; exists {
+				return ResolvedResourceProgram{}, fmt.Errorf("resource type %q is bound to both protocols %q and %q", name, previous, declaration.Name)
+			}
+			resourceProtocols[name] = declaration.Name
+			resourceTypes[name] = true
+			resolved.Types = append(resolved.Types, ResolvedResourceType{Name: name, Protocol: declaration.Name})
+		}
+	}
+
+	// A stable type order makes emitted semantic modules independent of map
+	// iteration and of later resolver implementation details.
+	sort.Slice(resolved.Types, func(i, j int) bool {
+		if resolved.Types[i].Name != resolved.Types[j].Name {
+			return resolved.Types[i].Name < resolved.Types[j].Name
+		}
+		return resolved.Types[i].Protocol < resolved.Types[j].Protocol
+	})
+
+	callableSemantics := make(map[string]ResourceOperation)
+	for _, declaration := range declarations {
+		stateNames := make(map[string]bool, len(declaration.States))
+		states := make([]string, 0, len(declaration.States))
+		for _, state := range declaration.States {
+			if state == "" {
+				return ResolvedResourceProgram{}, fmt.Errorf("resource protocol %q has an empty state", declaration.Name)
+			}
+			if stateNames[state] {
+				return ResolvedResourceProgram{}, fmt.Errorf("resource protocol %q duplicates state %q", declaration.Name, state)
+			}
+			stateNames[state] = true
+			states = append(states, state)
+		}
+		if len(states) == 0 {
+			return ResolvedResourceProgram{}, fmt.Errorf("resource protocol %q has no states", declaration.Name)
+		}
+		if !stateNames[declaration.Initial] {
+			return ResolvedResourceProgram{}, fmt.Errorf("resource protocol %q initial state %q does not exist", declaration.Name, declaration.Initial)
+		}
+
+		protocol := ResolvedResourceProtocol{
+			Name:    declaration.Name,
+			States:  states,
+			Initial: declaration.Initial,
+		}
+		transitionNames := make(map[string]bool, len(declaration.Transitions))
+		for _, transition := range declaration.Transitions {
+			if transition.Name == "" {
+				return ResolvedResourceProgram{}, fmt.Errorf("resource protocol %q has a transition with empty name", declaration.Name)
+			}
+			if transitionNames[transition.Name] {
+				return ResolvedResourceProgram{}, fmt.Errorf("resource protocol %q duplicates transition %q", declaration.Name, transition.Name)
+			}
+			transitionNames[transition.Name] = true
+			if transition.Callable == "" {
+				return ResolvedResourceProgram{}, fmt.Errorf("resource protocol %q transition %q has no resolved callable binding", declaration.Name, transition.Name)
+			}
+			if !stateNames[transition.From] {
+				return ResolvedResourceProgram{}, fmt.Errorf("resource protocol %q transition %q references unknown source state %q", declaration.Name, transition.Name, transition.From)
+			}
+			if !stateNames[transition.To] {
+				return ResolvedResourceProgram{}, fmt.Errorf("resource protocol %q transition %q references unknown target state %q", declaration.Name, transition.Name, transition.To)
+			}
+
+			callableType, exists := tc.env.GetType(transition.Callable)
+			if !exists || callableType == nil {
+				return ResolvedResourceProgram{}, fmt.Errorf("resource protocol %q transition %q references unknown callable %q", declaration.Name, transition.Name, transition.Callable)
+			}
+			function, ok := callableType.(*FunctionType)
+			if !ok {
+				return ResolvedResourceProgram{}, fmt.Errorf("resource protocol %q transition %q binds %q, which is not a function", declaration.Name, transition.Name, transition.Callable)
+			}
+
+			consumes := append([]int(nil), transition.Consumes...)
+			sort.Ints(consumes)
+			for i, index := range consumes {
+				if index < 0 || index >= len(function.Parameters) {
+					return ResolvedResourceProgram{}, fmt.Errorf("resource callable %q consumes argument %d outside its %d parameters", transition.Callable, index, len(function.Parameters))
+				}
+				if i > 0 && consumes[i-1] == index {
+					return ResolvedResourceProgram{}, fmt.Errorf("resource callable %q consumes argument %d more than once", transition.Callable, index)
+				}
+				parameterName := nominalTypeName(function.Parameters[index])
+				if !resourceTypes[parameterName] {
+					return ResolvedResourceProgram{}, fmt.Errorf("resource callable %q argument %d has non-resource type %s", transition.Callable, index, function.Parameters[index])
+				}
+			}
+			if transition.ReturnsFresh {
+				returnName := nominalTypeName(function.ReturnType)
+				if !resourceTypes[returnName] {
+					return ResolvedResourceProgram{}, fmt.Errorf("resource callable %q marks a fresh return but returns non-resource type %s", transition.Callable, function.ReturnType)
+				}
+			}
+
+			operation := ResourceOperation{Consumes: consumes, ReturnsFresh: transition.ReturnsFresh}
+			if previous, exists := callableSemantics[transition.Callable]; exists && !sameResourceOperation(previous, operation) {
+				return ResolvedResourceProgram{}, fmt.Errorf("resource callable %q has conflicting semantics across protocols", transition.Callable)
+			}
+			callableSemantics[transition.Callable] = operation
+			protocol.Transitions = append(protocol.Transitions, ResolvedResourceTransition{
+				Name:         transition.Name,
+				Callable:     transition.Callable,
+				From:         transition.From,
+				To:           transition.To,
+				Consumes:     consumes,
+				ReturnsFresh: transition.ReturnsFresh,
+			})
+		}
+		resolved.Protocols = append(resolved.Protocols, protocol)
+	}
+
+	return resolved, nil
+}
+
+func nominalTypeName(typ Type) string {
+	switch t := typ.(type) {
+	case *RecordType:
+		return t.Name
+	case *ADTType:
+		return t.Name
+	case *GenericType:
+		return t.Name
+	case *NarrowedADTVariantType:
+		return t.ADTName
+	case *InterfaceType:
+		return t.Name
+	default:
+		return ""
+	}
+}

--- a/typechecker/resource_resolution_nominal_test.go
+++ b/typechecker/resource_resolution_nominal_test.go
@@ -1,0 +1,32 @@
+package typechecker
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveResourceDeclarationsRejectsStructuralRecordResourceType(t *testing.T) {
+	const input = `
+Handle: type = { id: u32 }
+close: (h: Handle): () = {}
+`
+	tc := checkedResourceProgram(t, input)
+	declarations := []ResourceProtocolDeclaration{{
+		Name:          "HandleLifecycle",
+		ResourceTypes: []string{"Handle"},
+		States:        []string{"Open", "Closed"},
+		Initial:       "Open",
+		Transitions: []ResourceTransitionDeclaration{{
+			Name:     "close-transition",
+			Callable: "close",
+			From:     "Open",
+			To:       "Closed",
+			Consumes: []int{0},
+		}},
+	}}
+
+	_, err := tc.ResolveResourceDeclarations(declarations)
+	if err == nil || !strings.Contains(err.Error(), "concrete nominal Oak type") {
+		t.Fatalf("expected structural resource type rejection, got %v", err)
+	}
+}

--- a/typechecker/resource_resolution_test.go
+++ b/typechecker/resource_resolution_test.go
@@ -1,0 +1,206 @@
+package typechecker
+
+import (
+	"strings"
+	"testing"
+)
+
+func checkedResourceProgram(t *testing.T, input string) *TypeChecker {
+	t.Helper()
+	tc := setupTypeChecker(input)
+	program := parseProgram(input)
+	tc.CheckProgram(program)
+	if errors := tc.Errors(); len(errors) != 0 {
+		t.Fatalf("test program failed ordinary type checking: %v", errors)
+	}
+	return tc
+}
+
+func handleResourceDeclarations() []ResourceProtocolDeclaration {
+	return []ResourceProtocolDeclaration{{
+		Name:          "HandleLifecycle",
+		ResourceTypes: []string{"Handle"},
+		States:        []string{"Open", "Closed"},
+		Initial:       "Open",
+		Transitions: []ResourceTransitionDeclaration{
+			{
+				Name:     "close-transition",
+				Callable: "close",
+				From:     "Open",
+				To:       "Closed",
+				Consumes: []int{0},
+			},
+			{
+				Name:         "renew-transition",
+				Callable:     "renew",
+				From:         "Open",
+				To:           "Open",
+				Consumes:     []int{0},
+				ReturnsFresh: true,
+			},
+		},
+	}}
+}
+
+func TestResolveResourceDeclarationsBindsCheckedTypesAndCallables(t *testing.T) {
+	const input = `
+Handle: type = struct { id: u32 }
+close: (h: Handle): () = {}
+renew: (h: Handle): Handle = h
+`
+	tc := checkedResourceProgram(t, input)
+	resolved, err := tc.ResolveResourceDeclarations(handleResourceDeclarations())
+	if err != nil {
+		t.Fatalf("resource resolution failed: %v", err)
+	}
+	if len(resolved.Types) != 1 || resolved.Types[0].Name != "Handle" || resolved.Types[0].Protocol != "HandleLifecycle" {
+		t.Fatalf("unexpected resolved resource types: %#v", resolved.Types)
+	}
+	if len(resolved.Protocols) != 1 || len(resolved.Protocols[0].Transitions) != 2 {
+		t.Fatalf("unexpected resolved protocols: %#v", resolved.Protocols)
+	}
+	closeTransition := resolved.Protocols[0].Transitions[0]
+	if closeTransition.Name != "close-transition" || closeTransition.Callable != "close" {
+		t.Fatalf("transition label must stay distinct from resolved callable: %#v", closeTransition)
+	}
+	if len(closeTransition.Consumes) != 1 || closeTransition.Consumes[0] != 0 || closeTransition.ReturnsFresh {
+		t.Fatalf("unexpected close semantics: %#v", closeTransition)
+	}
+	if !resolved.Protocols[0].Transitions[1].ReturnsFresh {
+		t.Fatal("renew transition should return fresh authority")
+	}
+}
+
+func TestResolveResourceDeclarationsRequiresExplicitCallableBinding(t *testing.T) {
+	const input = `
+Handle: type = struct { id: u32 }
+close: (h: Handle): () = {}
+`
+	tc := checkedResourceProgram(t, input)
+	declarations := handleResourceDeclarations()
+	declarations[0].Transitions = declarations[0].Transitions[:1]
+	declarations[0].Transitions[0].Callable = ""
+
+	_, err := tc.ResolveResourceDeclarations(declarations)
+	if err == nil || !strings.Contains(err.Error(), "no resolved callable binding") {
+		t.Fatalf("expected missing callable rejection, got %v", err)
+	}
+}
+
+func TestResolveResourceDeclarationsRejectsUnknownCallable(t *testing.T) {
+	const input = `
+Handle: type = struct { id: u32 }
+`
+	tc := checkedResourceProgram(t, input)
+	declarations := handleResourceDeclarations()
+	declarations[0].Transitions = declarations[0].Transitions[:1]
+	declarations[0].Transitions[0].Callable = "missing"
+
+	_, err := tc.ResolveResourceDeclarations(declarations)
+	if err == nil || !strings.Contains(err.Error(), `unknown callable "missing"`) {
+		t.Fatalf("expected unknown callable rejection, got %v", err)
+	}
+}
+
+func TestResolveResourceDeclarationsRejectsNonResourceConsumedArgument(t *testing.T) {
+	const input = `
+Handle: type = struct { id: u32 }
+close_id: (id: u32): () = {}
+`
+	tc := checkedResourceProgram(t, input)
+	declarations := []ResourceProtocolDeclaration{{
+		Name:          "HandleLifecycle",
+		ResourceTypes: []string{"Handle"},
+		States:        []string{"Open", "Closed"},
+		Initial:       "Open",
+		Transitions: []ResourceTransitionDeclaration{{
+			Name:     "close-transition",
+			Callable: "close_id",
+			From:     "Open",
+			To:       "Closed",
+			Consumes: []int{0},
+		}},
+	}}
+
+	_, err := tc.ResolveResourceDeclarations(declarations)
+	if err == nil || !strings.Contains(err.Error(), "non-resource type") {
+		t.Fatalf("expected non-resource consumed argument rejection, got %v", err)
+	}
+}
+
+func TestResolveResourceDeclarationsRejectsFreshNonResourceReturn(t *testing.T) {
+	const input = `
+Handle: type = struct { id: u32 }
+finish: (h: Handle): u32 = h.id
+`
+	tc := checkedResourceProgram(t, input)
+	declarations := []ResourceProtocolDeclaration{{
+		Name:          "HandleLifecycle",
+		ResourceTypes: []string{"Handle"},
+		States:        []string{"Open"},
+		Initial:       "Open",
+		Transitions: []ResourceTransitionDeclaration{{
+			Name:         "finish-transition",
+			Callable:     "finish",
+			From:         "Open",
+			To:           "Open",
+			Consumes:     []int{0},
+			ReturnsFresh: true,
+		}},
+	}}
+
+	_, err := tc.ResolveResourceDeclarations(declarations)
+	if err == nil || !strings.Contains(err.Error(), "fresh return") {
+		t.Fatalf("expected non-resource fresh return rejection, got %v", err)
+	}
+}
+
+func TestResolveResourceDeclarationsRejectsConsumeIndexOutsideSignature(t *testing.T) {
+	const input = `
+Handle: type = struct { id: u32 }
+close: (h: Handle): () = {}
+`
+	tc := checkedResourceProgram(t, input)
+	declarations := handleResourceDeclarations()
+	declarations[0].Transitions = declarations[0].Transitions[:1]
+	declarations[0].Transitions[0].Consumes = []int{1}
+
+	_, err := tc.ResolveResourceDeclarations(declarations)
+	if err == nil || !strings.Contains(err.Error(), "outside its 1 parameters") {
+		t.Fatalf("expected consume index rejection, got %v", err)
+	}
+}
+
+func TestResolveResourceDeclarationsRejectsConflictingCallableSemantics(t *testing.T) {
+	const input = `
+Left: type = struct { id: u32 }
+Right: type = struct { id: u32 }
+transfer: (left: Left, right: Right): () = {}
+`
+	tc := checkedResourceProgram(t, input)
+	declarations := []ResourceProtocolDeclaration{
+		{
+			Name:          "LeftLifecycle",
+			ResourceTypes: []string{"Left"},
+			States:        []string{"Live"},
+			Initial:       "Live",
+			Transitions: []ResourceTransitionDeclaration{{
+				Name: "left-transfer", Callable: "transfer", From: "Live", To: "Live", Consumes: []int{0},
+			}},
+		},
+		{
+			Name:          "RightLifecycle",
+			ResourceTypes: []string{"Right"},
+			States:        []string{"Live"},
+			Initial:       "Live",
+			Transitions: []ResourceTransitionDeclaration{{
+				Name: "right-transfer", Callable: "transfer", From: "Live", To: "Live", Consumes: []int{1},
+			}},
+		},
+	}
+
+	_, err := tc.ResolveResourceDeclarations(declarations)
+	if err == nil || !strings.Contains(err.Error(), "conflicting semantics") {
+		t.Fatalf("expected conflicting callable semantics rejection, got %v", err)
+	}
+}


### PR DESCRIPTION
Adds the first production SemIR projection at the checked compiler boundary without freezing resource surface syntax.

- Introduces syntax-independent resource protocol declarations and resolves them against the checked Oak type environment.
- Requires concrete nominal resource identity; structural records/interfaces cannot opt into non-duplicable authority and bypass it through structural/dynamic compatibility.
- Requires explicit resolved callable bindings; transition labels are never treated as callable identity.
- Validates consumed argument indices/types, fresh resource returns, states, duplicates, and conflicting callable semantics before emission.
- Adds `Compilation.ResourceSemIR`, which emits canonical `Authority.Resource`, `Transition.Callable`, `resource.consume[arg:N]`, and `resource.return-fresh` facts.
- Keeps resource liveness orthogonal to temporary ownership: this resource-only projection leaves `Authority.Ownership`, representation, and detailed type shape unspecified instead of inventing unrelated facts.
- Feeds the emitted SemIR back through `ResourceModelFromSemIR` and path-sensitive `CheckResourceFlow` without rerunning ordinary type checking.
- Adds resolver and compiler integration tests, including OAK-B0111 through the production compiler stage, fresh-return authority, rejection of structural record resource declarations, and preservation of orthogonal SemIR axes.

Resource declarations remain internal semantic input until source/ABI ownership syntax is frozen.