### PR TITLE
Wire resource semantics into default checking

### DIFF
--- a/compiler/compilation.go
+++ b/compiler/compilation.go
@@ -46,8 +46,9 @@ type Options struct {
 // modified copies so callers can cheaply derive configurations without hidden
 // mutation between compiler phases.
 type Compilation struct {
-	source  SourceText
-	options Options
+	source            SourceText
+	options           Options
+	resourceProtocols []typechecker.ResourceProtocolDeclaration
 }
 
 // SyntaxTree is a parsed Oak source file.
@@ -116,6 +117,15 @@ func (comp Compilation) WithProfile(profile string) Compilation {
 	return comp
 }
 
+// WithResourceProtocols configures syntax-independent resource semantics for
+// the ordinary Check pipeline. These declarations are resolved against Oak's
+// checked type/callable environment; this API intentionally freezes no source
+// spelling for resource protocols, consumption, or fresh authority.
+func (comp Compilation) WithResourceProtocols(declarations []typechecker.ResourceProtocolDeclaration) Compilation {
+	comp.resourceProtocols = cloneResourceProtocolDeclarations(declarations)
+	return comp
+}
+
 // Options returns the effective compilation options.
 func (comp Compilation) Options() Options {
 	return comp.options
@@ -159,11 +169,17 @@ func (comp Compilation) SyntaxTree() Stage[*SyntaxTree] {
 }
 
 // Check parses and semantically checks the source: type checking, borrow
-// checking (memory safety), and discipline analysis (bounded execution) all
-// gate compilation. Error-severity diagnostics always reject; in the strict
-// profile, warnings (recorded unsafe assumptions, tail-recursion
-// obligations, unnecessary-code warnings) reject too (85-discipline §7).
+// checking (memory safety), configured resource-authority checking, and
+// discipline analysis (bounded execution) all gate compilation. Resource
+// semantics enter through syntax-independent resolved declarations rather than
+// a source spelling. Error-severity diagnostics always reject; in the strict
+// profile, warnings (recorded unsafe assumptions, tail-recursion obligations,
+// unnecessary-code warnings) reject too (85-discipline §7).
 func (comp Compilation) Check() Stage[*SemanticModel] {
+	return comp.check(comp.resourceProtocols)
+}
+
+func (comp Compilation) check(resourceProtocols []typechecker.ResourceProtocolDeclaration) Stage[*SemanticModel] {
 	return comp.Parse().Then(func(tree *SyntaxTree) (*SemanticModel, error) {
 		publicRoot, ok := cloneSyntax(reflect.ValueOf(tree.Root)).Interface().(*ast.Program)
 		if !ok || publicRoot == nil {
@@ -179,17 +195,25 @@ func (comp Compilation) Check() Stage[*SemanticModel] {
 			return nil, err
 		}
 
+		model := &SemanticModel{Tree: tree, PublicRoot: publicRoot, TypeChecker: tc}
+
 		bc := borrowchecker.New()
 		bc.CheckProgram(tree.Root, tc.Env())
 		if err := comp.gate("borrowcheck", bc.Diagnostics()); err != nil {
 			return nil, err
 		}
 
+		if len(resourceProtocols) != 0 {
+			if _, _, err := comp.checkResourceProtocols(model, resourceProtocols); err != nil {
+				return nil, err
+			}
+		}
+
 		if err := comp.gate("discipline", discipline.AnalyzeProgram(tree.Root).Diagnostics()); err != nil {
 			return nil, err
 		}
 
-		return &SemanticModel{Tree: tree, PublicRoot: publicRoot, TypeChecker: tc}, nil
+		return model, nil
 	})
 }
 

--- a/compiler/resource_default_pipeline_test.go
+++ b/compiler/resource_default_pipeline_test.go
@@ -1,0 +1,100 @@
+package compiler
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/SCKelemen/oak/typechecker"
+)
+
+func compilerCloseResourceDeclarations() []typechecker.ResourceProtocolDeclaration {
+	declarations := compilerResourceDeclarations()
+	declarations[0].Transitions = declarations[0].Transitions[:1]
+	return declarations
+}
+
+func requireResourceUseAfterConsume(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected resource use-after-consume rejection")
+	}
+	var diagnosticErr *DiagnosticError
+	if !errors.As(err, &diagnosticErr) {
+		t.Fatalf("expected first-class DiagnosticError, got %T: %v", err, err)
+	}
+	if diagnosticErr.Phase != "resource" {
+		t.Fatalf("expected resource phase rejection, got %q", diagnosticErr.Phase)
+	}
+	for _, diagnostic := range diagnosticErr.Diagnostics {
+		if diagnostic != nil && diagnostic.Code == typechecker.CodeResourceUsedAfterConsume {
+			return
+		}
+	}
+	t.Fatalf("expected %s in resource diagnostics: %#v", typechecker.CodeResourceUsedAfterConsume, diagnosticErr.Diagnostics)
+}
+
+func TestCheckRunsConfiguredResourceSemantics(t *testing.T) {
+	const source = `
+Handle: type = struct { id: u32 }
+close: (h: Handle): () = {}
+f: (h: Handle): u32 {
+  close(h)
+  h.id
+}
+`
+
+	_, err := New().
+		WithSource("default-resource.oak", source).
+		WithResourceProtocols(compilerCloseResourceDeclarations()).
+		Check().
+		Get()
+	requireResourceUseAfterConsume(t, err)
+}
+
+func TestCheckConfiguredFreshReturnCarriesNewAuthority(t *testing.T) {
+	const source = `
+Handle: type = struct { id: u32 }
+close: (h: Handle): () = {}
+renew: (h: Handle): Handle = h
+f: (h: Handle): u32 {
+  next: Handle = renew(h)
+  next.id
+}
+`
+
+	if _, err := New().
+		WithSource("default-resource-fresh.oak", source).
+		WithResourceProtocols(compilerResourceDeclarations()).
+		Check().
+		Get(); err != nil {
+		t.Fatalf("configured resource semantics should accept fresh returned authority: %v", err)
+	}
+}
+
+func TestWithResourceProtocolsPreservesCompilationValueSemantics(t *testing.T) {
+	const source = `
+Handle: type = struct { id: u32 }
+close: (h: Handle): () = {}
+f: (h: Handle): u32 {
+  close(h)
+  h.id
+}
+`
+
+	declarations := compilerCloseResourceDeclarations()
+	base := New().WithSource("resource-copy.oak", source)
+	configured := base.WithResourceProtocols(declarations)
+
+	// Mutating the caller-owned declaration graph after configuration must not
+	// alter the immutable Compilation value.
+	declarations[0].ResourceTypes[0] = "Missing"
+	declarations[0].Transitions[0].Callable = "missing"
+	declarations[0].Transitions[0].Consumes[0] = 99
+
+	_, configuredErr := configured.Check().Get()
+	requireResourceUseAfterConsume(t, configuredErr)
+
+	if _, err := base.Check().Get(); err != nil {
+		t.Fatalf("unconfigured compilation unexpectedly inherited resource semantics: %v", err)
+	}
+}

--- a/compiler/resource_semir.go
+++ b/compiler/resource_semir.go
@@ -20,29 +20,14 @@ type ResourceSemanticIR struct {
 // declarations against the checked type environment, emits canonical SemIR,
 // and runs the path-sensitive resource checker from that emitted module.
 //
-// Resource declarations remain an internal semantic input until Oak freezes a
-// source or ABI spelling. The projection below is therefore reusable by either
-// future frontend without teaching the AST to guess ownership semantics.
+// The declarations passed to this explicit stage are authoritative for the
+// stage. Compilation-level resource configuration is intentionally not run a
+// second time. Resource declarations remain an internal semantic input until
+// Oak freezes a source or ABI spelling.
 func (comp Compilation) ResourceSemIR(declarations []typechecker.ResourceProtocolDeclaration) Stage[*ResourceSemanticIR] {
-	return comp.Check().Then(func(model *SemanticModel) (*ResourceSemanticIR, error) {
-		resolved, err := model.TypeChecker.ResolveResourceDeclarations(declarations)
+	return comp.check(nil).Then(func(model *SemanticModel) (*ResourceSemanticIR, error) {
+		resolved, module, err := comp.checkResourceProtocols(model, declarations)
 		if err != nil {
-			return nil, fmt.Errorf("resource resolution failed: %w", err)
-		}
-
-		module, err := emitResourceSemIR(resolved)
-		if err != nil {
-			return nil, fmt.Errorf("resource SemIR emission failed: %w", err)
-		}
-
-		resourceModel, err := typechecker.ResourceModelFromSemIR(module)
-		if err != nil {
-			return nil, fmt.Errorf("resource SemIR projection failed: %w", err)
-		}
-		// Check() already performed ordinary type checking. Run only resource
-		// flow here so diagnostics are not duplicated by a second CheckProgram.
-		model.TypeChecker.CheckResourceFlow(model.Tree.Root, resourceModel)
-		if err := comp.gate("resource", model.TypeChecker.Diagnostics()); err != nil {
 			return nil, err
 		}
 
@@ -52,6 +37,52 @@ func (comp Compilation) ResourceSemIR(declarations []typechecker.ResourceProtoco
 			Resources: resolved,
 		}, nil
 	})
+}
+
+func (comp Compilation) checkResourceProtocols(
+	model *SemanticModel,
+	declarations []typechecker.ResourceProtocolDeclaration,
+) (typechecker.ResolvedResourceProgram, semir.Module, error) {
+	resolved, err := model.TypeChecker.ResolveResourceDeclarations(declarations)
+	if err != nil {
+		return typechecker.ResolvedResourceProgram{}, semir.Module{}, fmt.Errorf("resource resolution failed: %w", err)
+	}
+
+	module, err := emitResourceSemIR(resolved)
+	if err != nil {
+		return typechecker.ResolvedResourceProgram{}, semir.Module{}, fmt.Errorf("resource SemIR emission failed: %w", err)
+	}
+
+	resourceModel, err := typechecker.ResourceModelFromSemIR(module)
+	if err != nil {
+		return typechecker.ResolvedResourceProgram{}, semir.Module{}, fmt.Errorf("resource SemIR projection failed: %w", err)
+	}
+	// Ordinary type checking has already populated the environment. Run only
+	// resource flow here so diagnostics are not duplicated by CheckProgram.
+	model.TypeChecker.CheckResourceFlow(model.Tree.Root, resourceModel)
+	if err := comp.gate("resource", model.TypeChecker.Diagnostics()); err != nil {
+		return typechecker.ResolvedResourceProgram{}, semir.Module{}, err
+	}
+
+	return resolved, module, nil
+}
+
+func cloneResourceProtocolDeclarations(declarations []typechecker.ResourceProtocolDeclaration) []typechecker.ResourceProtocolDeclaration {
+	if len(declarations) == 0 {
+		return nil
+	}
+	cloned := make([]typechecker.ResourceProtocolDeclaration, len(declarations))
+	for i, declaration := range declarations {
+		cloned[i] = declaration
+		cloned[i].ResourceTypes = append([]string(nil), declaration.ResourceTypes...)
+		cloned[i].States = append([]string(nil), declaration.States...)
+		cloned[i].Transitions = make([]typechecker.ResourceTransitionDeclaration, len(declaration.Transitions))
+		for j, transition := range declaration.Transitions {
+			cloned[i].Transitions[j] = transition
+			cloned[i].Transitions[j].Consumes = append([]int(nil), transition.Consumes...)
+		}
+	}
+	return cloned
 }
 
 func emitResourceSemIR(resources typechecker.ResolvedResourceProgram) (semir.Module, error) {


### PR DESCRIPTION
## Summary

- carry syntax-independent resource protocol declarations on `Compilation`
- resolve and emit canonical resource SemIR from the ordinary `Check()` pipeline
- run path-sensitive resource flow without re-running ordinary typechecking
- keep explicit `ResourceSemIR(...)` declarations authoritative and avoid double-running configured resource semantics
- deep-copy resource metadata so `Compilation` retains value semantics

## Coverage

- default `Check()` rejects `OAK-B0111` after configured consumption
- fresh-return transitions carry new authority
- mutating caller-owned resource declarations does not mutate an already-configured compilation

## Syntax

No parser, grammar, or resource surface-syntax changes are included. Tests use Oak's existing `name: (...): ...` declaration form; this PR does not freeze a `consume` spelling or receiver syntax.