### PR TITLE
Model receiver consumption as explicit resource authority

### DIFF
--- a/compiler/resource_receiver_semir_test.go
+++ b/compiler/resource_receiver_semir_test.go
@@ -1,0 +1,78 @@
+package compiler
+
+import (
+	"testing"
+
+	"github.com/SCKelemen/oak/typechecker"
+)
+
+func TestEmitResourceSemIRPreservesReceiverConsumption(t *testing.T) {
+	resources := typechecker.ResolvedResourceProgram{
+		Types: []typechecker.ResolvedResourceType{{
+			Name:     "Handle",
+			Protocol: "HandleLifecycle",
+		}},
+		Protocols: []typechecker.ResolvedResourceProtocol{{
+			Name:    "HandleLifecycle",
+			States:  []string{"Open", "Closed"},
+			Initial: "Open",
+			Transitions: []typechecker.ResolvedResourceTransition{{
+				Name:             "close-method-transition",
+				Callable:         "Handle::close",
+				From:             "Open",
+				To:               "Closed",
+				ConsumesReceiver: true,
+			}},
+		}},
+	}
+
+	module, err := emitResourceSemIR(resources)
+	if err != nil {
+		t.Fatalf("resource SemIR emission failed: %v", err)
+	}
+	if len(module.Protocols) != 1 || len(module.Protocols[0].Transitions) != 1 {
+		t.Fatalf("unexpected emitted resource protocols: %#v", module.Protocols)
+	}
+	transition := module.Protocols[0].Transitions[0]
+	semantics, present, err := transition.ResourceSemantics()
+	if err != nil || !present {
+		t.Fatalf("receiver resource effects did not decode: present=%v err=%v", present, err)
+	}
+	if !semantics.ConsumesReceiver || len(semantics.Consumes) != 0 || semantics.ReturnsFresh {
+		t.Fatalf("unexpected emitted receiver semantics: %#v", semantics)
+	}
+}
+
+func TestEmitResourceSemIRKeepsReceiverAndArgumentsDistinct(t *testing.T) {
+	resources := typechecker.ResolvedResourceProgram{
+		Types: []typechecker.ResolvedResourceType{{
+			Name:     "Handle",
+			Protocol: "HandleLifecycle",
+		}},
+		Protocols: []typechecker.ResolvedResourceProtocol{{
+			Name:    "HandleLifecycle",
+			States:  []string{"Open"},
+			Initial: "Open",
+			Transitions: []typechecker.ResolvedResourceTransition{{
+				Name:             "transfer-transition",
+				Callable:         "Handle::transfer",
+				From:             "Open",
+				To:               "Open",
+				Consumes:         []int{0},
+				ConsumesReceiver: true,
+			}},
+		}},
+	}
+
+	module, err := emitResourceSemIR(resources)
+	if err != nil {
+		t.Fatalf("resource SemIR emission failed: %v", err)
+	}
+	semantics, present, err := module.Protocols[0].Transitions[0].ResourceSemantics()
+	if err != nil || !present {
+		t.Fatalf("mixed receiver/argument resource effects did not decode: present=%v err=%v", present, err)
+	}
+	if !semantics.ConsumesReceiver || len(semantics.Consumes) != 1 || semantics.Consumes[0] != 0 {
+		t.Fatalf("receiver was conflated with explicit argument zero: %#v", semantics)
+	}
+}

--- a/compiler/resource_semir.go
+++ b/compiler/resource_semir.go
@@ -116,6 +116,9 @@ func emitResourceSemIR(resources typechecker.ResolvedResourceProgram) (semir.Mod
 				From:     resourceTransition.From,
 				To:       resourceTransition.To,
 			}
+			if resourceTransition.ConsumesReceiver {
+				transition.Effects = append(transition.Effects, semir.ResourceConsumeReceiver())
+			}
 			for _, index := range resourceTransition.Consumes {
 				transition.Effects = append(transition.Effects, semir.ResourceConsumeArgument(index))
 			}

--- a/semir/resource_effects.go
+++ b/semir/resource_effects.go
@@ -16,22 +16,35 @@ const (
 )
 
 // ResourceTransitionSemantics is the resource-authority projection of one
