### PR TITLE
Respect disabled NEON in freestanding AArch64 SIMD lowering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       run: go mod verify
 
     - name: Run tests
-      run: go test -v -race ./...
+      run: go test -v -race -timeout 20m ./...
 
   aarch64-memory-refinement:
     name: AArch64 Memory Refinement

--- a/.github/workflows/no-neon.yml
+++ b/.github/workflows/no-neon.yml
@@ -1,0 +1,20 @@
+name: Freestanding SIMD
+on:
+  pull_request:
+    branches: [specification]
+jobs:
+  target:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.27.1'
+      - name: Require Clang
+        run: clang --version
+      - name: Check scalar and NEON target lowering
+        run: go test ./codegen -run '^TestAArch64(SimdWithoutNeon|ExplicitVector)' -count=1
+      - name: Verify golden output
+        run: go test ./serialize -run TestGoldenCorpusMatches -count=1
+      - name: Check formatting
+        run: test -z "$(gofmt -l codegen/simd.go codegen/aarch64_no_neon_test.go)"

--- a/.github/workflows/stdlib.yml
+++ b/.github/workflows/stdlib.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Test deque and ID pool
         run: go test ./compiler -run 'TestE2EStdlib(Deque|IdPool|Serenity)' -count=1
       - name: Test standard library and compiler
-        run: go test -race ./...
+        run: go test -race -timeout 20m ./...
       - name: Check formatting
         if: always()
         run: |

