### PR TITLE
Resolve resource calls by semantic callable identity

### DIFF
--- a/typechecker/resource_callable_test.go
+++ b/typechecker/resource_callable_test.go
@@ -1,0 +1,164 @@
+package typechecker
+
+import (
+	"testing"
+
+	"github.com/SCKelemen/oak/ast"
+	"github.com/SCKelemen/oak/resourceflow"
+)
+
+func callableResourceAnalysis() (*TypeChecker, *typedResourceAnalysis) {
+	tc := setupTypeChecker("")
+	tc.globalEnv = tc.env
+	model := NewResourceModel()
+	model.MarkResourceType("Handle")
+	analysis := &typedResourceAnalysis{
+		tc:       tc,
+		model:    model,
+		flow:     resourceflow.New(),
+		reported: make(map[string]bool),
+	}
+	analysis.pushScope()
+	return tc, analysis
+}
+
+func TestResolveResourceDeclarationsAcceptsSemanticMethodIdentity(t *testing.T) {
+	tc := setupTypeChecker("")
+	tc.env.SetType("Handle", &ADTType{Name: "Handle"})
+	tc.env.SetType("Handle::transfer", &FunctionType{
+		Parameters: []Type{&ADTType{Name: "Handle"}},
+		ReturnType: &UnitType{},
+	})
+
+	resolved, err := tc.ResolveResourceDeclarations([]ResourceProtocolDeclaration{{
+		Name:          "HandleLifecycle",
+		ResourceTypes: []string{"Handle"},
+		States:        []string{"Open"},
+		Initial:       "Open",
+		Transitions: []ResourceTransitionDeclaration{{
+			Name:     "transfer-transition",
+			Callable: "Handle::transfer",
+			From:     "Open",
+			To:       "Open",
+			Consumes: []int{0},
+		}},
+	}})
+	if err != nil {
+		t.Fatalf("semantic method callable failed resource resolution: %v", err)
+	}
+	transition := resolved.Protocols[0].Transitions[0]
+	if transition.Callable != "Handle::transfer" || len(transition.Consumes) != 1 || transition.Consumes[0] != 0 {
+		t.Fatalf("unexpected resolved method transition: %#v", transition)
+	}
+}
+
+func TestResourceCallableIdentityRejectsLexicallyShadowedGlobal(t *testing.T) {
+	tc, analysis := callableResourceAnalysis()
+	tc.globalEnv.SetType("close", &FunctionType{
+		Parameters: []Type{&ADTType{Name: "Handle"}},
+		ReturnType: &UnitType{},
+	})
+	analysis.model.MarkOperation("close", ResourceOperation{Consumes: []int{0}})
+
+	call := &ast.InvocationExpression{Function: &ast.Identifier{Value: "close"}}
+	if identity, ok := analysis.callableIdentity(call); !ok || identity != "close" {
+		t.Fatalf("global callable identity = (%q, %v), want (close, true)", identity, ok)
+	}
+
+	analysis.bind("close")
+	if identity, ok := analysis.callableIdentity(call); ok {
+		t.Fatalf("lexically shadowed global resolved as resource callable %q", identity)
+	}
+}
+
+func TestResourceCallableIdentityUsesCheckedReceiverType(t *testing.T) {
+	tc, analysis := callableResourceAnalysis()
+	tc.globalEnv.SetType("Handle::transfer", &FunctionType{
+		Parameters: []Type{&ADTType{Name: "Handle"}},
+		ReturnType: &UnitType{},
+	})
+	analysis.model.MarkOperation("Handle::transfer", ResourceOperation{Consumes: []int{0}})
+
+	receiver := &ast.Identifier{Value: "self"}
+	argument := &ast.Identifier{Value: "other"}
+	method := &ast.Identifier{Value: "transfer"}
+	call := &ast.InvocationExpression{
+		Function: &ast.IndexExpression{Dot: true, Left: receiver, Index: method},
+		Arguments: []ast.Expression{argument},
+	}
+	tc.env.borrowMetadata().expressions[receiver] = &ADTType{Name: "Handle"}
+
+	identity, ok := analysis.callableIdentity(call)
+	if !ok || identity != "Handle::transfer" {
+		t.Fatalf("method callable identity = (%q, %v), want (Handle::transfer, true)", identity, ok)
+	}
+
+	analysis.bind("self")
+	analysis.bind("other")
+	analysis.flow.Register("self", receiver)
+	analysis.flow.Register("other", argument)
+	analysis.invocation(call)
+
+	if !analysis.flow.CanUse("self") {
+		t.Fatal("explicit argument consumption unexpectedly consumed method receiver")
+	}
+	if analysis.flow.CanUse("other") {
+		t.Fatal("receiver-qualified consuming method did not consume its explicit resource argument")
+	}
+}
+
+func TestResourceCallableIdentityDoesNotMatchMethodSpellingAcrossReceivers(t *testing.T) {
+	tc, analysis := callableResourceAnalysis()
+	tc.globalEnv.SetType("Handle::transfer", &FunctionType{ReturnType: &UnitType{}})
+	tc.globalEnv.SetType("Other::transfer", &FunctionType{ReturnType: &UnitType{}})
+	analysis.model.MarkOperation("Handle::transfer", ResourceOperation{})
+
+	receiver := &ast.Identifier{Value: "other"}
+	call := &ast.InvocationExpression{
+		Function: &ast.IndexExpression{
+			Dot:   true,
+			Left:  receiver,
+			Index: &ast.Identifier{Value: "transfer"},
+		},
+	}
+	tc.env.borrowMetadata().expressions[receiver] = &ADTType{Name: "Other"}
+
+	identity, ok := analysis.callableIdentity(call)
+	if !ok || identity != "Other::transfer" {
+		t.Fatalf("method callable identity = (%q, %v), want (Other::transfer, true)", identity, ok)
+	}
+	if _, resource := analysis.operation(call); resource {
+		t.Fatal("resource semantics leaked across receivers that share a method spelling")
+	}
+}
+
+func TestFreshMethodResultUsesResolvedCallableIdentity(t *testing.T) {
+	tc, analysis := callableResourceAnalysis()
+	tc.globalEnv.SetType("Handle::renew", &FunctionType{
+		ReturnType: &ADTType{Name: "Handle"},
+	})
+	analysis.model.MarkOperation("Handle::renew", ResourceOperation{ReturnsFresh: true})
+
+	receiver := &ast.Identifier{Value: "self"}
+	call := &ast.InvocationExpression{
+		Function: &ast.IndexExpression{
+			Dot:   true,
+			Left:  receiver,
+			Index: &ast.Identifier{Value: "renew"},
+		},
+	}
+	tc.env.borrowMetadata().expressions[receiver] = &ADTType{Name: "Handle"}
+	analysis.bind("self")
+	analysis.flow.Register("self", receiver)
+
+	analysis.variable(&ast.VariableDeclaration{
+		Name:  &ast.Identifier{Value: "next"},
+		Value: call,
+	})
+	if !analysis.flow.Registered("next") || !analysis.flow.CanUse("next") {
+		t.Fatal("fresh method result was not registered as a new live authority class")
+	}
+	if !analysis.flow.CanUse("self") {
+		t.Fatal("fresh method result unexpectedly consumed the receiver")
+	}
+}

