### PR TITLE
Build filter, hash-table and bit libraries in Oak

### DIFF
--- a/.github/workflows/oak-libraries.yml
+++ b/.github/workflows/oak-libraries.yml
@@ -1,0 +1,18 @@
+name: Oak libraries
+on:
+  push:
+    branches: [codex/oak-library-ports]
+  pull_request:
+    branches: [specification]
+jobs:
+  native:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.27.1'
+      - name: Native Oak library models
+        run: go test ./compiler -run '^TestE2EOakLibraries' -count=1
+      - name: Check formatting
+        run: test -z "$(gofmt -l stdlib/source.go compiler/e2e_oak_libraries_test.go)"

--- a/compiler/e2e_oak_libraries_test.go
+++ b/compiler/e2e_oak_libraries_test.go
@@ -1,0 +1,284 @@
+package compiler
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+const oakLibraryPrelude = `
+import(std)
+filter_ok: (r: Result[Bool, FilterError]): Bool = r ? | .Ok(v) => v | .Err(e) => false
+filter_code: (r: Result[Bool, FilterError]): u32 = r ?
+ | .Ok(v) => u32(0)
+ | .Err(e) => e ?
+   | .InvalidConfig => u32(1)
+   | .StorageTooSmall => u32(2)
+   | .CounterOverflow => u32(3)
+   | .NotPresent => u32(4)
+   | .Incompatible => u32(5)
+table_code: (r: Result[Bool, HashTableError]): u32 = r ?
+ | .Ok(v) => (v ? u32(1) | u32(2))
+ | .Err(e) => u32(3)
+`
+
+func oakLibraryRun(t *testing.T, source string) {
+	t.Helper()
+	c, err := New().WithSource("oaklibraries.oak", source).EmitC().Get()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"OAK_UNSUPPORTED", "OAK_UNRESOLVED", "malloc(", "calloc(", "realloc("} {
+		if strings.Contains(c, forbidden) {
+			t.Fatalf("generated C contains %q", forbidden)
+		}
+	}
+	code, abnormal := buildAndRun(t, "oaklibraries", source)
+	if abnormal || code != 42 {
+		t.Fatalf("exit=(%d,%v)", code, abnormal)
+	}
+}
+
+func oakFilterMix(x uint64) uint64 {
+	x = (x ^ (x >> 30)) * 0xbf58476d1ce4e5b9
+	x = (x ^ (x >> 27)) * 0x94d049bb133111eb
+	return x ^ (x >> 31)
+}
+
+func oakFilterIndex(hash, seed uint64, cells, probe int, blocked bool) int {
+	a := oakFilterMix(hash ^ seed)
+	b := oakFilterMix(a+0x9e3779b97f4a7c15) | 1
+	v := a + b*uint64(probe)
+	if blocked {
+		return int((a>>32)%uint64(cells/512))*512 + int(v%512)
+	}
+	return int(v % uint64(cells))
+}
+
+func TestE2EOakLibrariesFilters(t *testing.T) {
+	for _, tc := range []struct {
+		cells   int
+		probes  int
+		blocked bool
+	}{{1, 64, false}, {67, 6, false}, {1024, 6, true}} {
+		t.Run(fmt.Sprint(tc), func(t *testing.T) {
+			var src strings.Builder
+			src.WriteString(oakLibraryPrelude)
+			n := (tc.cells + 7) / 8
+			fmt.Fprintf(&src, "main: (): i32 {\ncfg: BloomConfig = BloomConfig { cells: u32(%d), probes: u32(%d), seed: u64(17), blocked: %t }\ndata: [%d]u8\ncounters: [%d]u8\n", tc.cells, tc.probes, tc.blocked, n+1, tc.cells+1)
+			backing := make([]byte, n+1)
+			counts := make([]byte, tc.cells+1)
+			// Padding and unused storage must survive all filter operations.
+			backing[n] = 165
+			counts[tc.cells] = 165
+			fmt.Fprintf(&src, "data[%d] = u8(165)\ncounters[%d] = u8(165)\n", n, tc.cells)
+			for hash := uint64(0); hash < 18; hash++ {
+				fmt.Fprintf(&src, "true ? {\ns: [*]u8 = span(&data)\nc: [*]u8 = span(&counters)\nassert(filter_code(bloom_insert(s, cfg, u64(%d))) == u32(0))\nassert(filter_ok(counting_bloom_update(c, cfg, u64(%d), true)))\n}\n", hash, hash)
+				seen := map[int]bool{}
+				for p := 0; p < tc.probes; p++ {
+					i := oakFilterIndex(hash, 17, tc.cells, p, tc.blocked)
+					backing[i/8] |= 1 << (i % 8)
+					if !seen[i] {
+						counts[i]++
+						seen[i] = true
+					}
+				}
+			}
+			for i, v := range backing {
+				fmt.Fprintf(&src, "assert(data[%d] == u8(%d))\n", i, v)
+			}
+			for i, v := range counts {
+				fmt.Fprintf(&src, "assert(counters[%d] == u8(%d))\n", i, v)
+			}
+			src.WriteString("true ? {\nv: []u8 = view(&data)\nc: []u8 = view(&counters)\n")
+			for hash := uint64(0); hash < 50; hash++ {
+				present, counted := true, true
+				for p := 0; p < tc.probes; p++ {
+					i := oakFilterIndex(hash, 17, tc.cells, p, tc.blocked)
+					present = present && backing[i/8]&(1<<(i%8)) != 0
+					counted = counted && counts[i] > 0
+				}
+				fmt.Fprintf(&src, "assert(filter_ok(bloom_query(v, cfg, u64(%d))) == %t)\nassert(filter_ok(counting_bloom_query(c, cfg, u64(%d))) == %t)\n", hash, present, hash, counted)
+			}
+			src.WriteString("}\ntrue ? {\nc: [*]u8 = span(&counters)\n")
+			for hash := uint64(0); hash < 18; hash++ {
+				fmt.Fprintf(&src, "assert(filter_ok(counting_bloom_update(c, cfg, u64(%d), false)))\n", hash)
+			}
+			src.WriteString("}\n")
+			for i := 0; i < tc.cells; i++ {
+				fmt.Fprintf(&src, "assert(counters[%d] == u8(0))\n", i)
+			}
+			fmt.Fprintf(&src, "assert(counters[%d] == u8(165))\ntrue ? {\ns: [*]u8 = span(&data)\nassert(filter_ok(bloom_clear(s, cfg)))\n}\n", tc.cells)
+			for i := 0; i < n; i++ {
+				fmt.Fprintf(&src, "assert(data[%d] == u8(0))\n", i)
+			}
+			fmt.Fprintf(&src, "assert(data[%d] == u8(165))\n42\n}\n", n)
+			oakLibraryRun(t, src.String())
+		})
+	}
+}
+
+func TestE2EOakLibrariesFilterFailures(t *testing.T) {
+	oakLibraryRun(t, oakLibraryPrelude+`
+main: (): i32 {
+ cfg: BloomConfig = BloomConfig { cells: u32(1), probes: u32(64), seed: u64(0), blocked: false }
+ bad: BloomConfig = BloomConfig { cells: u32(0), probes: u32(0), seed: u64(0), blocked: false }
+ short: BloomConfig = BloomConfig { cells: u32(17), probes: u32(6), seed: u64(0), blocked: false }
+ blocked: BloomConfig = BloomConfig { cells: u32(1), probes: u32(6), seed: u64(0), blocked: true }
+ data: [2]u8
+ s: [*]u8 = span(&data)
+ s[0] = u8(254)
+ s[1] = u8(165)
+ assert(filter_code(counting_bloom_update(s, cfg, u64(9), true)) == u32(0))
+ assert(s[0] == u8(255))
+ assert(filter_code(counting_bloom_update(s, cfg, u64(9), true)) == u32(3))
+ assert(s[0] == u8(255))
+ assert(filter_code(bloom_insert(s, bad, u64(9))) == u32(1))
+ assert(filter_code(bloom_insert(s, blocked, u64(9))) == u32(1))
+ assert(filter_code(bloom_insert(s, short, u64(9))) == u32(2))
+ assert(filter_code(counting_bloom_update(s, short, u64(9), true)) == u32(2))
+ assert(s[0] == u8(255))
+ assert(s[1] == u8(165))
+ assert(filter_ok(bloom_clear(s, cfg)))
+ assert(s[0] == u8(254))
+ s[0] = u8(0)
+ assert(filter_code(counting_bloom_update(s, cfg, u64(9), false)) == u32(4))
+ assert(s[0] == u8(0))
+ assert(s[1] == u8(165))
+ 42
+}
+`)
+}
+
+func TestE2EOakLibrariesHashTable(t *testing.T) {
+	for _, capacity := range []int{1, 7} {
+		t.Run(fmt.Sprint(capacity), func(t *testing.T) {
+			var src strings.Builder
+			src.WriteString(oakLibraryPrelude)
+			fmt.Fprintf(&src, "Entry: type = struct { key: u64, state: u8, value: u32 }\nmain: (): i32 {\ndata: [%d]Entry\n", capacity)
+			// All keys share their initial bucket, including a cluster wrapping at the end.
+			keys := []uint64{}
+			for k := uint64(0); len(keys) < capacity+2; k++ {
+				if oakFilterMix(k)%uint64(capacity) == uint64(capacity-1) {
+					keys = append(keys, k)
+				}
+			}
+			model := map[uint64]uint32{}
+			seed := uint32(45)
+			for step := 0; step < 100; step++ {
+				seed = seed*1664525 + 1013904223
+				key := keys[int(seed>>16)%len(keys)]
+				op := int(seed>>28) % 5
+				src.WriteString("true ? {\ns: [*]Entry = span(&data)\n")
+				switch op {
+				case 0, 1, 2:
+					_, existed := model[key]
+					code := 1
+					if existed {
+						code = 2
+					} else if len(model) == capacity {
+						code = 3
+					}
+					if code != 3 {
+						model[key] = seed >> 8
+					}
+					fmt.Fprintf(&src, "item: Entry = Entry { key: u64(%d), state: u8(99), value: u32(%d) }\nassert(table_code(hash_table_put(s, item)) == u32(%d))\n", key, seed>>8, code)
+				case 3:
+					_, existed := model[key]
+					delete(model, key)
+					fmt.Fprintf(&src, "assert(hash_table_remove(s, u64(%d)) == %t)\n", key, existed)
+				case 4:
+					if step%9 == 0 {
+						src.WriteString("hash_table_clear(s)\n")
+						clear(model)
+					}
+				}
+				src.WriteString("}\ntrue ? {\nv: []Entry = view(&data)\n")
+				fmt.Fprintf(&src, "assert(hash_table_count(v) == u32(%d))\n", len(model))
+				for i, k := range keys {
+					value, found := model[k]
+					fmt.Fprintf(&src, "r%d: Option[u32] = hash_table_find(v, u64(%d))\nf%d: Bool = r%d ? | .Some(index) => true | .None => false\nassert(f%d == %t)\n", i, k, i, i, i, found)
+					if found {
+						fmt.Fprintf(&src, "ix%d: u32 = option_or(r%d, u32(4294967295))\nassert(v[ix%d].value == u32(%d))\n", i, i, i, value)
+					}
+				}
+				src.WriteString("}\n")
+			}
+			src.WriteString("42\n}\n")
+			oakLibraryRun(t, src.String())
+		})
+	}
+}
+
+func TestE2EOakLibrariesBitsAndSet(t *testing.T) {
+	oakLibraryRun(t, oakLibraryPrelude+`
+bits_ok: (r: Result[Bool, BitSetError]): Bool = r ? | .Ok(v) => v | .Err(e) => false
+flag_value: (r: Result[FlagBits, FlagError]): FlagBits = r ?
+ | .Ok(v) => v
+ | .Err(e) => FlagBits { bits: u64(0), allowed: u64(0) }
+flag_error: (r: Result[FlagBits, FlagError]): Bool = r ? | .Ok(v) => false | .Err(e) => true
+found_bit: (r: Result[Option[u32], BitSetError]): u32 = r ?
+ | .Ok(v) => option_or(v, u32(99))
+ | .Err(e) => u32(98)
+main: (): i32 {
+ data: [3]u8
+ other: [2]u8
+ data[0] = u8(5)
+ data[1] = u8(254)
+ data[2] = u8(165)
+ other[0] = u8(6)
+ other[1] = u8(1)
+ true ? {
+  s: [*]u8 = span(&data)
+  v: []u8 = view(&other)
+  assert(bits_ok(bitset_combine(s, v, u32(9), .Union)))
+  assert(s[0] == u8(7))
+  assert(s[1] == u8(255))
+  assert(bits_ok(bitset_combine(s, v, u32(9), .Difference)))
+  assert(s[0] == u8(1))
+  assert(s[1] == u8(254))
+  assert(bits_ok(bitset_combine(s, v, u32(9), .SymmetricDifference)))
+  assert(s[0] == u8(7))
+  assert(s[1] == u8(255))
+  assert(bits_ok(bitset_combine(s, v, u32(9), .Intersection)))
+  assert(s[0] == u8(6))
+  assert(s[1] == u8(255))
+  assert(s[2] == u8(165))
+ }
+ true ? {
+  v: []u8 = view(&data)
+  assert(found_bit(bitset_find_next(v, u32(9), u32(0), true)) == u32(1))
+  assert(found_bit(bitset_find_next(v, u32(9), u32(3), true)) == u32(8))
+  assert(found_bit(bitset_find_next(v, u32(9), u32(9), true)) == u32(99))
+  assert(found_bit(bitset_find_next(v, u32(9), u32(0), false)) == u32(0))
+ }
+ f: FlagBits = flag_value(flags_create(u64(1), u64(7)))
+ assert(flags_contains_all(f, u64(1)))
+ assert(!flags_contains_any(f, u64(2)))
+ assert(flag_error(flags_create(u64(8), u64(7))))
+ assert(flag_error(flags_update(f, u64(8), true)))
+ g: FlagBits = flag_value(flags_update(f, u64(6), true))
+ assert(g.bits == u64(7))
+ h: FlagBits = flag_value(flags_update(g, u64(2), false))
+ assert(h.bits == u64(5))
+ assert(!flags_contains_all(h, u64(8)))
+ slots: [2]HashSetSlot
+ true ? {
+  s: [*]HashSetSlot = span(&slots)
+  assert(table_code(hash_set_insert(s, u64(0))) == u32(1))
+  assert(table_code(hash_set_insert(s, u64(0))) == u32(2))
+  assert(table_code(hash_set_insert(s, u64(1))) == u32(1))
+  assert(table_code(hash_set_insert(s, u64(2))) == u32(3))
+  assert(hash_set_remove(s, u64(0)))
+  assert(table_code(hash_set_insert(s, u64(2))) == u32(1))
+ }
+ true ? {
+  v: []HashSetSlot = view(&slots)
+  assert(!hash_set_contains(v, u64(0)))
+  assert(hash_set_contains(v, u64(1)))
+  assert(hash_set_contains(v, u64(2)))
+ }
+ 42
+}
+`)
+}