--- a/codegen/aarch64_no_neon_test.go
+++ b/codegen/aarch64_no_neon_test.go
@@ -77,8 +77,15 @@ fn sum(input: simd.U8x16) -> u32 { arm64.uaddlv_u8x16(input) }
 	if err := os.WriteFile(cPath, []byte(generated), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	output, err := exec.Command(clang, "--target=aarch64-none-elf", "-mgeneral-regs-only", "-ffreestanding", "-std=c11", "-c", cPath, "-o", filepath.Join(dir, "vector.o")).CombinedOutput()
-	if err == nil || !strings.Contains(string(output), "arm64 vector intrinsics require NEON") {
-		t.Fatalf("expected explicit NEON target error, got %v:\n%s", err, output)
+	for _, extra := range [][]string{
+		{"-mgeneral-regs-only"},
+		{"-DOAK_SCALAR_SIMD=1"},
+	} {
+		args := append([]string{"--target=aarch64-none-elf"}, extra...)
+		args = append(args, "-ffreestanding", "-std=c11", "-c", cPath, "-o", filepath.Join(dir, "vector.o"))
+		output, err := exec.Command(clang, args...).CombinedOutput()
+		if err == nil || !strings.Contains(string(output), "arm64 vector intrinsics require NEON") {
+			t.Fatalf("expected explicit NEON target error, got %v:\n%s", err, output)
+		}
 	}
 }

--- a/codegen/aarch64_no_neon_test.go
+++ b/codegen/aarch64_no_neon_test.go
@@ -1,0 +1,82 @@
+package codegen
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestAArch64SimdWithoutNeonPreservesMachineIntrinsics(t *testing.T) {
+	clang := requireAArch64Clang(t)
+	generated := generateSourceC(t, `
+package main
+fn probe(address: u64, input: simd.U8x16) -> u64 {
+  limited: simd.U8x16 = simd.min_u8x16(input, simd.splat_u8x16(u8(7)))
+  present: Bool = simd.any_u8x16(limited)
+  value: u32 = present ? u32(1) | u32(0)
+  arm64.mmio_write_wo_u32(arm64.mmio_unsafe_wo_u32(address), value)
+  arm64.isb()
+  arm64.read_currentel()
+}
+`)
+	dir := t.TempDir()
+	cPath := filepath.Join(dir, "probe.c")
+	if err := os.WriteFile(cPath, []byte(generated), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, neon := range []bool{false, true} {
+		name := "scalar"
+		if neon {
+			name = "neon"
+		}
+		t.Run(name, func(t *testing.T) {
+			sPath := filepath.Join(dir, name+".s")
+			args := []string{"--target=aarch64-none-elf", "-march=armv8-a", "-std=c11", "-O2", "-ffreestanding", "-Wall", "-Wextra", "-Werror", "-Wno-unused-function"}
+			if !neon {
+				args = append(args, "-mgeneral-regs-only", "-mstrict-align")
+			}
+			args = append(args, "-S", cPath, "-o", sPath)
+			if output, err := exec.Command(clang, args...).CombinedOutput(); err != nil {
+				t.Fatalf("cross-compile: %v\n%s", err, output)
+			}
+			data, err := os.ReadFile(sPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			body := aarch64FunctionBody(t, strings.ToLower(string(data)), "probe")
+			for _, instruction := range []string{"mrs", "isb", "str"} {
+				requireInstruction(t, body, instruction)
+			}
+			if !strings.Contains(body, "currentel") {
+				t.Fatalf("CurrentEL access disappeared:\n%s", body)
+			}
+			vectorRegister := regexp.MustCompile(`\b[vdqshb][0-9]+\b`)
+			if !neon && vectorRegister.MatchString(body) {
+				t.Fatalf("general-register target uses SIMD/FP registers:\n%s", body)
+			}
+			if neon {
+				requireInstruction(t, body, "umin")
+			}
+		})
+	}
+}
+
+func TestAArch64ExplicitVectorRequiresNeon(t *testing.T) {
+	clang := requireAArch64Clang(t)
+	generated := generateSourceC(t, `
+package main
+fn sum(input: simd.U8x16) -> u32 { arm64.uaddlv_u8x16(input) }
+`)
+	dir := t.TempDir()
+	cPath := filepath.Join(dir, "vector.c")
+	if err := os.WriteFile(cPath, []byte(generated), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	output, err := exec.Command(clang, "--target=aarch64-none-elf", "-mgeneral-regs-only", "-ffreestanding", "-std=c11", "-c", cPath, "-o", filepath.Join(dir, "vector.o")).CombinedOutput()
+	if err == nil || !strings.Contains(string(output), "arm64 vector intrinsics require NEON") {
+		t.Fatalf("expected explicit NEON target error, got %v:\n%s", err, output)
+	}
+}

--- a/codegen/aarch64_no_neon_test.go
+++ b/codegen/aarch64_no_neon_test.go
@@ -27,16 +27,18 @@ fn probe(address: u64, input: simd.U8x16) -> u64 {
 	if err := os.WriteFile(cPath, []byte(generated), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	for _, neon := range []bool{false, true} {
-		name := "scalar"
-		if neon {
-			name = "neon"
-		}
+	for _, name := range []string{"scalar", "forced-scalar", "neon"} {
+		neon := name == "neon"
 		t.Run(name, func(t *testing.T) {
 			sPath := filepath.Join(dir, name+".s")
 			args := []string{"--target=aarch64-none-elf", "-march=armv8-a", "-std=c11", "-O2", "-ffreestanding", "-Wall", "-Wextra", "-Werror", "-Wno-unused-function"}
 			if !neon {
 				args = append(args, "-mgeneral-regs-only", "-mstrict-align")
+			}
+			if name == "forced-scalar" {
+				// Some build drivers advertise NEON to preprocessing despite
+				// disabling it for code generation. The kernel override wins.
+				args = append(args, "-D__ARM_NEON=1", "-DOAK_SCALAR_SIMD=1")
 			}
 			args = append(args, "-S", cPath, "-o", sPath)
 			if output, err := exec.Command(clang, args...).CombinedOutput(); err != nil {

--- a/codegen/simd.go
+++ b/codegen/simd.go
@@ -133,12 +133,12 @@ func (cg *CodeGenerator) emitSimdSupport(program *ast.Program) {
 	// Explicit architecture-vector calls must not silently become scalar on
 	// an AArch64 target that disables NEON. Portable simd calls may fall back.
 	if len(arm64Vector) != 0 {
-		cg.write("#if defined(__aarch64__) && !defined(__ARM_NEON) && !defined(OAK_PORTABLE_INTRINSICS)\n")
+		cg.write("#if defined(__aarch64__) && !defined(__ARM_NEON) && !defined(OAK_SCALAR_SIMD) && !defined(OAK_PORTABLE_INTRINSICS)\n")
 		cg.write("#error \"arm64 vector intrinsics require NEON\"\n")
 		cg.write("#endif\n")
 	}
 	cg.write("/* portable SIMD vectors: docs/spec/93-simd.md */\n")
-	cg.write("#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_PORTABLE_INTRINSICS)\n")
+	cg.write("#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_SCALAR_SIMD) && !defined(OAK_PORTABLE_INTRINSICS)\n")
 	cg.write("#include <arm_neon.h>\n")
 	cg.write("#endif\n")
 	for _, shape := range typechecker.SimdShapes {
@@ -217,7 +217,7 @@ func (cg *CodeGenerator) programMentionsSimdLocals(program *ast.Program) bool {
 	return found
 }
 
-const neonGuard = "#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_PORTABLE_INTRINSICS)"
+const neonGuard = "#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_SCALAR_SIMD) && !defined(OAK_PORTABLE_INTRINSICS)"
 
 // simdHelperSource builds the helper for one operation of one vector shape.
 // Inputs come only from the fixed catalogs above.
@@ -312,7 +312,7 @@ func neonReduction(op, vec, neon string) string {
 // helpers (docs/spec/93-simd.md section 2).
 var arm64VectorIntrinsicSources = map[string]string{
 	"uaddlv_u8x16": `static inline u32 oak_arm64_uaddlv_u8x16( u8x16 x ) {
-#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_PORTABLE_INTRINSICS)
+#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_SCALAR_SIMD) && !defined(OAK_PORTABLE_INTRINSICS)
   return (u32)vaddlvq_u8(vld1q_u8(x.lanes));
 #else
   u32 sum = 0;
@@ -322,7 +322,7 @@ var arm64VectorIntrinsicSources = map[string]string{
 }
 `,
 	"umaxv_u8x16": `static inline u8 oak_arm64_umaxv_u8x16( u8x16 x ) {
-#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_PORTABLE_INTRINSICS)
+#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_SCALAR_SIMD) && !defined(OAK_PORTABLE_INTRINSICS)
   return vmaxvq_u8(vld1q_u8(x.lanes));
 #else
   u8 best = 0;
@@ -332,7 +332,7 @@ var arm64VectorIntrinsicSources = map[string]string{
 }
 `,
 	"uminv_u8x16": `static inline u8 oak_arm64_uminv_u8x16( u8x16 x ) {
-#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_PORTABLE_INTRINSICS)
+#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_SCALAR_SIMD) && !defined(OAK_PORTABLE_INTRINSICS)
   return vminvq_u8(vld1q_u8(x.lanes));
 #else
   u8 best = 255;
@@ -343,7 +343,7 @@ var arm64VectorIntrinsicSources = map[string]string{
 `,
 	"cnt_u8x16": `static inline u8x16 oak_arm64_cnt_u8x16( u8x16 x ) {
   u8x16 r;
-#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_PORTABLE_INTRINSICS)
+#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_SCALAR_SIMD) && !defined(OAK_PORTABLE_INTRINSICS)
   vst1q_u8(r.lanes, vcntq_u8(vld1q_u8(x.lanes)));
 #else
   for (int i = 0; i < 16; i++) {

--- a/codegen/simd.go
+++ b/codegen/simd.go
@@ -133,7 +133,7 @@ func (cg *CodeGenerator) emitSimdSupport(program *ast.Program) {
 	// Explicit architecture-vector calls must not silently become scalar on
 	// an AArch64 target that disables NEON. Portable simd calls may fall back.
 	if len(arm64Vector) != 0 {
-		cg.write("#if defined(__aarch64__) && !defined(__ARM_NEON) && !defined(OAK_SCALAR_SIMD) && !defined(OAK_PORTABLE_INTRINSICS)\n")
+		cg.write("#if defined(__aarch64__) && (!defined(__ARM_NEON) || defined(OAK_SCALAR_SIMD)) && !defined(OAK_PORTABLE_INTRINSICS)\n")
 		cg.write("#error \"arm64 vector intrinsics require NEON\"\n")
 		cg.write("#endif\n")
 	}

--- a/codegen/simd.go
+++ b/codegen/simd.go
@@ -3,7 +3,7 @@ package codegen
 // C backend lowering for the portable simd library and the arm64 vector
 // instruction functions (docs/spec/93-simd.md). One struct ABI per vector
 // type serves both lowerings; each used operation gets one static inline
-// helper — the NEON instruction under __aarch64__, the portable C99 lane
+// helper — NEON when the AArch64 target enables it, the portable C99 lane
 // loop otherwise. All emitted names come from the fixed compiler catalog;
 // no user-controlled strings reach the generated C.
 
@@ -130,8 +130,15 @@ func (cg *CodeGenerator) emitSimdSupport(program *ast.Program) {
 		return
 	}
 
+	// Explicit architecture-vector calls must not silently become scalar on
+	// an AArch64 target that disables NEON. Portable simd calls may fall back.
+	if len(arm64Vector) != 0 {
+		cg.write("#if defined(__aarch64__) && !defined(__ARM_NEON) && !defined(OAK_PORTABLE_INTRINSICS)\n")
+		cg.write("#error \"arm64 vector intrinsics require NEON\"\n")
+		cg.write("#endif\n")
+	}
 	cg.write("/* portable SIMD vectors: docs/spec/93-simd.md */\n")
-	cg.write("#if defined(__aarch64__) && !defined(OAK_PORTABLE_INTRINSICS)\n")
+	cg.write("#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_PORTABLE_INTRINSICS)\n")
 	cg.write("#include <arm_neon.h>\n")
 	cg.write("#endif\n")
 	for _, shape := range typechecker.SimdShapes {
@@ -210,7 +217,7 @@ func (cg *CodeGenerator) programMentionsSimdLocals(program *ast.Program) bool {
 	return found
 }
 
-const neonGuard = "#if defined(__aarch64__) && !defined(OAK_PORTABLE_INTRINSICS)"
+const neonGuard = "#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_PORTABLE_INTRINSICS)"
 
 // simdHelperSource builds the helper for one operation of one vector shape.
 // Inputs come only from the fixed catalogs above.
@@ -305,7 +312,7 @@ func neonReduction(op, vec, neon string) string {
 // helpers (docs/spec/93-simd.md section 2).
 var arm64VectorIntrinsicSources = map[string]string{
 	"uaddlv_u8x16": `static inline u32 oak_arm64_uaddlv_u8x16( u8x16 x ) {
-#if defined(__aarch64__) && !defined(OAK_PORTABLE_INTRINSICS)
+#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_PORTABLE_INTRINSICS)
   return (u32)vaddlvq_u8(vld1q_u8(x.lanes));
 #else
   u32 sum = 0;
@@ -315,7 +322,7 @@ var arm64VectorIntrinsicSources = map[string]string{
 }
 `,
 	"umaxv_u8x16": `static inline u8 oak_arm64_umaxv_u8x16( u8x16 x ) {
-#if defined(__aarch64__) && !defined(OAK_PORTABLE_INTRINSICS)
+#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_PORTABLE_INTRINSICS)
   return vmaxvq_u8(vld1q_u8(x.lanes));
 #else
   u8 best = 0;
@@ -325,7 +332,7 @@ var arm64VectorIntrinsicSources = map[string]string{
 }
 `,
 	"uminv_u8x16": `static inline u8 oak_arm64_uminv_u8x16( u8x16 x ) {
-#if defined(__aarch64__) && !defined(OAK_PORTABLE_INTRINSICS)
+#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_PORTABLE_INTRINSICS)
   return vminvq_u8(vld1q_u8(x.lanes));
 #else
   u8 best = 255;
@@ -336,7 +343,7 @@ var arm64VectorIntrinsicSources = map[string]string{
 `,
 	"cnt_u8x16": `static inline u8x16 oak_arm64_cnt_u8x16( u8x16 x ) {
   u8x16 r;
-#if defined(__aarch64__) && !defined(OAK_PORTABLE_INTRINSICS)
+#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_PORTABLE_INTRINSICS)
   vst1q_u8(r.lanes, vcntq_u8(vld1q_u8(x.lanes)));
 #else
   for (int i = 0; i < 16; i++) {

--- a/golden/simd_kernel_7_codegen.c
+++ b/golden/simd_kernel_7_codegen.c
@@ -120,8 +120,11 @@ static Bool oak_is_valid_utf8(oak_view_u8 v) {
   return oak_Bool_True;
 }
 
+#if defined(__aarch64__) && !defined(__ARM_NEON) && !defined(OAK_PORTABLE_INTRINSICS)
+#error "arm64 vector intrinsics require NEON"
+#endif
 /* portable SIMD vectors: docs/spec/93-simd.md */
-#if defined(__aarch64__) && !defined(OAK_PORTABLE_INTRINSICS)
+#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_PORTABLE_INTRINSICS)
 #include <arm_neon.h>
 #endif
 typedef struct oak_u8x16 { u8 lanes[16]; } u8x16;
@@ -130,7 +133,7 @@ typedef struct oak_u32x4 { u32 lanes[4]; } u32x4;
 typedef struct oak_u64x2 { u64 lanes[2]; } u64x2;
 
 static inline Bool oak_simd_any_u8x16( u8x16 v ) {
-#if defined(__aarch64__) && !defined(OAK_PORTABLE_INTRINSICS)
+#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_PORTABLE_INTRINSICS)
   return vmaxvq_u8(vld1q_u8(v.lanes)) != 0u ? oak_Bool_True : oak_Bool_False;
 #else
   for (int i = 0; i < 16; i++) { if (v.lanes[i] != 0) { return oak_Bool_True; } }
@@ -140,7 +143,7 @@ static inline Bool oak_simd_any_u8x16( u8x16 v ) {
 
 static inline u8x16 oak_simd_eq_u8x16( u8x16 a, u8x16 b ) {
   u8x16 r;
-#if defined(__aarch64__) && !defined(OAK_PORTABLE_INTRINSICS)
+#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_PORTABLE_INTRINSICS)
   vst1q_u8(r.lanes, vceqq_u8(vld1q_u8(a.lanes), vld1q_u8(b.lanes)));
 #else
   for (int i = 0; i < 16; i++) {
@@ -154,7 +157,7 @@ static inline u8x16 oak_simd_eq_u8x16( u8x16 a, u8x16 b ) {
 static inline u8x16 oak_simd_load_u8x16( oak_view_u8 v, u32 off ) {
   if ((u64)off + 16u > (u64)v.len) { __builtin_trap(); }
   u8x16 r;
-#if defined(__aarch64__) && !defined(OAK_PORTABLE_INTRINSICS)
+#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_PORTABLE_INTRINSICS)
   vst1q_u8(r.lanes, vld1q_u8(v.base + off));
 #else
   for (int i = 0; i < 16; i++) { r.lanes[i] = v.base[off + (u32)i]; }
@@ -164,7 +167,7 @@ static inline u8x16 oak_simd_load_u8x16( oak_view_u8 v, u32 off ) {
 
 static inline u8x16 oak_simd_splat_u8x16( u8 x ) {
   u8x16 r;
-#if defined(__aarch64__) && !defined(OAK_PORTABLE_INTRINSICS)
+#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_PORTABLE_INTRINSICS)
   vst1q_u8(r.lanes, vdupq_n_u8(x));
 #else
   for (int i = 0; i < 16; i++) { r.lanes[i] = x; }
@@ -189,7 +192,7 @@ static inline void oak_span_store_u8(oak_span_u8 v, u64 i, u8 value) {
 
 static inline void oak_simd_store_u8x16( oak_span_u8 s, u32 off, u8x16 val ) {
   if ((u64)off + 16u > (u64)s.len) { __builtin_trap(); }
-#if defined(__aarch64__) && !defined(OAK_PORTABLE_INTRINSICS)
+#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_PORTABLE_INTRINSICS)
   vst1q_u8(s.base + off, vld1q_u8(val.lanes));
 #else
   for (int i = 0; i < 16; i++) { s.base[off + (u32)i] = val.lanes[i]; }
@@ -197,7 +200,7 @@ static inline void oak_simd_store_u8x16( oak_span_u8 s, u32 off, u8x16 val ) {
 }
 
 static inline u32 oak_arm64_uaddlv_u8x16( u8x16 x ) {
-#if defined(__aarch64__) && !defined(OAK_PORTABLE_INTRINSICS)
+#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_PORTABLE_INTRINSICS)
   return (u32)vaddlvq_u8(vld1q_u8(x.lanes));
 #else
   u32 sum = 0;

--- a/golden/simd_kernel_7_codegen.c
+++ b/golden/simd_kernel_7_codegen.c
@@ -120,7 +120,7 @@ static Bool oak_is_valid_utf8(oak_view_u8 v) {
   return oak_Bool_True;
 }
 
-#if defined(__aarch64__) && !defined(__ARM_NEON) && !defined(OAK_SCALAR_SIMD) && !defined(OAK_PORTABLE_INTRINSICS)
+#if defined(__aarch64__) && (!defined(__ARM_NEON) || defined(OAK_SCALAR_SIMD)) && !defined(OAK_PORTABLE_INTRINSICS)
 #error "arm64 vector intrinsics require NEON"
 #endif
 /* portable SIMD vectors: docs/spec/93-simd.md */

--- a/golden/simd_kernel_7_codegen.c
+++ b/golden/simd_kernel_7_codegen.c
@@ -120,11 +120,11 @@ static Bool oak_is_valid_utf8(oak_view_u8 v) {
   return oak_Bool_True;
 }
 
-#if defined(__aarch64__) && !defined(__ARM_NEON) && !defined(OAK_PORTABLE_INTRINSICS)
+#if defined(__aarch64__) && !defined(__ARM_NEON) && !defined(OAK_SCALAR_SIMD) && !defined(OAK_PORTABLE_INTRINSICS)
 #error "arm64 vector intrinsics require NEON"
 #endif
 /* portable SIMD vectors: docs/spec/93-simd.md */
-#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_PORTABLE_INTRINSICS)
+#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_SCALAR_SIMD) && !defined(OAK_PORTABLE_INTRINSICS)
 #include <arm_neon.h>
 #endif
 typedef struct oak_u8x16 { u8 lanes[16]; } u8x16;
@@ -133,7 +133,7 @@ typedef struct oak_u32x4 { u32 lanes[4]; } u32x4;
 typedef struct oak_u64x2 { u64 lanes[2]; } u64x2;
 
 static inline Bool oak_simd_any_u8x16( u8x16 v ) {
-#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_PORTABLE_INTRINSICS)
+#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_SCALAR_SIMD) && !defined(OAK_PORTABLE_INTRINSICS)
   return vmaxvq_u8(vld1q_u8(v.lanes)) != 0u ? oak_Bool_True : oak_Bool_False;
 #else
   for (int i = 0; i < 16; i++) { if (v.lanes[i] != 0) { return oak_Bool_True; } }
@@ -143,7 +143,7 @@ static inline Bool oak_simd_any_u8x16( u8x16 v ) {
 
 static inline u8x16 oak_simd_eq_u8x16( u8x16 a, u8x16 b ) {
   u8x16 r;
-#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_PORTABLE_INTRINSICS)
+#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_SCALAR_SIMD) && !defined(OAK_PORTABLE_INTRINSICS)
   vst1q_u8(r.lanes, vceqq_u8(vld1q_u8(a.lanes), vld1q_u8(b.lanes)));
 #else
   for (int i = 0; i < 16; i++) {
@@ -157,7 +157,7 @@ static inline u8x16 oak_simd_eq_u8x16( u8x16 a, u8x16 b ) {
 static inline u8x16 oak_simd_load_u8x16( oak_view_u8 v, u32 off ) {
   if ((u64)off + 16u > (u64)v.len) { __builtin_trap(); }
   u8x16 r;
-#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_PORTABLE_INTRINSICS)
+#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_SCALAR_SIMD) && !defined(OAK_PORTABLE_INTRINSICS)
   vst1q_u8(r.lanes, vld1q_u8(v.base + off));
 #else
   for (int i = 0; i < 16; i++) { r.lanes[i] = v.base[off + (u32)i]; }
@@ -167,7 +167,7 @@ static inline u8x16 oak_simd_load_u8x16( oak_view_u8 v, u32 off ) {
 
 static inline u8x16 oak_simd_splat_u8x16( u8 x ) {
   u8x16 r;
-#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_PORTABLE_INTRINSICS)
+#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_SCALAR_SIMD) && !defined(OAK_PORTABLE_INTRINSICS)
   vst1q_u8(r.lanes, vdupq_n_u8(x));
 #else
   for (int i = 0; i < 16; i++) { r.lanes[i] = x; }
@@ -192,7 +192,7 @@ static inline void oak_span_store_u8(oak_span_u8 v, u64 i, u8 value) {
 
 static inline void oak_simd_store_u8x16( oak_span_u8 s, u32 off, u8x16 val ) {
   if ((u64)off + 16u > (u64)s.len) { __builtin_trap(); }
-#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_PORTABLE_INTRINSICS)
+#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_SCALAR_SIMD) && !defined(OAK_PORTABLE_INTRINSICS)
   vst1q_u8(s.base + off, vld1q_u8(val.lanes));
 #else
   for (int i = 0; i < 16; i++) { s.base[off + (u32)i] = val.lanes[i]; }
@@ -200,7 +200,7 @@ static inline void oak_simd_store_u8x16( oak_span_u8 s, u32 off, u8x16 val ) {
 }
 
 static inline u32 oak_arm64_uaddlv_u8x16( u8x16 x ) {
-#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_PORTABLE_INTRINSICS)
+#if defined(__aarch64__) && defined(__ARM_NEON) && !defined(OAK_SCALAR_SIMD) && !defined(OAK_PORTABLE_INTRINSICS)
   return (u32)vaddlvq_u8(vld1q_u8(x.lanes));
 #else
   u32 sum = 0;


### PR DESCRIPTION
The OS Oak collection payload imports std, whose SIMD helpers currently select NEON solely from __aarch64__. That fails on the kernel's general-register-only target, even though portable scalar helpers already exist.

Require __ARM_NEON for the NEON header and helper branches. Portable simd operations use scalar loops when NEON is disabled; MMIO, system registers and barriers retain real architecture lowering. Explicit arm64 vector operations fail with a targeted diagnostic on a no-NEON AArch64 target, instead of silently becoming scalar.

Adds cross-compilation tests with and without NEON, checking real CurrentEL/MMIO/ISB operations, absence of vector registers in the scalar path, and explicit-vector rejection. Updates the SIMD golden fixture and adds a focused CI gate.

Discovered by https://github.com/SCKelemen/os/pull/16. Validation: all eight PR workflows passed on eddc5ff9df1b07a808991ef365c18cbe264d9f5a, including scalar/NEON cross-compilation, explicit-vector rejection, full Go/race suites, golden output, formal proofs, API snapshots and generalization checks. The OS ReleaseSafe QEMU payload also passed with this exact compiler pin.

Adds OAK_SCALAR_SIMD as an explicit portable-library override for build drivers whose preprocessor feature macros disagree with code-generation features; it leaves privileged machine operations enabled. Explicit arm64 vectors reject this mode too.

The growing full race suite reached Go's default ten-minute package limit while beginning a new text smoke test. Both full-suite workflows now permit twenty minutes, retaining every test and race detection.