--- a/typechecker/resource_flow.go
+++ b/typechecker/resource_flow.go
@@ -79,11 +79,19 @@ func (tc *TypeChecker) CheckResourceFlow(program *ast.Program, model ResourceMod
 			flow:     resourceflow.New(),
 			reported: make(map[string]bool),
 		}
-		if fn.Receiver != nil && fn.Receiver.Name != nil && model.isResourceType(fn.Receiver.Type) {
-			analysis.flow.Register(fn.Receiver.Name.Value, fn.Receiver.Name)
+		analysis.pushScope()
+		if fn.Receiver != nil && fn.Receiver.Name != nil {
+			analysis.bind(fn.Receiver.Name.Value)
+			if model.isResourceType(fn.Receiver.Type) {
+				analysis.flow.Register(fn.Receiver.Name.Value, fn.Receiver.Name)
+			}
 		}
 		for _, parameter := range fn.Parameters {
-			if parameter != nil && parameter.Name != nil && model.isResourceType(parameter.Type) {
+			if parameter == nil || parameter.Name == nil {
+				continue
+			}
+			analysis.bind(parameter.Name.Value)
+			if model.isResourceType(parameter.Type) {
 				analysis.flow.Register(parameter.Name.Value, parameter.Name)
 			}
 		}
@@ -96,6 +104,7 @@ type typedResourceAnalysis struct {
 	model    ResourceModel
 	flow     *resourceflow.Flow
 	reported map[string]bool
+	scopes   []map[string]struct{}
 }
 
 func (m ResourceModel) isResourceType(expr ast.Expression) bool {
@@ -114,13 +123,105 @@ func (m ResourceModel) isResourceType(expr ast.Expression) bool {
 	return m.ResourceTypes[expr.String()]
 }
 
-func (m ResourceModel) operation(expr ast.Expression) (ResourceOperation, bool) {
-	ident, ok := expr.(*ast.Identifier)
-	if !ok || ident == nil {
+func (m ResourceModel) operationByName(name string) (ResourceOperation, bool) {
+	if name == "" {
 		return ResourceOperation{}, false
 	}
-	op, exists := m.Operations[ident.Value]
+	op, exists := m.Operations[name]
 	return op, exists
+}
+
+func (a *typedResourceAnalysis) pushScope() {
+	if a == nil {
+		return
+	}
+	a.scopes = append(a.scopes, make(map[string]struct{}))
+}
+
+func (a *typedResourceAnalysis) popScope() {
+	if a == nil || len(a.scopes) == 0 {
+		return
+	}
+	a.scopes = a.scopes[:len(a.scopes)-1]
+}
+
+func (a *typedResourceAnalysis) bind(name string) {
+	if a == nil || name == "" {
+		return
+	}
+	if len(a.scopes) == 0 {
+		a.pushScope()
+	}
+	a.scopes[len(a.scopes)-1][name] = struct{}{}
+}
+
+func (a *typedResourceAnalysis) isLocalBinding(name string) bool {
+	if a == nil || name == "" {
+		return false
+	}
+	for i := len(a.scopes) - 1; i >= 0; i-- {
+		if _, exists := a.scopes[i][name]; exists {
+			return true
+		}
+	}
+	return false
+}
+
+// callableIdentity resolves a checked invocation to the semantic callable key
+// used by ResourceModel. Direct calls must still denote a global function after
+// lexical shadowing; method calls use the checked receiver type and the same
+// Receiver::method key as the type environment. No resource rule is inferred
+// from source spelling alone.
+func (a *typedResourceAnalysis) callableIdentity(expr *ast.InvocationExpression) (string, bool) {
+	if a == nil || a.tc == nil || a.tc.globalEnv == nil || expr == nil {
+		return "", false
+	}
+	switch function := expr.Function.(type) {
+	case *ast.Identifier:
+		if function == nil || function.Value == "" || a.isLocalBinding(function.Value) {
+			return "", false
+		}
+		typ, exists := a.tc.globalEnv.GetType(function.Value)
+		if !exists || typ == nil {
+			return "", false
+		}
+		if _, ok := typ.(*FunctionType); !ok {
+			return "", false
+		}
+		return function.Value, true
+
+	case *ast.IndexExpression:
+		if function == nil || !function.Dot {
+			return "", false
+		}
+		method, ok := function.Index.(*ast.Identifier)
+		if !ok || method == nil || method.Value == "" {
+			return "", false
+		}
+		receiverType := a.tc.env.CheckedExpressionType(function.Left)
+		receiverName := nominalTypeName(receiverType)
+		if receiverName == "" {
+			return "", false
+		}
+		key := receiverName + "::" + method.Value
+		typ, exists := a.tc.globalEnv.GetType(key)
+		if !exists || typ == nil {
+			return "", false
+		}
+		if _, ok := typ.(*FunctionType); !ok {
+			return "", false
+		}
+		return key, true
+	}
+	return "", false
+}
+
+func (a *typedResourceAnalysis) operation(expr *ast.InvocationExpression) (ResourceOperation, bool) {
+	identity, ok := a.callableIdentity(expr)
+	if !ok {
+		return ResourceOperation{}, false
+	}
+	return a.model.operationByName(identity)
 }
 
 func (a *typedResourceAnalysis) statement(stmt ast.Statement) {
@@ -155,6 +256,8 @@ func (a *typedResourceAnalysis) block(block *ast.BlockStatement) {
 	if block == nil {
 		return
 	}
+	a.pushScope()
+	defer a.popScope()
 	for _, stmt := range block.Statements {
 		a.statement(stmt)
 	}
@@ -164,13 +267,17 @@ func (a *typedResourceAnalysis) variable(stmt *ast.VariableDeclaration) {
 	if stmt == nil || stmt.Name == nil {
 		return
 	}
+	// The declaration becomes visible only after its initializer has been
+	// evaluated, so a local with the same name as a global callable does not
+	// retroactively shadow that callable inside its own initializer.
+	defer a.bind(stmt.Name.Value)
 	if stmt.Value != nil {
 		a.expression(stmt.Value)
 	}
 	isResource := a.model.isResourceType(stmt.Type)
 	if !isResource {
 		if call, ok := stmt.Value.(*ast.InvocationExpression); ok {
-			if op, exists := a.model.operation(call.Function); exists && op.ReturnsFresh {
+			if op, exists := a.operation(call); exists && op.ReturnsFresh {
 				isResource = true
 			}
 		}
@@ -296,10 +403,19 @@ func (a *typedResourceAnalysis) expression(expr ast.Expression) {
 		// Capturing resource closures are rejected by the existing closure
 		// discipline. Analyze the body independently so local resource uses
 		// are still checked without lending outer authority to the closure.
-		outer := a.flow
+		outerFlow := a.flow
+		outerScopes := a.scopes
 		a.flow = resourceflow.New()
+		a.scopes = nil
+		a.pushScope()
+		for _, argument := range e.Arguments {
+			if argument != nil {
+				a.bind(argument.Value)
+			}
+		}
 		a.block(e.Body)
-		a.flow = outer
+		a.flow = outerFlow
+		a.scopes = outerScopes
 	}
 }
 
@@ -316,7 +432,7 @@ func (a *typedResourceAnalysis) invocation(expr *ast.InvocationExpression) {
 		a.expression(argument)
 	}
 
-	op, consuming := a.model.operation(expr.Function)
+	op, consuming := a.operation(expr)
 	if !consuming {
 		return
 	}


### PR DESCRIPTION
## Summary

- resolve resource operations from checked callable identity instead of callee AST spelling
- qualify method operations by the checked receiver type (`Receiver::method`)
- reject resource semantics for lexically shadowed global callables
- preserve fresh-return resource inference through resolved method identities
- track lexical bindings only for semantic call resolution; resource authority flow remains the existing path-sensitive lattice

## Coverage

- syntax-independent method identity resolves through `ResourceProtocolDeclaration`
- method operations consume only configured explicit arguments
- identical method spellings on different receiver types do not share resource semantics
- local function-valued bindings cannot accidentally inherit a global consuming rule
- fresh method results create a new live authority class
- existing direct-call resource-flow tests continue to cover `OAK-B0111`, joins, aliases, and short-circuit paths

## Syntax

No parser, grammar, receiver syntax, or source-level consume syntax changes. This PR deliberately operates on checked semantic identities so future surface syntax can change independently.