-// protocol transition. Consumes contains zero-based callable argument indices;
-// ReturnsFresh means the transition's result carries new live authority rather
-// than reviving any consumed input value.
+// protocol transition. Consumes contains zero-based explicit callable argument
+// indices; ConsumesReceiver marks the receiver authority independently of those
+// arguments. ReturnsFresh means the transition's result carries new live
+// authority rather than reviving any consumed input value.
 type ResourceTransitionSemantics struct {
-	Consumes     []int
-	ReturnsFresh bool
+	Consumes         []int
+	ConsumesReceiver bool
+	ReturnsFresh     bool
 }
 
 // ResourceConsumeArgument constructs the canonical semantic effect for a
-// consuming parameter. Negative indices are retained so validation can reject
-// malformed generated SemIR instead of silently rewriting it.
+// consuming explicit parameter. Negative indices are retained so validation
+// can reject malformed generated SemIR instead of silently rewriting it.
 func ResourceConsumeArgument(index int) Effect {
 	return Effect{
 		Namespace:  ResourceEffectNamespace,
 		Name:       ResourceEffectConsume,
 		Parameters: []string{"arg:" + strconv.Itoa(index)},
+	}
+}
+
+// ResourceConsumeReceiver constructs the canonical semantic effect for a
+// consuming method receiver. The receiver is a distinct authority target, not
+// argument zero: method FunctionType parameters contain only explicit args.
+func ResourceConsumeReceiver() Effect {
+	return Effect{
+		Namespace:  ResourceEffectNamespace,
+		Name:       ResourceEffectConsume,
+		Parameters: []string{"receiver"},
 	}
 }
 