--- a/compiler/e2e_oak_libraries_test.go
+++ b/compiler/e2e_oak_libraries_test.go
@@ -123,7 +123,7 @@ func TestE2EOakLibrariesFilterFailures(t *testing.T) {
 main: (): i32 {
  cfg: BloomConfig = BloomConfig { cells: u32(1), probes: u32(64), seed: u64(0), blocked: false }
  bad: BloomConfig = BloomConfig { cells: u32(0), probes: u32(0), seed: u64(0), blocked: false }
- short: BloomConfig = BloomConfig { cells: u32(17), probes: u32(6), seed: u64(0), blocked: false }
+ undersized: BloomConfig = BloomConfig { cells: u32(17), probes: u32(6), seed: u64(0), blocked: false }
  blocked: BloomConfig = BloomConfig { cells: u32(1), probes: u32(6), seed: u64(0), blocked: true }
  data: [2]u8
  s: [*]u8 = span(&data)
@@ -135,8 +135,8 @@ main: (): i32 {
  assert(s[0] == u8(255))
  assert(filter_code(bloom_insert(s, bad, u64(9))) == u32(1))
  assert(filter_code(bloom_insert(s, blocked, u64(9))) == u32(1))
- assert(filter_code(bloom_insert(s, short, u64(9))) == u32(2))
- assert(filter_code(counting_bloom_update(s, short, u64(9), true)) == u32(2))
+ assert(filter_code(bloom_insert(s, undersized, u64(9))) == u32(2))
+ assert(filter_code(counting_bloom_update(s, undersized, u64(9), true)) == u32(2))
  assert(s[0] == u8(255))
  assert(s[1] == u8(165))
  assert(filter_ok(bloom_clear(s, cfg)))
@@ -281,4 +281,54 @@ main: (): i32 {
  42
 }
 `)
+}
+
+func TestE2EOakLibrariesBoundaries(t *testing.T) {
+	var src strings.Builder
+	src.WriteString(oakLibraryPrelude)
+	src.WriteString(`
+main: (): i32 {
+ high: u64 = u64(1) << u64(63)
+`)
+	for _, value := range []uint64{0, 1, 0x8000000000000000, 0xffffffffffffffff, 0x123456789abcdef0} {
+		want := oakFilterMix(value)
+		fmt.Fprintf(&src, "assert(filter_mix((u64(%d) << u64(32)) | u64(%d)) == ((u64(%d) << u64(32)) | u64(%d)))\n", value>>32, uint32(value), want>>32, uint32(want))
+	}
+	src.WriteString(`
+ cfg: BloomConfig = BloomConfig { cells: u32(17), probes: u32(6), seed: u64(17), blocked: false }
+ counters: [18]u8
+ s: [*]u8 = span(&counters)
+ i: u32 = 0
+ while i < u32(18) { s[i] = u8(7); i = i + u32(1) }
+ last: u32 = filter_index(cfg, u64(0), u32(5))
+ s[last] = u8(255)
+ assert(filter_code(counting_bloom_update(s, cfg, u64(0), true)) == u32(3))
+ i = u32(0)
+ while i < u32(18) {
+  expected: u8 = i == last ? u8(255) | u8(7)
+  assert(s[i] == expected)
+  i = i + u32(1)
+ }
+ s[last] = u8(0)
+ assert(filter_code(counting_bloom_update(s, cfg, u64(0), false)) == u32(4))
+ i = u32(0)
+ while i < u32(18) {
+  after: u8 = i == last ? u8(0) | u8(7)
+  assert(s[i] == after)
+  i = i + u32(1)
+ }
+ one: [1]HashSetSlot
+ q: [*]HashSetSlot = span(&one)
+ assert(table_code(hash_set_insert(q, high)) == u32(1))
+ assert(table_code(hash_set_insert(q, high)) == u32(2))
+ assert(table_code(hash_set_insert(q, u64(0))) == u32(3))
+ assert(q[0].key == high)
+ assert(hash_set_remove(q, high))
+ assert(table_code(hash_set_insert(q, u64(0))) == u32(1))
+ assert(hash_set_remove(q, u64(0)))
+ assert(!hash_set_remove(q, u64(0)))
+ 42
+}
+`)
+	oakLibraryRun(t, src.String())
 }

--- a/stdlib/COLLECTION_PORTS.md
+++ b/stdlib/COLLECTION_PORTS.md
@@ -1,0 +1,86 @@
+# Oak collection ports
+
+These implementations live in Oak source and are included by `import(std)`.
+The host Go code only embeds the source. All storage is supplied by the caller;
+the libraries allocate nothing and provide no synchronization.
+
+## Filters
+
+`BloomConfig { cells, probes, seed, blocked }` selects ordinary Bloom
+(`blocked: false`) or 512-bit blocked Bloom (`blocked: true`). Cells must be
+positive; probes must be 1..64. Blocked configurations require a multiple of 512
+cells. Keep configuration unchanged while storage contains entries.
+
+- `bloom_insert`, `bloom_query`, `bloom_clear` use byte-packed bits.
+- `counting_bloom_update(storage, config, hash, insert)` and
+  `counting_bloom_query` use one u8 counter per cell. Repeated probe locations
+  are counted once. Counter overflow/underflow is checked before any mutation.
+- Queries return `Result[Bool, FilterError]`: false means definitely absent;
+  true means possibly present. Configuration/storage errors are distinct.
+- Removal requires proof of a successful unmatched insertion. A positive query
+  is insufficient, since it can be a false positive.
+- Inputs are caller-computed u64 key hashes. Hash collisions contribute to
+  false positives. The deterministic mixer is not cryptographic.
+- Zero-initialize active storage. Padding and spare bytes are preserved.
+  Clear counters explicitly before reusing them with another configuration.
+- The mixer and probe sequence match the OS Zig Bloom implementations.
+  u64 arithmetic relies on the current backend's unsigned modulo arithmetic.
+
+## Hash maps and sets
+
+`hash_table_put[T]`, `hash_table_find[T]`, `hash_table_remove[T]`,
+`hash_table_count[T]`, and `hash_table_clear[T]` operate on caller-owned slot
+arrays. A slot has `key: u64`, reserved `state: u8`, and any inline value fields:
+
+```oak
+Entry: type = struct { key: u64, state: u8, value: u32 }
+```
+
+This is an exact u64-key map, not an arbitrary-key comparator API. State is
+0 empty, 1 occupied, 2 tombstone; begin with zeroed slots. Do not modify live
+keys/state except through the API. Keep storage and capacity fixed while active.
+Put normalizes the incoming state and returns Ok(true) for insertion, Ok(false)
+for replacement, or Err(Full) without mutation. Find returns an optional slot
+index; read the payload through the same view. Indices are not stable handles
+across remove, clear, or reuse. Removal and clear leave stale payload bytes.
+
+Linear probing is bounded by capacity, remembers tombstones, and continues
+searching for an existing key before reusing one. Full-table replacement works.
+Count scans the array; there is no hidden cursor, allocation, resize or rehash.
+Worst-case operations are linear in capacity. Rebuild externally when tombstones
+or high load degrade lookup performance.
+
+`HashSetSlot` plus `hash_set_insert/contains/remove` provides an exact u64 set.
+Use the generic count/clear functions for sets too.
+
+## Bits and flags
+
+`bitset_combine` supports Union, Intersection, Difference and SymmetricDifference.
+Both arrays must cover the same logical bit count. It preflights lengths and
+preserves destination padding/spare bytes. `bitset_find_next` finds the next set
+or clear bit at/after a start index, returning None beyond the logical domain.
+Normal Oak borrow rules apply to the mutable destination and immutable source.
+
+`FlagBits { bits, allowed }` supports validated construction/update and all/any
+membership. Unknown mask bits are rejected. It is a runtime u64 mask domain,
+not compile-time separation of two flag types with the same representation.
+Use domain-specific wrapper records to express that distinction. Treat fields
+as private by convention and construct values with `flags_create`.
+
+## Remaining parity with SCKelemen/os
+
+Already present before this port: array lists, rings, deques, indexed intrusive
+singly/doubly linked lists, queues, min heaps, basic bitsets, and bitmap ID pools.
+
+This batch adds the filter/map/bit foundations above. Still to port:
+cuckoo, quotient and counting quotient filters; static XOR/fuse filters;
+generational freelists/slabs; skip lists; tries; balanced and intrusive trees;
+interval trees; debug event rings, per-CPU adapters and wire encoding; and the
+OS assertion contracts beyond Oak's existing assert builtin. Pointer-intrusive
+structures also need an explicit Oak borrowing/ownership design. The OS still
+contains Zig infrastructure; this batch does not convert kernel call sites.
+
+Native tests in `compiler/e2e_oak_libraries_test.go` check exact filter bytes,
+counting probe deduplication and saturation, collision-heavy map traces against
+a Go map, flag validation, bitset padding, and emitted allocator-free C.
+Run `go test ./compiler -run '^TestE2EOakLibraries' -count=1`.

--- a/stdlib/README.md
+++ b/stdlib/README.md
@@ -521,3 +521,8 @@ The standard-library workflow runs the full Go suite with the race detector. The
 Apple Silicon execution, PAC/tag representations, capability transfer/revocation,
 allocator-backed pools, intrusive trees/hash tables, concurrent rings, broader collections and persistence
 protocols remain separate work; importing this module does not implement them.
+
+
+See [Oak collection ports](COLLECTION_PORTS.md) for Bloom/counting Bloom filters,
+u64-key hash maps and sets, bitset algebra, validated flags, and the remaining OS
+library parity work.

--- a/stdlib/bitset_algebra.oak
+++ b/stdlib/bitset_algebra.oak
@@ -1,0 +1,67 @@
+// Bitset algebra preserves bits outside the logical domain, including padding.
+BitSetOperation: type = Union | Intersection | Difference | SymmetricDifference
+
+bitset_combine: (dst: [*]u8, src: []u8, bits: u32, operation: BitSetOperation): Result[Bool, BitSetError] {
+  n: u32 = bitset_storage_bytes(bits)
+  len(dst) < n || len(src) < n ? { .Err(.StorageTooSmall) } | {
+    changed: Bool = false
+    i: u32 = 0
+    while i < n {
+      mask: u8 = u8(255)
+      i == n - u32(1) && bits % u32(8) != u32(0) ? {
+        mask = u8_trunc_u32((u32(1) << (bits % u32(8))) - u32(1))
+      }
+      left: u8 = dst[i]
+      right: u8 = src[i]
+      combined: u8 = operation ?
+        | .Union => (left | right)
+        | .Intersection => left & right
+        | .Difference => left & (right ^ u8(255))
+        | .SymmetricDifference => left ^ right
+      next: u8 = (left & (mask ^ u8(255))) | (combined & mask)
+      changed = changed || next != left
+      dst[i] = next
+      i = i + u32(1)
+    }
+    .Ok(changed)
+  }
+}
+
+bitset_find_next: (storage: []u8, bits: u32, start: u32, value: Bool): Result[Option[u32], BitSetError] {
+  len(storage) < bitset_storage_bytes(bits) ? { .Err(.StorageTooSmall) } | {
+    index: u32 = start
+    found: Bool = false
+    while index < bits && !found {
+      mask: u8 = u8(1) << u8_trunc_u32(index % u32(8))
+      found = ((storage[index / u32(8)] & mask) != u8(0)) == value
+      !found ? { index = index + u32(1) }
+    }
+    found ? { .Ok(.Some(index)) } | { .Ok(.None) }
+  }
+}
+
+// Runtime-validated u64 flag domain. For nominal domains wrap FlagBits in a
+// domain-specific record; this base type does not distinguish two equal masks.
+FlagBits: type = struct { bits: u64, allowed: u64 }
+FlagError: type = | UnknownBits
+
+flags_create: (bits: u64, allowed: u64): Result[FlagBits, FlagError] {
+  (bits & ^allowed) != u64(0) ? { .Err(.UnknownBits) } | {
+    .Ok(FlagBits { bits: bits, allowed: allowed })
+  }
+}
+
+flags_contains_all: (flags: FlagBits, mask: u64): Bool {
+  (mask & ^flags.allowed) == u64(0) && (flags.bits & mask) == mask
+}
+
+flags_contains_any: (flags: FlagBits, mask: u64): Bool {
+  (mask & ^flags.allowed) == u64(0) && (flags.bits & mask) != u64(0)
+}
+
+flags_update: (flags: FlagBits, mask: u64, enabled: Bool): Result[FlagBits, FlagError] {
+  ((flags.bits | mask) & ^flags.allowed) != u64(0) ? { .Err(.UnknownBits) } | {
+    next: u64 = enabled ? (flags.bits | mask) | (flags.bits & ^mask)
+    .Ok(FlagBits { bits: next, allowed: flags.allowed })
+  }
+}

--- a/stdlib/filters.oak
+++ b/stdlib/filters.oak
@@ -1,0 +1,139 @@
+// Allocator-free filters over caller-supplied 64-bit key hashes.
+// Hash collisions contribute to false positives. This mixer is not cryptographic.
+FilterError: type = InvalidConfig | StorageTooSmall | CounterOverflow | NotPresent | Incompatible
+BloomConfig: type = struct { cells: u32, probes: u32, seed: u64, blocked: Bool }
+
+filter_mix: (input: u64): u64 {
+  x: u64 = input
+  multiplier1: u64 = (u64(3210233709) << u64(32)) | u64(484763065)
+  multiplier2: u64 = (u64(2496678331) << u64(32)) | u64(321982955)
+  x = (x ^ (x >> u64(30))) * multiplier1
+  x = (x ^ (x >> u64(27))) * multiplier2
+  x ^ (x >> u64(31))
+}
+
+filter_config_valid: (config: BloomConfig): Bool {
+  config.cells > u32(0) && config.probes > u32(0) && config.probes <= u32(64) &&
+    (!config.blocked || config.cells % u32(512) == u32(0))
+}
+
+// u64 arithmetic wraps modulo 2^64; the C backend uses uint64_t.
+filter_index: (config: BloomConfig, hash: u64, probe: u32): u32 {
+  a: u64 = filter_mix(hash ^ config.seed)
+  increment: u64 = (u64(2654435769) << u64(32)) | u64(2135587861)
+  b: u64 = filter_mix(a + increment) | u64(1)
+  combined: u64 = a + b * u64(probe)
+  config.blocked ? {
+    block: u64 = (a >> u64(32)) % u64(config.cells / u32(512))
+    u32_trunc_u64(block * u64(512) + combined % u64(512))
+  } | {
+    u32_trunc_u64(combined % u64(config.cells))
+  }
+}
+
+bloom_insert: (storage: [*]u8, config: BloomConfig, hash: u64): Result[Bool, FilterError] {
+  !filter_config_valid(config) ? { .Err(.InvalidConfig) } | {
+    len(storage) < bitset_storage_bytes(config.cells) ? { .Err(.StorageTooSmall) } | {
+      changed: Bool = false
+      p: u32 = 0
+      while p < config.probes {
+        index: u32 = filter_index(config, hash, p)
+        mask: u8 = u8(1) << u8_trunc_u32(index % u32(8))
+        slot: u32 = index / u32(8)
+        changed = changed || (storage[slot] & mask) == u8(0)
+        storage[slot] = storage[slot] | mask
+        p = p + u32(1)
+      }
+      .Ok(changed)
+    }
+  }
+}
+
+bloom_query: (storage: []u8, config: BloomConfig, hash: u64): Result[Bool, FilterError] {
+  !filter_config_valid(config) ? { .Err(.InvalidConfig) } | {
+    len(storage) < bitset_storage_bytes(config.cells) ? { .Err(.StorageTooSmall) } | {
+      present: Bool = true
+      p: u32 = 0
+      while p < config.probes && present {
+        index: u32 = filter_index(config, hash, p)
+        mask: u8 = u8(1) << u8_trunc_u32(index % u32(8))
+        present = (storage[index / u32(8)] & mask) != u8(0)
+        p = p + u32(1)
+      }
+      .Ok(present)
+    }
+  }
+}
+
+bloom_clear: (storage: [*]u8, config: BloomConfig): Result[Bool, FilterError] {
+  !filter_config_valid(config) ? { .Err(.InvalidConfig) } | {
+    n: u32 = bitset_storage_bytes(config.cells)
+    len(storage) < n ? { .Err(.StorageTooSmall) } | {
+      i: u32 = 0
+      while i < n {
+        // Preserve padding and spare bytes, like the other Oak bitset functions.
+        last: Bool = i == n - u32(1) && config.cells % u32(8) != u32(0)
+        last ? {
+          mask: u8 = u8_trunc_u32((u32(1) << (config.cells % u32(8))) - u32(1))
+          storage[i] = storage[i] & (mask ^ u8(255))
+        } | { storage[i] = u8(0) }
+        i = i + u32(1)
+      }
+      .Ok(true)
+    }
+  }
+}
+
+// Deduplicate probes: small filters may map several probes to the same cell.
+filter_first_probe: (config: BloomConfig, hash: u64, probe: u32, index: u32): Bool {
+  first: Bool = true
+  previous: u32 = 0
+  while previous < probe && first {
+    first = filter_index(config, hash, previous) != index
+    previous = previous + u32(1)
+  }
+  first
+}
+
+counting_bloom_query: (storage: []u8, config: BloomConfig, hash: u64): Result[Bool, FilterError] {
+  !filter_config_valid(config) ? { .Err(.InvalidConfig) } | {
+    len(storage) < config.cells ? { .Err(.StorageTooSmall) } | {
+      present: Bool = true
+      p: u32 = 0
+      while p < config.probes && present {
+        present = storage[filter_index(config, hash, p)] != u8(0)
+        p = p + u32(1)
+      }
+      .Ok(present)
+    }
+  }
+}
+
+// Removal requires caller proof of a successful, unmatched insertion.
+// A positive query alone is not proof: false positives are possible.
+counting_bloom_update: (storage: [*]u8, config: BloomConfig, hash: u64, insert: Bool): Result[Bool, FilterError] {
+  !filter_config_valid(config) ? { .Err(.InvalidConfig) } | {
+    len(storage) < config.cells ? { .Err(.StorageTooSmall) } | {
+      allowed: Bool = true
+      p: u32 = 0
+      while p < config.probes {
+        index: u32 = filter_index(config, hash, p)
+        allowed = allowed && (insert ? storage[index] < u8(255) | storage[index] > u8(0))
+        p = p + u32(1)
+      }
+      !allowed ? {
+        insert ? { .Err(.CounterOverflow) } | { .Err(.NotPresent) }
+      } | {
+        p = u32(0)
+        while p < config.probes {
+          index: u32 = filter_index(config, hash, p)
+          filter_first_probe(config, hash, p, index) ? {
+            storage[index] = insert ? storage[index] + u8(1) | storage[index] - u8(1)
+          }
+          p = p + u32(1)
+        }
+        .Ok(true)
+      }
+    }
+  }
+}

--- a/stdlib/hash_table.oak
+++ b/stdlib/hash_table.oak
@@ -1,0 +1,118 @@
+// Open-addressed tables with exact u64 key equality and linear probing.
+// T supplies key:u64 and state:u8 plus any inline payload fields.
+// state is reserved: 0=empty, 1=occupied, 2=tombstone.
+// Start with zeroed storage; keep its length fixed until clear/rebuild.
+HashSetSlot: type = struct { key: u64, state: u8 }
+HashTableError: type = | Full
+
+hash_table_next: (index: u32, capacity: u32): u32 {
+  index == capacity - u32(1) ? u32(0) | index + u32(1)
+}
+
+hash_table_find[T]: (storage: []T, key: u64): Option[u32] {
+  capacity: u32 = len(storage)
+  capacity == u32(0) ? { .None } | {
+    index: u32 = u32_trunc_u64(filter_mix(key) % u64(capacity))
+    visited: u32 = 0
+    found: Bool = false
+    stop: Bool = false
+    answer: u32 = 0
+    while visited < capacity && !stop {
+      storage[index].state == u8(0) ? { stop = true } | {
+        storage[index].state == u8(1) && storage[index].key == key ? {
+          found = true
+          answer = index
+          stop = true
+        }
+      }
+      index = hash_table_next(index, capacity)
+      visited = visited + u32(1)
+    }
+    found ? { .Some(answer) } | { .None }
+  }
+}
+
+// Ok(true) inserts; Ok(false) replaces an existing key, including in a full table.
+// A tombstone is remembered, but probing continues to avoid duplicate keys.
+hash_table_put[T]: (storage: [*]T, item: T): Result[Bool, HashTableError] {
+  capacity: u32 = len(storage)
+  capacity == u32(0) ? { .Err(.Full) } | {
+    index: u32 = u32_trunc_u64(filter_mix(item.key) % u64(capacity))
+    visited: u32 = 0
+    target: u32 = capacity
+    found: Bool = false
+    stop: Bool = false
+    while visited < capacity && !stop {
+      storage[index].state == u8(1) ? {
+        storage[index].key == item.key ? {
+          target = index
+          found = true
+          stop = true
+        }
+      } | {
+        target == capacity ? { target = index }
+        storage[index].state == u8(0) ? { stop = true }
+      }
+      index = hash_table_next(index, capacity)
+      visited = visited + u32(1)
+    }
+    target == capacity ? { .Err(.Full) } | {
+      storage[target] = item
+      storage[target].state = u8(1)
+      .Ok(!found)
+    }
+  }
+}
+
+hash_table_remove[T]: (storage: [*]T, key: u64): Bool {
+  capacity: u32 = len(storage)
+  removed: Bool = false
+  capacity > u32(0) ? {
+    index: u32 = u32_trunc_u64(filter_mix(key) % u64(capacity))
+    visited: u32 = 0
+    stop: Bool = false
+    while visited < capacity && !stop {
+      storage[index].state == u8(0) ? { stop = true } | {
+        storage[index].state == u8(1) && storage[index].key == key ? {
+          storage[index].state = u8(2)
+          removed = true
+          stop = true
+        }
+      }
+      index = hash_table_next(index, capacity)
+      visited = visited + u32(1)
+    }
+  }
+  removed
+}
+
+hash_table_count[T]: (storage: []T): u32 {
+  count: u32 = 0
+  i: u32 = 0
+  while i < len(storage) {
+    storage[i].state == u8(1) ? { count = count + u32(1) }
+    i = i + u32(1)
+  }
+  count
+}
+
+hash_table_clear[T]: (storage: [*]T): () {
+  i: u32 = 0
+  while i < len(storage) {
+    storage[i].state = u8(0)
+    i = i + u32(1)
+  }
+}
+
+hash_set_insert: (storage: [*]HashSetSlot, key: u64): Result[Bool, HashTableError] {
+  item: HashSetSlot = HashSetSlot { key: key, state: u8(1) }
+  hash_table_put(storage, item)
+}
+
+hash_set_contains: (storage: []HashSetSlot, key: u64): Bool {
+  hash_table_find(storage, key) ? | .Some(index) => true | .None => false
+}
+
+hash_set_remove: (storage: [*]HashSetSlot, key: u64): Bool {
+  hash_table_remove(storage, key)
+}

--- a/stdlib/source.go
+++ b/stdlib/source.go
@@ -20,4 +20,13 @@ var stringsSource string
 //go:embed unicode.oak
 var unicodeSource string
 
-var Source = baseSource + "\n" + causalFrontierSource + "\n" + unicodeSource + "\n" + stringsSource
+//go:embed filters.oak
+var filtersSource string
+
+//go:embed hash_table.oak
+var hashTableSource string
+
+//go:embed bitset_algebra.oak
+var bitsetAlgebraSource string
+
+var Source = baseSource + "\n" + causalFrontierSource + "\n" + unicodeSource + "\n" + stringsSource + "\n" + filtersSource + "\n" + hashTableSource + "\n" + bitsetAlgebraSource


### PR DESCRIPTION
The OS collection work needs actual Oak implementations to drive language/OS co-development.

Adds allocator-free Oak Bloom, blocked Bloom and counting Bloom filters; exact u64-key maps with arbitrary inline payloads and sets; bitset algebra/scanning; and runtime-validated u64 flags through import(std). Storage is caller-owned, failure checks precede mutation, and probing is capacity-bounded.

Adds native C-backend differential tests against Go models, collision/deletion traces, counter saturation/deduplication checks, padding/flag checks, and a focused CI workflow. Full compiler and stdlib CI also run.

stdlib/COLLECTION_PORTS.md documents APIs, contracts and remaining parity. Cuckoo/quotient/static filters, generational pools, skip lists, tries/trees, and OS debug adapters remain follow-up work; this does not convert Zig kernel call sites.

Validation: all seven PR workflows passed on 072c8696e7337d0062d311a9bf212008611c1e6a: native Oak library model tests, full Go/race compiler and standard-library suites, AArch64 refinement, golden corpus, API snapshots, generalization safety and formal verification. Formatting passed. The dependent OS PR https://github.com/SCKelemen/os/pull/15 also passed its host collection smoke, kernel/assert/Oak EL2 QEMU smokes, host tests, TLA+ models and benchmark smoke.