@@ -47,6 +60,7 @@ func ResourceReturnFresh() Effect {
 func (t Transition) ResourceSemantics() (ResourceTransitionSemantics, bool, error) {
 	result := ResourceTransitionSemantics{}
 	seenConsume := make(map[int]bool)
+	seenReceiver := false
 	seenFresh := false
 	present := false
 
@@ -59,12 +73,21 @@ func (t Transition) ResourceSemantics() (ResourceTransitionSemantics, bool, erro
 		case ResourceEffectConsume:
 			if len(effect.Parameters) != 1 {
 				return ResourceTransitionSemantics{}, true,
-					fmt.Errorf("resource.consume expects exactly one arg:<index> parameter")
+					fmt.Errorf("resource.consume expects exactly one receiver or arg:<index> parameter")
 			}
 			parameter := effect.Parameters[0]
+			if parameter == "receiver" {
+				if seenReceiver {
+					return ResourceTransitionSemantics{}, true,
+						fmt.Errorf("resource.consume duplicates receiver")
+				}
+				seenReceiver = true
+				result.ConsumesReceiver = true
+				continue
+			}
 			if !strings.HasPrefix(parameter, "arg:") {
 				return ResourceTransitionSemantics{}, true,
-					fmt.Errorf("resource.consume parameter %q must be arg:<index>", parameter)
+					fmt.Errorf("resource.consume parameter %q must be receiver or arg:<index>", parameter)
 			}
 			index, err := strconv.Atoi(strings.TrimPrefix(parameter, "arg:"))
 			if err != nil || index < 0 {
@@ -100,14 +123,30 @@ func (t Transition) ResourceSemantics() (ResourceTransitionSemantics, bool, erro
 	return result, present, nil
 }
 
+func resourceReceiverFromCallable(callable string) string {
+	separator := strings.LastIndex(callable, "::")
+	if separator <= 0 || separator+2 >= len(callable) {
+		return ""
+	}
+	return callable[:separator]
+}
+
 // ValidateResourceSemantics validates every resource-specific transition fact
 // in the module. Resource effects require an explicit resolved Callable so a
 // protocol-local transition label cannot accidentally affect an unrelated
-// source callable with the same spelling.
+// source callable with the same spelling. Receiver consumption additionally
+// requires a receiver-qualified callable whose receiver is resource-bearing.
 func (m Module) ValidateResourceSemantics() error {
+	resourceDefinitions := make(map[string]bool)
+	for _, definition := range m.Definitions {
+		if definition.Authority.Resource != ResourceAuthorityUnspecified {
+			resourceDefinitions[definition.Name] = true
+		}
+	}
+
 	for _, protocol := range m.Protocols {
 		for _, transition := range protocol.Transitions {
-			_, present, err := transition.ResourceSemantics()
+			semantics, present, err := transition.ResourceSemantics()
 			if err != nil {
 				return fmt.Errorf("protocol %q transition %q: %w", protocol.Name, transition.Name, err)
 			}
@@ -117,6 +156,25 @@ func (m Module) ValidateResourceSemantics() error {
 					protocol.Name,
 					transition.Name,
 				)
+			}
+			if semantics.ConsumesReceiver {
+				receiver := resourceReceiverFromCallable(transition.Callable)
+				if receiver == "" {
+					return fmt.Errorf(
+						"protocol %q transition %q consumes a receiver but callable %q has no receiver identity",
+						protocol.Name,
+						transition.Name,
+						transition.Callable,
+					)
+				}
+				if !resourceDefinitions[receiver] {
+					return fmt.Errorf(
+						"protocol %q transition %q consumes receiver %q without a resource-bearing definition",
+						protocol.Name,
+						transition.Name,
+						receiver,
+					)
+				}
 			}
 		}
 	}

--- a/semir/resource_effects_test.go
+++ b/semir/resource_effects_test.go
@@ -11,6 +11,7 @@ func TestResourceTransitionSemanticsDecodesStructuredEffects(t *testing.T) {
 		Effects: []Effect{
 			ResourceConsumeArgument(2),
 			{Namespace: "memory", Name: "write"},
+			ResourceConsumeReceiver(),
 			ResourceConsumeArgument(0),
 			ResourceReturnFresh(),
 		},
@@ -26,6 +27,9 @@ func TestResourceTransitionSemanticsDecodesStructuredEffects(t *testing.T) {
 	if len(semantics.Consumes) != 2 || semantics.Consumes[0] != 0 || semantics.Consumes[1] != 2 {
 		t.Fatalf("expected sorted consumed arguments [0 2], got %v", semantics.Consumes)
 	}
+	if !semantics.ConsumesReceiver {
+		t.Fatal("expected receiver-consumption semantic fact")
+	}
 	if !semantics.ReturnsFresh {
 		t.Fatal("expected fresh-return semantic fact")
 	}
@@ -37,7 +41,7 @@ func TestResourceTransitionSemanticsIgnoresUnrelatedEffects(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unrelated effect rejected: %v", err)
 	}
-	if present || len(semantics.Consumes) != 0 || semantics.ReturnsFresh {
+	if present || len(semantics.Consumes) != 0 || semantics.ConsumesReceiver || semantics.ReturnsFresh {
 		t.Fatalf("unrelated effects must not invent resource semantics: %#v", semantics)
 	}
 }
@@ -55,6 +59,21 @@ func TestResourceTransitionSemanticsRejectsMalformedConsume(t *testing.T) {
 	_, present, err := transition.ResourceSemantics()
 	if !present || err == nil || !strings.Contains(err.Error(), "invalid argument index") {
 		t.Fatalf("expected malformed consume rejection, got present=%v err=%v", present, err)
+	}
+}
+
+func TestResourceTransitionSemanticsRejectsDuplicateReceiverConsume(t *testing.T) {
+	transition := Transition{
+		Name: "close",
+		Effects: []Effect{
+			ResourceConsumeReceiver(),
+			ResourceConsumeReceiver(),
+		},
+	}
+
+	_, present, err := transition.ResourceSemantics()
+	if !present || err == nil || !strings.Contains(err.Error(), "duplicates receiver") {
+		t.Fatalf("expected duplicate receiver consume rejection, got present=%v err=%v", present, err)
 	}
 }
 
@@ -76,6 +95,55 @@ func TestValidateResourceSemanticsRequiresResolvedCallable(t *testing.T) {
 	err := module.ValidateResourceSemantics()
 	if err == nil || !strings.Contains(err.Error(), "no resolved callable") {
 		t.Fatalf("expected resource transition callable requirement, got %v", err)
+	}
+}
+
+func TestValidateResourceSemanticsRejectsReceiverConsumeOnFreeCallable(t *testing.T) {
+	module := Module{
+		Definitions: []Definition{{
+			Name:      "Handle",
+			Authority: Authority{Resource: ResourceAuthorityLive},
+		}},
+		Protocols: []Protocol{{
+			Name:    "HandleLifecycle",
+			Initial: "Open",
+			States:  []State{{Name: "Open"}},
+			Transitions: []Transition{{
+				Name:     "CloseTransition",
+				Callable: "close",
+				From:     "Open",
+				To:       "Open",
+				Effects:  []Effect{ResourceConsumeReceiver()},
+			}},
+		}},
+	}
+
+	err := module.ValidateResourceSemantics()
+	if err == nil || !strings.Contains(err.Error(), "no receiver identity") {
+		t.Fatalf("expected free-callable receiver rejection, got %v", err)
+	}
+}
+
+func TestValidateResourceSemanticsRequiresResourceBearingReceiverDefinition(t *testing.T) {
+	module := Module{
+		Definitions: []Definition{{Name: "Handle"}},
+		Protocols: []Protocol{{
+			Name:    "HandleLifecycle",
+			Initial: "Open",
+			States:  []State{{Name: "Open"}},
+			Transitions: []Transition{{
+				Name:     "CloseTransition",
+				Callable: "Handle::close",
+				From:     "Open",
+				To:       "Open",
+				Effects:  []Effect{ResourceConsumeReceiver()},
+			}},
+		}},
+	}
+
+	err := module.ValidateResourceSemantics()
+	if err == nil || !strings.Contains(err.Error(), "without a resource-bearing definition") {
+		t.Fatalf("expected non-resource receiver definition rejection, got %v", err)
 	}
 }
 

--- a/typechecker/resource_callable_test.go
+++ b/typechecker/resource_callable_test.go
@@ -1,6 +1,7 @@
 package typechecker
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/SCKelemen/oak/ast"
@@ -36,19 +37,67 @@ func TestResolveResourceDeclarationsAcceptsSemanticMethodIdentity(t *testing.T) 
 		States:        []string{"Open"},
 		Initial:       "Open",
 		Transitions: []ResourceTransitionDeclaration{{
-			Name:     "transfer-transition",
-			Callable: "Handle::transfer",
-			From:     "Open",
-			To:       "Open",
-			Consumes: []int{0},
+			Name:             "transfer-transition",
+			Callable:         "Handle::transfer",
+			From:             "Open",
+			To:               "Open",
+			Consumes:         []int{0},
+			ConsumesReceiver: true,
 		}},
 	}})
 	if err != nil {
 		t.Fatalf("semantic method callable failed resource resolution: %v", err)
 	}
 	transition := resolved.Protocols[0].Transitions[0]
-	if transition.Callable != "Handle::transfer" || len(transition.Consumes) != 1 || transition.Consumes[0] != 0 {
+	if transition.Callable != "Handle::transfer" || !transition.ConsumesReceiver || len(transition.Consumes) != 1 || transition.Consumes[0] != 0 {
 		t.Fatalf("unexpected resolved method transition: %#v", transition)
+	}
+}
+
+func TestResolveResourceDeclarationsRejectsReceiverConsumeOnFreeFunction(t *testing.T) {
+	tc := setupTypeChecker("")
+	tc.env.SetType("Handle", &ADTType{Name: "Handle"})
+	tc.env.SetType("close", &FunctionType{ReturnType: &UnitType{}})
+
+	_, err := tc.ResolveResourceDeclarations([]ResourceProtocolDeclaration{{
+		Name:          "HandleLifecycle",
+		ResourceTypes: []string{"Handle"},
+		States:        []string{"Open"},
+		Initial:       "Open",
+		Transitions: []ResourceTransitionDeclaration{{
+			Name:             "close-transition",
+			Callable:         "close",
+			From:             "Open",
+			To:               "Open",
+			ConsumesReceiver: true,
+		}},
+	}})
+	if err == nil || !strings.Contains(err.Error(), "no resolved nominal receiver identity") {
+		t.Fatalf("expected free-function receiver-consume rejection, got %v", err)
+	}
+}
+
+func TestResolveResourceDeclarationsRejectsNonResourceReceiverConsume(t *testing.T) {
+	tc := setupTypeChecker("")
+	tc.env.SetType("Handle", &ADTType{Name: "Handle"})
+	tc.env.SetType("Other", &ADTType{Name: "Other"})
+	tc.env.SetType("Other::close", &FunctionType{ReturnType: &UnitType{}})
+
+	_, err := tc.ResolveResourceDeclarations([]ResourceProtocolDeclaration{{
+		Name:          "HandleLifecycle",
+		ResourceTypes: []string{"Handle"},
+		States:        []string{"Open"},
+		Initial:       "Open",
+		Transitions: []ResourceTransitionDeclaration{{
+			Name:             "close-transition",
+			Callable:         "Other::close",
+			From:             "Open",
+			To:               "Open",
+			ConsumesReceiver: true,
+		}},
+	}})
+	if err == nil || !strings.Contains(err.Error(), "non-resource type") {
+		t.Fatalf("expected non-resource receiver-consume rejection, got %v", err)
 	}
 }
 
@@ -107,6 +156,32 @@ func TestResourceCallableIdentityUsesCheckedReceiverType(t *testing.T) {
 	}
 }
 
+func TestResourceReceiverConsumptionInvalidatesAliasClass(t *testing.T) {
+	tc, analysis := callableResourceAnalysis()
+	tc.globalEnv.SetType("Handle::close", &FunctionType{ReturnType: &UnitType{}})
+	analysis.model.MarkOperation("Handle::close", ResourceOperation{ConsumesReceiver: true})
+
+	root := &ast.Identifier{Value: "self"}
+	receiver := &ast.Identifier{Value: "alias"}
+	call := &ast.InvocationExpression{
+		Function: &ast.IndexExpression{
+			Dot:   true,
+			Left:  receiver,
+			Index: &ast.Identifier{Value: "close"},
+		},
+	}
+	tc.env.borrowMetadata().expressions[receiver] = &ADTType{Name: "Handle"}
+	analysis.bind("self")
+	analysis.bind("alias")
+	analysis.flow.Register("self", root)
+	analysis.flow.Alias("alias", "self", receiver)
+	analysis.invocation(call)
+
+	if analysis.flow.CanUse("alias") || analysis.flow.CanUse("self") {
+		t.Fatal("consuming receiver did not invalidate its complete authority alias class")
+	}
+}
+
 func TestResourceCallableIdentityDoesNotMatchMethodSpellingAcrossReceivers(t *testing.T) {
 	tc, analysis := callableResourceAnalysis()
 	tc.globalEnv.SetType("Handle::transfer", &FunctionType{ReturnType: &UnitType{}})
@@ -137,7 +212,10 @@ func TestFreshMethodResultUsesResolvedCallableIdentity(t *testing.T) {
 	tc.globalEnv.SetType("Handle::renew", &FunctionType{
 		ReturnType: &ADTType{Name: "Handle"},
 	})
-	analysis.model.MarkOperation("Handle::renew", ResourceOperation{ReturnsFresh: true})
+	analysis.model.MarkOperation("Handle::renew", ResourceOperation{
+		ConsumesReceiver: true,
+		ReturnsFresh:     true,
+	})
 
 	receiver := &ast.Identifier{Value: "self"}
 	call := &ast.InvocationExpression{
@@ -158,7 +236,7 @@ func TestFreshMethodResultUsesResolvedCallableIdentity(t *testing.T) {
 	if !analysis.flow.Registered("next") || !analysis.flow.CanUse("next") {
 		t.Fatal("fresh method result was not registered as a new live authority class")
 	}
-	if !analysis.flow.CanUse("self") {
-		t.Fatal("fresh method result unexpectedly consumed the receiver")
+	if analysis.flow.CanUse("self") {
+		t.Fatal("consuming fresh-return method left old receiver authority live")
 	}
 }

--- a/typechecker/resource_flow.go
+++ b/typechecker/resource_flow.go
@@ -15,11 +15,13 @@ import (
 const CodeResourceUsedAfterConsume = "OAK-B0111"
 
 // ResourceOperation is internal semantic metadata for a callable. It freezes
-// no source syntax: frontends/protocol lowering can mark which arguments lose
-// old authority, and whether the result denotes fresh authority.
+// no source syntax: frontends/protocol lowering can mark which explicit
+// arguments and/or receiver lose old authority, and whether the result denotes
+// fresh authority.
 type ResourceOperation struct {
-	Consumes     []int
-	ReturnsFresh bool
+	Consumes         []int
+	ConsumesReceiver bool
+	ReturnsFresh     bool
 }
 
 // ResourceModel is the syntax-independent bridge from resolved types/callables
@@ -436,6 +438,9 @@ func (a *typedResourceAnalysis) invocation(expr *ast.InvocationExpression) {
 	if !consuming {
 		return
 	}
+	if op.ConsumesReceiver {
+		a.consumeReceiver(expr)
+	}
 	for _, index := range op.Consumes {
 		if index < 0 || index >= len(expr.Arguments) {
 			continue
@@ -449,6 +454,26 @@ func (a *typedResourceAnalysis) invocation(expr *ast.InvocationExpression) {
 		if a.flow.CanUse(ident.Value) {
 			a.flow.Consume(ident.Value, expr)
 		}
+	}
+}
+
+func (a *typedResourceAnalysis) consumeReceiver(expr *ast.InvocationExpression) {
+	if a == nil || a.flow == nil || expr == nil {
+		return
+	}
+	access, ok := expr.Function.(*ast.IndexExpression)
+	if !ok || access == nil || !access.Dot {
+		return
+	}
+	receiver, ok := access.Left.(*ast.Identifier)
+	if !ok || receiver == nil || !a.flow.Registered(receiver.Value) {
+		return
+	}
+	// Receiver evaluation already performed the ordinary Use check. As with
+	// explicit consuming arguments, avoid duplicating that diagnostic when the
+	// authority was unavailable before the invocation.
+	if a.flow.CanUse(receiver.Value) {
+		a.flow.Consume(receiver.Value, expr)
 	}
 }
 

--- a/typechecker/resource_resolution.go
+++ b/typechecker/resource_resolution.go
@@ -3,6 +3,7 @@ package typechecker
 import (
 	"fmt"
 	"sort"
+	"strings"
 )
 
 // ResourceProtocolDeclaration is syntax-independent resource protocol input to
@@ -20,12 +21,13 @@ type ResourceProtocolDeclaration struct {
 // ResourceTransitionDeclaration binds one protocol-local transition label to
 // an explicit callable identity. Callable is never inferred from Name.
 type ResourceTransitionDeclaration struct {
-	Name         string
-	Callable     string
-	From         string
-	To           string
-	Consumes     []int
-	ReturnsFresh bool
+	Name             string
+	Callable         string
+	From             string
+	To               string
+	Consumes         []int
+	ConsumesReceiver bool
+	ReturnsFresh     bool
 }
 
 // ResolvedResourceProgram contains only resource facts that have been checked
@@ -48,12 +50,13 @@ type ResolvedResourceProtocol struct {
 }
 
 type ResolvedResourceTransition struct {
-	Name         string
-	Callable     string
-	From         string
-	To           string
-	Consumes     []int
-	ReturnsFresh bool
+	Name             string
+	Callable         string
+	From             string
+	To               string
+	Consumes         []int
+	ConsumesReceiver bool
+	ReturnsFresh     bool
 }
 
 // ResolveResourceDeclarations resolves internal protocol facts against the
@@ -186,6 +189,15 @@ func (tc *TypeChecker) ResolveResourceDeclarations(declarations []ResourceProtoc
 					return ResolvedResourceProgram{}, fmt.Errorf("resource callable %q argument %d has non-resource type %s", transition.Callable, index, function.Parameters[index])
 				}
 			}
+			if transition.ConsumesReceiver {
+				receiverName := resourceCallableReceiverName(tc.env, transition.Callable)
+				if receiverName == "" {
+					return ResolvedResourceProgram{}, fmt.Errorf("resource callable %q consumes its receiver but has no resolved nominal receiver identity", transition.Callable)
+				}
+				if !resourceTypes[receiverName] {
+					return ResolvedResourceProgram{}, fmt.Errorf("resource callable %q consumes receiver of non-resource type %q", transition.Callable, receiverName)
+				}
+			}
 			if transition.ReturnsFresh {
 				returnName := nominalTypeName(function.ReturnType)
 				if !resourceTypes[returnName] {
@@ -193,24 +205,49 @@ func (tc *TypeChecker) ResolveResourceDeclarations(declarations []ResourceProtoc
 				}
 			}
 
-			operation := ResourceOperation{Consumes: consumes, ReturnsFresh: transition.ReturnsFresh}
+			operation := ResourceOperation{
+				Consumes:         consumes,
+				ConsumesReceiver: transition.ConsumesReceiver,
+				ReturnsFresh:     transition.ReturnsFresh,
+			}
 			if previous, exists := callableSemantics[transition.Callable]; exists && !sameResourceOperation(previous, operation) {
 				return ResolvedResourceProgram{}, fmt.Errorf("resource callable %q has conflicting semantics across protocols", transition.Callable)
 			}
 			callableSemantics[transition.Callable] = operation
 			protocol.Transitions = append(protocol.Transitions, ResolvedResourceTransition{
-				Name:         transition.Name,
-				Callable:     transition.Callable,
-				From:         transition.From,
-				To:           transition.To,
-				Consumes:     consumes,
-				ReturnsFresh: transition.ReturnsFresh,
+				Name:             transition.Name,
+				Callable:         transition.Callable,
+				From:             transition.From,
+				To:               transition.To,
+				Consumes:         consumes,
+				ConsumesReceiver: transition.ConsumesReceiver,
+				ReturnsFresh:     transition.ReturnsFresh,
 			})
 		}
 		resolved.Protocols = append(resolved.Protocols, protocol)
 	}
 
 	return resolved, nil
+}
+
+// resourceCallableReceiverName projects the nominal receiver component from
+// the typechecker's canonical method identity Receiver::method. It validates
+// the receiver against the semantic environment, so arbitrary text containing
+// "::" cannot manufacture receiver authority.
+func resourceCallableReceiverName(env *TypeEnvironment, callable string) string {
+	if env == nil {
+		return ""
+	}
+	separator := strings.LastIndex(callable, "::")
+	if separator <= 0 || separator+2 >= len(callable) {
+		return ""
+	}
+	receiver := callable[:separator]
+	typ, exists := env.GetType(receiver)
+	if !exists || typ == nil || nominalTypeName(typ) != receiver {
+		return ""
+	}
+	return receiver
 }
 
 // nominalTypeName returns the authority-bearing nominal base. Structural

--- a/typechecker/resource_semir.go
+++ b/typechecker/resource_semir.go
@@ -53,8 +53,9 @@ func ResourceModelFromSemIR(module semir.Module) (ResourceModel, error) {
 			}
 
 			operation := ResourceOperation{
-				Consumes:     append([]int(nil), semantics.Consumes...),
-				ReturnsFresh: semantics.ReturnsFresh,
+				Consumes:         append([]int(nil), semantics.Consumes...),
+				ConsumesReceiver: semantics.ConsumesReceiver,
+				ReturnsFresh:     semantics.ReturnsFresh,
 			}
 			callable := transition.Callable
 			if existing, exists := model.Operations[callable]; exists {
@@ -86,7 +87,9 @@ func (tc *TypeChecker) CheckProgramWithSemIR(program *ast.Program, module semir.
 }
 
 func sameResourceOperation(left, right ResourceOperation) bool {
-	if left.ReturnsFresh != right.ReturnsFresh || len(left.Consumes) != len(right.Consumes) {
+	if left.ConsumesReceiver != right.ConsumesReceiver ||
+		left.ReturnsFresh != right.ReturnsFresh ||
+		len(left.Consumes) != len(right.Consumes) {
 		return false
 	}
 	for i := range left.Consumes {

--- a/typechecker/resource_semir_test.go
+++ b/typechecker/resource_semir_test.go
@@ -51,6 +51,13 @@ func resourceSemanticModule() semir.Module {
 							semir.ResourceReturnFresh(),
 						},
 					},
+					{
+						Name:     "CloseMethodTransition",
+						Callable: "Handle::close",
+						From:     "Open",
+						To:       "Closed",
+						Effects:  []semir.Effect{semir.ResourceConsumeReceiver()},
+					},
 				},
 			},
 			{
@@ -82,12 +89,16 @@ func TestResourceModelFromSemIRDerivesTypesAndResolvedCallables(t *testing.T) {
 		t.Fatal("protocol membership alone must not invent resource authority")
 	}
 	closeOp, ok := model.Operations["close"]
-	if !ok || len(closeOp.Consumes) != 1 || closeOp.Consumes[0] != 0 || closeOp.ReturnsFresh {
+	if !ok || len(closeOp.Consumes) != 1 || closeOp.Consumes[0] != 0 || closeOp.ConsumesReceiver || closeOp.ReturnsFresh {
 		t.Fatalf("unexpected close resource operation: %#v", closeOp)
 	}
 	renewOp, ok := model.Operations["renew"]
-	if !ok || len(renewOp.Consumes) != 1 || renewOp.Consumes[0] != 0 || !renewOp.ReturnsFresh {
+	if !ok || len(renewOp.Consumes) != 1 || renewOp.Consumes[0] != 0 || renewOp.ConsumesReceiver || !renewOp.ReturnsFresh {
 		t.Fatalf("unexpected renew resource operation: %#v", renewOp)
+	}
+	methodOp, ok := model.Operations["Handle::close"]
+	if !ok || !methodOp.ConsumesReceiver || len(methodOp.Consumes) != 0 || methodOp.ReturnsFresh {
+		t.Fatalf("unexpected receiver-consuming method operation: %#v", methodOp)
 	}
 	if _, ok := model.Operations["CloseTransition"]; ok {
 		t.Fatal("protocol-local transition labels must not be treated as callable identities")
@@ -137,6 +148,10 @@ f: (h: Handle): u32 {
 
 func TestResourceModelFromSemIRRejectsConflictingCallableSemantics(t *testing.T) {
 	module := semir.Module{
+		Definitions: []semir.Definition{{
+			Name:      "Handle",
+			Authority: semir.Authority{Resource: semir.ResourceAuthorityLive},
+		}},
 		Protocols: []semir.Protocol{
 			{
 				Name:    "Left",
@@ -144,10 +159,10 @@ func TestResourceModelFromSemIRRejectsConflictingCallableSemantics(t *testing.T)
 				States:  []semir.State{{Name: "S"}},
 				Transitions: []semir.Transition{{
 					Name:     "LeftClose",
-					Callable: "close",
+					Callable: "Handle::close",
 					From:     "S",
 					To:       "S",
-					Effects:  []semir.Effect{semir.ResourceConsumeArgument(0)},
+					Effects:  []semir.Effect{semir.ResourceConsumeReceiver()},
 				}},
 			},
 			{
@@ -156,10 +171,10 @@ func TestResourceModelFromSemIRRejectsConflictingCallableSemantics(t *testing.T)
 				States:  []semir.State{{Name: "S"}},
 				Transitions: []semir.Transition{{
 					Name:     "RightClose",
-					Callable: "close",
+					Callable: "Handle::close",
 					From:     "S",
 					To:       "S",
-					Effects:  []semir.Effect{semir.ResourceConsumeArgument(1)},
+					Effects:  []semir.Effect{semir.ResourceConsumeArgument(0)},
 				}},
 			},
 		},

--- a/typechecker/resource_semir_test.go
+++ b/typechecker/resource_semir_test.go
@@ -150,6 +150,7 @@ func TestResourceModelFromSemIRRejectsConflictingCallableSemantics(t *testing.T)
 	module := semir.Module{
 		Definitions: []semir.Definition{{
 			Name:      "Handle",
+			Type:      semir.Type{Kind: semir.TypeRecord},
 			Authority: semir.Authority{Resource: semir.ResourceAuthorityLive},
 		}},
 		Protocols: []semir.Protocol{


### PR DESCRIPTION
## Summary

- model method-receiver consumption independently from explicit argument indices
- emit canonical `resource.consume[receiver]` SemIR instead of overloading argument zero
- validate receiver-qualified callable identity against a concrete declared resource type
- fail closed when generated SemIR consumes a receiver on a free callable or non-resource receiver
- invalidate the complete receiver alias class in path-sensitive resource flow
- preserve consuming + fresh-return methods as old-authority invalidation plus a distinct live result

## Coverage

- SemIR decoding and duplicate-receiver rejection
- fail-closed SemIR receiver validation
- resolver rejection for free-function and non-resource receiver consumption
- receiver alias-class invalidation
- explicit argument consumption remains independent from receiver consumption
- fresh result remains live after old receiver authority is consumed
- compiler emission keeps receiver and argument zero distinct

## Syntax

No parser, grammar, method-receiver syntax, or source-level consume spelling changes. Receiver consumption is a semantic fact attached to the already-resolved callable identity.