### PR TITLE
Add oak test, property shrinking, fuzz harnesses, and deterministic event simulation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       run: go mod verify
 
     - name: Run tests
-      run: go test -v -race ./...
+      run: go test -v -race -timeout 20m ./...
 
   aarch64-memory-refinement:
     name: AArch64 Memory Refinement
@@ -57,3 +57,4 @@ jobs:
 
     - name: Verify memory-model litmus outcomes
       run: go test -v ./semir -run '^TestLitmus'
+

--- a/.github/workflows/stdlib.yml
+++ b/.github/workflows/stdlib.yml
@@ -31,10 +31,11 @@ jobs:
       - name: Test deque and ID pool
         run: go test ./compiler -run 'TestE2EStdlib(Deque|IdPool|Serenity)' -count=1
       - name: Test standard library and compiler
-        run: go test -race ./...
+        run: go test -race -timeout 20m ./...
       - name: Check formatting
         if: always()
         run: |
           gofmt -d compiler/e2e_codec_type_arguments_test.go parser/parser.go compiler/codecs.go compiler/e2e_derived_json_test.go compiler/e2e_json_codec_test.go borrowchecker/simd_effects_test.go typechecker/ffi.go borrowchecker/global_effects.go lsp/position_index.go lsp/position_index_test.go typechecker/string_views.go borrowchecker/string_views.go borrowchecker/string_views_test.go codegen/string_views.go compiler/e2e_string_views_test.go typechecker/borrow_storage.go typechecker/borrow_storage_test.go borrowchecker/borrowchecker.go borrowchecker/escape.go borrowchecker/aggregate_escape_test.go borrowchecker/aggregate_storage.go borrowchecker/aggregate_storage_test.go compiler/stdlib.go compiler/text_literals.go compiler/e2e_stdlib_text_test.go codegen/slices.go compiler/fluent.go compiler/syntax_walk.go compiler/e2e_stdlib_test.go compiler/e2e_stdlib_bits_endian_test.go compiler/e2e_stdlib_buffer_test.go compiler/e2e_stdlib_collections_test.go compiler/e2e_stdlib_splice_test.go compiler/e2e_stdlib_heap_test.go compiler/e2e_stdlib_deque_id_test.go compiler/compilation.go stdlib/source.go codegen/codegen.go typechecker/typechecker.go typechecker/mono.go token/token.go lowering/lowering.go
+
 
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -20,6 +20,11 @@ jobs:
           go build -o build/oak .
       - name: Run Oak test suite
         run: ./build/oak test -runs 20 examples/testing
+      - name: Exercise coverage-guided native fuzz harness
+        run: |
+          ./build/oak test -fuzz '^FuzzUtf8$' -emit-fuzz-harness build/fuzz.c examples/testing
+          clang -std=c11 -g -O1 -fsanitize=fuzzer,address,undefined -fno-sanitize-recover=all build/fuzz.c -o build/fuzz
+          ./build/fuzz -runs=100 -max_len=256
       - name: Fuzz runner internals
         run: |
           go test ./testrunner -run '^$' -fuzz '^FuzzMinimize$' -fuzztime 5s

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,36 @@
+name: Oak testing tools
+on:
+  push:
+    branches: [specification, codex/oak-testing-tools]
+  pull_request:
+    branches: [specification]
+jobs:
+  native:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.27.1'
+      - name: Test runner and failure replay
+        run: go test -race ./testrunner -count=1 -v
+      - name: Build Oak CLI
+        run: |
+          mkdir -p build
+          go build -o build/oak .
+      - name: Run Oak test suite
+        run: ./build/oak test -runs 20 examples/testing
+      - name: Fuzz runner internals
+        run: |
+          go test ./testrunner -run '^$' -fuzz '^FuzzMinimize$' -fuzztime 5s
+          go test ./testrunner -run '^$' -fuzz '^FuzzMutationBounds$' -fuzztime 5s
+      - name: Formatting patch
+        if: always()
+        run: |
+          mkdir -p build
+          gofmt -d main.go compiler/stdlib.go stdlib/source.go testrunner/*.go > build/format.patch
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: oak-testing-linux
+          path: build/

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -33,7 +33,7 @@ jobs:
         if: always()
         run: |
           mkdir -p build
-          gofmt -d main.go compiler/stdlib.go stdlib/source.go testrunner/*.go > build/format.patch
+          gofmt -d main.go compiler/compilation.go compiler/stdlib.go compiler/simulation.go stdlib/source.go testrunner/*.go > build/format.patch
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,6 +16,7 @@ jobs:
         run: |
           mkdir -p build
           go build -o build/oak .
+          cp "$(go env GOROOT)/bin/gofmt" build/gofmt
       - name: Test runner and failure replay
         run: go test -race ./testrunner -count=1 -v
       - name: Run Oak test suite

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,7 +1,7 @@
 name: Oak testing tools
 on:
   push:
-    branches: [specification, codex/oak-testing-tools]
+    branches: [specification]
   pull_request:
     branches: [specification]
 jobs:
@@ -12,12 +12,12 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.27.1'
-      - name: Test runner and failure replay
-        run: go test -race ./testrunner -count=1 -v
       - name: Build Oak CLI
         run: |
           mkdir -p build
           go build -o build/oak .
+      - name: Test runner and failure replay
+        run: go test -race ./testrunner -count=1 -v
       - name: Run Oak test suite
         run: ./build/oak test -runs 20 examples/testing
       - name: Exercise coverage-guided native fuzz harness

--- a/README.md
+++ b/README.md
@@ -1062,3 +1062,11 @@ fn schedule[T: IntrusiveListNode[T, ReadyQueue]](
 ---
 
 *Oak is actively developed. Check the latest documentation for updates and new features.*
+
+
+## Native test tooling
+
+`oak test` runs compiled unit tests, property tests, fuzz targets, and bounded
+deterministic event simulations. See [the runner guide](testrunner/README.md)
+and [the testing contract](docs/spec/110-testing.md) for examples, shrinking,
+corpus replay, and Clang/libFuzzer harness export.

--- a/compiler/compilation.go
+++ b/compiler/compilation.go
@@ -46,10 +46,10 @@ type Options struct {
 // modified copies so callers can cheaply derive configurations without hidden
 // mutation between compiler phases.
 type Compilation struct {
-	source            SourceText
-	options           Options
-	resourceProtocols []typechecker.ResourceProtocolDeclaration
-	simulation        bool
+	source             SourceText
+	options            Options
+	resourceProtocols  []typechecker.ResourceProtocolDeclaration
+	simulation         bool
 	simulationBindings []SimulationBinding
 }
 

--- a/compiler/compilation.go
+++ b/compiler/compilation.go
@@ -49,6 +49,8 @@ type Compilation struct {
 	source            SourceText
 	options           Options
 	resourceProtocols []typechecker.ResourceProtocolDeclaration
+	simulation        bool
+	simulationBindings []SimulationBinding
 }
 
 // SyntaxTree is a parsed Oak source file.
@@ -187,6 +189,11 @@ func (comp Compilation) check(resourceProtocols []typechecker.ResourceProtocolDe
 		}
 		if err := loadStandardLibrary(tree); err != nil {
 			return nil, err
+		}
+		if comp.simulation {
+			if err := checkSimulation(tree.Root, comp.simulationBindings); err != nil {
+				return nil, err
+			}
 		}
 		env := object.NewEnvironment()
 		tc := typechecker.NewWithPlatformSizes(env, comp.options.IntSize, comp.options.PtrSize)

--- a/compiler/simulation.go
+++ b/compiler/simulation.go
@@ -1,0 +1,110 @@
+package compiler
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+
+	"github.com/SCKelemen/oak/ast"
+	"github.com/SCKelemen/oak/semir"
+	"github.com/SCKelemen/oak/typechecker"
+)
+
+// SimulationBinding describes an explicitly trusted scalar C boundary. Native
+// implementations remain a trust boundary: the compiler cannot prove their
+// determinism. Names, symbols and exact ABI types must all match.
+type SimulationBinding struct {
+	Name string `json:"name"`
+	Symbol string `json:"symbol"`
+	Parameters []string `json:"parameters"`
+	Return string `json:"return"`
+}
+
+// WithSimulation enables a conservative whole-package boundary check before
+// type checking/specialization. Dead functions, generic templates, closures and
+// global initializers are covered too. This is not a reachability/effect proof.
+func (comp Compilation) WithSimulation(bindings []SimulationBinding) Compilation {
+	comp.simulation = true
+	comp.simulationBindings = make([]SimulationBinding, len(bindings))
+	for i, binding := range bindings {
+		comp.simulationBindings[i] = binding
+		comp.simulationBindings[i].Parameters = append([]string(nil), binding.Parameters...)
+	}
+	return comp
+}
+
+func simulationABI(expr ast.Expression) string {
+	if id, ok := expr.(*ast.Identifier); ok && id.Value == "()" { return "()" }
+	if member, ok := expr.(*ast.IndexExpression); ok && member.Dot {
+		base, bok := member.Left.(*ast.Identifier)
+		name, nok := member.Index.(*ast.Identifier)
+		if bok && nok && base.Value == "c" {
+			return "c." + name.Value
+		}
+	}
+	return ""
+}
+
+func matchesSimulationBinding(fn *ast.FunctionStatement, b SimulationBinding) bool {
+	if fn.Name == nil || fn.Name.Value != b.Name || fn.ExternSymbol != b.Symbol || fn.Receiver != nil || len(fn.TypeParams) != 0 || len(fn.Parameters) != len(b.Parameters) || simulationABI(fn.ReturnType) != b.Return || b.Return == "" { return false }
+	for i, p := range fn.Parameters {
+		if p.Variadic || b.Parameters[i] == "" || simulationABI(p.Type) != b.Parameters[i] { return false }
+	}
+	return true
+}
+
+func checkSimulation(root *ast.Program, bindings []SimulationBinding) error {
+	reporters := []SimulationBinding{
+		{Name: "testing_fail_host", Symbol: "oak_test_host_fail", Parameters: []string{"c.UInt32"}, Return: "()"},
+		{Name: "testing_discard", Symbol: "oak_test_host_discard", Return: "()"},
+		{Name: "testing_classify_host", Symbol: "oak_test_host_classify", Parameters: []string{"c.UInt32"}, Return: "()"},
+	}
+	return walkSimulation(reflect.ValueOf(root), func(value any) error {
+		switch n := value.(type) {
+		case *ast.UnsafeBlock:
+			return fmt.Errorf("simulation boundary: unsafe blocks are not permitted; move hardware effects behind a trusted adapter")
+		case *ast.Identifier:
+			// Reject names even when they occur in uncalled code or are used as
+			// values. Conservative shadowing rejection avoids resolution holes.
+			_, atomic := semir.LookupAtomicBuiltin(n.Value)
+			if atomic || n.Value == "Atomic" || typechecker.CompilerKnownLibrary(n.Value) && n.Value != "c" && n.Value != "simd" {
+				return fmt.Errorf("simulation boundary: %s requires an explicit simulated adapter", n.Value)
+			}
+		case *ast.FunctionStatement:
+			if n.ExternSymbol == "" { return nil }
+			if n.Token.SemanticContext == "testing-host" {
+				for _, b := range reporters { if matchesSimulationBinding(n, b) { return nil } }
+			}
+			for _, b := range bindings { if matchesSimulationBinding(n, b) { return nil } }
+			return fmt.Errorf("simulation boundary: undeclared extern %s (%s), or adapter ABI mismatch", n.Name.Value, n.ExternSymbol)
+		}
+		return nil
+	})
+}
+
+// Unlike transformSyntax this visits statements as well as expressions. Only
+// exported AST data is walked; no trivia, semantic environments or cycles.
+func walkSimulation(v reflect.Value, visit func(any) error) error {
+	if !v.IsValid() { return nil }
+	switch v.Kind() {
+	case reflect.Interface, reflect.Pointer:
+		if v.IsNil() { return nil }
+		if v.Kind() == reflect.Pointer && v.CanInterface() {
+			if err := visit(v.Interface()); err != nil { return err }
+		}
+		return walkSimulation(v.Elem(), visit)
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			if v.Type().Field(i).IsExported() {
+				if err := walkSimulation(v.Field(i), visit); err != nil { return err }
+			}
+		}
+	case reflect.Slice:
+		for i := 0; i < v.Len(); i++ { if err := walkSimulation(v.Index(i), visit); err != nil { return err } }
+	case reflect.Map:
+		keys := v.MapKeys()
+		sort.Slice(keys, func(i, j int) bool { return keys[i].String() < keys[j].String() })
+		for _, key := range keys { if err := walkSimulation(v.MapIndex(key), visit); err != nil { return err } }
+	}
+	return nil
+}

--- a/compiler/simulation.go
+++ b/compiler/simulation.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strings"
 
 	"github.com/SCKelemen/oak/ast"
 	"github.com/SCKelemen/oak/semir"
@@ -14,10 +15,10 @@ import (
 // implementations remain a trust boundary: the compiler cannot prove their
 // determinism. Names, symbols and exact ABI types must all match.
 type SimulationBinding struct {
-	Name string `json:"name"`
-	Symbol string `json:"symbol"`
+	Name       string   `json:"name"`
+	Symbol     string   `json:"symbol"`
 	Parameters []string `json:"parameters"`
-	Return string `json:"return"`
+	Return     string   `json:"return"`
 }
 
 // WithSimulation enables a conservative whole-package boundary check before
@@ -34,23 +35,22 @@ func (comp Compilation) WithSimulation(bindings []SimulationBinding) Compilation
 }
 
 func simulationABI(expr ast.Expression) string {
-	if id, ok := expr.(*ast.Identifier); ok && id.Value == "()" { return "()" }
-	// Qualified type syntax currently uses IndexExpression without setting
-	// Dot. Ordinary type checking remains the authority for legal C types.
-	if member, ok := expr.(*ast.IndexExpression); ok {
-		base, bok := member.Left.(*ast.Identifier)
-		name, nok := member.Index.(*ast.Identifier)
-		if bok && nok && base.Value == "c" {
-			return "c." + name.Value
-		}
+	// Type-position qualification is stored as a single identifier; value
+	// member access uses IndexExpression. CheckProgram validates legal types.
+	if id, ok := expr.(*ast.Identifier); ok && (id.Value == "()" || strings.HasPrefix(id.Value, "c.")) {
+		return id.Value
 	}
 	return ""
 }
 
 func matchesSimulationBinding(fn *ast.FunctionStatement, b SimulationBinding) bool {
-	if fn.Name == nil || fn.Name.Value != b.Name || fn.ExternSymbol != b.Symbol || fn.Receiver != nil || len(fn.TypeParams) != 0 || len(fn.Parameters) != len(b.Parameters) || simulationABI(fn.ReturnType) != b.Return || b.Return == "" { return false }
+	if fn.Name == nil || fn.Name.Value != b.Name || fn.ExternSymbol != b.Symbol || fn.Receiver != nil || len(fn.TypeParams) != 0 || len(fn.Parameters) != len(b.Parameters) || simulationABI(fn.ReturnType) != b.Return || b.Return == "" {
+		return false
+	}
 	for i, p := range fn.Parameters {
-		if p.Variadic || b.Parameters[i] == "" || simulationABI(p.Type) != b.Parameters[i] { return false }
+		if p.Variadic || b.Parameters[i] == "" || simulationABI(p.Type) != b.Parameters[i] {
+			return false
+		}
 	}
 	return true
 }
@@ -73,11 +73,21 @@ func checkSimulation(root *ast.Program, bindings []SimulationBinding) error {
 				return fmt.Errorf("simulation boundary: %s requires an explicit simulated adapter", n.Value)
 			}
 		case *ast.FunctionStatement:
-			if n.ExternSymbol == "" { return nil }
-			if n.Token.SemanticContext == "testing-host" {
-				for _, b := range reporters { if matchesSimulationBinding(n, b) { return nil } }
+			if n.ExternSymbol == "" {
+				return nil
 			}
-			for _, b := range bindings { if matchesSimulationBinding(n, b) { return nil } }
+			if n.Token.SemanticContext == "testing-host" {
+				for _, b := range reporters {
+					if matchesSimulationBinding(n, b) {
+						return nil
+					}
+				}
+			}
+			for _, b := range bindings {
+				if matchesSimulationBinding(n, b) {
+					return nil
+				}
+			}
 			return fmt.Errorf("simulation boundary: undeclared extern %s (%s), or adapter ABI mismatch", n.Name.Value, n.ExternSymbol)
 		}
 		return nil
@@ -87,26 +97,42 @@ func checkSimulation(root *ast.Program, bindings []SimulationBinding) error {
 // Unlike transformSyntax this visits statements as well as expressions. Only
 // exported AST data is walked; no trivia, semantic environments or cycles.
 func walkSimulation(v reflect.Value, visit func(any) error) error {
-	if !v.IsValid() { return nil }
+	if !v.IsValid() {
+		return nil
+	}
 	switch v.Kind() {
 	case reflect.Interface, reflect.Pointer:
-		if v.IsNil() { return nil }
+		if v.IsNil() {
+			return nil
+		}
 		if v.Kind() == reflect.Pointer && v.CanInterface() {
-			if err := visit(v.Interface()); err != nil { return err }
+			if err := visit(v.Interface()); err != nil {
+				return err
+			}
 		}
 		return walkSimulation(v.Elem(), visit)
 	case reflect.Struct:
 		for i := 0; i < v.NumField(); i++ {
 			if v.Type().Field(i).IsExported() {
-				if err := walkSimulation(v.Field(i), visit); err != nil { return err }
+				if err := walkSimulation(v.Field(i), visit); err != nil {
+					return err
+				}
 			}
 		}
 	case reflect.Slice:
-		for i := 0; i < v.Len(); i++ { if err := walkSimulation(v.Index(i), visit); err != nil { return err } }
+		for i := 0; i < v.Len(); i++ {
+			if err := walkSimulation(v.Index(i), visit); err != nil {
+				return err
+			}
+		}
 	case reflect.Map:
 		keys := v.MapKeys()
 		sort.Slice(keys, func(i, j int) bool { return keys[i].String() < keys[j].String() })
-		for _, key := range keys { if err := walkSimulation(v.MapIndex(key), visit); err != nil { return err } }
+		for _, key := range keys {
+			if err := walkSimulation(v.MapIndex(key), visit); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }

--- a/compiler/simulation.go
+++ b/compiler/simulation.go
@@ -35,7 +35,9 @@ func (comp Compilation) WithSimulation(bindings []SimulationBinding) Compilation
 
 func simulationABI(expr ast.Expression) string {
 	if id, ok := expr.(*ast.Identifier); ok && id.Value == "()" { return "()" }
-	if member, ok := expr.(*ast.IndexExpression); ok && member.Dot {
+	// Qualified type syntax currently uses IndexExpression without setting
+	// Dot. Ordinary type checking remains the authority for legal C types.
+	if member, ok := expr.(*ast.IndexExpression); ok {
 		base, bok := member.Left.(*ast.Identifier)
 		name, nok := member.Index.(*ast.Identifier)
 		if bok && nok && base.Value == "c" {

--- a/compiler/stdlib.go
+++ b/compiler/stdlib.go
@@ -14,21 +14,29 @@ import (
 func loadStandardLibrary(tree *SyntaxTree) error {
 	var user []ast.Statement
 	imported := false
+	testingImported := false
 	for _, stmt := range tree.Root.Statements {
 		imp, ok := stmt.(*ast.ImportStatement)
 		if !ok {
 			user = append(user, stmt)
 			continue
 		}
-		if imp.Path == nil || imp.Path.Value != "std" || imp.Alias != nil {
-			return fmt.Errorf("import: only unaliased import(std) is supported by the bootstrap module loader")
+		if imp.Path == nil || imp.Alias != nil {
+			return fmt.Errorf("import: only unaliased import(std) and import(testing) are supported")
 		}
-		imported = true
+		switch imp.Path.Value {
+		case "std": imported = true
+		case "testing": testingImported = true
+		default: return fmt.Errorf("import: unsupported module %q", imp.Path.Value)
+		}
 	}
-	if !imported {
+	if !imported && !testingImported {
 		return nil
 	}
-	lib, err := New().WithSource("std.oak", stdlib.Source).Parse().Get()
+	librarySource := ""
+	if imported { librarySource = stdlib.Source }
+	if testingImported { librarySource += "\n" + stdlib.TestingSource }
+	lib, err := New().WithSource("stdlib.oak", librarySource).Parse().Get()
 	if err != nil {
 		return fmt.Errorf("standard library: %w", err)
 	}
@@ -53,10 +61,11 @@ func loadStandardLibrary(tree *SyntaxTree) error {
 	}
 	for _, stmt := range user {
 		if name := declarationName(stmt); exports[name] {
-			return fmt.Errorf("import(std): declaration %q conflicts with a standard library export", name)
+			return fmt.Errorf("import: declaration %q conflicts with a standard library export", name)
 		}
 	}
 	tree.Root.Statements = append(lib.Root.Statements, user...)
+	if !imported { return nil }
 	if err := lowerDerivedCodecs(tree.Root); err != nil {
 		return err
 	}
@@ -79,3 +88,4 @@ func declarationName(stmt ast.Statement) string {
 	}
 	return ""
 }
+

--- a/compiler/stdlib.go
+++ b/compiler/stdlib.go
@@ -25,17 +25,24 @@ func loadStandardLibrary(tree *SyntaxTree) error {
 			return fmt.Errorf("import: only unaliased import(std) and import(testing) are supported")
 		}
 		switch imp.Path.Value {
-		case "std": imported = true
-		case "testing": testingImported = true
-		default: return fmt.Errorf("import: unsupported module %q", imp.Path.Value)
+		case "std":
+			imported = true
+		case "testing":
+			testingImported = true
+		default:
+			return fmt.Errorf("import: unsupported module %q", imp.Path.Value)
 		}
 	}
 	if !imported && !testingImported {
 		return nil
 	}
 	librarySource := ""
-	if imported { librarySource = stdlib.Source }
-	if testingImported { librarySource += "\n" + stdlib.TestingSource }
+	if imported {
+		librarySource = stdlib.Source
+	}
+	if testingImported {
+		librarySource += "\n" + stdlib.TestingSource
+	}
 	lib, err := New().WithSource("stdlib.oak", librarySource).Parse().Get()
 	if err != nil {
 		return fmt.Errorf("standard library: %w", err)
@@ -65,7 +72,9 @@ func loadStandardLibrary(tree *SyntaxTree) error {
 		}
 	}
 	tree.Root.Statements = append(lib.Root.Statements, user...)
-	if !imported { return nil }
+	if !imported {
+		return nil
+	}
 	if err := lowerDerivedCodecs(tree.Root); err != nil {
 		return err
 	}
@@ -88,4 +97,3 @@ func declarationName(stmt ast.Statement) string {
 	}
 	return ""
 }
-

--- a/compiler/stdlib.go
+++ b/compiler/stdlib.go
@@ -60,7 +60,12 @@ func loadStandardLibrary(tree *SyntaxTree) error {
 	}); err != nil {
 		return err
 	}
-	exports := map[string]bool{"text_literal": true, "encode": true, "encoded_size": true, "from": true}
+	exports := map[string]bool{}
+	if imported {
+		for _, name := range []string{"text_literal", "encode", "encoded_size", "from"} {
+			exports[name] = true
+		}
+	}
 	for _, stmt := range lib.Root.Statements {
 		if name := declarationName(stmt); name != "" {
 			exports[name] = true

--- a/compiler/stdlib.go
+++ b/compiler/stdlib.go
@@ -67,6 +67,9 @@ func loadStandardLibrary(tree *SyntaxTree) error {
 		}
 	}
 	for _, stmt := range lib.Root.Statements {
+		if fn, ok := stmt.(*ast.FunctionStatement); ok && fn.ExternSymbol != "" && testingImported {
+			fn.Token.SemanticContext = "testing-host"
+		}
 		if name := declarationName(stmt); name != "" {
 			exports[name] = true
 		}

--- a/docs/spec/110-testing.md
+++ b/docs/spec/110-testing.md
@@ -1,0 +1,177 @@
+# Native testing, generated inputs, fuzzing, and simulation
+
+Status: initial executable host tooling and Oak helper library. `tested` is not
+`proved`, `model-checked`, or a refinement witness. This document specifies the
+implemented bootstrap contract and explicitly identifies its limits.
+
+## Entry points and discovery
+
+`oak test [flags] [directory | ./... ...]` compiles each selected directory as
+one bootstrap package through the ordinary checked C backend. Flags precede
+paths. An omitted path means the current directory. Recursive discovery skips
+hidden directories, `vendor`, and `testdata`. Discovery and execution order are
+stable, and overlapping directory arguments are deduplicated.
+
+All immediate `.oak` siblings participate in the compilation. Only top-level
+functions in `*_test.oak` register tests. Names have an ASCII identifier spelling
+and start with a prefix followed by an uppercase ASCII letter or underscore:
+
+| Prefix | Signature | Ordinary `oak test` behavior |
+| --- | --- | --- |
+| `Test` | `(): ()` | One execution |
+| `Property` | `(data: []u8): ()` | Corpus plus generated cases |
+| `Fuzz` | `(data: []u8): ()` | Corpus plus four built-in seeds |
+| `Sim` | `(data: []u8): ()` | Corpus plus generated simulation inputs |
+
+Methods, generic tests, extern tests, variadics, and other signatures reject.
+All functions still undergo the normal type, borrow, and discipline checks.
+The application `main` is compiled but is not used as the test entry point.
+`-run` filters all kinds; `-fuzz` selects mutation fuzz campaigns; `-sim` selects
+simulation campaigns. No matching tests is an error, including empty discovery.
+`-list` discovers and validates registrations without native compilation.
+
+Bootstrap package source is concatenated in filename order with source-boundary
+comments. Test registrations retain original filename and line. Compiler errors
+currently refer to positions in the assembled `<oak-test-package>` source.
+General package resolution and fully source-mapped multi-file diagnostics are
+separate compiler work; this runner does not invent a second module system.
+
+## Isolation, outcomes, and reporting
+
+Every normal runner case starts a fresh native child process. Assertions and
+bounds traps cannot terminate the host runner. `-timeout` bounds each execution;
+`-build-timeout` bounds C compilation. Native stdout/stderr and the control
+report are independently bounded to 64 KiB. Excess user output is truncated;
+control-report overflow fails the case. The control report is separate from
+stdout, so ordinary test output cannot corrupt `-json` results.
+
+This is process isolation for trusted development tests, not a security sandbox.
+Tests may use the host permissions available to them. Sanitizers are opt-in via
+`-sanitize` and require a supporting C compiler/runtime.
+
+`import(testing)` provides:
+
+- `test_check(condition, id)`: fail with an author-assigned stable `u32` invariant
+  ID. The explicit C reporting boundary is supplied by the host harness.
+- `test_assume(condition)`: reject an input. Rejections do not count as passing
+  cases; exceeding `-max-discards` fails. A unit test cannot discard.
+- `testing_classify(id)`: mark a class reached in this execution. Each accepted
+  execution counts once per class, even if a loop emits it repeatedly.
+- `-cover 10:5,20:1`: require minimum accepted-case counts for these class IDs in
+  each selected non-unit test. These are semantic labels, not code coverage.
+
+Ordinary `assert` remains always enabled. A generic trap has an exit/signal
+signature; `test_check` provides stronger failure identity for minimization.
+Source-specific assertion diffs, subtests, cleanup callbacks, expected-trap
+annotations, and compile-fail registration are not yet part of this API.
+
+## Choice tapes and property testing
+
+A `TestChoices` cursor consumes a caller-supplied byte view through `test_byte`,
+`test_bool`, `test_u32`, and `test_range`. Unsigned words consume four bytes in
+little-endian order. Exhaustion supplies zero without advancing the cursor.
+Thus every finite tape describes a complete run. There is no hidden target
+allocation. Separate the host's storage needs from the effects of tested code.
+
+Generators are ordinary composable Oak functions over the cursor and tape.
+Dependent generators construct valid values from previous choices. Stateful
+tests construct legal command sequences and compare execution with a separately
+represented model; see `examples/testing/irq_test.oak`. Do not repair arbitrary
+raw-memory encodings into unsafe values or assume every proposition admits an
+efficient generator. Automatic ADT/refinement derivation is future work.
+
+`test_range` is inclusive and handles the entire `u32` domain without overflow.
+Its modulo mapping is deliberately biased; no uniform or cryptographic sampling
+claim is made. The runner includes empty, zero-filled, 0xff-filled and ascending
+byte seeds, then variable-length generated tapes. Root seed, target name, and
+attempt independently derive a fixed SplitMix64 stream. There is no dependence
+on Go's random implementation or earlier tests consuming random numbers.
+
+Failure minimization deletes chunks and then reduces bytes. Every accepted
+candidate is smaller by length or lexicographic order and must reproduce the
+same failure signature. Both an execution budget and a time budget apply. One
+in-flight execution may extend the shrink deadline by at most its case timeout.
+An initial repeat checks failure stability. Timeouts and harness failures are
+saved but not minimized. The result is budget-minimized, not globally minimal.
+A generic signal signature cannot distinguish two unrelated traps with the same
+signal; stable invariant IDs are preferred for stateful properties.
+
+## Corpus and replay
+
+Failures are atomically saved in `testdata/oak/<TestName>/<digest>.json` with:
+
+- schema and engine versions;
+- test name and kind;
+- native build fingerprint;
+- root seed and attempt;
+- maximum input size and sanitizer mode;
+- failure signature and concrete minimized input (JSON base64).
+
+The build fingerprint covers generated C, the harness, native compilation flags,
+and C compiler version output. It is a useful drift check, not an attestation of
+all host libraries, environment variables, CPU features, or external effects.
+Exact replay still requires preserving the relevant execution environment.
+
+`-replay artifact.json directory` executes exactly one concrete input and checks
+both the build fingerprint and failure signature. A reproduced failure exits
+nonzero. Divergence is reported explicitly, including a now-passing input.
+Filtering does not change the compiled registration table, so selecting one test
+for replay does not itself invalidate a multi-test failure artifact.
+
+Ordinary test runs replay corpus inputs before generating new ones and do not
+require the historical build fingerprint: checked-in regressions must survive
+source changes. `.bin` files in the same directory are additional raw seeds.
+Unknown/malformed artifact schemas, mismatched test identities, and oversized
+inputs reject. Commit valuable minimized failures, not random campaign output.
+
+## Fuzzing
+
+`-fuzz` uses deterministic byte insertion, deletion, bit flips, replacement and
+fresh-input exploration over corpus/built-in seeds. This portable engine is
+mutation fuzzing, not coverage-guided fuzzing. `-runs` is a finite accepted-case
+budget, making it usable in CI.
+
+`-fuzz '^FuzzName$' -emit-fuzz-harness path.c` emits one checked translation unit
+with `LLVMFuzzerTestOneInput`. Compile it with Clang's
+`-fsanitize=fuzzer,address,undefined` for coverage-guided native fuzzing. Export
+requires one target and refuses to overwrite an existing file. The emitted
+harness preserves invariant IDs, skips oversized input, and translates rejected
+inputs to a return to libFuzzer. libFuzzer owns its corpus, crash files and
+minimization. Copy useful raw crash files into the runner's `.bin` corpus to
+reproduce and reduce them with `oak test`.
+
+libFuzzer is persistent: all tested state must be constructed/reset inside the
+fuzz function. Target-side state must not escape across calls. Avoid nontrivial
+resource cleanup obligations around `test_assume` in this mode: rejection uses
+a host `setjmp`/`longjmp` boundary. The ordinary isolated runner does not require
+persistent-process reset discipline.
+
+## Deterministic event simulation
+
+`SimClock`, `SimQueue`, and caller-owned `SimEvent` storage implement a bounded
+discrete-event queue. Scheduling in the past rejects; full capacity returns
+false without altering the queue. `sim_next` advances to the earliest event and
+uses a choice to select among equal-time events. Removing an event swaps in the
+last slot; this deterministic storage order is part of this version's replay
+contract. Queue operations are bounded linear scans. Empty dequeue rejects.
+
+Scenario code owns production state, independent models, allowed fault actions,
+and invariants. It also owns finite step budgets. The IRQ/timer pilot checks
+state transitions and a recovery suffix with explicit progress assumptions.
+The host additionally applies a watchdog to runaway test code.
+
+This first implementation does not intercept arbitrary clocks, entropy, FFI,
+MMIO, threads, or atomics. Determinism is conditional on the scenario routing
+all relevant inputs through modeled boundaries. Compiler-enforced simulation
+effect closure, storage persistence/fault models, general scheduling adapters,
+and integration with the OS's replay/debug event schema remain future work.
+Single-thread event interleavings are not an ARM weak-memory model and do not
+replace the existing memory-model litmus tests or hardware validation.
+
+## Validation
+
+Go tests execute compiled Oak programs for registration, native unit/property/
+fuzz/simulation modes, rejection budgets, coverage labels, crash and timeout
+isolation, minimization, strict replay, source drift, and corpus reuse. Go fuzz
+targets exercise reducer invariants and mutation bounds. The dedicated workflow
+runs the native Oak examples and a coverage-guided libFuzzer smoke campaign.

--- a/docs/spec/110-testing.md
+++ b/docs/spec/110-testing.md
@@ -172,7 +172,8 @@ replace the existing memory-model litmus tests or hardware validation.
 
 Go tests execute compiled Oak programs for registration, native unit/property/
 fuzz/simulation modes, rejection budgets, coverage labels, crash and timeout
-isolation, minimization, strict replay, source drift, and corpus reuse. A mutation test deliberately drops edges arriving while active in the IRQ
+isolation, minimization, strict replay, source drift, and corpus reuse. A mutation
+test deliberately drops edges arriving while active in the IRQ
 pilot and requires the model to detect invariant 2011 with the four-command
 counterexample `enable, inject, acknowledge, inject`. Go fuzz targets exercise
 reducer invariants and mutation bounds. The dedicated workflow

--- a/docs/spec/110-testing.md
+++ b/docs/spec/110-testing.md
@@ -104,7 +104,7 @@ Failures are atomically saved in `testdata/oak/<TestName>/<digest>.json` with:
 - test name and kind;
 - native build fingerprint;
 - root seed and attempt;
-- maximum input size and sanitizer mode;
+- maximum input size, execution timeout, and sanitizer mode;
 - failure signature and concrete minimized input (JSON base64).
 
 The build fingerprint covers generated C, the harness, native compilation flags,
@@ -172,6 +172,8 @@ replace the existing memory-model litmus tests or hardware validation.
 
 Go tests execute compiled Oak programs for registration, native unit/property/
 fuzz/simulation modes, rejection budgets, coverage labels, crash and timeout
-isolation, minimization, strict replay, source drift, and corpus reuse. Go fuzz
-targets exercise reducer invariants and mutation bounds. The dedicated workflow
+isolation, minimization, strict replay, source drift, and corpus reuse. A mutation test deliberately drops edges arriving while active in the IRQ
+pilot and requires the model to detect invariant 2011 with the four-command
+counterexample `enable, inject, acknowledge, inject`. Go fuzz targets exercise
+reducer invariants and mutation bounds. The dedicated workflow
 runs the native Oak examples and a coverage-guided libFuzzer smoke campaign.

--- a/docs/spec/110-testing.md
+++ b/docs/spec/110-testing.md
@@ -108,7 +108,7 @@ Failures are atomically saved in `testdata/oak/<TestName>/<digest>.json` with:
 - failure signature and concrete minimized input (JSON base64).
 
 The build fingerprint covers generated C, the harness, native compilation flags,
-and C compiler version output. It is a useful drift check, not an attestation of
+C compiler version output, and any adapter manifest and object hashes. It is a useful drift check, not an attestation of
 all host libraries, environment variables, CPU features, or external effects.
 Exact replay still requires preserving the relevant execution environment.
 
@@ -160,13 +160,63 @@ and invariants. It also owns finite step budgets. The IRQ/timer pilot checks
 state transitions and a recovery suffix with explicit progress assumptions.
 The host additionally applies a watchdog to runaway test code.
 
-This first implementation does not intercept arbitrary clocks, entropy, FFI,
-MMIO, threads, or atomics. Determinism is conditional on the scenario routing
-all relevant inputs through modeled boundaries. Compiler-enforced simulation
-effect closure, storage persistence/fault models, general scheduling adapters,
-and integration with the OS's replay/debug event schema remain future work.
+Packages containing any registered `Sim` test compile with `WithSimulation`.
+The compiler checks the complete imported syntax tree before specialization,
+including unused functions, generic templates, closures and global initializers.
+Unsafe blocks, `Atomic` storage/operations, machine library names, and undeclared
+extern functions reject. C scalar conversions and portable SIMD remain available.
+This deliberately conservative check also rejects shadowed machine names; it is
+a whole-package boundary restriction, not a reachability-based effect proof.
+The same profile applies when selecting another test or exporting fuzz code from
+that package, preserving replay identities across filtering.
+
+Only the actual imported testing reporter declarations are automatically
+trusted. User declarations cannot obtain that trust by copying a reporter name
+or symbol. Other foreign boundaries require an explicit native adapter.
+No arbitrary clocks, entropy, MMIO, threads or atomics are automatically
+intercepted. Storage persistence/fault models, general scheduling adapters, and
+integration with the OS's replay/debug event schema remain future work.
 Single-thread event interleavings are not an ARM weak-memory model and do not
 replace the existing memory-model litmus tests or hardware validation.
+
+## Trusted native adapters
+
+`-adapter manifest.json` links a prebuilt native adapter. The version-1 manifest
+requires a name, `deterministic: true`, exact Oak binding names/C symbols, scalar
+ABI signatures, and 1..32 `.a`/`.o` objects with SHA-256 digests. Parameters and
+results are fixed-width signed/unsigned `c.Int8` through `c.UInt64`; `()` is also
+allowed as a result. Pointer/variadic interfaces are intentionally excluded.
+`oak_` symbols are reserved for generated code and the testing harness.
+
+```json
+{
+  "version": 1,
+  "name": "my-device-v1",
+  "deterministic": true,
+  "bindings": [
+    {"name": "device_step", "symbol": "device_step_native",
+     "parameters": ["c.UInt32"], "return": "c.UInt32"}
+  ],
+  "objects": [{"path": "build/device.a", "sha256": "<64 lowercase hex digits>"}]
+}
+```
+
+Object paths resolve relative to the manifest. The runner verifies and snapshots
+their bytes before linking. Thin archives, shared libraries and linker scripts
+reject; accepted inputs are self-contained archives or ELF relocatable objects,
+at most 64 MiB each. Manifest/object identities enter the replay fingerprint;
+locator paths do not. Supply `-adapter` again for replay and preserve the original
+objects. Replay artifacts never cause automatic native-code loading.
+
+The manifest is an explicit assertion of trust, **not proof of native code's
+determinism**. Adapter code must route time/entropy/scheduling through explicit
+inputs, reset state for each scenario, and avoid unmodeled host effects. Normal
+type/borrow/discipline checks still apply to the Oak program. This is not a
+security sandbox or runtime syscall filter.
+
+Fuzz export validates the adapter and records its manifest identity in the C
+file; link the pinned objects explicitly when compiling that export. The external
+link command and any instrumentation of the adapter are the caller's responsibility.
 
 ## Validation
 

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -104,3 +104,7 @@ explicit refinement for load-bearing compiler/runtime components
 ```
 
 The first refinement targets should be small and foundational: the type lattice, delimited parser cursor contract, borrow-state transitions, effect subsumption, exact source-span conversions, and first-class diagnostic structure.
+
+
+- [Native testing and simulation](110-testing.md): `oak test`, generated inputs,
+  shrinking, corpus/replay, libFuzzer export, and bounded virtual-time events.

--- a/docs/spec/STATUS.md
+++ b/docs/spec/STATUS.md
@@ -134,3 +134,13 @@ A green Lean build means the stated theorems type-check against the pinned proof
 Do not mark a feature **R** merely because Go/Zig tests mirror theorem examples.
 
 `R` requires an explicit formal relation between concrete implementation state/operations and the formal model, with preservation proved by the proof system.
+
+
+## Native testing tools
+
+`oak test` and `import(testing)` implement the bootstrap contract in
+`110-testing.md`: native isolated cases, choice-tape properties/minimization,
+mutation fuzzing, libFuzzer export, persistent corpus/replay, and bounded
+discrete-event simulation. These are execution-tested tools, not a formal
+refinement claim. Whole-machine simulation, compiler-enforced effect closure,
+and automatic generator derivation remain unimplemented.

--- a/examples/testing/arithmetic.oak
+++ b/examples/testing/arithmetic.oak
@@ -1,0 +1,3 @@
+// Production function compiled alongside its tests.
+clamp: (value: u32, low: u32, high: u32): u32 =
+  value < low ? low | (value > high ? high | value)

--- a/examples/testing/arithmetic_test.oak
+++ b/examples/testing/arithmetic_test.oak
@@ -22,4 +22,11 @@ PropertyClamp: (data: []u8): () {
 FuzzUtf8: (data: []u8): () {
   valid: Bool = is_valid_utf8(data)
   len(data) == u32(0) ? { test_check(valid, u32(1020)) }
+  ascii: Bool = true
+  i: u32 = u32(0)
+  while i < len(data) {
+    data[i] >= u8(128) ? { ascii = false }
+    i = i + u32(1)
+  }
+  ascii ? { test_check(valid, u32(1021)) }
 }

--- a/examples/testing/arithmetic_test.oak
+++ b/examples/testing/arithmetic_test.oak
@@ -1,0 +1,25 @@
+import(testing)
+
+TestClamp: (): () {
+  test_check(clamp(u32(2), u32(5), u32(10)) == u32(5), u32(1001))
+  test_check(clamp(u32(20), u32(5), u32(10)) == u32(10), u32(1002))
+}
+
+PropertyClamp: (data: []u8): () {
+  state: [1]TestChoices
+  choices: [*]TestChoices = span(&state)
+  low: u32 = test_range(choices, data, u32(0), u32(1000))
+  high: u32 = test_range(choices, data, low, u32(2000))
+  value: u32 = test_u32(choices, data)
+  result: u32 = clamp(value, low, high)
+  test_check(result >= low && result <= high, u32(1010))
+  test_check(clamp(result, low, high) == result, u32(1011))
+  result == low ? { testing_classify(u32(1)) }
+  result == high ? { testing_classify(u32(2)) }
+}
+
+// Malformed inputs are ordinary input, not rejected by the generator.
+FuzzUtf8: (data: []u8): () {
+  valid: Bool = is_valid_utf8(data)
+  len(data) == u32(0) ? { test_check(valid, u32(1020)) }
+}

--- a/examples/testing/irq.oak
+++ b/examples/testing/irq.oak
@@ -1,0 +1,24 @@
+// Single-IRQ Oak pilot of SCKelemen/os core/src/virq.zig. This is an executable
+// adaptation, not a claim that these tests execute or refine the Zig EL2 core.
+Irq: type = struct {
+  enabled: Bool
+  latched: Bool
+  active: Bool
+  level: Bool
+}
+
+irq_deliverable: (irq: Irq): Bool = irq.enabled && !irq.active && (irq.latched || irq.level)
+
+irq_apply: (state: [*]Irq, action: u32): () {
+  assert(len(state) == u32(1))
+  action == u32(0) ? { state[0].enabled = true }
+  action == u32(1) ? { state[0].enabled = false }
+  action == u32(2) ? { state[0].latched = true }
+  action == u32(3) ? { state[0].level = true }
+  action == u32(4) ? { state[0].level = false }
+  action == u32(5) && irq_deliverable(state[0]) ? {
+    state[0].latched = false
+    state[0].active = true
+  }
+  action == u32(6) ? { state[0].active = false }
+}

--- a/examples/testing/irq_test.oak
+++ b/examples/testing/irq_test.oak
@@ -1,0 +1,112 @@
+import(testing)
+
+TestEdgeDuringActive: (): () {
+  storage: [1]Irq
+  state: [*]Irq = span(&storage)
+  irq_apply(state, u32(0))
+  irq_apply(state, u32(2))
+  irq_apply(state, u32(5))
+  test_check(state[0].active && !state[0].latched, u32(2001))
+  irq_apply(state, u32(2))
+  test_check(!irq_deliverable(state[0]), u32(2002))
+  irq_apply(state, u32(6))
+  test_check(irq_deliverable(state[0]), u32(2003))
+}
+
+// Independently represented reference state: enabled=1, latched=2,
+// active=4, level=8. Invalid acknowledgement is a no-op in this pilot.
+irq_model: (bits: u8, action: u32): u8 {
+  result: u8 = bits
+  action == u32(0) ? { result = bits | u8(1) }
+  action == u32(1) ? { result = bits & u8(14) }
+  action == u32(2) ? { result = bits | u8(2) }
+  action == u32(3) ? { result = bits | u8(8) }
+  action == u32(4) ? { result = bits & u8(7) }
+  action == u32(5) && (bits & u8(5)) == u8(1) && (bits & u8(10)) != u8(0) ? {
+    result = (bits & u8(13)) | u8(4)
+  }
+  action == u32(6) ? { result = bits & u8(11) }
+  result
+}
+
+PropertyIrqHistory: (data: []u8): () {
+  storage: [1]Irq
+  state: [*]Irq = span(&storage)
+  tape: [1]TestChoices
+  choices: [*]TestChoices = span(&tape)
+  model: u8 = u8(0)
+  step: u32 = u32(0)
+  while step < u32(64) {
+    action: u32 = u32(test_byte(choices, data)) % u32(8)
+    before: Irq = state[0]
+    irq_apply(state, action)
+    model = irq_model(model, action)
+    after: Irq = state[0]
+    test_check(after.enabled == ((model & u8(1)) != u8(0)), u32(2010))
+    test_check(after.latched == ((model & u8(2)) != u8(0)), u32(2011))
+    test_check(after.active == ((model & u8(4)) != u8(0)), u32(2012))
+    test_check(after.level == ((model & u8(8)) != u8(0)), u32(2013))
+    before.latched && !after.latched ? {
+      test_check(action == u32(5) && before.enabled && !before.active && after.active, u32(2014))
+    }
+    !before.active && after.active ? {
+      test_check(irq_deliverable(before), u32(2015))
+    }
+    after.active ? { test_check(!irq_deliverable(after), u32(2016)) }
+    testing_classify(action)
+    step = step + u32(1)
+  }
+}
+
+// Virtual timer composition. Random events delay/reorder timer programming,
+// masking, acknowledgement, EOI and edge injection. The recovery suffix
+// restores explicit progress assumptions instead of asserting liveness
+// under permanent faults.
+SimTimerIrq: (data: []u8): () {
+  storage: [1]Irq
+  state: [*]Irq = span(&storage)
+  irq_apply(state, u32(0))
+  tape: [1]TestChoices
+  choices: [*]TestChoices = span(&tape)
+  clock_storage: [1]SimClock
+  clock: [*]SimClock = span(&clock_storage)
+  queue_storage: [1]SimQueue
+  queue: [*]SimQueue = span(&queue_storage)
+  event_storage: [12]SimEvent
+  events: [*]SimEvent = span(&event_storage)
+  i: u32 = u32(0)
+  while i < u32(12) {
+    at: u64 = u64(test_range(choices, data, u32(0), u32(100)))
+    kind: u32 = test_range(choices, data, u32(0), u32(5))
+    value: u32 = test_range(choices, data, u32(0), u32(100))
+    test_check(sim_schedule(queue, events, clock, SimEvent { at: at, kind: kind, value: value }), u32(2020))
+    i = i + u32(1)
+  }
+  compare: u64 = u64(10)
+  masked: Bool = false
+  while queue[0].count > u32(0) {
+    previous: u64 = clock[0].now
+    event: SimEvent = sim_next(queue, events, clock, choices, data)
+    test_check(clock[0].now >= previous, u32(2021))
+    event.kind == u32(0) ? { compare = u64(event.value) }
+    event.kind == u32(1) ? { masked = true }
+    event.kind == u32(2) ? { masked = false }
+    // Sample timer level at every scheduling boundary before delivery.
+    state[0].level = clock[0].now >= compare && !masked
+    event.kind == u32(3) ? { irq_apply(state, u32(5)) }
+    event.kind == u32(4) ? { irq_apply(state, u32(6)) }
+    event.kind == u32(5) ? { irq_apply(state, u32(2)) }
+    state[0].active ? { test_check(!irq_deliverable(state[0]), u32(2022)) }
+    masked && !state[0].latched ? { test_check(!irq_deliverable(state[0]), u32(2023)) }
+    testing_classify(event.kind)
+  }
+  // Heal: time passes compare, source unmasked, handler finishes its IRQ.
+  clock[0].now = u64(101)
+  state[0].level = clock[0].now >= compare
+  irq_apply(state, u32(6))
+  test_check(irq_deliverable(state[0]), u32(2030))
+  irq_apply(state, u32(5))
+  test_check(state[0].active, u32(2031))
+  irq_apply(state, u32(6))
+  test_check(irq_deliverable(state[0]), u32(2032))
+}

--- a/main.go
+++ b/main.go
@@ -60,4 +60,3 @@ func main() {
 	fmt.Printf("Type Oak code or 'exit' to quit\n")
 	repl.Start(os.Stdin, os.Stdout)
 }
-

--- a/main.go
+++ b/main.go
@@ -8,9 +8,14 @@ import (
 
 	"github.com/SCKelemen/oak/compiler"
 	"github.com/SCKelemen/oak/repl"
+	"github.com/SCKelemen/oak/testrunner"
 )
 
 func main() {
+	if len(os.Args) > 1 && os.Args[1] == "test" {
+		os.Exit(testrunner.Main(os.Args[2:], os.Stdout, os.Stderr))
+	}
+
 	if len(os.Args) > 1 {
 		// Compile mode: oak file.oak
 		filename := os.Args[1]
@@ -55,3 +60,4 @@ func main() {
 	fmt.Printf("Type Oak code or 'exit' to quit\n")
 	repl.Start(os.Stdin, os.Stdout)
 }
+

--- a/stdlib/source.go
+++ b/stdlib/source.go
@@ -34,8 +34,8 @@ var bitsetAlgebraSource string
 
 var Source = baseSource + "\n" + causalFrontierSource + "\n" + unicodeSource + "\n" + stringsSource + "\n" + jsonSource + "\n" + filtersSource + "\n" + hashTableSource + "\n" + bitsetAlgebraSource
 
-
 // TestingSource is the opt-in import(testing) module. Its reporting boundary
 // is supplied by oak test; generated target helpers use caller-owned storage.
+//
 //go:embed testing.oak
 var TestingSource string

--- a/stdlib/source.go
+++ b/stdlib/source.go
@@ -33,3 +33,9 @@ var hashTableSource string
 var bitsetAlgebraSource string
 
 var Source = baseSource + "\n" + causalFrontierSource + "\n" + unicodeSource + "\n" + stringsSource + "\n" + jsonSource + "\n" + filtersSource + "\n" + hashTableSource + "\n" + bitsetAlgebraSource
+
+
+// TestingSource is the opt-in import(testing) module. Its reporting boundary
+// is supplied by oak test; generated target helpers use caller-owned storage.
+//go:embed testing.oak
+var TestingSource string

--- a/stdlib/testing.oak
+++ b/stdlib/testing.oak
@@ -1,0 +1,103 @@
+// Test reporting is an explicit host boundary, supplied by oak test.
+// Numeric invariant IDs are chosen by the test author and must keep their meaning.
+testing_fail: (id: u32): () = c.extern("oak_testing_fail")
+testing_discard: (): () = c.extern("oak_testing_discard")
+testing_classify: (id: u32): () = c.extern("oak_testing_classify")
+
+test_check: (condition: Bool, id: u32): () {
+  !condition ? { testing_fail(id) }
+}
+
+test_assume: (condition: Bool): () {
+  !condition ? { testing_discard() }
+}
+
+// The choice tape is shared by property testing, fuzzing and simulation.
+// Exhaustion supplies zero, so every finite tape describes a complete run.
+// Construct domain values from choices; shrinking reruns the construction.
+TestChoices: type = struct { offset: u32 }
+
+test_byte: (choices: [*]TestChoices, data: []u8): u8 {
+  assert(len(choices) == u32(1))
+  offset: u32 = choices[0].offset
+  offset < len(data) ? {
+    choices[0].offset = offset + u32(1)
+    data[offset]
+  } | { u8(0) }
+}
+
+test_bool: (choices: [*]TestChoices, data: []u8): Bool =
+  (test_byte(choices, data) & u8(1)) == u8(1)
+
+test_u32: (choices: [*]TestChoices, data: []u8): u32 {
+  a: u32 = u32(test_byte(choices, data))
+  b: u32 = u32(test_byte(choices, data))
+  c: u32 = u32(test_byte(choices, data))
+  d: u32 = u32(test_byte(choices, data))
+  a | (b << u32(8)) | (c << u32(16)) | (d << u32(24))
+}
+
+// Inclusive range. Modulo bias is intentional and documented; this is a
+// shrink-friendly testing distribution, not a cryptographic random source.
+test_range: (choices: [*]TestChoices, data: []u8, low: u32, high: u32): u32 {
+  assert(low <= high)
+  value: u32 = test_u32(choices, data)
+  width: u32 = high - low
+  width == u32(4294967295) ? { value } | { low + value % (width + u32(1)) }
+}
+
+// Bounded discrete-event simulator. The caller owns event storage and the
+// model/production state. Each successful next removes one enabled event.
+SimClock: type = struct { now: u64 }
+SimEvent: type = struct { at: u64, kind: u32, value: u32 }
+SimQueue: type = struct { count: u32 }
+
+sim_schedule: (queue: [*]SimQueue, events: [*]SimEvent, clock: [*]SimClock, event: SimEvent): Bool {
+  assert(len(queue) == u32(1))
+  assert(len(clock) == u32(1))
+  assert(queue[0].count <= len(events))
+  assert(event.at >= clock[0].now)
+  queue[0].count == len(events) ? { false } | {
+    events[queue[0].count] = event
+    queue[0].count = queue[0].count + u32(1)
+    true
+  }
+}
+
+// Advance only to the earliest timestamp. A choice controls ordering among
+// simultaneous events; the model chooses which faults/actions are legal.
+sim_next: (queue: [*]SimQueue, events: [*]SimEvent, clock: [*]SimClock, choices: [*]TestChoices, data: []u8): SimEvent {
+  assert(len(queue) == u32(1))
+  assert(len(clock) == u32(1))
+  count: u32 = queue[0].count
+  assert(count > u32(0) && count <= len(events))
+  earliest: u64 = events[0].at
+  i: u32 = u32(1)
+  while i < count {
+    events[i].at < earliest ? { earliest = events[i].at }
+    i = i + u32(1)
+  }
+  ties: u32 = u32(0)
+  i = u32(0)
+  while i < count {
+    events[i].at == earliest ? { ties = ties + u32(1) }
+    i = i + u32(1)
+  }
+  selected: u32 = test_range(choices, data, u32(0), ties - u32(1))
+  index: u32 = u32(0)
+  seen: u32 = u32(0)
+  i = u32(0)
+  while i < count {
+    events[i].at == earliest ? {
+      seen == selected ? { index = i }
+      seen = seen + u32(1)
+    }
+    i = i + u32(1)
+  }
+  result: SimEvent = events[index]
+  assert(result.at >= clock[0].now)
+  clock[0].now = result.at
+  queue[0].count = count - u32(1)
+  events[index] = events[count - u32(1)]
+  result
+}

--- a/stdlib/testing.oak
+++ b/stdlib/testing.oak
@@ -1,8 +1,11 @@
 // Test reporting is an explicit host boundary, supplied by oak test.
 // Numeric invariant IDs are chosen by the test author and must keep their meaning.
-testing_fail: (id: u32): () = c.extern("oak_testing_fail")
+testing_fail_host: (id: c.UInt32): () = c.extern("oak_testing_fail")
 testing_discard: (): () = c.extern("oak_testing_discard")
-testing_classify: (id: u32): () = c.extern("oak_testing_classify")
+testing_classify_host: (id: c.UInt32): () = c.extern("oak_testing_classify")
+
+testing_fail: (id: u32): () { testing_fail_host(c.UInt32(id)) }
+testing_classify: (id: u32): () { testing_classify_host(c.UInt32(id)) }
 
 test_check: (condition: Bool, id: u32): () {
   !condition ? { testing_fail(id) }

--- a/stdlib/testing.oak
+++ b/stdlib/testing.oak
@@ -1,8 +1,8 @@
 // Test reporting is an explicit host boundary, supplied by oak test.
 // Numeric invariant IDs are chosen by the test author and must keep their meaning.
-testing_fail_host: (id: c.UInt32): () = c.extern("oak_testing_fail")
-testing_discard: (): () = c.extern("oak_testing_discard")
-testing_classify_host: (id: c.UInt32): () = c.extern("oak_testing_classify")
+testing_fail_host: (id: c.UInt32): () = c.extern("oak_test_host_fail")
+testing_discard: (): () = c.extern("oak_test_host_discard")
+testing_classify_host: (id: c.UInt32): () = c.extern("oak_test_host_classify")
 
 testing_fail: (id: u32): () { testing_fail_host(c.UInt32(id)) }
 testing_classify: (id: u32): () { testing_classify_host(c.UInt32(id)) }

--- a/testrunner/README.md
+++ b/testrunner/README.md
@@ -1,0 +1,60 @@
+# Oak test
+
+Build the CLI with `go build -o build/oak .` from the repository root. A host C
+compiler (`cc` by default) is required. Then:
+
+```sh
+./build/oak test examples/testing
+./build/oak test -list ./...
+./build/oak test -run '^Property' -seed 42 -runs 1000 examples/testing
+./build/oak test -sim '^SimTimerIrq$' -seed 42 -runs 1000 examples/testing
+./build/oak test -fuzz '^FuzzUtf8$' -runs 10000 examples/testing
+./build/oak test -json -runs 20 examples/testing
+```
+
+Flags precede directory arguments. Put tests in `*_test.oak` alongside the
+production `.oak` sources they exercise:
+
+```oak
+import(testing)
+
+TestAddition: (): () {
+  test_check(u32(2) + u32(3) == u32(5), u32(1001))
+}
+
+PropertyRange: (data: []u8): () {
+  state: [1]TestChoices
+  choices: [*]TestChoices = span(&state)
+  low: u32 = test_range(choices, data, u32(0), u32(100))
+  high: u32 = test_range(choices, data, low, u32(200))
+  test_check(low <= high, u32(1002))
+}
+```
+
+A failure prints an exact replay command and saves its minimized input under
+`testdata/oak/<TestName>/`. Keep useful failures in version control. Ordinary
+runs execute the corpus before exploring new inputs. `-replay` checks the exact
+build and expected failure; a reproduced failure still exits nonzero.
+
+`-timeout`, `-max-bytes`, `-max-discards`, `-shrink`, and `-shrink-timeout` make
+campaign costs explicit. `-cover 1:10,2:1` requires sample counts for IDs emitted
+by `testing_classify`. Rejected inputs never count as passes. Use `-sanitize`
+when your C compiler supports address/undefined-behavior sanitizers.
+
+For coverage-guided fuzzing:
+
+```sh
+./build/oak test -fuzz '^FuzzUtf8$' -emit-fuzz-harness build/fuzz.c examples/testing
+clang -std=c11 -O1 -g -fsanitize=fuzzer,address,undefined \
+  -fno-sanitize-recover=all build/fuzz.c -o build/fuzz
+mkdir -p build/fuzz-corpus
+./build/fuzz -max_len=256 -runs=100000 build/fuzz-corpus
+```
+
+Use a new output path for each export. libFuzzer executes many inputs in one
+process, so reset all tested state per call. Copy useful libFuzzer crash files
+to `testdata/oak/FuzzUtf8/*.bin` for the ordinary runner to replay.
+
+The [testing specification](../docs/spec/110-testing.md) records exact semantics
+and limits. The event simulator is an explicit bounded foundation; whole-OS
+simulation and automatic external-effect interception are not implemented.

--- a/testrunner/README.md
+++ b/testrunner/README.md
@@ -55,6 +55,19 @@ Use a new output path for each export. libFuzzer executes many inputs in one
 process, so reset all tested state per call. Copy useful libFuzzer crash files
 to `testdata/oak/FuzzUtf8/*.bin` for the ordinary runner to replay.
 
+Packages with `Sim` tests reject unsafe blocks, machine/atomic operations and
+unlisted FFI across the whole package. For native OS components, use an explicit
+adapter manifest with exact scalar ABI declarations and hash-pinned objects:
+
+```sh
+./build/oak test -adapter path/to/adapter.json -sim '^SimDevice$' path/to/tests
+./build/oak test -adapter path/to/adapter.json -replay path/to/failure.json path/to/tests
+```
+
+The adapter itself is trusted code; the compiler does not prove its determinism.
+Retain the original manifest and native archive for exact replay. Fuzz exports
+also accept `-adapter`; link the archive explicitly alongside the exported C.
+
 The [testing specification](../docs/spec/110-testing.md) records exact semantics
 and limits. The event simulator is an explicit bounded foundation; whole-OS
 simulation and automatic external-effect interception are not implemented.

--- a/testrunner/adapter.go
+++ b/testrunner/adapter.go
@@ -15,20 +15,20 @@ import (
 )
 
 type adapterObject struct {
-	Path string `json:"path"`
+	Path   string `json:"path"`
 	SHA256 string `json:"sha256"`
 }
 type adapterManifest struct {
-	Version int `json:"version"`
-	Name string `json:"name"`
-	Deterministic bool `json:"deterministic"`
-	Bindings []compiler.SimulationBinding `json:"bindings"`
-	Objects []adapterObject `json:"objects"`
+	Version       int                          `json:"version"`
+	Name          string                       `json:"name"`
+	Deterministic bool                         `json:"deterministic"`
+	Bindings      []compiler.SimulationBinding `json:"bindings"`
+	Objects       []adapterObject              `json:"objects"`
 }
 type nativeAdapter struct {
 	manifest adapterManifest
 	identity string
-	objects [][]byte
+	objects  [][]byte
 }
 
 // Adapter paths resolve from the manifest, never from a replay artifact. Each
@@ -37,23 +37,32 @@ type nativeAdapter struct {
 // ELF relocatable objects are accepted; thin archives/shared libraries/scripts
 // could introduce dependencies outside the recorded build.
 func loadAdapter(path string) (*nativeAdapter, error) {
-	if path == "" { return nil, nil }
+	if path == "" {
+		return nil, nil
+	}
 	f, err := os.Open(path)
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	defer f.Close()
 	dec := json.NewDecoder(io.LimitReader(f, 1<<20))
 	dec.DisallowUnknownFields()
 	var m adapterManifest
-	if err := dec.Decode(&m); err != nil { return nil, fmt.Errorf("adapter manifest: %w", err) }
+	if err := dec.Decode(&m); err != nil {
+		return nil, fmt.Errorf("adapter manifest: %w", err)
+	}
 	var extra any
-	if err := dec.Decode(&extra); err != io.EOF { return nil, fmt.Errorf("adapter manifest: trailing data") }
+	if err := dec.Decode(&extra); err != io.EOF {
+		return nil, fmt.Errorf("adapter manifest: trailing data")
+	}
 	if m.Version != 1 || m.Name == "" || !m.Deterministic || len(m.Objects) == 0 || len(m.Objects) > 32 || len(m.Bindings) == 0 {
 		return nil, fmt.Errorf("adapter manifest requires version 1, name, deterministic: true, bindings and 1..32 objects")
 	}
 	names, symbols := map[string]bool{}, map[string]bool{}
 	validABI := func(s string) bool {
 		switch s {
-		case "c.UInt8", "c.UInt16", "c.UInt32", "c.UInt64", "c.Int8", "c.Int16", "c.Int32", "c.Int64": return true
+		case "c.UInt8", "c.UInt16", "c.UInt32", "c.UInt64", "c.Int8", "c.Int16", "c.Int32", "c.Int64":
+			return true
 		}
 		return false
 	}
@@ -61,7 +70,11 @@ func loadAdapter(path string) (*nativeAdapter, error) {
 		if !cIdentifier.MatchString(b.Name) || !cIdentifier.MatchString(b.Symbol) || strings.HasPrefix(b.Symbol, "oak_") || names[b.Name] || symbols[b.Symbol] || !(b.Return == "()" || validABI(b.Return)) {
 			return nil, fmt.Errorf("adapter manifest: invalid or duplicate binding %q; oak_ symbols are reserved", b.Name)
 		}
-		for _, p := range b.Parameters { if !validABI(p) { return nil, fmt.Errorf("adapter manifest: %s requires fixed-width scalar C parameters", b.Name) } }
+		for _, p := range b.Parameters {
+			if !validABI(p) {
+				return nil, fmt.Errorf("adapter manifest: %s requires fixed-width scalar C parameters", b.Name)
+			}
+		}
 		names[b.Name], symbols[b.Symbol] = true, true
 	}
 	a := &nativeAdapter{manifest: m}
@@ -70,25 +83,41 @@ func loadAdapter(path string) (*nativeAdapter, error) {
 	identity := m
 	identity.Objects = append([]adapterObject(nil), m.Objects...)
 	for i, obj := range m.Objects {
-		if obj.Path == "" || (filepath.Ext(obj.Path) != ".a" && filepath.Ext(obj.Path) != ".o") { return nil, fmt.Errorf("adapter object must be .a or .o") }
+		if obj.Path == "" || (filepath.Ext(obj.Path) != ".a" && filepath.Ext(obj.Path) != ".o") {
+			return nil, fmt.Errorf("adapter object must be .a or .o")
+		}
 		p := obj.Path
-		if !filepath.IsAbs(p) { p = filepath.Join(filepath.Dir(path), p) }
+		if !filepath.IsAbs(p) {
+			p = filepath.Join(filepath.Dir(path), p)
+		}
 		file, err := os.Open(p)
-		if err != nil { return nil, err }
+		if err != nil {
+			return nil, err
+		}
 		data, readErr := io.ReadAll(io.LimitReader(file, (64<<20)+1))
 		file.Close()
-		if readErr != nil { return nil, readErr }
-		if len(data) > 64<<20 { return nil, fmt.Errorf("adapter object exceeds 64 MiB") }
+		if readErr != nil {
+			return nil, readErr
+		}
+		if len(data) > 64<<20 {
+			return nil, fmt.Errorf("adapter object exceeds 64 MiB")
+		}
 		hash := sha256.Sum256(data)
-		if obj.SHA256 != hex.EncodeToString(hash[:]) { return nil, fmt.Errorf("adapter object %s: SHA-256 mismatch", obj.Path) }
+		if obj.SHA256 != hex.EncodeToString(hash[:]) {
+			return nil, fmt.Errorf("adapter object %s: SHA-256 mismatch", obj.Path)
+		}
 		archive := bytes.HasPrefix(data, []byte("!<arch>\n"))
 		elf := len(data) >= 18 && bytes.Equal(data[:4], []byte{127, 'E', 'L', 'F'}) && (data[5] == 1 && data[16] == 1 && data[17] == 0 || data[5] == 2 && data[16] == 0 && data[17] == 1)
-		if !archive && !elf { return nil, fmt.Errorf("adapter object %s: expected self-contained archive or ELF relocatable object", obj.Path) }
+		if !archive && !elf {
+			return nil, fmt.Errorf("adapter object %s: expected self-contained archive or ELF relocatable object", obj.Path)
+		}
 		a.objects = append(a.objects, data)
 		identity.Objects[i].Path = ""
 	}
 	encoded, err := json.Marshal(identity)
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	a.identity = string(encoded)
 	return a, nil
 }
@@ -100,7 +129,9 @@ func packageCompilation(pkg Package, adapter *nativeAdapter) compiler.Compilatio
 	for _, test := range pkg.Registry {
 		if test.Kind == "simulation" {
 			var bindings []compiler.SimulationBinding
-			if adapter != nil { bindings = adapter.manifest.Bindings }
+			if adapter != nil {
+				bindings = adapter.manifest.Bindings
+			}
 			return comp.WithSimulation(bindings)
 		}
 	}

--- a/testrunner/adapter.go
+++ b/testrunner/adapter.go
@@ -1,0 +1,108 @@
+package testrunner
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/SCKelemen/oak/compiler"
+)
+
+type adapterObject struct {
+	Path string `json:"path"`
+	SHA256 string `json:"sha256"`
+}
+type adapterManifest struct {
+	Version int `json:"version"`
+	Name string `json:"name"`
+	Deterministic bool `json:"deterministic"`
+	Bindings []compiler.SimulationBinding `json:"bindings"`
+	Objects []adapterObject `json:"objects"`
+}
+type nativeAdapter struct {
+	manifest adapterManifest
+	identity string
+	objects [][]byte
+}
+
+// Adapter paths resolve from the manifest, never from a replay artifact. Each
+// object is verified and snapshotted before compilation so a rebuild cannot
+// race between fingerprinting and linking. Only self-contained archives and
+// ELF relocatable objects are accepted; thin archives/shared libraries/scripts
+// could introduce dependencies outside the recorded build.
+func loadAdapter(path string) (*nativeAdapter, error) {
+	if path == "" { return nil, nil }
+	f, err := os.Open(path)
+	if err != nil { return nil, err }
+	defer f.Close()
+	dec := json.NewDecoder(io.LimitReader(f, 1<<20))
+	dec.DisallowUnknownFields()
+	var m adapterManifest
+	if err := dec.Decode(&m); err != nil { return nil, fmt.Errorf("adapter manifest: %w", err) }
+	var extra any
+	if err := dec.Decode(&extra); err != io.EOF { return nil, fmt.Errorf("adapter manifest: trailing data") }
+	if m.Version != 1 || m.Name == "" || !m.Deterministic || len(m.Objects) == 0 || len(m.Objects) > 32 || len(m.Bindings) == 0 {
+		return nil, fmt.Errorf("adapter manifest requires version 1, name, deterministic: true, bindings and 1..32 objects")
+	}
+	names, symbols := map[string]bool{}, map[string]bool{}
+	validABI := func(s string) bool {
+		switch s {
+		case "c.UInt8", "c.UInt16", "c.UInt32", "c.UInt64", "c.Int8", "c.Int16", "c.Int32", "c.Int64": return true
+		}
+		return false
+	}
+	for _, b := range m.Bindings {
+		if !cIdentifier.MatchString(b.Name) || !cIdentifier.MatchString(b.Symbol) || strings.HasPrefix(b.Symbol, "oak_") || names[b.Name] || symbols[b.Symbol] || !(b.Return == "()" || validABI(b.Return)) {
+			return nil, fmt.Errorf("adapter manifest: invalid or duplicate binding %q; oak_ symbols are reserved", b.Name)
+		}
+		for _, p := range b.Parameters { if !validABI(p) { return nil, fmt.Errorf("adapter manifest: %s requires fixed-width scalar C parameters", b.Name) } }
+		names[b.Name], symbols[b.Symbol] = true, true
+	}
+	a := &nativeAdapter{manifest: m}
+	// Paths are locators, not build identity. Moving the same adapter must not
+	// break exact replay; declaration order and object link order are identity.
+	identity := m
+	identity.Objects = append([]adapterObject(nil), m.Objects...)
+	for i, obj := range m.Objects {
+		if obj.Path == "" || (filepath.Ext(obj.Path) != ".a" && filepath.Ext(obj.Path) != ".o") { return nil, fmt.Errorf("adapter object must be .a or .o") }
+		p := obj.Path
+		if !filepath.IsAbs(p) { p = filepath.Join(filepath.Dir(path), p) }
+		file, err := os.Open(p)
+		if err != nil { return nil, err }
+		data, readErr := io.ReadAll(io.LimitReader(file, (64<<20)+1))
+		file.Close()
+		if readErr != nil { return nil, readErr }
+		if len(data) > 64<<20 { return nil, fmt.Errorf("adapter object exceeds 64 MiB") }
+		hash := sha256.Sum256(data)
+		if obj.SHA256 != hex.EncodeToString(hash[:]) { return nil, fmt.Errorf("adapter object %s: SHA-256 mismatch", obj.Path) }
+		archive := bytes.HasPrefix(data, []byte("!<arch>\n"))
+		elf := len(data) >= 18 && bytes.Equal(data[:4], []byte{127, 'E', 'L', 'F'}) && (data[5] == 1 && data[16] == 1 && data[17] == 0 || data[5] == 2 && data[16] == 0 && data[17] == 1)
+		if !archive && !elf { return nil, fmt.Errorf("adapter object %s: expected self-contained archive or ELF relocatable object", obj.Path) }
+		a.objects = append(a.objects, data)
+		identity.Objects[i].Path = ""
+	}
+	encoded, err := json.Marshal(identity)
+	if err != nil { return nil, err }
+	a.identity = string(encoded)
+	return a, nil
+}
+
+func packageCompilation(pkg Package, adapter *nativeAdapter) compiler.Compilation {
+	comp := compiler.New().WithSource(filepath.Join(pkg.Dir, "<oak-test-package>"), pkg.Source)
+	// All invocations of a package containing Sim tests use the same profile,
+	// preserving fingerprints across test selection and exact replay.
+	for _, test := range pkg.Registry {
+		if test.Kind == "simulation" {
+			var bindings []compiler.SimulationBinding
+			if adapter != nil { bindings = adapter.manifest.Bindings }
+			return comp.WithSimulation(bindings)
+		}
+	}
+	return comp
+}

--- a/testrunner/adapter_test.go
+++ b/testrunner/adapter_test.go
@@ -1,0 +1,102 @@
+package testrunner
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/SCKelemen/oak/compiler"
+)
+
+func TestSimulationRejectsHiddenEffects(t *testing.T) {
+	for name, hidden := range map[string]string{
+		"unused-ffi": `clock: (): c.UInt64 = c.extern("get_clock")`,
+		"spoof-reporter": `testing_discard: (): () = c.extern("oak_test_host_discard")`,
+		"unsafe": `hidden: (): () { unsafe {} }`,
+		"generic": `hidden[T]: (x: T): T { arm64.isb(); x }`,
+		"machine": `hidden: (): () { arm64.wfe() }`,
+		"atomic-storage": `cell: Atomic[u32]`,
+		"atomic-call": `hidden: (): () { atomic_fence_seq_cst() }`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := compiler.New().WithSimulation(nil).WithSource("hidden.oak", hidden + "\nSimSafe: (data: []u8): () {}\n").EmitC().Get()
+			if err == nil || !strings.Contains(err.Error(), "simulation boundary:") { t.Fatalf("hidden effect escaped boundary check: %v", err) }
+		})
+	}
+}
+
+func compileAdapterFixture(t *testing.T, dir, source string) string {
+	t.Helper()
+	if _, err := exec.LookPath("cc"); err != nil { t.Skip("requires cc") }
+	cpath, object := filepath.Join(dir, "adapter.c"), filepath.Join(dir, "adapter.o")
+	if err := os.WriteFile(cpath, []byte(source), 0600); err != nil { t.Fatal(err) }
+	if out, err := exec.Command("cc", "-c", cpath, "-o", object).CombinedOutput(); err != nil { t.Fatalf("compile adapter: %v %s", err, out) }
+	data, err := os.ReadFile(object)
+	if err != nil { t.Fatal(err) }
+	hash := sha256.Sum256(data)
+	m := adapterManifest{Version: 1, Name: "fixture", Deterministic: true,
+		Bindings: []compiler.SimulationBinding{{Name: "adapt", Symbol: "fixture_apply", Parameters: []string{"c.UInt32"}, Return: "c.UInt32"}},
+		Objects: []adapterObject{{Path: "adapter.o", SHA256: hex.EncodeToString(hash[:])}},
+	}
+	encoded, err := json.Marshal(m)
+	if err != nil { t.Fatal(err) }
+	manifest := filepath.Join(dir, "adapter.json")
+	if err := os.WriteFile(manifest, encoded, 0600); err != nil { t.Fatal(err) }
+	return manifest
+}
+
+func TestNativeAdapterReplayPinsImplementation(t *testing.T) {
+	dir := fixture(t, map[string]string{"a_test.oak": `import(testing)
+adapt: (x: c.UInt32): c.UInt32 = c.extern("fixture_apply")
+SimNative: (data: []u8): () {
+  state: [1]TestChoices
+  choices: [*]TestChoices = span(&state)
+  value: u32 = u32(test_byte(choices, data))
+  test_check(u32(adapt(c.UInt32(value))) < u32(7), u32(7002))
+}
+`})
+	manifest := compileAdapterFixture(t, dir, "#include <stdint.h>\nuint32_t fixture_apply(uint32_t x) { return x; }\n")
+	code, results, stderr := runCLI(t, "-adapter", manifest, "-runs", "4", dir)
+	if code != 1 || len(results) != 1 || results[0].Failure != "invariant:7002" { t.Fatalf("adapter: %d %+v %s", code, results, stderr) }
+	artifact := results[0].Artifact
+	code, results, stderr = runCLI(t, "-adapter", manifest, "-replay", artifact, dir)
+	if code != 1 || results[0].Failure != "reproduced invariant:7002" { t.Fatalf("replay: %d %+v %s", code, results, stderr) }
+	// A stale manifest fails before linking. A rebuilt, re-pinned manifest
+	// passes validation but still cannot masquerade as the original build.
+	object := filepath.Join(dir, "adapter.o")
+	data, _ := os.ReadFile(object)
+	os.WriteFile(object, append(data, 0), 0600)
+	code, results, _ = runCLI(t, "-adapter", manifest, "-replay", artifact, dir)
+	if code != 2 || !strings.Contains(results[0].Failure, "SHA-256 mismatch") { t.Fatalf("hash drift: %d %+v", code, results) }
+	compileAdapterFixture(t, dir, "#include <stdint.h>\nuint32_t fixture_apply(uint32_t x) { return x + 1; }\n")
+	code, results, _ = runCLI(t, "-adapter", manifest, "-replay", artifact, dir)
+	if code != 2 || !strings.Contains(results[0].Failure, "build mismatch") { t.Fatalf("object drift: %d %+v", code, results) }
+	code, results, _ = runCLI(t, "-runs", "1", dir)
+	if code != 2 || !strings.Contains(results[0].Failure, "undeclared extern") { t.Fatalf("missing manifest: %d %+v", code, results) }
+	path := filepath.Join(dir, "a_test.oak")
+	source, _ := os.ReadFile(path)
+	os.WriteFile(path, []byte(strings.Replace(string(source), "(x: c.UInt32): c.UInt32", "(x: c.UInt64): c.UInt32", 1)), 0600)
+	code, results, _ = runCLI(t, "-adapter", manifest, "-runs", "1", dir)
+	if code != 2 || !strings.Contains(results[0].Failure, "ABI mismatch") { t.Fatalf("ABI drift: %d %+v", code, results) }
+}
+
+func TestAdapterRejectsUnpinnedDependencies(t *testing.T) {
+	dir := t.TempDir()
+	manifest := compileAdapterFixture(t, dir, "#include <stdint.h>\nuint32_t fixture_apply(uint32_t x) { return x; }\n")
+	for _, data := range [][]byte{[]byte("!<thin>\n"), []byte("INPUT(/tmp/outside.so)"), {127, 'E', 'L', 'F', 2, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0}} {
+		raw, _ := os.ReadFile(manifest)
+		var m adapterManifest
+		json.Unmarshal(raw, &m)
+		hash := sha256.Sum256(data)
+		m.Objects[0].SHA256 = hex.EncodeToString(hash[:])
+		encoded, _ := json.Marshal(m)
+		os.WriteFile(manifest, encoded, 0600)
+		os.WriteFile(filepath.Join(dir, "adapter.o"), data, 0600)
+		if _, err := loadAdapter(manifest); err == nil || !strings.Contains(err.Error(), "self-contained") { t.Fatalf("untracked dependency accepted: %v", err) }
+	}
+}

--- a/testrunner/adapter_test.go
+++ b/testrunner/adapter_test.go
@@ -15,38 +15,52 @@ import (
 
 func TestSimulationRejectsHiddenEffects(t *testing.T) {
 	for name, hidden := range map[string]string{
-		"unused-ffi": `clock: (): c.UInt64 = c.extern("get_clock")`,
+		"unused-ffi":     `clock: (): c.UInt64 = c.extern("get_clock")`,
 		"spoof-reporter": `testing_discard: (): () = c.extern("oak_test_host_discard")`,
-		"unsafe": `hidden: (): () { unsafe {} }`,
-		"generic": `hidden[T]: (x: T): T { arm64.isb(); x }`,
-		"machine": `hidden: (): () { arm64.wfe() }`,
+		"unsafe":         `hidden: (): () { unsafe {} }`,
+		"generic":        `hidden[T]: (x: T): T { arm64.isb(); x }`,
+		"machine":        `hidden: (): () { arm64.wfe() }`,
 		"atomic-storage": `cell: Atomic[u32]`,
-		"atomic-call": `hidden: (): () { atomic_fence_seq_cst() }`,
+		"atomic-call":    `hidden: (): () { atomic_fence_seq_cst() }`,
 	} {
 		t.Run(name, func(t *testing.T) {
-			_, err := compiler.New().WithSimulation(nil).WithSource("hidden.oak", hidden + "\nSimSafe: (data: []u8): () {}\n").EmitC().Get()
-			if err == nil || !strings.Contains(err.Error(), "simulation boundary:") { t.Fatalf("hidden effect escaped boundary check: %v", err) }
+			_, err := compiler.New().WithSimulation(nil).WithSource("hidden.oak", hidden+"\nSimSafe: (data: []u8): () {}\n").EmitC().Get()
+			if err == nil || !strings.Contains(err.Error(), "simulation boundary:") {
+				t.Fatalf("hidden effect escaped boundary check: %v", err)
+			}
 		})
 	}
 }
 
 func compileAdapterFixture(t *testing.T, dir, source string) string {
 	t.Helper()
-	if _, err := exec.LookPath("cc"); err != nil { t.Skip("requires cc") }
+	if _, err := exec.LookPath("cc"); err != nil {
+		t.Skip("requires cc")
+	}
 	cpath, object := filepath.Join(dir, "adapter.c"), filepath.Join(dir, "adapter.o")
-	if err := os.WriteFile(cpath, []byte(source), 0600); err != nil { t.Fatal(err) }
-	if out, err := exec.Command("cc", "-c", cpath, "-o", object).CombinedOutput(); err != nil { t.Fatalf("compile adapter: %v %s", err, out) }
+	if err := os.WriteFile(cpath, []byte(source), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := exec.Command("cc", "-c", cpath, "-o", object).CombinedOutput(); err != nil {
+		t.Fatalf("compile adapter: %v %s", err, out)
+	}
 	data, err := os.ReadFile(object)
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 	hash := sha256.Sum256(data)
 	m := adapterManifest{Version: 1, Name: "fixture", Deterministic: true,
 		Bindings: []compiler.SimulationBinding{{Name: "adapt", Symbol: "fixture_apply", Parameters: []string{"c.UInt32"}, Return: "c.UInt32"}},
-		Objects: []adapterObject{{Path: "adapter.o", SHA256: hex.EncodeToString(hash[:])}},
+		Objects:  []adapterObject{{Path: "adapter.o", SHA256: hex.EncodeToString(hash[:])}},
 	}
 	encoded, err := json.Marshal(m)
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 	manifest := filepath.Join(dir, "adapter.json")
-	if err := os.WriteFile(manifest, encoded, 0600); err != nil { t.Fatal(err) }
+	if err := os.WriteFile(manifest, encoded, 0600); err != nil {
+		t.Fatal(err)
+	}
 	return manifest
 }
 
@@ -62,27 +76,39 @@ SimNative: (data: []u8): () {
 `})
 	manifest := compileAdapterFixture(t, dir, "#include <stdint.h>\nuint32_t fixture_apply(uint32_t x) { return x; }\n")
 	code, results, stderr := runCLI(t, "-adapter", manifest, "-runs", "4", dir)
-	if code != 1 || len(results) != 1 || results[0].Failure != "invariant:7002" { t.Fatalf("adapter: %d %+v %s", code, results, stderr) }
+	if code != 1 || len(results) != 1 || results[0].Failure != "invariant:7002" {
+		t.Fatalf("adapter: %d %+v %s", code, results, stderr)
+	}
 	artifact := results[0].Artifact
 	code, results, stderr = runCLI(t, "-adapter", manifest, "-replay", artifact, dir)
-	if code != 1 || results[0].Failure != "reproduced invariant:7002" { t.Fatalf("replay: %d %+v %s", code, results, stderr) }
+	if code != 1 || results[0].Failure != "reproduced invariant:7002" {
+		t.Fatalf("replay: %d %+v %s", code, results, stderr)
+	}
 	// A stale manifest fails before linking. A rebuilt, re-pinned manifest
 	// passes validation but still cannot masquerade as the original build.
 	object := filepath.Join(dir, "adapter.o")
 	data, _ := os.ReadFile(object)
 	os.WriteFile(object, append(data, 0), 0600)
 	code, results, _ = runCLI(t, "-adapter", manifest, "-replay", artifact, dir)
-	if code != 2 || !strings.Contains(results[0].Failure, "SHA-256 mismatch") { t.Fatalf("hash drift: %d %+v", code, results) }
+	if code != 2 || !strings.Contains(results[0].Failure, "SHA-256 mismatch") {
+		t.Fatalf("hash drift: %d %+v", code, results)
+	}
 	compileAdapterFixture(t, dir, "#include <stdint.h>\nuint32_t fixture_apply(uint32_t x) { return x + 1; }\n")
 	code, results, _ = runCLI(t, "-adapter", manifest, "-replay", artifact, dir)
-	if code != 2 || !strings.Contains(results[0].Failure, "build mismatch") { t.Fatalf("object drift: %d %+v", code, results) }
+	if code != 2 || !strings.Contains(results[0].Failure, "build mismatch") {
+		t.Fatalf("object drift: %d %+v", code, results)
+	}
 	code, results, _ = runCLI(t, "-runs", "1", dir)
-	if code != 2 || !strings.Contains(results[0].Failure, "undeclared extern") { t.Fatalf("missing manifest: %d %+v", code, results) }
+	if code != 2 || !strings.Contains(results[0].Failure, "undeclared extern") {
+		t.Fatalf("missing manifest: %d %+v", code, results)
+	}
 	path := filepath.Join(dir, "a_test.oak")
 	source, _ := os.ReadFile(path)
 	os.WriteFile(path, []byte(strings.Replace(string(source), "(x: c.UInt32): c.UInt32", "(x: c.UInt64): c.UInt32", 1)), 0600)
 	code, results, _ = runCLI(t, "-adapter", manifest, "-runs", "1", dir)
-	if code != 2 || !strings.Contains(results[0].Failure, "ABI mismatch") { t.Fatalf("ABI drift: %d %+v", code, results) }
+	if code != 2 || !strings.Contains(results[0].Failure, "ABI mismatch") {
+		t.Fatalf("ABI drift: %d %+v", code, results)
+	}
 }
 
 func TestAdapterRejectsUnpinnedDependencies(t *testing.T) {
@@ -97,6 +123,8 @@ func TestAdapterRejectsUnpinnedDependencies(t *testing.T) {
 		encoded, _ := json.Marshal(m)
 		os.WriteFile(manifest, encoded, 0600)
 		os.WriteFile(filepath.Join(dir, "adapter.o"), data, 0600)
-		if _, err := loadAdapter(manifest); err == nil || !strings.Contains(err.Error(), "self-contained") { t.Fatalf("untracked dependency accepted: %v", err) }
+		if _, err := loadAdapter(manifest); err == nil || !strings.Contains(err.Error(), "self-contained") {
+			t.Fatalf("untracked dependency accepted: %v", err)
+		}
 	}
 }

--- a/testrunner/discover.go
+++ b/testrunner/discover.go
@@ -1,0 +1,123 @@
+// Package testrunner implements the host side of oak test. Test bodies always
+// pass through Compilation.EmitC and execute as native, isolated processes.
+package testrunner
+
+import (
+ "fmt"
+ "io/fs"
+ "os"
+ "path/filepath"
+ "regexp"
+ "sort"
+ "strings"
+
+ "github.com/SCKelemen/oak/ast"
+ "github.com/SCKelemen/oak/compiler"
+)
+
+type Test struct {
+ Name string `json:"name"`
+ File string `json:"file"`
+ Line int `json:"line"`
+ Kind string `json:"kind"`
+}
+
+type Package struct {
+ Dir string
+ Source string
+ Tests []Test
+ Registry []Test
+}
+
+var cIdentifier = regexp.MustCompile(`^[A-Za-z_][A-Za-z_0-9]*$`)
+
+// Discover treats each directory as a bootstrap package. Only *_test.oak files
+// register tests; all sibling .oak files supply production code and helpers.
+// Recursive discovery excludes hidden directories, vendor and testdata.
+func Discover(paths []string) ([]Package, error) {
+ if len(paths) == 0 { paths = []string{"."} }
+ dirs := map[string]bool{}
+ for _, path := range paths {
+  recursive := path == "..." || strings.HasSuffix(path, string(filepath.Separator)+"...")
+  if recursive {
+   root := strings.TrimSuffix(path, "...")
+   if root == "" { root = "." }
+   err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+    if err != nil { return err }
+    if d.IsDir() {
+     if p != root && (strings.HasPrefix(d.Name(), ".") || d.Name() == "vendor" || d.Name() == "testdata") { return filepath.SkipDir }
+    } else if strings.HasSuffix(d.Name(), "_test.oak") { dirs[filepath.Dir(p)] = true }
+    return nil
+   })
+   if err != nil { return nil, err }
+  } else {
+   info, err := os.Stat(path)
+   if err != nil { return nil, err }
+   if !info.IsDir() { return nil, fmt.Errorf("oak test expects a directory or ./..., got %s", path) }
+   dirs[path] = true
+  }
+ }
+ canonical := map[string]bool{}
+ for dir := range dirs { abs, err := filepath.Abs(dir); if err != nil { return nil, err }; canonical[abs] = true }
+ names := make([]string, 0, len(canonical))
+ for dir := range canonical { names = append(names, dir) }
+ sort.Strings(names)
+ var packages []Package
+ for _, dir := range names {
+  entries, err := os.ReadDir(dir)
+  if err != nil { return nil, err }
+  var pkg Package
+  pkg.Dir = dir
+  var src strings.Builder
+  for _, entry := range entries {
+   if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".oak") || strings.HasPrefix(entry.Name(), ".") { continue }
+   path := filepath.Join(dir, entry.Name())
+   data, err := os.ReadFile(path)
+   if err != nil { return nil, err }
+   // Newlines prevent final comments/layout blocks from eating the next file.
+   fmt.Fprintf(&src, "\n// oak test source: %s\n%s\n", entry.Name(), data)
+   if !strings.HasSuffix(entry.Name(), "_test.oak") { continue }
+   tree, err := compiler.New().WithSource(path, string(data)).Parse().Get()
+   if err != nil { return nil, fmt.Errorf("%s: %w", path, err) }
+   for _, stmt := range tree.Root.Statements {
+    fn, ok := stmt.(*ast.FunctionStatement)
+    if !ok || fn.Name == nil { continue }
+    kind := testKind(fn.Name.Value)
+    if kind == "" { continue }
+    if err := validateTest(fn, kind); err != nil { return nil, fmt.Errorf("%s:%d: %w", path, fn.Token.Line, err) }
+    pkg.Tests = append(pkg.Tests, Test{Name: fn.Name.Value, File: entry.Name(), Line: fn.Token.Line, Kind: kind})
+   }
+  }
+  pkg.Source = src.String()
+  sort.Slice(pkg.Tests, func(i,j int) bool { return pkg.Tests[i].Name < pkg.Tests[j].Name })
+  for i := 1; i < len(pkg.Tests); i++ { if pkg.Tests[i-1].Name == pkg.Tests[i].Name { return nil, fmt.Errorf("duplicate test %s in %s", pkg.Tests[i].Name, dir) } }
+  pkg.Registry = append([]Test(nil), pkg.Tests...)
+  if len(pkg.Tests) != 0 { packages = append(packages, pkg) }
+ }
+ return packages, nil
+}
+
+func testKind(name string) string {
+ for _, p := range []struct{prefix, kind string}{{"Property", "property"}, {"Fuzz", "fuzz"}, {"Sim", "simulation"}, {"Test", "unit"}} {
+  if strings.HasPrefix(name, p.prefix) && len(name) > len(p.prefix) {
+   next := name[len(p.prefix)]
+   if next == '_' || next >= 'A' && next <= 'Z' { return p.kind }
+  }
+ }
+ return ""
+}
+
+func validateTest(fn *ast.FunctionStatement, kind string) error {
+ bad := func() error { return fmt.Errorf("%s must be a non-generic %s test returning (), with %s", fn.Name.Value, kind, map[bool]string{true:"no arguments", false:"one []u8 argument"}[kind == "unit"]) }
+ if !cIdentifier.MatchString(fn.Name.Value) || fn.Receiver != nil || len(fn.TypeParams) != 0 || fn.ExternSymbol != "" { return bad() }
+ ret, ok := fn.ReturnType.(*ast.Identifier)
+ if !ok || ret.Value != "()" { return bad() }
+ if kind == "unit" { if len(fn.Parameters) != 0 { return bad() }; return nil }
+ if len(fn.Parameters) != 1 || fn.Parameters[0].Variadic { return bad() }
+ view, ok := fn.Parameters[0].Type.(*ast.IndexExpression)
+ if !ok || view.Dot { return bad() }
+ element, eok := view.Left.(*ast.Identifier)
+ marker, mok := view.Index.(*ast.Identifier)
+ if !eok || !mok || element.Value != "u8" || marker.Value != "" { return bad() }
+ return nil
+}

--- a/testrunner/discover.go
+++ b/testrunner/discover.go
@@ -3,30 +3,30 @@
 package testrunner
 
 import (
- "fmt"
- "io/fs"
- "os"
- "path/filepath"
- "regexp"
- "sort"
- "strings"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
 
- "github.com/SCKelemen/oak/ast"
- "github.com/SCKelemen/oak/compiler"
+	"github.com/SCKelemen/oak/ast"
+	"github.com/SCKelemen/oak/compiler"
 )
 
 type Test struct {
- Name string `json:"name"`
- File string `json:"file"`
- Line int `json:"line"`
- Kind string `json:"kind"`
+	Name string `json:"name"`
+	File string `json:"file"`
+	Line int    `json:"line"`
+	Kind string `json:"kind"`
 }
 
 type Package struct {
- Dir string
- Source string
- Tests []Test
- Registry []Test
+	Dir      string
+	Source   string
+	Tests    []Test
+	Registry []Test
 }
 
 var cIdentifier = regexp.MustCompile(`^[A-Za-z_][A-Za-z_0-9]*$`)
@@ -35,89 +35,154 @@ var cIdentifier = regexp.MustCompile(`^[A-Za-z_][A-Za-z_0-9]*$`)
 // register tests; all sibling .oak files supply production code and helpers.
 // Recursive discovery excludes hidden directories, vendor and testdata.
 func Discover(paths []string) ([]Package, error) {
- if len(paths) == 0 { paths = []string{"."} }
- dirs := map[string]bool{}
- for _, path := range paths {
-  recursive := path == "..." || strings.HasSuffix(path, string(filepath.Separator)+"...")
-  if recursive {
-   root := strings.TrimSuffix(path, "...")
-   if root == "" { root = "." }
-   err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
-    if err != nil { return err }
-    if d.IsDir() {
-     if p != root && (strings.HasPrefix(d.Name(), ".") || d.Name() == "vendor" || d.Name() == "testdata") { return filepath.SkipDir }
-    } else if strings.HasSuffix(d.Name(), "_test.oak") { dirs[filepath.Dir(p)] = true }
-    return nil
-   })
-   if err != nil { return nil, err }
-  } else {
-   info, err := os.Stat(path)
-   if err != nil { return nil, err }
-   if !info.IsDir() { return nil, fmt.Errorf("oak test expects a directory or ./..., got %s", path) }
-   dirs[path] = true
-  }
- }
- canonical := map[string]bool{}
- for dir := range dirs { abs, err := filepath.Abs(dir); if err != nil { return nil, err }; canonical[abs] = true }
- names := make([]string, 0, len(canonical))
- for dir := range canonical { names = append(names, dir) }
- sort.Strings(names)
- var packages []Package
- for _, dir := range names {
-  entries, err := os.ReadDir(dir)
-  if err != nil { return nil, err }
-  var pkg Package
-  pkg.Dir = dir
-  var src strings.Builder
-  for _, entry := range entries {
-   if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".oak") || strings.HasPrefix(entry.Name(), ".") { continue }
-   path := filepath.Join(dir, entry.Name())
-   data, err := os.ReadFile(path)
-   if err != nil { return nil, err }
-   // Newlines prevent final comments/layout blocks from eating the next file.
-   fmt.Fprintf(&src, "\n// oak test source: %s\n%s\n", entry.Name(), data)
-   if !strings.HasSuffix(entry.Name(), "_test.oak") { continue }
-   tree, err := compiler.New().WithSource(path, string(data)).Parse().Get()
-   if err != nil { return nil, fmt.Errorf("%s: %w", path, err) }
-   for _, stmt := range tree.Root.Statements {
-    fn, ok := stmt.(*ast.FunctionStatement)
-    if !ok || fn.Name == nil { continue }
-    kind := testKind(fn.Name.Value)
-    if kind == "" { continue }
-    if err := validateTest(fn, kind); err != nil { return nil, fmt.Errorf("%s:%d: %w", path, fn.Token.Line, err) }
-    pkg.Tests = append(pkg.Tests, Test{Name: fn.Name.Value, File: entry.Name(), Line: fn.Token.Line, Kind: kind})
-   }
-  }
-  pkg.Source = src.String()
-  sort.Slice(pkg.Tests, func(i,j int) bool { return pkg.Tests[i].Name < pkg.Tests[j].Name })
-  for i := 1; i < len(pkg.Tests); i++ { if pkg.Tests[i-1].Name == pkg.Tests[i].Name { return nil, fmt.Errorf("duplicate test %s in %s", pkg.Tests[i].Name, dir) } }
-  pkg.Registry = append([]Test(nil), pkg.Tests...)
-  if len(pkg.Tests) != 0 { packages = append(packages, pkg) }
- }
- return packages, nil
+	if len(paths) == 0 {
+		paths = []string{"."}
+	}
+	dirs := map[string]bool{}
+	for _, path := range paths {
+		recursive := path == "..." || strings.HasSuffix(path, string(filepath.Separator)+"...")
+		if recursive {
+			root := strings.TrimSuffix(path, "...")
+			if root == "" {
+				root = "."
+			}
+			err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+				if err != nil {
+					return err
+				}
+				if d.IsDir() {
+					if p != root && (strings.HasPrefix(d.Name(), ".") || d.Name() == "vendor" || d.Name() == "testdata") {
+						return filepath.SkipDir
+					}
+				} else if strings.HasSuffix(d.Name(), "_test.oak") {
+					dirs[filepath.Dir(p)] = true
+				}
+				return nil
+			})
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			info, err := os.Stat(path)
+			if err != nil {
+				return nil, err
+			}
+			if !info.IsDir() {
+				return nil, fmt.Errorf("oak test expects a directory or ./..., got %s", path)
+			}
+			dirs[path] = true
+		}
+	}
+	canonical := map[string]bool{}
+	for dir := range dirs {
+		abs, err := filepath.Abs(dir)
+		if err != nil {
+			return nil, err
+		}
+		canonical[abs] = true
+	}
+	names := make([]string, 0, len(canonical))
+	for dir := range canonical {
+		names = append(names, dir)
+	}
+	sort.Strings(names)
+	var packages []Package
+	for _, dir := range names {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			return nil, err
+		}
+		var pkg Package
+		pkg.Dir = dir
+		var src strings.Builder
+		for _, entry := range entries {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".oak") || strings.HasPrefix(entry.Name(), ".") {
+				continue
+			}
+			path := filepath.Join(dir, entry.Name())
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return nil, err
+			}
+			// Newlines prevent final comments/layout blocks from eating the next file.
+			fmt.Fprintf(&src, "\n// oak test source: %s\n%s\n", entry.Name(), data)
+			if !strings.HasSuffix(entry.Name(), "_test.oak") {
+				continue
+			}
+			tree, err := compiler.New().WithSource(path, string(data)).Parse().Get()
+			if err != nil {
+				return nil, fmt.Errorf("%s: %w", path, err)
+			}
+			for _, stmt := range tree.Root.Statements {
+				fn, ok := stmt.(*ast.FunctionStatement)
+				if !ok || fn.Name == nil {
+					continue
+				}
+				kind := testKind(fn.Name.Value)
+				if kind == "" {
+					continue
+				}
+				if err := validateTest(fn, kind); err != nil {
+					return nil, fmt.Errorf("%s:%d: %w", path, fn.Token.Line, err)
+				}
+				pkg.Tests = append(pkg.Tests, Test{Name: fn.Name.Value, File: entry.Name(), Line: fn.Token.Line, Kind: kind})
+			}
+		}
+		pkg.Source = src.String()
+		sort.Slice(pkg.Tests, func(i, j int) bool { return pkg.Tests[i].Name < pkg.Tests[j].Name })
+		for i := 1; i < len(pkg.Tests); i++ {
+			if pkg.Tests[i-1].Name == pkg.Tests[i].Name {
+				return nil, fmt.Errorf("duplicate test %s in %s", pkg.Tests[i].Name, dir)
+			}
+		}
+		pkg.Registry = append([]Test(nil), pkg.Tests...)
+		if len(pkg.Tests) != 0 {
+			packages = append(packages, pkg)
+		}
+	}
+	return packages, nil
 }
 
 func testKind(name string) string {
- for _, p := range []struct{prefix, kind string}{{"Property", "property"}, {"Fuzz", "fuzz"}, {"Sim", "simulation"}, {"Test", "unit"}} {
-  if strings.HasPrefix(name, p.prefix) && len(name) > len(p.prefix) {
-   next := name[len(p.prefix)]
-   if next == '_' || next >= 'A' && next <= 'Z' { return p.kind }
-  }
- }
- return ""
+	for _, p := range []struct{ prefix, kind string }{{"Property", "property"}, {"Fuzz", "fuzz"}, {"Sim", "simulation"}, {"Test", "unit"}} {
+		if strings.HasPrefix(name, p.prefix) && len(name) > len(p.prefix) {
+			next := name[len(p.prefix)]
+			if next == '_' || next >= 'A' && next <= 'Z' {
+				return p.kind
+			}
+		}
+	}
+	return ""
 }
 
 func validateTest(fn *ast.FunctionStatement, kind string) error {
- bad := func() error { return fmt.Errorf("%s must be a non-generic %s test returning (), with %s", fn.Name.Value, kind, map[bool]string{true:"no arguments", false:"one []u8 argument"}[kind == "unit"]) }
- if !cIdentifier.MatchString(fn.Name.Value) || fn.Receiver != nil || len(fn.TypeParams) != 0 || fn.ExternSymbol != "" { return bad() }
- ret, ok := fn.ReturnType.(*ast.Identifier)
- if !ok || ret.Value != "()" { return bad() }
- if kind == "unit" { if len(fn.Parameters) != 0 { return bad() }; return nil }
- if len(fn.Parameters) != 1 || fn.Parameters[0].Variadic { return bad() }
- view, ok := fn.Parameters[0].Type.(*ast.IndexExpression)
- if !ok || view.Dot { return bad() }
- element, eok := view.Left.(*ast.Identifier)
- marker, mok := view.Index.(*ast.Identifier)
- if !eok || !mok || element.Value != "u8" || marker.Value != "" { return bad() }
- return nil
+	bad := func() error {
+		return fmt.Errorf("%s must be a non-generic %s test returning (), with %s", fn.Name.Value, kind, map[bool]string{true: "no arguments", false: "one []u8 argument"}[kind == "unit"])
+	}
+	if !cIdentifier.MatchString(fn.Name.Value) || fn.Receiver != nil || len(fn.TypeParams) != 0 || fn.ExternSymbol != "" {
+		return bad()
+	}
+	ret, ok := fn.ReturnType.(*ast.Identifier)
+	if !ok || ret.Value != "()" {
+		return bad()
+	}
+	if kind == "unit" {
+		if len(fn.Parameters) != 0 {
+			return bad()
+		}
+		return nil
+	}
+	if len(fn.Parameters) != 1 || fn.Parameters[0].Variadic {
+		return bad()
+	}
+	view, ok := fn.Parameters[0].Type.(*ast.IndexExpression)
+	if !ok || view.Dot {
+		return bad()
+	}
+	element, eok := view.Left.(*ast.Identifier)
+	marker, mok := view.Index.(*ast.Identifier)
+	if !eok || !mok || element.Value != "u8" || marker.Value != "" {
+		return bad()
+	}
+	return nil
 }

--- a/testrunner/engine.go
+++ b/testrunner/engine.go
@@ -1,0 +1,153 @@
+package testrunner
+
+import (
+ "context"
+ "crypto/sha256"
+ "encoding/binary"
+ "encoding/hex"
+ "encoding/json"
+ "fmt"
+ "io"
+ "os"
+ "path/filepath"
+ "sort"
+ "strings"
+)
+
+// SplitMix64's transition is fixed by engineVersion, independent of Go's
+// evolving math/rand implementations and of worker/test discovery ordering.
+type random struct { state uint64 }
+func (r *random) next() uint64 {
+ r.state += 0x9e3779b97f4a7c15
+ z := r.state
+ z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9
+ z = (z ^ (z >> 27)) * 0x94d049bb133111eb
+ return z ^ (z >> 31)
+}
+func randomFor(seed uint64, name string, attempt int) random {
+ sum := sha256.Sum256([]byte(name))
+ return random{state:seed ^ binary.LittleEndian.Uint64(sum[:8]) ^ uint64(attempt)*0x9e3779b97f4a7c15}
+}
+func generate(r *random, attempt, max int) []byte {
+ if attempt == 0 || max == 0 { return nil }
+ if attempt <= 3 {
+  out := make([]byte, max)
+  for i := range out { if attempt == 2 { out[i] = 255 }; if attempt == 3 { out[i] = byte(i) } }
+  return out
+ }
+ out := make([]byte, int(r.next()%uint64(max+1)))
+ for i := range out { out[i] = byte(r.next()) }
+ return out
+}
+func mutate(r *random, seeds [][]byte, max int) []byte {
+ input := append([]byte(nil), seeds[int(r.next()%uint64(len(seeds)))]...)
+ if max == 0 { return nil }
+ switch r.next()%5 {
+ case 0:
+  if len(input) < max { i := int(r.next()%uint64(len(input)+1)); input = append(input, 0); copy(input[i+1:], input[i:]); input[i] = byte(r.next()) }
+ case 1:
+  if len(input)>0 { i := int(r.next()%uint64(len(input))); input = append(input[:i], input[i+1:]...) }
+ case 2:
+  if len(input)>0 { i:=int(r.next()%uint64(len(input))); input[i] ^= 1 << (r.next()%8) }
+ case 3:
+  if len(input)>0 { input[int(r.next()%uint64(len(input)))] = byte(r.next()) }
+ case 4:
+  return generate(r, 4, max)
+ }
+ return input
+}
+
+// Minimize accepts only candidates preserving the caller's failure signature.
+// It first deletes chunks, then reduces bytes. Every accepted candidate is
+// strictly smaller by (length, lexicographic bytes), so reduction terminates.
+// It is budgeted minimization, not a promise of a globally minimal example.
+func Minimize(ctx context.Context, input []byte, budget int, fails func([]byte) bool) []byte {
+ best := append([]byte(nil), input...)
+ try := func(candidate []byte) bool {
+  if budget <= 0 || ctx.Err() != nil { return false }
+  budget--
+  if fails(candidate) { best = append([]byte(nil), candidate...); return true }
+  return false
+ }
+ for chunk := len(best); chunk > 0 && budget > 0 && ctx.Err() == nil; chunk /= 2 {
+  for start:=0; start+chunk<=len(best) && budget>0 && ctx.Err()==nil; {
+   candidate := append(append([]byte(nil), best[:start]...), best[start+chunk:]...)
+   if !try(candidate) { start += chunk }
+  }
+ }
+ for i:=0; i<len(best) && budget>0 && ctx.Err()==nil; i++ {
+  original := best[i]
+  if original == 0 { continue }
+  candidate := append([]byte(nil), best...); candidate[i] = 0
+  if try(candidate) { continue }
+  for step:=int(original)/2; step>0 && budget>0 && ctx.Err()==nil; step/=2 {
+   if int(best[i]) < step { continue }
+   candidate = append([]byte(nil), best...); candidate[i] -= byte(step)
+   try(candidate)
+  }
+ }
+ return best
+}
+
+type Artifact struct {
+ Version int `json:"version"`
+ Engine string `json:"engine"`
+ Test string `json:"test"`
+ Kind string `json:"kind"`
+ Build string `json:"build"`
+ Seed uint64 `json:"seed"`
+ Attempt int `json:"attempt"`
+ MaxBytes int `json:"max_bytes"`
+ Sanitize bool `json:"sanitize"`
+ Signature string `json:"signature"`
+ Input []byte `json:"input"` // JSON base64, including arbitrary invalid UTF-8.
+}
+func readArtifact(path string, max int) (Artifact, error) {
+ var a Artifact
+ f, err := os.Open(path)
+ if err != nil { return a, err }; defer f.Close()
+ data, err := io.ReadAll(io.LimitReader(f, int64(max)*2+65537))
+ if err != nil { return a, err }
+ if len(data)>max*2+65536 { return a, fmt.Errorf("oversized replay artifact %s", path) }
+ decoder := json.NewDecoder(strings.NewReader(string(data)))
+ decoder.DisallowUnknownFields()
+ if err:=decoder.Decode(&a); err!=nil { return a, fmt.Errorf("%s: %w",path,err) }
+ var extra any
+ if err:=decoder.Decode(&extra); err!=io.EOF { return a, fmt.Errorf("trailing data in %s",path) }
+ if a.Version!=1 || a.Engine!=engineVersion || !cIdentifier.MatchString(a.Test) || a.Kind!=testKind(a.Test) || len(a.Input)>max || a.MaxBytes<0 || a.MaxBytes>1<<20 || len(a.Build)!=64 || a.Signature=="" { return a, fmt.Errorf("invalid or unsupported replay artifact %s",path) }
+ return a,nil
+}
+func corpusDir(pkg Package, test Test) string { return filepath.Join(pkg.Dir,"testdata","oak",test.Name) }
+func saveArtifact(pkg Package, test Test, a Artifact) (string,error) {
+ data,err:=json.MarshalIndent(a,"","  "); if err!=nil{return "",err};data=append(data,'\n')
+ sum:=sha256.Sum256(data)
+ dir:=corpusDir(pkg,test)
+ if err:=os.MkdirAll(dir,0755);err!=nil{return "",err}
+ path:=filepath.Join(dir,hex.EncodeToString(sum[:16])+".json")
+ f,err:=os.CreateTemp(dir,".pending-*");if err!=nil{return "",err}
+ temp:=f.Name();defer os.Remove(temp)
+ if _,err:=f.Write(data);err!=nil{f.Close();return "",err}
+ if err:=f.Close();err!=nil{return "",err}
+ if err:=os.Rename(temp,path);err!=nil{return "",err}
+ return path,nil
+}
+func loadCorpus(pkg Package,test Test,max int)([][]byte,error){
+ entries,err:=os.ReadDir(corpusDir(pkg,test));if os.IsNotExist(err){return nil,nil};if err!=nil{return nil,err}
+ var inputs [][]byte
+ for _,entry:=range entries{
+  if entry.IsDir() || strings.HasPrefix(entry.Name(),"."){continue}
+  path:=filepath.Join(corpusDir(pkg,test),entry.Name())
+  switch filepath.Ext(entry.Name()){
+  case ".json":
+   a,err:=readArtifact(path,max);if err!=nil{return nil,err};if a.Test!=test.Name || a.Kind!=test.Kind{return nil,fmt.Errorf("corpus identity mismatch: %s",path)}
+   inputs=append(inputs,a.Input)
+  case ".bin":
+   f,err:=os.Open(path);if err!=nil{return nil,err};data,err:=io.ReadAll(io.LimitReader(f,int64(max)+1));f.Close();if err!=nil{return nil,err};if len(data)>max{return nil,fmt.Errorf("corpus input exceeds -max-bytes: %s",path)};inputs=append(inputs,data)
+  }
+ }
+ // ReadDir already sorts names; explicitly deduplicate by bytes, not build ID.
+ seen:=map[string]bool{};var result [][]byte
+ for _,input:=range inputs{if !seen[string(input)]{result=append(result,input);seen[string(input)]=true}}
+ sort.Slice(result,func(i,j int)bool{return string(result[i])<string(result[j])})
+ return result,nil
+}

--- a/testrunner/engine.go
+++ b/testrunner/engine.go
@@ -81,9 +81,10 @@ func Minimize(ctx context.Context, input []byte, budget int, fails func([]byte) 
   candidate := append([]byte(nil), best...); candidate[i] = 0
   if try(candidate) { continue }
   for step:=int(original)/2; step>0 && budget>0 && ctx.Err()==nil; step/=2 {
-   if int(best[i]) < step { continue }
-   candidate = append([]byte(nil), best...); candidate[i] -= byte(step)
-   try(candidate)
+   for int(best[i]) >= step && budget>0 && ctx.Err()==nil {
+    candidate = append([]byte(nil), best...); candidate[i] -= byte(step)
+    if !try(candidate) { break }
+   }
   }
  }
  return best

--- a/testrunner/engine.go
+++ b/testrunner/engine.go
@@ -133,17 +133,18 @@ func Minimize(ctx context.Context, input []byte, budget int, fails func([]byte) 
 }
 
 type Artifact struct {
-	Version   int    `json:"version"`
-	Engine    string `json:"engine"`
-	Test      string `json:"test"`
-	Kind      string `json:"kind"`
-	Build     string `json:"build"`
-	Seed      uint64 `json:"seed"`
-	Attempt   int    `json:"attempt"`
-	MaxBytes  int    `json:"max_bytes"`
-	Sanitize  bool   `json:"sanitize"`
-	Signature string `json:"signature"`
-	Input     []byte `json:"input"` // JSON base64, including arbitrary invalid UTF-8.
+	TimeoutNanos int64  `json:"timeout_nanos"`
+	Version      int    `json:"version"`
+	Engine       string `json:"engine"`
+	Test         string `json:"test"`
+	Kind         string `json:"kind"`
+	Build        string `json:"build"`
+	Seed         uint64 `json:"seed"`
+	Attempt      int    `json:"attempt"`
+	MaxBytes     int    `json:"max_bytes"`
+	Sanitize     bool   `json:"sanitize"`
+	Signature    string `json:"signature"`
+	Input        []byte `json:"input"` // JSON base64, including arbitrary invalid UTF-8.
 }
 
 func readArtifact(path string, max int) (Artifact, error) {
@@ -169,8 +170,11 @@ func readArtifact(path string, max int) (Artifact, error) {
 	if err := decoder.Decode(&extra); err != io.EOF {
 		return a, fmt.Errorf("trailing data in %s", path)
 	}
-	if a.Version != 1 || a.Engine != engineVersion || !cIdentifier.MatchString(a.Test) || a.Kind != testKind(a.Test) || len(a.Input) > max || a.MaxBytes < 0 || a.MaxBytes > 1<<20 || len(a.Build) != 64 || a.Signature == "" {
+	if a.TimeoutNanos <= 0 || a.Version != 1 || a.Engine != engineVersion || !cIdentifier.MatchString(a.Test) || testKind(a.Test) == "" || a.Kind != testKind(a.Test) || len(a.Input) > a.MaxBytes || len(a.Input) > max || a.MaxBytes < 0 || a.MaxBytes > 1<<20 || len(a.Build) != 64 || a.Signature == "" {
 		return a, fmt.Errorf("invalid or unsupported replay artifact %s", path)
+	}
+	if _, err := hex.DecodeString(a.Build); err != nil {
+		return a, fmt.Errorf("invalid build fingerprint in %s", path)
 	}
 	return a, nil
 }

--- a/testrunner/engine.go
+++ b/testrunner/engine.go
@@ -1,60 +1,87 @@
 package testrunner
 
 import (
- "context"
- "crypto/sha256"
- "encoding/binary"
- "encoding/hex"
- "encoding/json"
- "fmt"
- "io"
- "os"
- "path/filepath"
- "sort"
- "strings"
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
 )
 
 // SplitMix64's transition is fixed by engineVersion, independent of Go's
 // evolving math/rand implementations and of worker/test discovery ordering.
-type random struct { state uint64 }
+type random struct{ state uint64 }
+
 func (r *random) next() uint64 {
- r.state += 0x9e3779b97f4a7c15
- z := r.state
- z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9
- z = (z ^ (z >> 27)) * 0x94d049bb133111eb
- return z ^ (z >> 31)
+	r.state += 0x9e3779b97f4a7c15
+	z := r.state
+	z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9
+	z = (z ^ (z >> 27)) * 0x94d049bb133111eb
+	return z ^ (z >> 31)
 }
 func randomFor(seed uint64, name string, attempt int) random {
- sum := sha256.Sum256([]byte(name))
- return random{state:seed ^ binary.LittleEndian.Uint64(sum[:8]) ^ uint64(attempt)*0x9e3779b97f4a7c15}
+	sum := sha256.Sum256([]byte(name))
+	return random{state: seed ^ binary.LittleEndian.Uint64(sum[:8]) ^ uint64(attempt)*0x9e3779b97f4a7c15}
 }
 func generate(r *random, attempt, max int) []byte {
- if attempt == 0 || max == 0 { return nil }
- if attempt <= 3 {
-  out := make([]byte, max)
-  for i := range out { if attempt == 2 { out[i] = 255 }; if attempt == 3 { out[i] = byte(i) } }
-  return out
- }
- out := make([]byte, int(r.next()%uint64(max+1)))
- for i := range out { out[i] = byte(r.next()) }
- return out
+	if attempt == 0 || max == 0 {
+		return nil
+	}
+	if attempt <= 3 {
+		out := make([]byte, max)
+		for i := range out {
+			if attempt == 2 {
+				out[i] = 255
+			}
+			if attempt == 3 {
+				out[i] = byte(i)
+			}
+		}
+		return out
+	}
+	out := make([]byte, int(r.next()%uint64(max+1)))
+	for i := range out {
+		out[i] = byte(r.next())
+	}
+	return out
 }
 func mutate(r *random, seeds [][]byte, max int) []byte {
- input := append([]byte(nil), seeds[int(r.next()%uint64(len(seeds)))]...)
- if max == 0 { return nil }
- switch r.next()%5 {
- case 0:
-  if len(input) < max { i := int(r.next()%uint64(len(input)+1)); input = append(input, 0); copy(input[i+1:], input[i:]); input[i] = byte(r.next()) }
- case 1:
-  if len(input)>0 { i := int(r.next()%uint64(len(input))); input = append(input[:i], input[i+1:]...) }
- case 2:
-  if len(input)>0 { i:=int(r.next()%uint64(len(input))); input[i] ^= 1 << (r.next()%8) }
- case 3:
-  if len(input)>0 { input[int(r.next()%uint64(len(input)))] = byte(r.next()) }
- case 4:
-  return generate(r, 4, max)
- }
- return input
+	input := append([]byte(nil), seeds[int(r.next()%uint64(len(seeds)))]...)
+	if max == 0 {
+		return nil
+	}
+	switch r.next() % 5 {
+	case 0:
+		if len(input) < max {
+			i := int(r.next() % uint64(len(input)+1))
+			input = append(input, 0)
+			copy(input[i+1:], input[i:])
+			input[i] = byte(r.next())
+		}
+	case 1:
+		if len(input) > 0 {
+			i := int(r.next() % uint64(len(input)))
+			input = append(input[:i], input[i+1:]...)
+		}
+	case 2:
+		if len(input) > 0 {
+			i := int(r.next() % uint64(len(input)))
+			input[i] ^= 1 << (r.next() % 8)
+		}
+	case 3:
+		if len(input) > 0 {
+			input[int(r.next()%uint64(len(input)))] = byte(r.next())
+		}
+	case 4:
+		return generate(r, 4, max)
+	}
+	return input
 }
 
 // Minimize accepts only candidates preserving the caller's failure signature.
@@ -62,93 +89,173 @@ func mutate(r *random, seeds [][]byte, max int) []byte {
 // strictly smaller by (length, lexicographic bytes), so reduction terminates.
 // It is budgeted minimization, not a promise of a globally minimal example.
 func Minimize(ctx context.Context, input []byte, budget int, fails func([]byte) bool) []byte {
- best := append([]byte(nil), input...)
- try := func(candidate []byte) bool {
-  if budget <= 0 || ctx.Err() != nil { return false }
-  budget--
-  if fails(candidate) { best = append([]byte(nil), candidate...); return true }
-  return false
- }
- for chunk := len(best); chunk > 0 && budget > 0 && ctx.Err() == nil; chunk /= 2 {
-  for start:=0; start+chunk<=len(best) && budget>0 && ctx.Err()==nil; {
-   candidate := append(append([]byte(nil), best[:start]...), best[start+chunk:]...)
-   if !try(candidate) { start += chunk }
-  }
- }
- for i:=0; i<len(best) && budget>0 && ctx.Err()==nil; i++ {
-  original := best[i]
-  if original == 0 { continue }
-  candidate := append([]byte(nil), best...); candidate[i] = 0
-  if try(candidate) { continue }
-  for step:=int(original)/2; step>0 && budget>0 && ctx.Err()==nil; step/=2 {
-   for int(best[i]) >= step && budget>0 && ctx.Err()==nil {
-    candidate = append([]byte(nil), best...); candidate[i] -= byte(step)
-    if !try(candidate) { break }
-   }
-  }
- }
- return best
+	best := append([]byte(nil), input...)
+	try := func(candidate []byte) bool {
+		if budget <= 0 || ctx.Err() != nil {
+			return false
+		}
+		budget--
+		if fails(candidate) {
+			best = append([]byte(nil), candidate...)
+			return true
+		}
+		return false
+	}
+	for chunk := len(best); chunk > 0 && budget > 0 && ctx.Err() == nil; chunk /= 2 {
+		for start := 0; start+chunk <= len(best) && budget > 0 && ctx.Err() == nil; {
+			candidate := append(append([]byte(nil), best[:start]...), best[start+chunk:]...)
+			if !try(candidate) {
+				start += chunk
+			}
+		}
+	}
+	for i := 0; i < len(best) && budget > 0 && ctx.Err() == nil; i++ {
+		original := best[i]
+		if original == 0 {
+			continue
+		}
+		candidate := append([]byte(nil), best...)
+		candidate[i] = 0
+		if try(candidate) {
+			continue
+		}
+		for step := int(original) / 2; step > 0 && budget > 0 && ctx.Err() == nil; step /= 2 {
+			for int(best[i]) >= step && budget > 0 && ctx.Err() == nil {
+				candidate = append([]byte(nil), best...)
+				candidate[i] -= byte(step)
+				if !try(candidate) {
+					break
+				}
+			}
+		}
+	}
+	return best
 }
 
 type Artifact struct {
- Version int `json:"version"`
- Engine string `json:"engine"`
- Test string `json:"test"`
- Kind string `json:"kind"`
- Build string `json:"build"`
- Seed uint64 `json:"seed"`
- Attempt int `json:"attempt"`
- MaxBytes int `json:"max_bytes"`
- Sanitize bool `json:"sanitize"`
- Signature string `json:"signature"`
- Input []byte `json:"input"` // JSON base64, including arbitrary invalid UTF-8.
+	Version   int    `json:"version"`
+	Engine    string `json:"engine"`
+	Test      string `json:"test"`
+	Kind      string `json:"kind"`
+	Build     string `json:"build"`
+	Seed      uint64 `json:"seed"`
+	Attempt   int    `json:"attempt"`
+	MaxBytes  int    `json:"max_bytes"`
+	Sanitize  bool   `json:"sanitize"`
+	Signature string `json:"signature"`
+	Input     []byte `json:"input"` // JSON base64, including arbitrary invalid UTF-8.
 }
+
 func readArtifact(path string, max int) (Artifact, error) {
- var a Artifact
- f, err := os.Open(path)
- if err != nil { return a, err }; defer f.Close()
- data, err := io.ReadAll(io.LimitReader(f, int64(max)*2+65537))
- if err != nil { return a, err }
- if len(data)>max*2+65536 { return a, fmt.Errorf("oversized replay artifact %s", path) }
- decoder := json.NewDecoder(strings.NewReader(string(data)))
- decoder.DisallowUnknownFields()
- if err:=decoder.Decode(&a); err!=nil { return a, fmt.Errorf("%s: %w",path,err) }
- var extra any
- if err:=decoder.Decode(&extra); err!=io.EOF { return a, fmt.Errorf("trailing data in %s",path) }
- if a.Version!=1 || a.Engine!=engineVersion || !cIdentifier.MatchString(a.Test) || a.Kind!=testKind(a.Test) || len(a.Input)>max || a.MaxBytes<0 || a.MaxBytes>1<<20 || len(a.Build)!=64 || a.Signature=="" { return a, fmt.Errorf("invalid or unsupported replay artifact %s",path) }
- return a,nil
+	var a Artifact
+	f, err := os.Open(path)
+	if err != nil {
+		return a, err
+	}
+	defer f.Close()
+	data, err := io.ReadAll(io.LimitReader(f, int64(max)*2+65537))
+	if err != nil {
+		return a, err
+	}
+	if len(data) > max*2+65536 {
+		return a, fmt.Errorf("oversized replay artifact %s", path)
+	}
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&a); err != nil {
+		return a, fmt.Errorf("%s: %w", path, err)
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		return a, fmt.Errorf("trailing data in %s", path)
+	}
+	if a.Version != 1 || a.Engine != engineVersion || !cIdentifier.MatchString(a.Test) || a.Kind != testKind(a.Test) || len(a.Input) > max || a.MaxBytes < 0 || a.MaxBytes > 1<<20 || len(a.Build) != 64 || a.Signature == "" {
+		return a, fmt.Errorf("invalid or unsupported replay artifact %s", path)
+	}
+	return a, nil
 }
-func corpusDir(pkg Package, test Test) string { return filepath.Join(pkg.Dir,"testdata","oak",test.Name) }
-func saveArtifact(pkg Package, test Test, a Artifact) (string,error) {
- data,err:=json.MarshalIndent(a,"","  "); if err!=nil{return "",err};data=append(data,'\n')
- sum:=sha256.Sum256(data)
- dir:=corpusDir(pkg,test)
- if err:=os.MkdirAll(dir,0755);err!=nil{return "",err}
- path:=filepath.Join(dir,hex.EncodeToString(sum[:16])+".json")
- f,err:=os.CreateTemp(dir,".pending-*");if err!=nil{return "",err}
- temp:=f.Name();defer os.Remove(temp)
- if _,err:=f.Write(data);err!=nil{f.Close();return "",err}
- if err:=f.Close();err!=nil{return "",err}
- if err:=os.Rename(temp,path);err!=nil{return "",err}
- return path,nil
+func corpusDir(pkg Package, test Test) string {
+	return filepath.Join(pkg.Dir, "testdata", "oak", test.Name)
 }
-func loadCorpus(pkg Package,test Test,max int)([][]byte,error){
- entries,err:=os.ReadDir(corpusDir(pkg,test));if os.IsNotExist(err){return nil,nil};if err!=nil{return nil,err}
- var inputs [][]byte
- for _,entry:=range entries{
-  if entry.IsDir() || strings.HasPrefix(entry.Name(),"."){continue}
-  path:=filepath.Join(corpusDir(pkg,test),entry.Name())
-  switch filepath.Ext(entry.Name()){
-  case ".json":
-   a,err:=readArtifact(path,max);if err!=nil{return nil,err};if a.Test!=test.Name || a.Kind!=test.Kind{return nil,fmt.Errorf("corpus identity mismatch: %s",path)}
-   inputs=append(inputs,a.Input)
-  case ".bin":
-   f,err:=os.Open(path);if err!=nil{return nil,err};data,err:=io.ReadAll(io.LimitReader(f,int64(max)+1));f.Close();if err!=nil{return nil,err};if len(data)>max{return nil,fmt.Errorf("corpus input exceeds -max-bytes: %s",path)};inputs=append(inputs,data)
-  }
- }
- // ReadDir already sorts names; explicitly deduplicate by bytes, not build ID.
- seen:=map[string]bool{};var result [][]byte
- for _,input:=range inputs{if !seen[string(input)]{result=append(result,input);seen[string(input)]=true}}
- sort.Slice(result,func(i,j int)bool{return string(result[i])<string(result[j])})
- return result,nil
+func saveArtifact(pkg Package, test Test, a Artifact) (string, error) {
+	data, err := json.MarshalIndent(a, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	data = append(data, '\n')
+	sum := sha256.Sum256(data)
+	dir := corpusDir(pkg, test)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", err
+	}
+	path := filepath.Join(dir, hex.EncodeToString(sum[:16])+".json")
+	f, err := os.CreateTemp(dir, ".pending-*")
+	if err != nil {
+		return "", err
+	}
+	temp := f.Name()
+	defer os.Remove(temp)
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		return "", err
+	}
+	if err := os.Rename(temp, path); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+func loadCorpus(pkg Package, test Test, max int) ([][]byte, error) {
+	entries, err := os.ReadDir(corpusDir(pkg, test))
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var inputs [][]byte
+	for _, entry := range entries {
+		if entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+		path := filepath.Join(corpusDir(pkg, test), entry.Name())
+		switch filepath.Ext(entry.Name()) {
+		case ".json":
+			a, err := readArtifact(path, max)
+			if err != nil {
+				return nil, err
+			}
+			if a.Test != test.Name || a.Kind != test.Kind {
+				return nil, fmt.Errorf("corpus identity mismatch: %s", path)
+			}
+			inputs = append(inputs, a.Input)
+		case ".bin":
+			f, err := os.Open(path)
+			if err != nil {
+				return nil, err
+			}
+			data, err := io.ReadAll(io.LimitReader(f, int64(max)+1))
+			f.Close()
+			if err != nil {
+				return nil, err
+			}
+			if len(data) > max {
+				return nil, fmt.Errorf("corpus input exceeds -max-bytes: %s", path)
+			}
+			inputs = append(inputs, data)
+		}
+	}
+	// ReadDir already sorts names; explicitly deduplicate by bytes, not build ID.
+	seen := map[string]bool{}
+	var result [][]byte
+	for _, input := range inputs {
+		if !seen[string(input)] {
+			result = append(result, input)
+			seen[string(input)] = true
+		}
+	}
+	sort.Slice(result, func(i, j int) bool { return string(result[i]) < string(result[j]) })
+	return result, nil
 }

--- a/testrunner/engine_test.go
+++ b/testrunner/engine_test.go
@@ -1,51 +1,88 @@
 package testrunner
 
 import (
- "bytes"
- "context"
- "testing"
+	"bytes"
+	"context"
+	"testing"
 )
 
 func TestRandomKnownVector(t *testing.T) {
- r:=random{}
- if got:=r.next();got!=0xe220a8397b1dcdaf {t.Fatalf("splitmix64 changed: %x",got)}
- a,b:=randomFor(42,"PropertyA",7),randomFor(42,"PropertyA",7)
- for i:=0;i<100;i++{if a.next()!=b.next(){t.Fatal("replay drift")}}
+	r := random{}
+	if got := r.next(); got != 0xe220a8397b1dcdaf {
+		t.Fatalf("splitmix64 changed: %x", got)
+	}
+	a, b := randomFor(42, "PropertyA", 7), randomFor(42, "PropertyA", 7)
+	for i := 0; i < 100; i++ {
+		if a.next() != b.next() {
+			t.Fatal("replay drift")
+		}
+	}
 }
-func TestMinimizePreservesFailure(t *testing.T){
- predicate:=func(input []byte)bool{for _,v:=range input{if v>=7{return true}};return false}
- input:=[]byte{1,2,255,4,5}
- best:=Minimize(context.Background(),input,200,predicate)
- if !bytes.Equal(best,[]byte{7}){t.Fatalf("got %v, want [7]",best)}
- if !bytes.Equal(input,[]byte{1,2,255,4,5}){t.Fatal("mutated original")}
+func TestMinimizePreservesFailure(t *testing.T) {
+	predicate := func(input []byte) bool {
+		for _, v := range input {
+			if v >= 7 {
+				return true
+			}
+		}
+		return false
+	}
+	input := []byte{1, 2, 255, 4, 5}
+	best := Minimize(context.Background(), input, 200, predicate)
+	if !bytes.Equal(best, []byte{7}) {
+		t.Fatalf("got %v, want [7]", best)
+	}
+	if !bytes.Equal(input, []byte{1, 2, 255, 4, 5}) {
+		t.Fatal("mutated original")
+	}
 }
-func TestMinimizeBudgetAndCancellation(t *testing.T){
- calls:=0
- predicate:=func([]byte)bool{calls++;return false}
- Minimize(context.Background(),[]byte{255,255},3,predicate)
- if calls!=3{t.Fatalf("calls %d",calls)}
- ctx,cancel:=context.WithCancel(context.Background());cancel()
- Minimize(ctx,[]byte{255},100,predicate)
- if calls!=3{t.Fatal("ignored cancellation")}
+func TestMinimizeBudgetAndCancellation(t *testing.T) {
+	calls := 0
+	predicate := func([]byte) bool { calls++; return false }
+	Minimize(context.Background(), []byte{255, 255}, 3, predicate)
+	if calls != 3 {
+		t.Fatalf("calls %d", calls)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	Minimize(ctx, []byte{255}, 100, predicate)
+	if calls != 3 {
+		t.Fatal("ignored cancellation")
+	}
 }
-func FuzzMinimize(t *testing.F){
- t.Add([]byte{0,1,7,255})
- t.Fuzz(func(t *testing.T,input []byte){
-  if len(input)>256{t.Skip()}
-  original:=append([]byte(nil),input...)
-  predicate:=func(data []byte)bool{return bytes.Contains(data,[]byte{7})}
-  best:=Minimize(context.Background(),input,100,predicate)
-  if predicate(input) && !predicate(best){t.Fatal("lost failure")}
-  if len(best)>len(input) || !bytes.Equal(input,original){t.Fatal("invalid shrink")}
- })
+func FuzzMinimize(t *testing.F) {
+	t.Add([]byte{0, 1, 7, 255})
+	t.Fuzz(func(t *testing.T, input []byte) {
+		if len(input) > 256 {
+			t.Skip()
+		}
+		original := append([]byte(nil), input...)
+		predicate := func(data []byte) bool { return bytes.Contains(data, []byte{7}) }
+		best := Minimize(context.Background(), input, 100, predicate)
+		if predicate(input) && !predicate(best) {
+			t.Fatal("lost failure")
+		}
+		if len(best) > len(input) || !bytes.Equal(input, original) {
+			t.Fatal("invalid shrink")
+		}
+	})
 }
-func FuzzMutationBounds(t *testing.F){
- t.Add(uint64(1),[]byte{0,255})
- t.Fuzz(func(t *testing.T,seed uint64,input []byte){
-  if len(input)>256{t.Skip()}
-  original:=append([]byte(nil),input...)
-  r:=random{state:seed}
-  for i:=0;i<20;i++{out:=mutate(&r,[][]byte{input},256);if len(out)>256{t.Fatal("unbounded mutation")}}
-  if !bytes.Equal(input,original){t.Fatal("mutated corpus")}
- })
+func FuzzMutationBounds(t *testing.F) {
+	t.Add(uint64(1), []byte{0, 255})
+	t.Fuzz(func(t *testing.T, seed uint64, input []byte) {
+		if len(input) > 256 {
+			t.Skip()
+		}
+		original := append([]byte(nil), input...)
+		r := random{state: seed}
+		for i := 0; i < 20; i++ {
+			out := mutate(&r, [][]byte{input}, 256)
+			if len(out) > 256 {
+				t.Fatal("unbounded mutation")
+			}
+		}
+		if !bytes.Equal(input, original) {
+			t.Fatal("mutated corpus")
+		}
+	})
 }

--- a/testrunner/engine_test.go
+++ b/testrunner/engine_test.go
@@ -1,0 +1,51 @@
+package testrunner
+
+import (
+ "bytes"
+ "context"
+ "testing"
+)
+
+func TestRandomKnownVector(t *testing.T) {
+ r:=random{}
+ if got:=r.next();got!=0xe220a8397b1dcdaf {t.Fatalf("splitmix64 changed: %x",got)}
+ a,b:=randomFor(42,"PropertyA",7),randomFor(42,"PropertyA",7)
+ for i:=0;i<100;i++{if a.next()!=b.next(){t.Fatal("replay drift")}}
+}
+func TestMinimizePreservesFailure(t *testing.T){
+ predicate:=func(input []byte)bool{for _,v:=range input{if v>=7{return true}};return false}
+ input:=[]byte{1,2,255,4,5}
+ best:=Minimize(context.Background(),input,200,predicate)
+ if !bytes.Equal(best,[]byte{7}){t.Fatalf("got %v, want [7]",best)}
+ if !bytes.Equal(input,[]byte{1,2,255,4,5}){t.Fatal("mutated original")}
+}
+func TestMinimizeBudgetAndCancellation(t *testing.T){
+ calls:=0
+ predicate:=func([]byte)bool{calls++;return false}
+ Minimize(context.Background(),[]byte{255,255},3,predicate)
+ if calls!=3{t.Fatalf("calls %d",calls)}
+ ctx,cancel:=context.WithCancel(context.Background());cancel()
+ Minimize(ctx,[]byte{255},100,predicate)
+ if calls!=3{t.Fatal("ignored cancellation")}
+}
+func FuzzMinimize(t *testing.F){
+ t.Add([]byte{0,1,7,255})
+ t.Fuzz(func(t *testing.T,input []byte){
+  if len(input)>256{t.Skip()}
+  original:=append([]byte(nil),input...)
+  predicate:=func(data []byte)bool{return bytes.Contains(data,[]byte{7})}
+  best:=Minimize(context.Background(),input,100,predicate)
+  if predicate(input) && !predicate(best){t.Fatal("lost failure")}
+  if len(best)>len(input) || !bytes.Equal(input,original){t.Fatal("invalid shrink")}
+ })
+}
+func FuzzMutationBounds(t *testing.F){
+ t.Add(uint64(1),[]byte{0,255})
+ t.Fuzz(func(t *testing.T,seed uint64,input []byte){
+  if len(input)>256{t.Skip()}
+  original:=append([]byte(nil),input...)
+  r:=random{state:seed}
+  for i:=0;i<20;i++{out:=mutate(&r,[][]byte{input},256);if len(out)>256{t.Fatal("unbounded mutation")}}
+  if !bytes.Equal(input,original){t.Fatal("mutated corpus")}
+ })
+}

--- a/testrunner/fuzz.go
+++ b/testrunner/fuzz.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-
 )
 
 // EmitFuzzHarness exports the checked C translation unit with a libFuzzer

--- a/testrunner/fuzz.go
+++ b/testrunner/fuzz.go
@@ -1,0 +1,52 @@
+package testrunner
+
+import (
+ "fmt"
+ "os"
+ "path/filepath"
+ "strings"
+
+ "github.com/SCKelemen/oak/compiler"
+)
+
+// EmitFuzzHarness exports the checked C translation unit with a libFuzzer
+// entry point. Clang instruments the production implementation itself.
+// Test code must reset all state on every invocation: libFuzzer is persistent.
+func EmitFuzzHarness(pkg Package, test Test, maxBytes int) (string, error) {
+ if test.Kind!="fuzz" || !cIdentifier.MatchString(test.Name) || maxBytes<0 || maxBytes>1<<20 { return "",fmt.Errorf("invalid fuzz harness target") }
+ generated,err:=compiler.New().WithSource(filepath.Join(pkg.Dir,"<oak-test-package>"),pkg.Source).EmitC().Get()
+ if err!=nil{return "",err}
+ var out strings.Builder
+ out.WriteString(`#include <stdint.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <setjmp.h>
+static jmp_buf oak_fuzz_discard;
+void oak_testing_fail(uint32_t id) {
+ fprintf(stderr, "Oak invariant %u failed\n", (unsigned)id);
+ abort();
+}
+void oak_testing_discard(void) { longjmp(oak_fuzz_discard, 1); }
+void oak_testing_classify(uint32_t id) { (void)id; }
+#define main oak_fuzz_application_entry
+`)
+ out.WriteString(generated)
+ out.WriteString("\n#undef main\n")
+ fmt.Fprintf(&out,`int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+ if (size > %d) return 0;
+ if (setjmp(oak_fuzz_discard)) return 0;
+ oak_%s((oak_view_u8){data, (u32)size});
+ return 0;
+}
+`,maxBytes,test.Name)
+ return out.String(),nil
+}
+
+func writeHarness(path, content string) error {
+ // O_EXCL prevents an export from destroying an existing source file.
+ f,err:=os.OpenFile(path,os.O_WRONLY|os.O_CREATE|os.O_EXCL,0644)
+ if err!=nil{return err}
+ if _,err:=f.WriteString(content);err!=nil{f.Close();os.Remove(path);return err}
+ return f.Close()
+}

--- a/testrunner/fuzz.go
+++ b/testrunner/fuzz.go
@@ -1,6 +1,7 @@
 package testrunner
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"os"
 	"strings"
@@ -11,14 +12,21 @@ import (
 // entry point. Clang instruments the production implementation itself.
 // Test code must reset all state on every invocation: libFuzzer is persistent.
 func EmitFuzzHarness(pkg Package, test Test, maxBytes int) (string, error) {
+	return emitFuzzHarness(pkg, test, maxBytes, nil)
+}
+
+func emitFuzzHarness(pkg Package, test Test, maxBytes int, adapter *nativeAdapter) (string, error) {
 	if test.Kind != "fuzz" || !cIdentifier.MatchString(test.Name) || maxBytes < 0 || maxBytes > 1<<20 {
 		return "", fmt.Errorf("invalid fuzz harness target")
 	}
-	generated, err := packageCompilation(pkg, nil).EmitC().Get()
+	generated, err := packageCompilation(pkg, adapter).EmitC().Get()
 	if err != nil {
 		return "", err
 	}
 	var out strings.Builder
+	if adapter != nil {
+		fmt.Fprintf(&out, "/* Trusted adapter manifest identity SHA-256: %x; link its pinned objects explicitly. */\n", sha256.Sum256([]byte(adapter.identity)))
+	}
 	out.WriteString(`#include <stdint.h>
 #include <stddef.h>
 #include <stdlib.h>

--- a/testrunner/fuzz.go
+++ b/testrunner/fuzz.go
@@ -1,52 +1,62 @@
 package testrunner
 
 import (
- "fmt"
- "os"
- "path/filepath"
- "strings"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 
- "github.com/SCKelemen/oak/compiler"
+	"github.com/SCKelemen/oak/compiler"
 )
 
 // EmitFuzzHarness exports the checked C translation unit with a libFuzzer
 // entry point. Clang instruments the production implementation itself.
 // Test code must reset all state on every invocation: libFuzzer is persistent.
 func EmitFuzzHarness(pkg Package, test Test, maxBytes int) (string, error) {
- if test.Kind!="fuzz" || !cIdentifier.MatchString(test.Name) || maxBytes<0 || maxBytes>1<<20 { return "",fmt.Errorf("invalid fuzz harness target") }
- generated,err:=compiler.New().WithSource(filepath.Join(pkg.Dir,"<oak-test-package>"),pkg.Source).EmitC().Get()
- if err!=nil{return "",err}
- var out strings.Builder
- out.WriteString(`#include <stdint.h>
+	if test.Kind != "fuzz" || !cIdentifier.MatchString(test.Name) || maxBytes < 0 || maxBytes > 1<<20 {
+		return "", fmt.Errorf("invalid fuzz harness target")
+	}
+	generated, err := compiler.New().WithSource(filepath.Join(pkg.Dir, "<oak-test-package>"), pkg.Source).EmitC().Get()
+	if err != nil {
+		return "", err
+	}
+	var out strings.Builder
+	out.WriteString(`#include <stdint.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <setjmp.h>
 static jmp_buf oak_fuzz_discard;
-void oak_testing_fail(uint32_t id) {
+void oak_test_host_fail(uint32_t id) {
  fprintf(stderr, "Oak invariant %u failed\n", (unsigned)id);
  abort();
 }
-void oak_testing_discard(void) { longjmp(oak_fuzz_discard, 1); }
-void oak_testing_classify(uint32_t id) { (void)id; }
+void oak_test_host_discard(void) { longjmp(oak_fuzz_discard, 1); }
+void oak_test_host_classify(uint32_t id) { (void)id; }
 #define main oak_fuzz_application_entry
 `)
- out.WriteString(generated)
- out.WriteString("\n#undef main\n")
- fmt.Fprintf(&out,`int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+	out.WriteString(generated)
+	out.WriteString("\n#undef main\n")
+	fmt.Fprintf(&out, `int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
  if (size > %d) return 0;
  if (setjmp(oak_fuzz_discard)) return 0;
  oak_%s((oak_view_u8){data, (u32)size});
  return 0;
 }
-`,maxBytes,test.Name)
- return out.String(),nil
+`, maxBytes, test.Name)
+	return out.String(), nil
 }
 
 func writeHarness(path, content string) error {
- // O_EXCL prevents an export from destroying an existing source file.
- f,err:=os.OpenFile(path,os.O_WRONLY|os.O_CREATE|os.O_EXCL,0644)
- if err!=nil{return err}
- if _,err:=f.WriteString(content);err!=nil{f.Close();os.Remove(path);return err}
- return f.Close()
+	// O_EXCL prevents an export from destroying an existing source file.
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
+	if err != nil {
+		return err
+	}
+	if _, err := f.WriteString(content); err != nil {
+		f.Close()
+		os.Remove(path)
+		return err
+	}
+	return f.Close()
 }

--- a/testrunner/fuzz.go
+++ b/testrunner/fuzz.go
@@ -3,10 +3,8 @@ package testrunner
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
-	"github.com/SCKelemen/oak/compiler"
 )
 
 // EmitFuzzHarness exports the checked C translation unit with a libFuzzer
@@ -16,7 +14,7 @@ func EmitFuzzHarness(pkg Package, test Test, maxBytes int) (string, error) {
 	if test.Kind != "fuzz" || !cIdentifier.MatchString(test.Name) || maxBytes < 0 || maxBytes > 1<<20 {
 		return "", fmt.Errorf("invalid fuzz harness target")
 	}
-	generated, err := compiler.New().WithSource(filepath.Join(pkg.Dir, "<oak-test-package>"), pkg.Source).EmitC().Get()
+	generated, err := packageCompilation(pkg, nil).EmitC().Get()
 	if err != nil {
 		return "", err
 	}

--- a/testrunner/native.go
+++ b/testrunner/native.go
@@ -1,0 +1,148 @@
+package testrunner
+
+import (
+ "bytes"
+ "context"
+ "crypto/sha256"
+ "encoding/hex"
+ "fmt"
+ "io"
+ "os"
+ "os/exec"
+ "path/filepath"
+ "strconv"
+ "strings"
+ "time"
+
+ "github.com/SCKelemen/oak/compiler"
+)
+
+const engineVersion = "oak-test-v1-splitmix64-choice-bytes"
+const outputLimit = 64 * 1024
+
+type limitedBuffer struct { bytes.Buffer; truncated bool }
+func (b *limitedBuffer) Write(p []byte) (int, error) {
+ n := len(p)
+ room := outputLimit - b.Len()
+ if len(p) > room { b.truncated = true; p = p[:room] }
+ _, _ = b.Buffer.Write(p)
+ return n, nil
+}
+func (b *limitedBuffer) text() string { s := b.String(); if b.truncated { s += "\n[output truncated]" }; return s }
+
+type nativeProgram struct { bin, dir, build string; maxBytes int; timeout time.Duration }
+type outcome struct { status, signature, output string; classes map[uint32]bool }
+
+func buildNative(pkg Package, cfg Config) (*nativeProgram, error) {
+ dir, err := os.MkdirTemp("", "oak-test-*")
+ if err != nil { return nil, err }
+ keep := false
+ defer func() { if !keep { _ = os.RemoveAll(dir) } }()
+ generated, err := compiler.New().WithSource(filepath.Join(pkg.Dir, "<oak-test-package>"), pkg.Source).EmitC().Get()
+ if err != nil { return nil, err }
+ var source strings.Builder
+ source.WriteString(nativePreamble)
+ source.WriteString("\n#define main oak_test_application_entry\n")
+ source.WriteString(generated)
+ source.WriteString("\n#undef main\n")
+ fmt.Fprintf(&source, `
+int main(int argc, char **argv) {
+ if (argc != 3) return 120;
+ oak_test_report = fopen(argv[2], "w");
+ if (!oak_test_report) return 121;
+ unsigned char *data = calloc(%d + 1u, 1u);
+ if (!data) return 122;
+ size_t size = fread(data, 1, %d + 1u, stdin);
+ if (ferror(stdin) || size > %d) return 123;
+ switch (strtol(argv[1], NULL, 10)) {
+`, cfg.MaxBytes, cfg.MaxBytes, cfg.MaxBytes)
+ for i, test := range pkg.Registry {
+  fmt.Fprintf(&source, "case %d: oak_%s(", i, test.Name)
+  if test.Kind != "unit" { source.WriteString("(oak_view_u8){data, (u32)size}") }
+  source.WriteString("); break;\n")
+ }
+ source.WriteString("default: return 124;\n}\nfputs(\"pass\\n\", oak_test_report);\nfclose(oak_test_report);\nfree(data);\nreturn 0;\n}\n")
+ cpath := filepath.Join(dir, "test.c")
+ if err := os.WriteFile(cpath, []byte(source.String()), 0600); err != nil { return nil, err }
+ cc, err := exec.LookPath(cfg.CC)
+ if err != nil { return nil, err }
+ flags := []string{"-std=c11", "-O1", "-g"}
+ if cfg.Sanitize { flags = append(flags, "-fsanitize=address,undefined", "-fno-sanitize-recover=all", "-fno-omit-frame-pointer") }
+ args := append(append([]string{}, flags...), "-o", filepath.Join(dir, "test"), cpath)
+ ctx, cancel := context.WithTimeout(context.Background(), cfg.BuildTimeout)
+ defer cancel()
+ var output limitedBuffer
+ cmd := exec.CommandContext(ctx, cc, args...)
+ cmd.Stdout, cmd.Stderr = &output, &output
+ if err := cmd.Run(); err != nil { return nil, fmt.Errorf("C compilation: %w\n%s", err, output.text()) }
+ version := exec.CommandContext(ctx, cc, "--version")
+ var versionOutput limitedBuffer
+ version.Stdout, version.Stderr = &versionOutput, &versionOutput
+ if err := version.Run(); err != nil { return nil, fmt.Errorf("C compiler identity: %w", err) }
+ // Generated C captures compiler/lowering changes; flags and compiler identity
+ // prevent replay under a silently different native build.
+ hash := sha256.Sum256([]byte(engineVersion + "\n" + source.String() + "\n" + strings.Join(flags, " ") + "\n" + versionOutput.String()))
+ keep = true
+ return &nativeProgram{bin:filepath.Join(dir,"test"),dir:dir,build:hex.EncodeToString(hash[:]), maxBytes:cfg.MaxBytes,timeout:cfg.Timeout}, nil
+}
+
+const nativePreamble = `
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+static FILE *oak_test_report;
+void oak_testing_fail(uint32_t id) {
+ if (oak_test_report) { fprintf(oak_test_report, "fail %u\n", (unsigned)id); fflush(oak_test_report); }
+ exit(101);
+}
+void oak_testing_discard(void) {
+ if (oak_test_report) { fputs("discard\n", oak_test_report); fflush(oak_test_report); }
+ exit(102);
+}
+void oak_testing_classify(uint32_t id) {
+ if (oak_test_report) { fprintf(oak_test_report, "class %u\n", (unsigned)id); fflush(oak_test_report); }
+}
+`
+
+func (p *nativeProgram) run(index int, input []byte) outcome {
+ result := outcome{status:"fail", classes:map[uint32]bool{}}
+ if len(input) > p.maxBytes { result.signature = "harness:input-too-large"; return result }
+ reportPath := filepath.Join(p.dir, "report")
+ _ = os.Remove(reportPath)
+ ctx, cancel := context.WithTimeout(context.Background(), p.timeout)
+ defer cancel()
+ cmd := exec.CommandContext(ctx, p.bin, strconv.Itoa(index), reportPath)
+ cmd.Stdin = bytes.NewReader(input)
+ var output limitedBuffer
+ cmd.Stdout, cmd.Stderr = &output, &output
+ // Bound pipe draining too: a descendant must not keep the runner waiting.
+ cmd.WaitDelay = 100 * time.Millisecond
+ err := cmd.Run()
+ result.output = output.text()
+ if ctx.Err() != nil { result.signature = "timeout"; return result }
+ var report []byte
+ if f, openErr := os.Open(reportPath); openErr == nil {
+  report, _ = io.ReadAll(io.LimitReader(f, outputLimit+1)); _ = f.Close()
+ }
+ if len(report) > outputLimit { result.signature = "harness:report-limit"; return result }
+ terminal := ""
+ for _, line := range strings.Split(strings.TrimSpace(string(report)), "\n") {
+  fields := strings.Fields(line)
+  if len(fields) == 0 { continue }
+  if len(fields) == 2 && (fields[0] == "class" || fields[0] == "fail") {
+   id, e := strconv.ParseUint(fields[1], 10, 32)
+   if e != nil { result.signature = "harness:bad-report"; return result }
+   if fields[0] == "class" { result.classes[uint32(id)] = true } else { terminal = "fail"; result.signature = "invariant:" + fields[1] }
+  } else if len(fields) == 1 && (fields[0] == "pass" || fields[0] == "discard") { terminal = fields[0] } else { result.signature = "harness:bad-report"; return result }
+ }
+ if err == nil && terminal == "pass" { result.status = "pass"; return result }
+ if exit, ok := err.(*exec.ExitError); ok {
+  if exit.ExitCode() == 102 && terminal == "discard" { result.status = "discard"; return result }
+  if exit.ExitCode() == 101 && terminal == "fail" { return result }
+  result.signature = "exit:" + exit.ProcessState.String()
+  return result
+ }
+ result.signature = "harness:missing-result"
+ if err != nil { result.output += "\n"+err.Error() }
+ return result
+}

--- a/testrunner/native.go
+++ b/testrunner/native.go
@@ -131,15 +131,15 @@ const nativePreamble = `
 #include <stdlib.h>
 #include <stdint.h>
 static FILE *oak_test_report;
-void oak_testing_fail(uint32_t id) {
+void oak_test_host_fail(uint32_t id) {
  if (oak_test_report) { fprintf(oak_test_report, "fail %u\n", (unsigned)id); fflush(oak_test_report); }
  exit(101);
 }
-void oak_testing_discard(void) {
+void oak_test_host_discard(void) {
  if (oak_test_report) { fputs("discard\n", oak_test_report); fflush(oak_test_report); }
  exit(102);
 }
-void oak_testing_classify(uint32_t id) {
+void oak_test_host_classify(uint32_t id) {
  if (oak_test_report) { fprintf(oak_test_report, "class %u\n", (unsigned)id); fflush(oak_test_report); }
 }
 `

--- a/testrunner/native.go
+++ b/testrunner/native.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/SCKelemen/oak/compiler"
 )
 
 const engineVersion = "oak-test-v1-splitmix64-choice-bytes"
@@ -64,7 +63,9 @@ func buildNative(pkg Package, cfg Config) (*nativeProgram, error) {
 			_ = os.RemoveAll(dir)
 		}
 	}()
-	generated, err := compiler.New().WithSource(filepath.Join(pkg.Dir, "<oak-test-package>"), pkg.Source).EmitC().Get()
+	adapter, err := loadAdapter(cfg.Adapter)
+	if err != nil { return nil, err }
+	generated, err := packageCompilation(pkg, adapter).EmitC().Get()
 	if err != nil {
 		return nil, err
 	}
@@ -105,6 +106,15 @@ int main(int argc, char **argv) {
 		flags = append(flags, "-fsanitize=address,undefined", "-fno-sanitize-recover=all", "-fno-omit-frame-pointer")
 	}
 	args := append(append([]string{}, flags...), "-o", filepath.Join(dir, "test"), cpath)
+	adapterIdentity := ""
+	if adapter != nil {
+		adapterIdentity = adapter.identity
+		for i, data := range adapter.objects {
+			path := filepath.Join(dir, fmt.Sprintf("adapter-%d%s", i, filepath.Ext(adapter.manifest.Objects[i].Path)))
+			if err := os.WriteFile(path, data, 0600); err != nil { return nil, err }
+			args = append(args, path)
+		}
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.BuildTimeout)
 	defer cancel()
 	var output limitedBuffer
@@ -121,7 +131,7 @@ int main(int argc, char **argv) {
 	}
 	// Generated C captures compiler/lowering changes; flags and compiler identity
 	// prevent replay under a silently different native build.
-	hash := sha256.Sum256([]byte(engineVersion + "\n" + source.String() + "\n" + strings.Join(flags, " ") + "\n" + versionOutput.String()))
+	hash := sha256.Sum256([]byte(engineVersion + "\n" + source.String() + "\n" + strings.Join(flags, " ") + "\n" + versionOutput.String() + "\nadapter-v1:" + adapterIdentity))
 	keep = true
 	return &nativeProgram{bin: filepath.Join(dir, "test"), dir: dir, build: hex.EncodeToString(hash[:]), maxBytes: cfg.MaxBytes, timeout: cfg.Timeout}, nil
 }

--- a/testrunner/native.go
+++ b/testrunner/native.go
@@ -1,51 +1,79 @@
 package testrunner
 
 import (
- "bytes"
- "context"
- "crypto/sha256"
- "encoding/hex"
- "fmt"
- "io"
- "os"
- "os/exec"
- "path/filepath"
- "strconv"
- "strings"
- "time"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
 
- "github.com/SCKelemen/oak/compiler"
+	"github.com/SCKelemen/oak/compiler"
 )
 
 const engineVersion = "oak-test-v1-splitmix64-choice-bytes"
 const outputLimit = 64 * 1024
 
-type limitedBuffer struct { bytes.Buffer; truncated bool }
-func (b *limitedBuffer) Write(p []byte) (int, error) {
- n := len(p)
- room := outputLimit - b.Len()
- if len(p) > room { b.truncated = true; p = p[:room] }
- _, _ = b.Buffer.Write(p)
- return n, nil
+type limitedBuffer struct {
+	bytes.Buffer
+	truncated bool
 }
-func (b *limitedBuffer) text() string { s := b.String(); if b.truncated { s += "\n[output truncated]" }; return s }
 
-type nativeProgram struct { bin, dir, build string; maxBytes int; timeout time.Duration }
-type outcome struct { status, signature, output string; classes map[uint32]bool }
+func (b *limitedBuffer) Write(p []byte) (int, error) {
+	n := len(p)
+	room := outputLimit - b.Len()
+	if len(p) > room {
+		b.truncated = true
+		p = p[:room]
+	}
+	_, _ = b.Buffer.Write(p)
+	return n, nil
+}
+func (b *limitedBuffer) text() string {
+	s := b.String()
+	if b.truncated {
+		s += "\n[output truncated]"
+	}
+	return s
+}
+
+type nativeProgram struct {
+	bin, dir, build string
+	maxBytes        int
+	timeout         time.Duration
+}
+type outcome struct {
+	status, signature, output string
+	classes                   map[uint32]bool
+}
 
 func buildNative(pkg Package, cfg Config) (*nativeProgram, error) {
- dir, err := os.MkdirTemp("", "oak-test-*")
- if err != nil { return nil, err }
- keep := false
- defer func() { if !keep { _ = os.RemoveAll(dir) } }()
- generated, err := compiler.New().WithSource(filepath.Join(pkg.Dir, "<oak-test-package>"), pkg.Source).EmitC().Get()
- if err != nil { return nil, err }
- var source strings.Builder
- source.WriteString(nativePreamble)
- source.WriteString("\n#define main oak_test_application_entry\n")
- source.WriteString(generated)
- source.WriteString("\n#undef main\n")
- fmt.Fprintf(&source, `
+	dir, err := os.MkdirTemp("", "oak-test-*")
+	if err != nil {
+		return nil, err
+	}
+	keep := false
+	defer func() {
+		if !keep {
+			_ = os.RemoveAll(dir)
+		}
+	}()
+	generated, err := compiler.New().WithSource(filepath.Join(pkg.Dir, "<oak-test-package>"), pkg.Source).EmitC().Get()
+	if err != nil {
+		return nil, err
+	}
+	var source strings.Builder
+	source.WriteString(nativePreamble)
+	source.WriteString("\n#define main oak_test_application_entry\n")
+	source.WriteString(generated)
+	source.WriteString("\n#undef main\n")
+	fmt.Fprintf(&source, `
 int main(int argc, char **argv) {
  if (argc != 3) return 120;
  oak_test_report = fopen(argv[2], "w");
@@ -56,34 +84,46 @@ int main(int argc, char **argv) {
  if (ferror(stdin) || size > %d) return 123;
  switch (strtol(argv[1], NULL, 10)) {
 `, cfg.MaxBytes, cfg.MaxBytes, cfg.MaxBytes)
- for i, test := range pkg.Registry {
-  fmt.Fprintf(&source, "case %d: oak_%s(", i, test.Name)
-  if test.Kind != "unit" { source.WriteString("(oak_view_u8){data, (u32)size}") }
-  source.WriteString("); break;\n")
- }
- source.WriteString("default: return 124;\n}\nfputs(\"pass\\n\", oak_test_report);\nfclose(oak_test_report);\nfree(data);\nreturn 0;\n}\n")
- cpath := filepath.Join(dir, "test.c")
- if err := os.WriteFile(cpath, []byte(source.String()), 0600); err != nil { return nil, err }
- cc, err := exec.LookPath(cfg.CC)
- if err != nil { return nil, err }
- flags := []string{"-std=c11", "-O1", "-g"}
- if cfg.Sanitize { flags = append(flags, "-fsanitize=address,undefined", "-fno-sanitize-recover=all", "-fno-omit-frame-pointer") }
- args := append(append([]string{}, flags...), "-o", filepath.Join(dir, "test"), cpath)
- ctx, cancel := context.WithTimeout(context.Background(), cfg.BuildTimeout)
- defer cancel()
- var output limitedBuffer
- cmd := exec.CommandContext(ctx, cc, args...)
- cmd.Stdout, cmd.Stderr = &output, &output
- if err := cmd.Run(); err != nil { return nil, fmt.Errorf("C compilation: %w\n%s", err, output.text()) }
- version := exec.CommandContext(ctx, cc, "--version")
- var versionOutput limitedBuffer
- version.Stdout, version.Stderr = &versionOutput, &versionOutput
- if err := version.Run(); err != nil { return nil, fmt.Errorf("C compiler identity: %w", err) }
- // Generated C captures compiler/lowering changes; flags and compiler identity
- // prevent replay under a silently different native build.
- hash := sha256.Sum256([]byte(engineVersion + "\n" + source.String() + "\n" + strings.Join(flags, " ") + "\n" + versionOutput.String()))
- keep = true
- return &nativeProgram{bin:filepath.Join(dir,"test"),dir:dir,build:hex.EncodeToString(hash[:]), maxBytes:cfg.MaxBytes,timeout:cfg.Timeout}, nil
+	for i, test := range pkg.Registry {
+		fmt.Fprintf(&source, "case %d: oak_%s(", i, test.Name)
+		if test.Kind != "unit" {
+			source.WriteString("(oak_view_u8){data, (u32)size}")
+		}
+		source.WriteString("); break;\n")
+	}
+	source.WriteString("default: return 124;\n}\nfputs(\"pass\\n\", oak_test_report);\nfclose(oak_test_report);\nfree(data);\nreturn 0;\n}\n")
+	cpath := filepath.Join(dir, "test.c")
+	if err := os.WriteFile(cpath, []byte(source.String()), 0600); err != nil {
+		return nil, err
+	}
+	cc, err := exec.LookPath(cfg.CC)
+	if err != nil {
+		return nil, err
+	}
+	flags := []string{"-std=c11", "-O1", "-g"}
+	if cfg.Sanitize {
+		flags = append(flags, "-fsanitize=address,undefined", "-fno-sanitize-recover=all", "-fno-omit-frame-pointer")
+	}
+	args := append(append([]string{}, flags...), "-o", filepath.Join(dir, "test"), cpath)
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.BuildTimeout)
+	defer cancel()
+	var output limitedBuffer
+	cmd := exec.CommandContext(ctx, cc, args...)
+	cmd.Stdout, cmd.Stderr = &output, &output
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("C compilation: %w\n%s", err, output.text())
+	}
+	version := exec.CommandContext(ctx, cc, "--version")
+	var versionOutput limitedBuffer
+	version.Stdout, version.Stderr = &versionOutput, &versionOutput
+	if err := version.Run(); err != nil {
+		return nil, fmt.Errorf("C compiler identity: %w", err)
+	}
+	// Generated C captures compiler/lowering changes; flags and compiler identity
+	// prevent replay under a silently different native build.
+	hash := sha256.Sum256([]byte(engineVersion + "\n" + source.String() + "\n" + strings.Join(flags, " ") + "\n" + versionOutput.String()))
+	keep = true
+	return &nativeProgram{bin: filepath.Join(dir, "test"), dir: dir, build: hex.EncodeToString(hash[:]), maxBytes: cfg.MaxBytes, timeout: cfg.Timeout}, nil
 }
 
 const nativePreamble = `
@@ -105,44 +145,79 @@ void oak_testing_classify(uint32_t id) {
 `
 
 func (p *nativeProgram) run(index int, input []byte) outcome {
- result := outcome{status:"fail", classes:map[uint32]bool{}}
- if len(input) > p.maxBytes { result.signature = "harness:input-too-large"; return result }
- reportPath := filepath.Join(p.dir, "report")
- _ = os.Remove(reportPath)
- ctx, cancel := context.WithTimeout(context.Background(), p.timeout)
- defer cancel()
- cmd := exec.CommandContext(ctx, p.bin, strconv.Itoa(index), reportPath)
- cmd.Stdin = bytes.NewReader(input)
- var output limitedBuffer
- cmd.Stdout, cmd.Stderr = &output, &output
- // Bound pipe draining too: a descendant must not keep the runner waiting.
- cmd.WaitDelay = 100 * time.Millisecond
- err := cmd.Run()
- result.output = output.text()
- if ctx.Err() != nil { result.signature = "timeout"; return result }
- var report []byte
- if f, openErr := os.Open(reportPath); openErr == nil {
-  report, _ = io.ReadAll(io.LimitReader(f, outputLimit+1)); _ = f.Close()
- }
- if len(report) > outputLimit { result.signature = "harness:report-limit"; return result }
- terminal := ""
- for _, line := range strings.Split(strings.TrimSpace(string(report)), "\n") {
-  fields := strings.Fields(line)
-  if len(fields) == 0 { continue }
-  if len(fields) == 2 && (fields[0] == "class" || fields[0] == "fail") {
-   id, e := strconv.ParseUint(fields[1], 10, 32)
-   if e != nil { result.signature = "harness:bad-report"; return result }
-   if fields[0] == "class" { result.classes[uint32(id)] = true } else { terminal = "fail"; result.signature = "invariant:" + fields[1] }
-  } else if len(fields) == 1 && (fields[0] == "pass" || fields[0] == "discard") { terminal = fields[0] } else { result.signature = "harness:bad-report"; return result }
- }
- if err == nil && terminal == "pass" { result.status = "pass"; return result }
- if exit, ok := err.(*exec.ExitError); ok {
-  if exit.ExitCode() == 102 && terminal == "discard" { result.status = "discard"; return result }
-  if exit.ExitCode() == 101 && terminal == "fail" { return result }
-  result.signature = "exit:" + exit.ProcessState.String()
-  return result
- }
- result.signature = "harness:missing-result"
- if err != nil { result.output += "\n"+err.Error() }
- return result
+	result := outcome{status: "fail", classes: map[uint32]bool{}}
+	if len(input) > p.maxBytes {
+		result.signature = "harness:input-too-large"
+		return result
+	}
+	reportPath := filepath.Join(p.dir, "report")
+	_ = os.Remove(reportPath)
+	ctx, cancel := context.WithTimeout(context.Background(), p.timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, p.bin, strconv.Itoa(index), reportPath)
+	cmd.Stdin = bytes.NewReader(input)
+	var output limitedBuffer
+	cmd.Stdout, cmd.Stderr = &output, &output
+	// Bound pipe draining too: a descendant must not keep the runner waiting.
+	cmd.WaitDelay = 100 * time.Millisecond
+	err := cmd.Run()
+	result.output = output.text()
+	if ctx.Err() != nil {
+		result.signature = "timeout"
+		return result
+	}
+	var report []byte
+	if f, openErr := os.Open(reportPath); openErr == nil {
+		report, _ = io.ReadAll(io.LimitReader(f, outputLimit+1))
+		_ = f.Close()
+	}
+	if len(report) > outputLimit {
+		result.signature = "harness:report-limit"
+		return result
+	}
+	terminal := ""
+	for _, line := range strings.Split(strings.TrimSpace(string(report)), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		if len(fields) == 2 && (fields[0] == "class" || fields[0] == "fail") {
+			id, e := strconv.ParseUint(fields[1], 10, 32)
+			if e != nil {
+				result.signature = "harness:bad-report"
+				return result
+			}
+			if fields[0] == "class" {
+				result.classes[uint32(id)] = true
+			} else {
+				terminal = "fail"
+				result.signature = "invariant:" + fields[1]
+			}
+		} else if len(fields) == 1 && (fields[0] == "pass" || fields[0] == "discard") {
+			terminal = fields[0]
+		} else {
+			result.signature = "harness:bad-report"
+			return result
+		}
+	}
+	if err == nil && terminal == "pass" {
+		result.status = "pass"
+		return result
+	}
+	if exit, ok := err.(*exec.ExitError); ok {
+		if exit.ExitCode() == 102 && terminal == "discard" {
+			result.status = "discard"
+			return result
+		}
+		if exit.ExitCode() == 101 && terminal == "fail" {
+			return result
+		}
+		result.signature = "exit:" + exit.ProcessState.String()
+		return result
+	}
+	result.signature = "harness:missing-result"
+	if err != nil {
+		result.output += "\n" + err.Error()
+	}
+	return result
 }

--- a/testrunner/native.go
+++ b/testrunner/native.go
@@ -13,7 +13,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
 )
 
 const engineVersion = "oak-test-v1-splitmix64-choice-bytes"
@@ -64,7 +63,9 @@ func buildNative(pkg Package, cfg Config) (*nativeProgram, error) {
 		}
 	}()
 	adapter, err := loadAdapter(cfg.Adapter)
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	generated, err := packageCompilation(pkg, adapter).EmitC().Get()
 	if err != nil {
 		return nil, err
@@ -111,7 +112,9 @@ int main(int argc, char **argv) {
 		adapterIdentity = adapter.identity
 		for i, data := range adapter.objects {
 			path := filepath.Join(dir, fmt.Sprintf("adapter-%d%s", i, filepath.Ext(adapter.manifest.Objects[i].Path)))
-			if err := os.WriteFile(path, data, 0600); err != nil { return nil, err }
+			if err := os.WriteFile(path, data, 0600); err != nil {
+				return nil, err
+			}
 			args = append(args, path)
 		}
 	}

--- a/testrunner/runner.go
+++ b/testrunner/runner.go
@@ -14,6 +14,7 @@ import (
 )
 
 type Config struct {
+	Adapter                              string
 	EmitFuzz                             string
 	CC                                   string
 	Runs, MaxBytes, Shrink, MaxDiscards  int
@@ -47,6 +48,7 @@ func Main(args []string, stdout, stderr io.Writer) int {
 	flags := flag.NewFlagSet("oak test", flag.ContinueOnError)
 	flags.SetOutput(stderr)
 	flags.StringVar(&cfg.CC, "cc", cfg.CC, "C compiler executable")
+	flags.StringVar(&cfg.Adapter, "adapter", "", "trusted deterministic native adapter manifest (also required for replay)")
 	flags.IntVar(&cfg.Runs, "runs", cfg.Runs, "accepted generated cases per property/simulation/fuzz campaign")
 	flags.IntVar(&cfg.MaxBytes, "max-bytes", cfg.MaxBytes, "maximum input/choice-tape bytes (0..1048576)")
 	flags.Uint64Var(&cfg.Seed, "seed", cfg.Seed, "reproducible root seed")
@@ -79,8 +81,8 @@ func Main(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "invalid test configuration")
 		return 2
 	}
-	if cfg.EmitFuzz != "" && (cfg.Fuzz == "" || cfg.Replay != "" || cfg.List) {
-		fmt.Fprintln(stderr, "-emit-fuzz-harness requires -fuzz and cannot combine with replay/list")
+	if cfg.EmitFuzz != "" && (cfg.Fuzz == "" || cfg.Replay != "" || cfg.List || cfg.Adapter != "") {
+		fmt.Fprintln(stderr, "-emit-fuzz-harness requires -fuzz and cannot combine with replay/list/adapter; export then link native dependencies explicitly")
 		return 2
 	}
 	run, err := regexp.Compile(cfg.Run)
@@ -182,7 +184,9 @@ func Main(args []string, stdout, stderr io.Writer) int {
 				fmt.Fprintln(stdout, "  "+result.Failure)
 			}
 			if result.Artifact != "" {
-				fmt.Fprintf(stdout, "  replay: oak test -replay %q %q\n", result.Artifact, result.Package)
+				adapterFlag := ""
+				if cfg.Adapter != "" { adapterFlag = fmt.Sprintf(" -adapter %q", cfg.Adapter) }
+				fmt.Fprintf(stdout, "  replay: oak test%s -replay %q %q\n", adapterFlag, result.Artifact, result.Package)
 			}
 			if result.Output != "" {
 				fmt.Fprintln(stdout, result.Output)

--- a/testrunner/runner.go
+++ b/testrunner/runner.go
@@ -110,6 +110,7 @@ func Main(args []string, stdout, stderr io.Writer) int {
 			fmt.Fprintln(stderr, err)
 			return 2
 		}
+		cfg.Timeout = time.Duration(a.TimeoutNanos)
 		cfg.MaxBytes = a.MaxBytes
 		cfg.Sanitize = a.Sanitize
 		replay = &a
@@ -213,8 +214,10 @@ func Main(args []string, stdout, stderr io.Writer) int {
 				}
 			}
 			result := runTest(pkg, test, index, native, cfg, cover, replay)
-			if result.Status == "error" { code = 2 }
-   if result.Status != "pass" && code == 0 {
+			if result.Status == "error" {
+				code = 2
+			}
+			if result.Status != "pass" && code == 0 {
 				code = 1
 			}
 			emit(result)
@@ -313,7 +316,7 @@ func runTest(pkg Package, test Test, index int, native *nativeProgram, cfg Confi
 				cancel()
 			}
 		}
-		artifact := Artifact{Version: 1, Engine: engineVersion, Test: test.Name, Kind: test.Kind, Build: native.build, Seed: cfg.Seed, Attempt: attempt, MaxBytes: cfg.MaxBytes, Sanitize: cfg.Sanitize, Signature: out.signature, Input: best}
+		artifact := Artifact{TimeoutNanos: int64(cfg.Timeout), Version: 1, Engine: engineVersion, Test: test.Name, Kind: test.Kind, Build: native.build, Seed: cfg.Seed, Attempt: attempt, MaxBytes: cfg.MaxBytes, Sanitize: cfg.Sanitize, Signature: out.signature, Input: best}
 		path, err := saveArtifact(pkg, test, artifact)
 		if err != nil {
 			result.Failure += "; cannot save failure: " + err.Error()

--- a/testrunner/runner.go
+++ b/testrunner/runner.go
@@ -81,8 +81,8 @@ func Main(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "invalid test configuration")
 		return 2
 	}
-	if cfg.EmitFuzz != "" && (cfg.Fuzz == "" || cfg.Replay != "" || cfg.List || cfg.Adapter != "") {
-		fmt.Fprintln(stderr, "-emit-fuzz-harness requires -fuzz and cannot combine with replay/list/adapter; export then link native dependencies explicitly")
+	if cfg.EmitFuzz != "" && (cfg.Fuzz == "" || cfg.Replay != "" || cfg.List) {
+		fmt.Fprintln(stderr, "-emit-fuzz-harness requires -fuzz and cannot combine with replay/list")
 		return 2
 	}
 	run, err := regexp.Compile(cfg.Run)
@@ -152,7 +152,9 @@ func Main(args []string, stdout, stderr io.Writer) int {
 		}
 		for _, pkg := range packages {
 			if len(pkg.Tests) == 1 {
-				content, err := EmitFuzzHarness(pkg, pkg.Tests[0], cfg.MaxBytes)
+				adapter, err := loadAdapter(cfg.Adapter)
+				content := ""
+				if err == nil { content, err = emitFuzzHarness(pkg, pkg.Tests[0], cfg.MaxBytes, adapter) }
 				if err == nil {
 					err = writeHarness(cfg.EmitFuzz, content)
 				}

--- a/testrunner/runner.go
+++ b/testrunner/runner.go
@@ -154,7 +154,9 @@ func Main(args []string, stdout, stderr io.Writer) int {
 			if len(pkg.Tests) == 1 {
 				adapter, err := loadAdapter(cfg.Adapter)
 				content := ""
-				if err == nil { content, err = emitFuzzHarness(pkg, pkg.Tests[0], cfg.MaxBytes, adapter) }
+				if err == nil {
+					content, err = emitFuzzHarness(pkg, pkg.Tests[0], cfg.MaxBytes, adapter)
+				}
 				if err == nil {
 					err = writeHarness(cfg.EmitFuzz, content)
 				}
@@ -187,7 +189,9 @@ func Main(args []string, stdout, stderr io.Writer) int {
 			}
 			if result.Artifact != "" {
 				adapterFlag := ""
-				if cfg.Adapter != "" { adapterFlag = fmt.Sprintf(" -adapter %q", cfg.Adapter) }
+				if cfg.Adapter != "" {
+					adapterFlag = fmt.Sprintf(" -adapter %q", cfg.Adapter)
+				}
 				fmt.Fprintf(stdout, "  replay: oak test%s -replay %q %q\n", adapterFlag, result.Artifact, result.Package)
 			}
 			if result.Output != "" {

--- a/testrunner/runner.go
+++ b/testrunner/runner.go
@@ -1,188 +1,357 @@
 package testrunner
 
 import (
- "context"
- "encoding/json"
- "flag"
- "fmt"
- "io"
- "os"
- "regexp"
- "strconv"
- "strings"
- "time"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
 )
 
 type Config struct {
- CC string
- Runs, MaxBytes, Shrink, MaxDiscards int
- Seed uint64
- Timeout, BuildTimeout, ShrinkTimeout time.Duration
- Run, Fuzz, Sim, Replay string
- JSON, List, Verbose, Sanitize bool
- Cover string
+ EmitFuzz string
+	CC                                   string
+	Runs, MaxBytes, Shrink, MaxDiscards  int
+	Seed                                 uint64
+	Timeout, BuildTimeout, ShrinkTimeout time.Duration
+	Run, Fuzz, Sim, Replay               string
+	JSON, List, Verbose, Sanitize        bool
+	Cover                                string
 }
-func Defaults() Config { return Config{CC:"cc",Runs:100,MaxBytes:256,Shrink:200,Seed:1,Timeout:2*time.Second,BuildTimeout:time.Minute,ShrinkTimeout:10*time.Second,MaxDiscards:1000} }
+
+func Defaults() Config {
+	return Config{CC: "cc", Runs: 100, MaxBytes: 256, Shrink: 200, Seed: 1, Timeout: 2 * time.Second, BuildTimeout: time.Minute, ShrinkTimeout: 10 * time.Second, MaxDiscards: 1000}
+}
 
 type Result struct {
- Test
- Package string `json:"package"`
- Status string `json:"status"`
- Cases int `json:"cases"`
- Discards int `json:"discards"`
- Seed uint64 `json:"seed"`
- Failure string `json:"failure,omitempty"`
- Artifact string `json:"artifact,omitempty"`
- Output string `json:"output,omitempty"`
- Classes map[uint32]int `json:"classes,omitempty"`
+	Test
+	Package  string         `json:"package"`
+	Status   string         `json:"status"`
+	Cases    int            `json:"cases"`
+	Discards int            `json:"discards"`
+	Seed     uint64         `json:"seed"`
+	Failure  string         `json:"failure,omitempty"`
+	Artifact string         `json:"artifact,omitempty"`
+	Output   string         `json:"output,omitempty"`
+	Classes  map[uint32]int `json:"classes,omitempty"`
 }
 
 // Main is usable without os.Exit, including by CLI integration tests.
 func Main(args []string, stdout, stderr io.Writer) int {
- cfg:=Defaults()
- flags:=flag.NewFlagSet("oak test",flag.ContinueOnError);flags.SetOutput(stderr)
- flags.StringVar(&cfg.CC,"cc",cfg.CC,"C compiler executable")
- flags.IntVar(&cfg.Runs,"runs",cfg.Runs,"accepted generated cases per property/simulation/fuzz campaign")
- flags.IntVar(&cfg.MaxBytes,"max-bytes",cfg.MaxBytes,"maximum input/choice-tape bytes (0..1048576)")
- flags.Uint64Var(&cfg.Seed,"seed",cfg.Seed,"reproducible root seed")
- flags.IntVar(&cfg.Shrink,"shrink",cfg.Shrink,"maximum minimization executions; 0 disables")
- flags.IntVar(&cfg.MaxDiscards,"max-discards",cfg.MaxDiscards,"maximum rejected generated cases")
- flags.DurationVar(&cfg.Timeout,"timeout",cfg.Timeout,"per-case process timeout")
- flags.DurationVar(&cfg.BuildTimeout,"build-timeout",cfg.BuildTimeout,"per-package C compiler timeout")
- flags.DurationVar(&cfg.ShrinkTimeout,"shrink-timeout",cfg.ShrinkTimeout,"minimization time budget (plus at most one case timeout)")
- flags.StringVar(&cfg.Run,"run","","test name regular expression")
- flags.StringVar(&cfg.Fuzz,"fuzz","","fuzz target regular expression; enables mutation")
- flags.StringVar(&cfg.Sim,"sim","","simulation name regular expression")
- flags.StringVar(&cfg.Replay,"replay","","replay one saved artifact against its exact build")
- flags.StringVar(&cfg.Cover,"cover","","required class sample counts, e.g. 10:5,20:1 (per selected generated test)")
- flags.BoolVar(&cfg.JSON,"json",false,"emit one JSON result per test")
- flags.BoolVar(&cfg.List,"list",false,"list matching tests without compilation")
- flags.BoolVar(&cfg.Verbose,"v",false,"include successful test output")
- flags.BoolVar(&cfg.Sanitize,"sanitize",false,"enable native address and undefined-behavior sanitizers")
- flags.Usage=func(){fmt.Fprintln(stderr,"Usage: oak test [flags] [directory | ./... ...]\nFlags precede paths. Tests live in *_test.oak files.");flags.PrintDefaults()}
- if err:=flags.Parse(args);err!=nil {if err==flag.ErrHelp{return 0};return 2}
- if cfg.Runs<1 || cfg.Runs>1000000 || cfg.MaxBytes<0 || cfg.MaxBytes>1<<20 || cfg.Shrink<0 || cfg.MaxDiscards<0 || cfg.Timeout<=0 || cfg.BuildTimeout<=0 || cfg.ShrinkTimeout<=0 || cfg.Fuzz!="" && cfg.Sim!="" || cfg.Replay!="" && (cfg.Fuzz!="" || cfg.Sim!="" || cfg.Run!="" || cfg.List || cfg.Cover!="") {
-  fmt.Fprintln(stderr,"invalid test configuration");return 2
+	cfg := Defaults()
+	flags := flag.NewFlagSet("oak test", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	flags.StringVar(&cfg.CC, "cc", cfg.CC, "C compiler executable")
+	flags.IntVar(&cfg.Runs, "runs", cfg.Runs, "accepted generated cases per property/simulation/fuzz campaign")
+	flags.IntVar(&cfg.MaxBytes, "max-bytes", cfg.MaxBytes, "maximum input/choice-tape bytes (0..1048576)")
+	flags.Uint64Var(&cfg.Seed, "seed", cfg.Seed, "reproducible root seed")
+	flags.IntVar(&cfg.Shrink, "shrink", cfg.Shrink, "maximum minimization executions; 0 disables")
+	flags.IntVar(&cfg.MaxDiscards, "max-discards", cfg.MaxDiscards, "maximum rejected generated cases")
+	flags.DurationVar(&cfg.Timeout, "timeout", cfg.Timeout, "per-case process timeout")
+	flags.DurationVar(&cfg.BuildTimeout, "build-timeout", cfg.BuildTimeout, "per-package C compiler timeout")
+	flags.DurationVar(&cfg.ShrinkTimeout, "shrink-timeout", cfg.ShrinkTimeout, "minimization time budget (plus at most one case timeout)")
+	flags.StringVar(&cfg.Run, "run", "", "test name regular expression")
+	flags.StringVar(&cfg.EmitFuzz, "emit-fuzz-harness", "", "export one -fuzz target as a libFuzzer C harness (new file)")
+ flags.StringVar(&cfg.Fuzz, "fuzz", "", "fuzz target regular expression; enables mutation")
+	flags.StringVar(&cfg.Sim, "sim", "", "simulation name regular expression")
+	flags.StringVar(&cfg.Replay, "replay", "", "replay one saved artifact against its exact build")
+	flags.StringVar(&cfg.Cover, "cover", "", "required class sample counts, e.g. 10:5,20:1 (per selected generated test)")
+	flags.BoolVar(&cfg.JSON, "json", false, "emit one JSON result per test")
+	flags.BoolVar(&cfg.List, "list", false, "list matching tests without compilation")
+	flags.BoolVar(&cfg.Verbose, "v", false, "include successful test output")
+	flags.BoolVar(&cfg.Sanitize, "sanitize", false, "enable native address and undefined-behavior sanitizers")
+	flags.Usage = func() {
+		fmt.Fprintln(stderr, "Usage: oak test [flags] [directory | ./... ...]\nFlags precede paths. Tests live in *_test.oak files.")
+		flags.PrintDefaults()
+	}
+	if err := flags.Parse(args); err != nil {
+		if err == flag.ErrHelp {
+			return 0
+		}
+		return 2
+	}
+	if cfg.Runs < 1 || cfg.Runs > 1000000 || cfg.MaxBytes < 0 || cfg.MaxBytes > 1<<20 || cfg.Shrink < 0 || cfg.MaxDiscards < 0 || cfg.Timeout <= 0 || cfg.BuildTimeout <= 0 || cfg.ShrinkTimeout <= 0 || cfg.Fuzz != "" && cfg.Sim != "" || cfg.Replay != "" && (cfg.Fuzz != "" || cfg.Sim != "" || cfg.Run != "" || cfg.List || cfg.Cover != "") {
+		fmt.Fprintln(stderr, "invalid test configuration")
+		return 2
+	}
+	if cfg.EmitFuzz!="" && (cfg.Fuzz=="" || cfg.Replay!="" || cfg.List) {fmt.Fprintln(stderr,"-emit-fuzz-harness requires -fuzz and cannot combine with replay/list");return 2}
+ run, err := regexp.Compile(cfg.Run)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
+	fuzz, err := regexp.Compile(cfg.Fuzz)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
+	sim, err := regexp.Compile(cfg.Sim)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
+	cover, err := parseCover(cfg.Cover)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
+	var replay *Artifact
+	if cfg.Replay != "" {
+		a, err := readArtifact(cfg.Replay, 1<<20)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 2
+		}
+		cfg.MaxBytes = a.MaxBytes
+		cfg.Sanitize = a.Sanitize
+		replay = &a
+	}
+	packages, err := Discover(flags.Args())
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
+	matched := 0
+	for i := range packages {
+		var selected []Test
+		for _, test := range packages[i].Tests {
+			if !run.MatchString(test.Name) || cfg.Fuzz != "" && (test.Kind != "fuzz" || !fuzz.MatchString(test.Name)) || cfg.Sim != "" && (test.Kind != "simulation" || !sim.MatchString(test.Name)) {
+				continue
+			}
+			if replay != nil && (test.Name != replay.Test || test.Kind != replay.Kind) {
+				continue
+			}
+			selected = append(selected, test)
+			matched++
+		}
+		packages[i].Tests = selected
+	}
+	if matched == 0 {
+		fmt.Fprintln(stderr, "no matching Oak tests")
+		return 2
+	}
+	if replay != nil && matched != 1 {
+		fmt.Fprintln(stderr, "replay requires exactly one matching test; select its package directory")
+		return 2
+	}
+	if cfg.EmitFuzz!="" {
+  if matched!=1 {fmt.Fprintln(stderr,"fuzz export requires exactly one matching target");return 2}
+  for _,pkg:=range packages {if len(pkg.Tests)==1 {
+   content,err:=EmitFuzzHarness(pkg,pkg.Tests[0],cfg.MaxBytes)
+   if err==nil {err=writeHarness(cfg.EmitFuzz,content)}
+   if err!=nil {fmt.Fprintln(stderr,err);return 2}
+   if cfg.JSON {if err:=json.NewEncoder(stdout).Encode(map[string]string{"status":"exported","path":cfg.EmitFuzz});err!=nil{return 2}} else {fmt.Fprintln(stdout,"Exported "+cfg.EmitFuzz)}
+  }}
+  return 0
  }
- run,err:=regexp.Compile(cfg.Run);if err!=nil{fmt.Fprintln(stderr,err);return 2}
- fuzz,err:=regexp.Compile(cfg.Fuzz);if err!=nil{fmt.Fprintln(stderr,err);return 2}
- sim,err:=regexp.Compile(cfg.Sim);if err!=nil{fmt.Fprintln(stderr,err);return 2}
- cover,err:=parseCover(cfg.Cover);if err!=nil{fmt.Fprintln(stderr,err);return 2}
- var replay *Artifact
- if cfg.Replay!="" {
-  a,err:=readArtifact(cfg.Replay,1<<20);if err!=nil{fmt.Fprintln(stderr,err);return 2}
-  cfg.MaxBytes=a.MaxBytes;cfg.Sanitize=a.Sanitize;replay=&a
- }
- packages,err:=Discover(flags.Args());if err!=nil{fmt.Fprintln(stderr,err);return 2}
- matched:=0
- for i:=range packages {
-  var selected []Test
-  for _,test:=range packages[i].Tests {
-   if !run.MatchString(test.Name) || cfg.Fuzz!="" && (test.Kind!="fuzz" || !fuzz.MatchString(test.Name)) || cfg.Sim!="" && (test.Kind!="simulation" || !sim.MatchString(test.Name)) {continue}
-   if replay!=nil && (test.Name!=replay.Test || test.Kind!=replay.Kind){continue}
-   selected=append(selected,test);matched++
-  }
-  packages[i].Tests=selected
- }
- if matched==0 {fmt.Fprintln(stderr,"no matching Oak tests");return 2}
- if replay!=nil && matched!=1 {fmt.Fprintln(stderr,"replay requires exactly one matching test; select its package directory");return 2}
- code:=0
- emit:=func(result Result){
-  if cfg.JSON {if err:=json.NewEncoder(stdout).Encode(result);err!=nil{fmt.Fprintln(stderr,err);code=2}} else {
-   fmt.Fprintf(stdout,"%s %s/%s (%d cases, %d discarded, seed %d)\n",strings.ToUpper(result.Status),result.Package,result.Name,result.Cases,result.Discards,result.Seed)
-   if result.Failure!="" {fmt.Fprintln(stdout,"  "+result.Failure)}
-   if result.Artifact!="" {fmt.Fprintf(stdout,"  replay: oak test -replay %q %q\n",result.Artifact,result.Package)}
-   if result.Output!="" {fmt.Fprintln(stdout,result.Output)}
-  }
- }
- for _,pkg:=range packages {
-  if len(pkg.Tests)==0{continue}
-  if cfg.List {for _,test:=range pkg.Tests {emit(Result{Test:test,Package:pkg.Dir,Status:"list",Seed:cfg.Seed})};continue}
-  native,err:=buildNative(pkg,cfg)
-  if err!=nil {emit(Result{Package:pkg.Dir,Status:"error",Failure:err.Error(),Seed:cfg.Seed});code=2;continue}
-  for _,test:=range pkg.Tests {
-   index:=0
-   for i, registered:=range pkg.Registry {if registered.Name==test.Name {index=i;break}}
-   result:=runTest(pkg,test,index,native,cfg,cover,replay)
-   if result.Status!="pass" && code==0{code=1}
-   emit(result)
-  }
-  _=os.RemoveAll(native.dir)
- }
- return code
+ code := 0
+	emit := func(result Result) {
+		if cfg.JSON {
+			if err := json.NewEncoder(stdout).Encode(result); err != nil {
+				fmt.Fprintln(stderr, err)
+				code = 2
+			}
+		} else {
+			fmt.Fprintf(stdout, "%s %s/%s (%d cases, %d discarded, seed %d)\n", strings.ToUpper(result.Status), result.Package, result.Name, result.Cases, result.Discards, result.Seed)
+			if result.Failure != "" {
+				fmt.Fprintln(stdout, "  "+result.Failure)
+			}
+			if result.Artifact != "" {
+				fmt.Fprintf(stdout, "  replay: oak test -replay %q %q\n", result.Artifact, result.Package)
+			}
+			if result.Output != "" {
+				fmt.Fprintln(stdout, result.Output)
+			}
+		}
+	}
+	for _, pkg := range packages {
+		if len(pkg.Tests) == 0 {
+			continue
+		}
+		if cfg.List {
+			for _, test := range pkg.Tests {
+				emit(Result{Test: test, Package: pkg.Dir, Status: "list", Seed: cfg.Seed})
+			}
+			continue
+		}
+		native, err := buildNative(pkg, cfg)
+		if err != nil {
+			emit(Result{Package: pkg.Dir, Status: "error", Failure: err.Error(), Seed: cfg.Seed})
+			code = 2
+			continue
+		}
+		for _, test := range pkg.Tests {
+			index := 0
+			for i, registered := range pkg.Registry {
+				if registered.Name == test.Name {
+					index = i
+					break
+				}
+			}
+			result := runTest(pkg, test, index, native, cfg, cover, replay)
+			if result.Status != "pass" && code == 0 {
+				code = 1
+			}
+			emit(result)
+		}
+		_ = os.RemoveAll(native.dir)
+	}
+	return code
 }
 
-func parseCover(raw string)(map[uint32]int,error){
- result:=map[uint32]int{}
- if raw==""{return result,nil}
- for _,item:=range strings.Split(raw,","){
-  parts:=strings.Split(item,":");if len(parts)!=2{return nil,fmt.Errorf("invalid coverage requirement %q",item)}
-  id,err:=strconv.ParseUint(parts[0],10,32);if err!=nil{return nil,err}
-  count,err:=strconv.Atoi(parts[1]);if err!=nil || count<1{return nil,fmt.Errorf("coverage count must be positive")}
-  result[uint32(id)]=count
- }
- return result,nil
+func parseCover(raw string) (map[uint32]int, error) {
+	result := map[uint32]int{}
+	if raw == "" {
+		return result, nil
+	}
+	for _, item := range strings.Split(raw, ",") {
+		parts := strings.Split(item, ":")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid coverage requirement %q", item)
+		}
+		id, err := strconv.ParseUint(parts[0], 10, 32)
+		if err != nil {
+			return nil, err
+		}
+		count, err := strconv.Atoi(parts[1])
+		if err != nil || count < 1 {
+			return nil, fmt.Errorf("coverage count must be positive")
+		}
+		result[uint32(id)] = count
+	}
+	return result, nil
 }
 
-func runTest(pkg Package,test Test,index int,native *nativeProgram,cfg Config,cover map[uint32]int,replay *Artifact) Result {
- result:=Result{Test:test,Package:pkg.Dir,Status:"pass",Seed:cfg.Seed,Classes:map[uint32]int{}}
- if replay!=nil {
-  result.Seed=replay.Seed
-  if replay.Build!=native.build{result.Status="error";result.Failure="replay build mismatch: use the original source, toolchain and configuration; ordinary oak test reruns corpus inputs across builds";return result}
-  out:=native.run(index,replay.Input);result.Cases=1;result.Output=out.output
-  if out.status=="fail" && out.signature==replay.Signature {result.Status="fail";result.Failure="reproduced "+out.signature} else {result.Status="error";result.Failure=fmt.Sprintf("replay diverged: expected %s, got %s %s",replay.Signature,out.status,out.signature)}
-  return result
- }
- corpus,err:=loadCorpus(pkg,test,cfg.MaxBytes);if err!=nil{result.Status="error";result.Failure=err.Error();return result}
- execute:=func(input []byte,attempt int)bool{
-  out:=native.run(index,input)
-  if out.status=="discard" {
-   result.Discards++
-   if test.Kind=="unit" || result.Discards>cfg.MaxDiscards {result.Status="fail";result.Failure="discard budget exhausted; rejected inputs are not passing tests";return false}
-   return true
-  }
-  result.Cases++
-  if out.status=="pass"{
-   for id:=range out.classes{result.Classes[id]++}
-   if cfg.Verbose && len(result.Output)<outputLimit{result.Output+=out.output}
-   return true
-  }
-  result.Status="fail";result.Failure=out.signature;result.Output=out.output
-  best:=input
-  // Timeouts and infrastructure failures are not stable shrink predicates.
-  if test.Kind!="unit" && cfg.Shrink>0 && out.signature!="timeout" && !strings.HasPrefix(out.signature,"harness:") {
-   confirmation:=native.run(index,input)
-   if confirmation.status!="fail" || confirmation.signature!=out.signature{result.Failure="non-reproducible failure: "+out.signature}else{
-    ctx,cancel:=context.WithTimeout(context.Background(),cfg.ShrinkTimeout)
-    best=Minimize(ctx,input,cfg.Shrink,func(candidate []byte)bool{r:=native.run(index,candidate);return r.status=="fail" && r.signature==out.signature})
-    cancel()
-   }
-  }
-  artifact:=Artifact{Version:1,Engine:engineVersion,Test:test.Name,Kind:test.Kind,Build:native.build,Seed:cfg.Seed,Attempt:attempt,MaxBytes:cfg.MaxBytes,Sanitize:cfg.Sanitize,Signature:out.signature,Input:best}
-  path,err:=saveArtifact(pkg,test,artifact)
-  if err!=nil{result.Failure+="; cannot save failure: "+err.Error()}else{result.Artifact=path}
-  return false
- }
- if test.Kind=="unit" {execute(nil,0);return result}
- // Regression corpus is always run before new inputs. Build identities are
- // intentionally not enforced here: regressions should survive source edits.
- for i,input:=range corpus{if !execute(input,-1-i){return result}}
- seeds:=append([][]byte{},corpus...)
- for i:=0;i<4;i++{r:=randomFor(cfg.Seed,test.Name,i);seeds=append(seeds,generate(&r,i,cfg.MaxBytes))}
- if test.Kind=="fuzz" && cfg.Fuzz==""{
-  for i,input:=range seeds[len(corpus):]{if !execute(input,i){return result}}
- }else{
-  accepted:=0
-  for attempt:=0;accepted<cfg.Runs;attempt++{
-   r:=randomFor(cfg.Seed,test.Name,attempt)
-   input:=generate(&r,attempt,cfg.MaxBytes)
-   if test.Kind=="fuzz" && attempt>=len(seeds){input=mutate(&r,seeds,cfg.MaxBytes)}else if test.Kind=="fuzz"{input=seeds[attempt]}
-   before:=result.Cases
-   if !execute(input,attempt){return result}
-   if result.Cases>before{accepted++}
-  }
- }
- if result.Cases==0{result.Status="fail";result.Failure="no accepted cases"}
- for id,min:=range cover{if result.Classes[id]<min{result.Status="fail";result.Failure+=fmt.Sprintf(" class %d covered by %d cases, require %d;",id,result.Classes[id],min)}}
- return result
+func runTest(pkg Package, test Test, index int, native *nativeProgram, cfg Config, cover map[uint32]int, replay *Artifact) Result {
+	result := Result{Test: test, Package: pkg.Dir, Status: "pass", Seed: cfg.Seed, Classes: map[uint32]int{}}
+	if replay != nil {
+		result.Seed = replay.Seed
+		if replay.Build != native.build {
+			result.Status = "error"
+			result.Failure = "replay build mismatch: use the original source, toolchain and configuration; ordinary oak test reruns corpus inputs across builds"
+			return result
+		}
+		out := native.run(index, replay.Input)
+		result.Cases = 1
+		result.Output = out.output
+		if out.status == "fail" && out.signature == replay.Signature {
+			result.Status = "fail"
+			result.Failure = "reproduced " + out.signature
+		} else {
+			result.Status = "error"
+			result.Failure = fmt.Sprintf("replay diverged: expected %s, got %s %s", replay.Signature, out.status, out.signature)
+		}
+		return result
+	}
+	corpus, err := loadCorpus(pkg, test, cfg.MaxBytes)
+	if err != nil {
+		result.Status = "error"
+		result.Failure = err.Error()
+		return result
+	}
+	execute := func(input []byte, attempt int) bool {
+		out := native.run(index, input)
+		if out.status == "discard" {
+			result.Discards++
+			if test.Kind == "unit" || result.Discards > cfg.MaxDiscards {
+				result.Status = "fail"
+				result.Failure = "discard budget exhausted; rejected inputs are not passing tests"
+				return false
+			}
+			return true
+		}
+		result.Cases++
+		if out.status == "pass" {
+			for id := range out.classes {
+				result.Classes[id]++
+			}
+			if cfg.Verbose && len(result.Output) < outputLimit {
+				result.Output += out.output
+			}
+			return true
+		}
+		result.Status = "fail"
+		result.Failure = out.signature
+		result.Output = out.output
+		best := input
+		// Timeouts and infrastructure failures are not stable shrink predicates.
+		if test.Kind != "unit" && cfg.Shrink > 0 && out.signature != "timeout" && !strings.HasPrefix(out.signature, "harness:") {
+			confirmation := native.run(index, input)
+			if confirmation.status != "fail" || confirmation.signature != out.signature {
+				result.Failure = "non-reproducible failure: " + out.signature
+			} else {
+				ctx, cancel := context.WithTimeout(context.Background(), cfg.ShrinkTimeout)
+				best = Minimize(ctx, input, cfg.Shrink, func(candidate []byte) bool {
+					r := native.run(index, candidate)
+					return r.status == "fail" && r.signature == out.signature
+				})
+				cancel()
+			}
+		}
+		artifact := Artifact{Version: 1, Engine: engineVersion, Test: test.Name, Kind: test.Kind, Build: native.build, Seed: cfg.Seed, Attempt: attempt, MaxBytes: cfg.MaxBytes, Sanitize: cfg.Sanitize, Signature: out.signature, Input: best}
+		path, err := saveArtifact(pkg, test, artifact)
+		if err != nil {
+			result.Failure += "; cannot save failure: " + err.Error()
+		} else {
+			result.Artifact = path
+		}
+		return false
+	}
+	if test.Kind == "unit" {
+		execute(nil, 0)
+		return result
+	}
+	// Regression corpus is always run before new inputs. Build identities are
+	// intentionally not enforced here: regressions should survive source edits.
+	for i, input := range corpus {
+		if !execute(input, -1-i) {
+			return result
+		}
+	}
+	seeds := append([][]byte{}, corpus...)
+	for i := 0; i < 4; i++ {
+		r := randomFor(cfg.Seed, test.Name, i)
+		seeds = append(seeds, generate(&r, i, cfg.MaxBytes))
+	}
+	if test.Kind == "fuzz" && cfg.Fuzz == "" {
+		for i, input := range seeds[len(corpus):] {
+			if !execute(input, i) {
+				return result
+			}
+		}
+	} else {
+		accepted := 0
+		for attempt := 0; accepted < cfg.Runs; attempt++ {
+			r := randomFor(cfg.Seed, test.Name, attempt)
+			input := generate(&r, attempt, cfg.MaxBytes)
+			if test.Kind == "fuzz" && attempt >= len(seeds) {
+				input = mutate(&r, seeds, cfg.MaxBytes)
+			} else if test.Kind == "fuzz" {
+				input = seeds[attempt]
+			}
+			before := result.Cases
+			if !execute(input, attempt) {
+				return result
+			}
+			if result.Cases > before {
+				accepted++
+			}
+		}
+	}
+	if result.Cases == 0 {
+		result.Status = "fail"
+		result.Failure = "no accepted cases"
+	}
+	for id, min := range cover {
+		if result.Classes[id] < min {
+			result.Status = "fail"
+			result.Failure += fmt.Sprintf(" class %d covered by %d cases, require %d;", id, result.Classes[id], min)
+		}
+	}
+	return result
 }

--- a/testrunner/runner.go
+++ b/testrunner/runner.go
@@ -14,7 +14,7 @@ import (
 )
 
 type Config struct {
- EmitFuzz string
+	EmitFuzz                             string
 	CC                                   string
 	Runs, MaxBytes, Shrink, MaxDiscards  int
 	Seed                                 uint64
@@ -57,7 +57,7 @@ func Main(args []string, stdout, stderr io.Writer) int {
 	flags.DurationVar(&cfg.ShrinkTimeout, "shrink-timeout", cfg.ShrinkTimeout, "minimization time budget (plus at most one case timeout)")
 	flags.StringVar(&cfg.Run, "run", "", "test name regular expression")
 	flags.StringVar(&cfg.EmitFuzz, "emit-fuzz-harness", "", "export one -fuzz target as a libFuzzer C harness (new file)")
- flags.StringVar(&cfg.Fuzz, "fuzz", "", "fuzz target regular expression; enables mutation")
+	flags.StringVar(&cfg.Fuzz, "fuzz", "", "fuzz target regular expression; enables mutation")
 	flags.StringVar(&cfg.Sim, "sim", "", "simulation name regular expression")
 	flags.StringVar(&cfg.Replay, "replay", "", "replay one saved artifact against its exact build")
 	flags.StringVar(&cfg.Cover, "cover", "", "required class sample counts, e.g. 10:5,20:1 (per selected generated test)")
@@ -79,8 +79,11 @@ func Main(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "invalid test configuration")
 		return 2
 	}
-	if cfg.EmitFuzz!="" && (cfg.Fuzz=="" || cfg.Replay!="" || cfg.List) {fmt.Fprintln(stderr,"-emit-fuzz-harness requires -fuzz and cannot combine with replay/list");return 2}
- run, err := regexp.Compile(cfg.Run)
+	if cfg.EmitFuzz != "" && (cfg.Fuzz == "" || cfg.Replay != "" || cfg.List) {
+		fmt.Fprintln(stderr, "-emit-fuzz-harness requires -fuzz and cannot combine with replay/list")
+		return 2
+	}
+	run, err := regexp.Compile(cfg.Run)
 	if err != nil {
 		fmt.Fprintln(stderr, err)
 		return 2
@@ -139,17 +142,33 @@ func Main(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "replay requires exactly one matching test; select its package directory")
 		return 2
 	}
-	if cfg.EmitFuzz!="" {
-  if matched!=1 {fmt.Fprintln(stderr,"fuzz export requires exactly one matching target");return 2}
-  for _,pkg:=range packages {if len(pkg.Tests)==1 {
-   content,err:=EmitFuzzHarness(pkg,pkg.Tests[0],cfg.MaxBytes)
-   if err==nil {err=writeHarness(cfg.EmitFuzz,content)}
-   if err!=nil {fmt.Fprintln(stderr,err);return 2}
-   if cfg.JSON {if err:=json.NewEncoder(stdout).Encode(map[string]string{"status":"exported","path":cfg.EmitFuzz});err!=nil{return 2}} else {fmt.Fprintln(stdout,"Exported "+cfg.EmitFuzz)}
-  }}
-  return 0
- }
- code := 0
+	if cfg.EmitFuzz != "" {
+		if matched != 1 {
+			fmt.Fprintln(stderr, "fuzz export requires exactly one matching target")
+			return 2
+		}
+		for _, pkg := range packages {
+			if len(pkg.Tests) == 1 {
+				content, err := EmitFuzzHarness(pkg, pkg.Tests[0], cfg.MaxBytes)
+				if err == nil {
+					err = writeHarness(cfg.EmitFuzz, content)
+				}
+				if err != nil {
+					fmt.Fprintln(stderr, err)
+					return 2
+				}
+				if cfg.JSON {
+					if err := json.NewEncoder(stdout).Encode(map[string]string{"status": "exported", "path": cfg.EmitFuzz}); err != nil {
+						return 2
+					}
+				} else {
+					fmt.Fprintln(stdout, "Exported "+cfg.EmitFuzz)
+				}
+			}
+		}
+		return 0
+	}
+	code := 0
 	emit := func(result Result) {
 		if cfg.JSON {
 			if err := json.NewEncoder(stdout).Encode(result); err != nil {
@@ -194,7 +213,8 @@ func Main(args []string, stdout, stderr io.Writer) int {
 				}
 			}
 			result := runTest(pkg, test, index, native, cfg, cover, replay)
-			if result.Status != "pass" && code == 0 {
+			if result.Status == "error" { code = 2 }
+   if result.Status != "pass" && code == 0 {
 				code = 1
 			}
 			emit(result)

--- a/testrunner/runner.go
+++ b/testrunner/runner.go
@@ -1,0 +1,188 @@
+package testrunner
+
+import (
+ "context"
+ "encoding/json"
+ "flag"
+ "fmt"
+ "io"
+ "os"
+ "regexp"
+ "strconv"
+ "strings"
+ "time"
+)
+
+type Config struct {
+ CC string
+ Runs, MaxBytes, Shrink, MaxDiscards int
+ Seed uint64
+ Timeout, BuildTimeout, ShrinkTimeout time.Duration
+ Run, Fuzz, Sim, Replay string
+ JSON, List, Verbose, Sanitize bool
+ Cover string
+}
+func Defaults() Config { return Config{CC:"cc",Runs:100,MaxBytes:256,Shrink:200,Seed:1,Timeout:2*time.Second,BuildTimeout:time.Minute,ShrinkTimeout:10*time.Second,MaxDiscards:1000} }
+
+type Result struct {
+ Test
+ Package string `json:"package"`
+ Status string `json:"status"`
+ Cases int `json:"cases"`
+ Discards int `json:"discards"`
+ Seed uint64 `json:"seed"`
+ Failure string `json:"failure,omitempty"`
+ Artifact string `json:"artifact,omitempty"`
+ Output string `json:"output,omitempty"`
+ Classes map[uint32]int `json:"classes,omitempty"`
+}
+
+// Main is usable without os.Exit, including by CLI integration tests.
+func Main(args []string, stdout, stderr io.Writer) int {
+ cfg:=Defaults()
+ flags:=flag.NewFlagSet("oak test",flag.ContinueOnError);flags.SetOutput(stderr)
+ flags.StringVar(&cfg.CC,"cc",cfg.CC,"C compiler executable")
+ flags.IntVar(&cfg.Runs,"runs",cfg.Runs,"accepted generated cases per property/simulation/fuzz campaign")
+ flags.IntVar(&cfg.MaxBytes,"max-bytes",cfg.MaxBytes,"maximum input/choice-tape bytes (0..1048576)")
+ flags.Uint64Var(&cfg.Seed,"seed",cfg.Seed,"reproducible root seed")
+ flags.IntVar(&cfg.Shrink,"shrink",cfg.Shrink,"maximum minimization executions; 0 disables")
+ flags.IntVar(&cfg.MaxDiscards,"max-discards",cfg.MaxDiscards,"maximum rejected generated cases")
+ flags.DurationVar(&cfg.Timeout,"timeout",cfg.Timeout,"per-case process timeout")
+ flags.DurationVar(&cfg.BuildTimeout,"build-timeout",cfg.BuildTimeout,"per-package C compiler timeout")
+ flags.DurationVar(&cfg.ShrinkTimeout,"shrink-timeout",cfg.ShrinkTimeout,"minimization time budget (plus at most one case timeout)")
+ flags.StringVar(&cfg.Run,"run","","test name regular expression")
+ flags.StringVar(&cfg.Fuzz,"fuzz","","fuzz target regular expression; enables mutation")
+ flags.StringVar(&cfg.Sim,"sim","","simulation name regular expression")
+ flags.StringVar(&cfg.Replay,"replay","","replay one saved artifact against its exact build")
+ flags.StringVar(&cfg.Cover,"cover","","required class sample counts, e.g. 10:5,20:1 (per selected generated test)")
+ flags.BoolVar(&cfg.JSON,"json",false,"emit one JSON result per test")
+ flags.BoolVar(&cfg.List,"list",false,"list matching tests without compilation")
+ flags.BoolVar(&cfg.Verbose,"v",false,"include successful test output")
+ flags.BoolVar(&cfg.Sanitize,"sanitize",false,"enable native address and undefined-behavior sanitizers")
+ flags.Usage=func(){fmt.Fprintln(stderr,"Usage: oak test [flags] [directory | ./... ...]\nFlags precede paths. Tests live in *_test.oak files.");flags.PrintDefaults()}
+ if err:=flags.Parse(args);err!=nil {if err==flag.ErrHelp{return 0};return 2}
+ if cfg.Runs<1 || cfg.Runs>1000000 || cfg.MaxBytes<0 || cfg.MaxBytes>1<<20 || cfg.Shrink<0 || cfg.MaxDiscards<0 || cfg.Timeout<=0 || cfg.BuildTimeout<=0 || cfg.ShrinkTimeout<=0 || cfg.Fuzz!="" && cfg.Sim!="" || cfg.Replay!="" && (cfg.Fuzz!="" || cfg.Sim!="" || cfg.Run!="" || cfg.List || cfg.Cover!="") {
+  fmt.Fprintln(stderr,"invalid test configuration");return 2
+ }
+ run,err:=regexp.Compile(cfg.Run);if err!=nil{fmt.Fprintln(stderr,err);return 2}
+ fuzz,err:=regexp.Compile(cfg.Fuzz);if err!=nil{fmt.Fprintln(stderr,err);return 2}
+ sim,err:=regexp.Compile(cfg.Sim);if err!=nil{fmt.Fprintln(stderr,err);return 2}
+ cover,err:=parseCover(cfg.Cover);if err!=nil{fmt.Fprintln(stderr,err);return 2}
+ var replay *Artifact
+ if cfg.Replay!="" {
+  a,err:=readArtifact(cfg.Replay,1<<20);if err!=nil{fmt.Fprintln(stderr,err);return 2}
+  cfg.MaxBytes=a.MaxBytes;cfg.Sanitize=a.Sanitize;replay=&a
+ }
+ packages,err:=Discover(flags.Args());if err!=nil{fmt.Fprintln(stderr,err);return 2}
+ matched:=0
+ for i:=range packages {
+  var selected []Test
+  for _,test:=range packages[i].Tests {
+   if !run.MatchString(test.Name) || cfg.Fuzz!="" && (test.Kind!="fuzz" || !fuzz.MatchString(test.Name)) || cfg.Sim!="" && (test.Kind!="simulation" || !sim.MatchString(test.Name)) {continue}
+   if replay!=nil && (test.Name!=replay.Test || test.Kind!=replay.Kind){continue}
+   selected=append(selected,test);matched++
+  }
+  packages[i].Tests=selected
+ }
+ if matched==0 {fmt.Fprintln(stderr,"no matching Oak tests");return 2}
+ if replay!=nil && matched!=1 {fmt.Fprintln(stderr,"replay requires exactly one matching test; select its package directory");return 2}
+ code:=0
+ emit:=func(result Result){
+  if cfg.JSON {if err:=json.NewEncoder(stdout).Encode(result);err!=nil{fmt.Fprintln(stderr,err);code=2}} else {
+   fmt.Fprintf(stdout,"%s %s/%s (%d cases, %d discarded, seed %d)\n",strings.ToUpper(result.Status),result.Package,result.Name,result.Cases,result.Discards,result.Seed)
+   if result.Failure!="" {fmt.Fprintln(stdout,"  "+result.Failure)}
+   if result.Artifact!="" {fmt.Fprintf(stdout,"  replay: oak test -replay %q %q\n",result.Artifact,result.Package)}
+   if result.Output!="" {fmt.Fprintln(stdout,result.Output)}
+  }
+ }
+ for _,pkg:=range packages {
+  if len(pkg.Tests)==0{continue}
+  if cfg.List {for _,test:=range pkg.Tests {emit(Result{Test:test,Package:pkg.Dir,Status:"list",Seed:cfg.Seed})};continue}
+  native,err:=buildNative(pkg,cfg)
+  if err!=nil {emit(Result{Package:pkg.Dir,Status:"error",Failure:err.Error(),Seed:cfg.Seed});code=2;continue}
+  for _,test:=range pkg.Tests {
+   index:=0
+   for i, registered:=range pkg.Registry {if registered.Name==test.Name {index=i;break}}
+   result:=runTest(pkg,test,index,native,cfg,cover,replay)
+   if result.Status!="pass" && code==0{code=1}
+   emit(result)
+  }
+  _=os.RemoveAll(native.dir)
+ }
+ return code
+}
+
+func parseCover(raw string)(map[uint32]int,error){
+ result:=map[uint32]int{}
+ if raw==""{return result,nil}
+ for _,item:=range strings.Split(raw,","){
+  parts:=strings.Split(item,":");if len(parts)!=2{return nil,fmt.Errorf("invalid coverage requirement %q",item)}
+  id,err:=strconv.ParseUint(parts[0],10,32);if err!=nil{return nil,err}
+  count,err:=strconv.Atoi(parts[1]);if err!=nil || count<1{return nil,fmt.Errorf("coverage count must be positive")}
+  result[uint32(id)]=count
+ }
+ return result,nil
+}
+
+func runTest(pkg Package,test Test,index int,native *nativeProgram,cfg Config,cover map[uint32]int,replay *Artifact) Result {
+ result:=Result{Test:test,Package:pkg.Dir,Status:"pass",Seed:cfg.Seed,Classes:map[uint32]int{}}
+ if replay!=nil {
+  result.Seed=replay.Seed
+  if replay.Build!=native.build{result.Status="error";result.Failure="replay build mismatch: use the original source, toolchain and configuration; ordinary oak test reruns corpus inputs across builds";return result}
+  out:=native.run(index,replay.Input);result.Cases=1;result.Output=out.output
+  if out.status=="fail" && out.signature==replay.Signature {result.Status="fail";result.Failure="reproduced "+out.signature} else {result.Status="error";result.Failure=fmt.Sprintf("replay diverged: expected %s, got %s %s",replay.Signature,out.status,out.signature)}
+  return result
+ }
+ corpus,err:=loadCorpus(pkg,test,cfg.MaxBytes);if err!=nil{result.Status="error";result.Failure=err.Error();return result}
+ execute:=func(input []byte,attempt int)bool{
+  out:=native.run(index,input)
+  if out.status=="discard" {
+   result.Discards++
+   if test.Kind=="unit" || result.Discards>cfg.MaxDiscards {result.Status="fail";result.Failure="discard budget exhausted; rejected inputs are not passing tests";return false}
+   return true
+  }
+  result.Cases++
+  if out.status=="pass"{
+   for id:=range out.classes{result.Classes[id]++}
+   if cfg.Verbose && len(result.Output)<outputLimit{result.Output+=out.output}
+   return true
+  }
+  result.Status="fail";result.Failure=out.signature;result.Output=out.output
+  best:=input
+  // Timeouts and infrastructure failures are not stable shrink predicates.
+  if test.Kind!="unit" && cfg.Shrink>0 && out.signature!="timeout" && !strings.HasPrefix(out.signature,"harness:") {
+   confirmation:=native.run(index,input)
+   if confirmation.status!="fail" || confirmation.signature!=out.signature{result.Failure="non-reproducible failure: "+out.signature}else{
+    ctx,cancel:=context.WithTimeout(context.Background(),cfg.ShrinkTimeout)
+    best=Minimize(ctx,input,cfg.Shrink,func(candidate []byte)bool{r:=native.run(index,candidate);return r.status=="fail" && r.signature==out.signature})
+    cancel()
+   }
+  }
+  artifact:=Artifact{Version:1,Engine:engineVersion,Test:test.Name,Kind:test.Kind,Build:native.build,Seed:cfg.Seed,Attempt:attempt,MaxBytes:cfg.MaxBytes,Sanitize:cfg.Sanitize,Signature:out.signature,Input:best}
+  path,err:=saveArtifact(pkg,test,artifact)
+  if err!=nil{result.Failure+="; cannot save failure: "+err.Error()}else{result.Artifact=path}
+  return false
+ }
+ if test.Kind=="unit" {execute(nil,0);return result}
+ // Regression corpus is always run before new inputs. Build identities are
+ // intentionally not enforced here: regressions should survive source edits.
+ for i,input:=range corpus{if !execute(input,-1-i){return result}}
+ seeds:=append([][]byte{},corpus...)
+ for i:=0;i<4;i++{r:=randomFor(cfg.Seed,test.Name,i);seeds=append(seeds,generate(&r,i,cfg.MaxBytes))}
+ if test.Kind=="fuzz" && cfg.Fuzz==""{
+  for i,input:=range seeds[len(corpus):]{if !execute(input,i){return result}}
+ }else{
+  accepted:=0
+  for attempt:=0;accepted<cfg.Runs;attempt++{
+   r:=randomFor(cfg.Seed,test.Name,attempt)
+   input:=generate(&r,attempt,cfg.MaxBytes)
+   if test.Kind=="fuzz" && attempt>=len(seeds){input=mutate(&r,seeds,cfg.MaxBytes)}else if test.Kind=="fuzz"{input=seeds[attempt]}
+   before:=result.Cases
+   if !execute(input,attempt){return result}
+   if result.Cases>before{accepted++}
+  }
+ }
+ if result.Cases==0{result.Status="fail";result.Failure="no accepted cases"}
+ for id,min:=range cover{if result.Classes[id]<min{result.Status="fail";result.Failure+=fmt.Sprintf(" class %d covered by %d cases, require %d;",id,result.Classes[id],min)}}
+ return result
+}

--- a/testrunner/runner_test.go
+++ b/testrunner/runner_test.go
@@ -192,33 +192,47 @@ func TestNoTestsAndInvalidFlagsFail(t *testing.T) {
 }
 
 func TestFuzzHarnessExportAndNativeExecution(t *testing.T) {
- dir := fixture(t, map[string]string{"a_test.oak": `import(testing)
+	dir := fixture(t, map[string]string{"a_test.oak": `import(testing)
 FuzzExport: (data: []u8): () {
   test_assume(len(data) > u32(0))
   test_check(data[0] != u8(7), u32(8080))
 }
 `})
- output := filepath.Join(t.TempDir(), "fuzz.c")
- var stdout, stderr bytes.Buffer
- code := Main([]string{"-fuzz", "^FuzzExport$", "-emit-fuzz-harness", output, dir}, &stdout, &stderr)
- if code != 0 { t.Fatalf("export: %d %s", code, stderr.String()) }
- if Main([]string{"-fuzz", "^FuzzExport$", "-emit-fuzz-harness", output, dir}, &stdout, &stderr) != 2 { t.Fatal("overwrote existing harness") }
- clang, err := exec.LookPath("clang")
- if err != nil { t.Skip("requires clang") }
- binary := filepath.Join(t.TempDir(), "fuzz")
- cmd := exec.Command(clang, "-std=c11", "-g", "-O1", "-fsanitize=fuzzer,address,undefined", "-fno-sanitize-recover=all", output, "-o", binary)
- if out,err:=cmd.CombinedOutput();err!=nil{t.Fatalf("clang: %v\n%s",err,out)}
- seed:=filepath.Join(t.TempDir(),"seed")
- os.WriteFile(seed,[]byte{1},0600)
- if out,err:=exec.Command(binary,"-runs=1",seed).CombinedOutput();err!=nil{t.Fatalf("valid seed: %v\n%s",err,out)}
- os.WriteFile(seed,[]byte{},0600)
- if out,err:=exec.Command(binary,"-runs=1",seed).CombinedOutput();err!=nil{t.Fatalf("discard: %v\n%s",err,out)}
- os.WriteFile(seed,[]byte{7},0600)
- if out,err:=exec.Command(binary,"-runs=1",seed).CombinedOutput();err==nil || !strings.Contains(string(out),"Oak invariant 8080 failed"){t.Fatalf("missed invariant: %v\n%s",err,out)}
+	output := filepath.Join(t.TempDir(), "fuzz.c")
+	var stdout, stderr bytes.Buffer
+	code := Main([]string{"-fuzz", "^FuzzExport$", "-emit-fuzz-harness", output, dir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("export: %d %s", code, stderr.String())
+	}
+	if Main([]string{"-fuzz", "^FuzzExport$", "-emit-fuzz-harness", output, dir}, &stdout, &stderr) != 2 {
+		t.Fatal("overwrote existing harness")
+	}
+	clang, err := exec.LookPath("clang")
+	if err != nil {
+		t.Skip("requires clang")
+	}
+	binary := filepath.Join(t.TempDir(), "fuzz")
+	cmd := exec.Command(clang, "-std=c11", "-g", "-O1", "-fsanitize=fuzzer,address,undefined", "-fno-sanitize-recover=all", output, "-o", binary)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("clang: %v\n%s", err, out)
+	}
+	seed := filepath.Join(t.TempDir(), "seed")
+	os.WriteFile(seed, []byte{1}, 0600)
+	if out, err := exec.Command(binary, "-runs=1", seed).CombinedOutput(); err != nil {
+		t.Fatalf("valid seed: %v\n%s", err, out)
+	}
+	os.WriteFile(seed, []byte{}, 0600)
+	if out, err := exec.Command(binary, "-runs=1", seed).CombinedOutput(); err != nil {
+		t.Fatalf("discard: %v\n%s", err, out)
+	}
+	os.WriteFile(seed, []byte{7}, 0600)
+	if out, err := exec.Command(binary, "-runs=1", seed).CombinedOutput(); err == nil || !strings.Contains(string(out), "Oak invariant 8080 failed") {
+		t.Fatalf("missed invariant: %v\n%s", err, out)
+	}
 }
 
 func TestTestingLibraryBoundaries(t *testing.T) {
- dir:=fixture(t,map[string]string{"a_test.oak":`import(testing)
+	dir := fixture(t, map[string]string{"a_test.oak": `import(testing)
 fill_four: (writable: [*]u8): () {
   writable[0] = u8(255)
   writable[1] = u8(255)
@@ -249,6 +263,40 @@ TestChoicesAndCapacity: (): () {
   test_check(result.value == u32(3) && queue[0].count == u32(0) && clock[0].now == u64(5), u32(9008))
 }
 `})
- code,results,stderr:=runCLI(t,dir)
- if code!=0{t.Fatalf("boundaries: %d %+v %s",code,results,stderr)}
+	code, results, stderr := runCLI(t, dir)
+	if code != 0 {
+		t.Fatalf("boundaries: %d %+v %s", code, results, stderr)
+	}
+}
+
+// Prove that the independent model detects a deliberately injected lost-edge
+// bug in the Oak IRQ pilot, and that its operation history can be minimized.
+func TestIRQMutationDetected(t *testing.T) {
+	files := map[string]string{}
+	for _, name := range []string{"irq.oak", "irq_test.oak"} {
+		data, err := os.ReadFile(filepath.Join("..", "examples", "testing", name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		files[name] = string(data)
+	}
+	original := "action == u32(2) ? { state[0].latched = true }"
+	mutant := "action == u32(2) && !state[0].active ? { state[0].latched = true }"
+	if !strings.Contains(files["irq.oak"], original) {
+		t.Fatal("mutation site changed")
+	}
+	files["irq.oak"] = strings.Replace(files["irq.oak"], original, mutant, 1)
+	files["testdata/oak/PropertyIrqHistory/lost-edge.bin"] = string([]byte{0, 2, 5, 2})
+	dir := fixture(t, files)
+	code, results, stderr := runCLI(t, "-run", "^PropertyIrqHistory$", "-runs", "1", dir)
+	if code != 1 || len(results) != 1 || results[0].Failure != "invariant:2011" {
+		t.Fatalf("mutation escaped: %d %+v %s", code, results, stderr)
+	}
+	a, err := readArtifact(results[0].Artifact, 256)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(a.Input, []byte{0, 2, 5, 2}) {
+		t.Fatalf("unexpected minimized history: %v", a.Input)
+	}
 }

--- a/testrunner/runner_test.go
+++ b/testrunner/runner_test.go
@@ -180,6 +180,14 @@ TestSurvives: (): () { test_check(true, u32(1)) }
 	if states["TestSurvives"].Status != "pass" || states["TestTimeout"].Failure != "timeout" || states["TestCrash"].Status != "fail" || states["PropertyDiscard"].Discards != 3 {
 		t.Fatalf("%+v", states)
 	}
+	a, err := readArtifact(states["TestTimeout"].Artifact, 256)
+	if err != nil || a.TimeoutNanos != 100000000 {
+		t.Fatalf("timeout configuration lost: %+v %v", a, err)
+	}
+	code, results, stderr = runCLI(t, "-replay", states["TestTimeout"].Artifact, dir)
+	if code != 1 || len(results) != 1 || results[0].Failure != "reproduced timeout" {
+		t.Fatalf("timeout replay: %d %+v %s", code, results, stderr)
+	}
 }
 func TestNoTestsAndInvalidFlagsFail(t *testing.T) {
 	dir := t.TempDir()
@@ -298,5 +306,17 @@ func TestIRQMutationDetected(t *testing.T) {
 	}
 	if !bytes.Equal(a.Input, []byte{0, 2, 5, 2}) {
 		t.Fatalf("unexpected minimized history: %v", a.Input)
+	}
+}
+
+// Importing testing alone must not reserve the unrelated std codec names.
+func TestTestingImportPreservesProductionNames(t *testing.T) {
+	dir := fixture(t, map[string]string{"a_test.oak": `import(testing)
+encode: (value: u32): u32 = value
+TestEncode: (): () { test_check(encode(u32(7)) == u32(7), u32(1)) }
+`})
+	code, results, stderr := runCLI(t, dir)
+	if code != 0 {
+		t.Fatalf("testing import reserved a production name: %d %+v %s", code, results, stderr)
 	}
 }

--- a/testrunner/runner_test.go
+++ b/testrunner/runner_test.go
@@ -190,3 +190,65 @@ func TestNoTestsAndInvalidFlagsFail(t *testing.T) {
 		}
 	}
 }
+
+func TestFuzzHarnessExportAndNativeExecution(t *testing.T) {
+ dir := fixture(t, map[string]string{"a_test.oak": `import(testing)
+FuzzExport: (data: []u8): () {
+  test_assume(len(data) > u32(0))
+  test_check(data[0] != u8(7), u32(8080))
+}
+`})
+ output := filepath.Join(t.TempDir(), "fuzz.c")
+ var stdout, stderr bytes.Buffer
+ code := Main([]string{"-fuzz", "^FuzzExport$", "-emit-fuzz-harness", output, dir}, &stdout, &stderr)
+ if code != 0 { t.Fatalf("export: %d %s", code, stderr.String()) }
+ if Main([]string{"-fuzz", "^FuzzExport$", "-emit-fuzz-harness", output, dir}, &stdout, &stderr) != 2 { t.Fatal("overwrote existing harness") }
+ clang, err := exec.LookPath("clang")
+ if err != nil { t.Skip("requires clang") }
+ binary := filepath.Join(t.TempDir(), "fuzz")
+ cmd := exec.Command(clang, "-std=c11", "-g", "-O1", "-fsanitize=fuzzer,address,undefined", "-fno-sanitize-recover=all", output, "-o", binary)
+ if out,err:=cmd.CombinedOutput();err!=nil{t.Fatalf("clang: %v\n%s",err,out)}
+ seed:=filepath.Join(t.TempDir(),"seed")
+ os.WriteFile(seed,[]byte{1},0600)
+ if out,err:=exec.Command(binary,"-runs=1",seed).CombinedOutput();err!=nil{t.Fatalf("valid seed: %v\n%s",err,out)}
+ os.WriteFile(seed,[]byte{},0600)
+ if out,err:=exec.Command(binary,"-runs=1",seed).CombinedOutput();err!=nil{t.Fatalf("discard: %v\n%s",err,out)}
+ os.WriteFile(seed,[]byte{7},0600)
+ if out,err:=exec.Command(binary,"-runs=1",seed).CombinedOutput();err==nil || !strings.Contains(string(out),"Oak invariant 8080 failed"){t.Fatalf("missed invariant: %v\n%s",err,out)}
+}
+
+func TestTestingLibraryBoundaries(t *testing.T) {
+ dir:=fixture(t,map[string]string{"a_test.oak":`import(testing)
+fill_four: (writable: [*]u8): () {
+  writable[0] = u8(255)
+  writable[1] = u8(255)
+  writable[2] = u8(255)
+  writable[3] = u8(255)
+}
+TestChoicesAndCapacity: (): () {
+  bytes: [4]u8
+  fill_four(span(&bytes))
+  data: []u8 = view(&bytes)
+  state: [1]TestChoices
+  choices: [*]TestChoices = span(&state)
+  test_check(test_range(choices, data, u32(0), u32(4294967295)) == u32(4294967295), u32(9001))
+  test_check(test_byte(choices, data) == u8(0), u32(9002))
+  test_check(choices[0].offset == u32(4), u32(9003))
+  test_check(test_range(choices, data, u32(7), u32(7)) == u32(7), u32(9004))
+  q: [1]SimQueue
+  e: [1]SimEvent
+  c: [1]SimClock
+  queue: [*]SimQueue = span(&q)
+  events: [*]SimEvent = span(&e)
+  clock: [*]SimClock = span(&c)
+  event: SimEvent = SimEvent { at: u64(5), kind: u32(2), value: u32(3) }
+  test_check(sim_schedule(queue, events, clock, event), u32(9005))
+  test_check(!sim_schedule(queue, events, clock, event), u32(9006))
+  test_check(queue[0].count == u32(1) && events[0].at == u64(5), u32(9007))
+  result: SimEvent = sim_next(queue, events, clock, choices, data)
+  test_check(result.value == u32(3) && queue[0].count == u32(0) && clock[0].now == u64(5), u32(9008))
+}
+`})
+ code,results,stderr:=runCLI(t,dir)
+ if code!=0{t.Fatalf("boundaries: %d %+v %s",code,results,stderr)}
+}

--- a/testrunner/runner_test.go
+++ b/testrunner/runner_test.go
@@ -1,0 +1,133 @@
+package testrunner
+
+import (
+ "bytes"
+ "encoding/json"
+ "os"
+ "os/exec"
+ "path/filepath"
+ "strings"
+ "testing"
+)
+
+func fixture(t *testing.T, files map[string]string) string {
+ t.Helper()
+ dir:=t.TempDir()
+ for path,src:=range files{
+  full:=filepath.Join(dir,path)
+  if err:=os.MkdirAll(filepath.Dir(full),0755);err!=nil{t.Fatal(err)}
+  if err:=os.WriteFile(full,[]byte(src),0600);err!=nil{t.Fatal(err)}
+ }
+ return dir
+}
+func runCLI(t *testing.T,args ...string)(int,[]Result,string){
+ t.Helper()
+ if _,err:=exec.LookPath("cc");err!=nil{t.Skip("requires cc")}
+ var stdout,stderr bytes.Buffer
+ args=append([]string{"-json"},args...)
+ code:=Main(args,&stdout,&stderr)
+ var results []Result
+ for _,line:=range strings.Split(strings.TrimSpace(stdout.String()),"\n"){
+  if line==""{continue};var r Result
+  if err:=json.Unmarshal([]byte(line),&r);err!=nil{t.Fatalf("invalid JSON: %v\n%s",err,line)}
+  results=append(results,r)
+ }
+ return code,results,stderr.String()
+}
+func TestDiscoveryAndValidation(t *testing.T){
+ dir:=fixture(t,map[string]string{
+  "production.oak":"TestNotRegistered: (): () {}",
+  "a_test.oak":"TestOne: (): () {}\nPropertyTwo: (data: []u8): () {}\nTesthelper: (): () {}",
+  "testdata/broken_test.oak":"not valid Oak",
+ })
+ packages,err:=Discover([]string{dir,filepath.Join(dir,"...")})
+ if err!=nil{t.Fatal(err)}
+ if len(packages)!=1 || len(packages[0].Tests)!=2{t.Fatalf("discovery: %+v",packages)}
+ bad:=fixture(t,map[string]string{"a_test.oak":"TestWrong: (x: u32): () {}"})
+ if _,err:=Discover([]string{bad});err==nil{t.Fatal("accepted invalid signature")}
+}
+func TestNativeUnitPropertyFuzzAndSim(t *testing.T){
+ dir:=fixture(t,map[string]string{
+  "production.oak":"double: (x: u32): u32 = x + x\nmain: (): i32 = 42",
+  "a_test.oak":`import(testing)
+TestArithmetic: (): () { test_check(double(u32(3)) == u32(6), u32(1)) }
+PropertyRange: (data: []u8): () {
+ state: [1]TestChoices
+ choices: [*]TestChoices = span(&state)
+ value: u32 = test_range(choices, data, u32(5), u32(10))
+ test_check(value >= u32(5) && value <= u32(10), u32(2))
+ testing_classify(u32(12))
+}
+FuzzBytes: (data: []u8): () { test_check(len(data) <= u32(256), u32(3)) }
+SimOrder: (data: []u8): () {
+ q: [1]SimQueue
+ e: [4]SimEvent
+ c: [1]SimClock
+ s: [1]TestChoices
+ queue: [*]SimQueue = span(&q)
+ events: [*]SimEvent = span(&e)
+ clock: [*]SimClock = span(&c)
+ choices: [*]TestChoices = span(&s)
+ test_check(sim_schedule(queue, events, clock, SimEvent { at: u64(20), kind: u32(1), value: u32(0) }), u32(4))
+ test_check(sim_schedule(queue, events, clock, SimEvent { at: u64(10), kind: u32(2), value: u32(0) }), u32(5))
+ first: SimEvent = sim_next(queue, events, clock, choices, data)
+ test_check(first.kind == u32(2) && clock[0].now == u64(10), u32(6))
+ second: SimEvent = sim_next(queue, events, clock, choices, data)
+ test_check(second.kind == u32(1) && clock[0].now == u64(20), u32(7))
+}`,
+ })
+ code,results,stderr:=runCLI(t,"-runs","8",dir)
+ if code!=0 || len(results)!=4{t.Fatalf("code %d: %+v\n%s",code,results,stderr)}
+ for _,r:=range results{if r.Status!="pass"{t.Fatalf("%+v",r)}}
+ code,results,stderr=runCLI(t,"-fuzz","FuzzBytes","-runs","20",dir)
+ if code!=0 || len(results)!=1 || results[0].Cases!=20{t.Fatalf("fuzz: %d %+v %s",code,results,stderr)}
+ code,results,stderr=runCLI(t,"-run","PropertyRange","-runs","5","-cover","12:5",dir)
+ if code!=0{t.Fatalf("coverage: %d %+v %s",code,results,stderr)}
+ code,results,_=runCLI(t,"-run","PropertyRange","-runs","5","-cover","13:1",dir)
+ if code!=1 || !strings.Contains(results[0].Failure,"class 13"){t.Fatalf("missed vacuous property: %d %+v",code,results)}
+}
+func TestFailureShrinkReplayAndCorpus(t *testing.T){
+ dir:=fixture(t,map[string]string{"a_test.oak":`import(testing)
+TestOther: (): () {}
+PropertyFails: (data: []u8): () {
+ state: [1]TestChoices
+ choices: [*]TestChoices = span(&state)
+ value: u8 = test_byte(choices, data)
+ test_check(value < u8(7), u32(7001))
+}`})
+ code,results,stderr:=runCLI(t,"-runs","4",dir)
+ if code!=1 || len(results)!=2{t.Fatalf("%d %+v %s",code,results,stderr)}
+ var failure Result
+ for _,r:=range results{if r.Name=="PropertyFails"{failure=r}}
+ if failure.Artifact=="" || failure.Failure!="invariant:7001"{t.Fatalf("%+v",failure)}
+ a,err:=readArtifact(failure.Artifact,256);if err!=nil{t.Fatal(err)}
+ if !bytes.Equal(a.Input,[]byte{7}){t.Fatalf("not minimized: %v",a.Input)}
+ code,results,stderr=runCLI(t,"-replay",failure.Artifact,dir)
+ if code!=1 || len(results)!=1 || results[0].Failure!="reproduced invariant:7001"{t.Fatalf("replay: %d %+v %s",code,results,stderr)}
+ // Corpus runs even with a different root seed and before the empty input.
+ code,results,stderr=runCLI(t,"-run","PropertyFails","-runs","1","-seed","999",dir)
+ if code!=1 || results[0].Cases!=1{t.Fatalf("corpus: %d %+v %s",code,results,stderr)}
+ // Source drift must not silently masquerade as exact replay.
+ f:=filepath.Join(dir,"a_test.oak");data,_:=os.ReadFile(f);os.WriteFile(f,append(data,[]byte("\nTestAdded: (): () {}\n")...),0600)
+ code,results,_=runCLI(t,"-replay",failure.Artifact,dir)
+ if code==0 || !strings.Contains(results[0].Failure,"build mismatch"){t.Fatalf("drift: %d %+v",code,results)}
+}
+func TestDiscardTimeoutAndCrashIsolation(t *testing.T){
+ dir:=fixture(t,map[string]string{"a_test.oak":`import(testing)
+PropertyDiscard: (data: []u8): () { test_assume(false) }
+TestCrash: (): () { assert(false) }
+TestTimeout: (): () { while true {} }
+TestSurvives: (): () { test_check(true, u32(1)) }
+`})
+ code,results,stderr:=runCLI(t,"-runs","1","-max-discards","2","-timeout","100ms","-shrink","0",dir)
+ if code!=1 || len(results)!=4{t.Fatalf("%d %+v %s",code,results,stderr)}
+ states:=map[string]Result{};for _,r:=range results{states[r.Name]=r}
+ if states["TestSurvives"].Status!="pass" || states["TestTimeout"].Failure!="timeout" || states["TestCrash"].Status!="fail" || states["PropertyDiscard"].Discards!=3{t.Fatalf("%+v",states)}
+}
+func TestNoTestsAndInvalidFlagsFail(t *testing.T){
+ dir:=t.TempDir()
+ for _,args:=range [][]string{{dir},{"-runs","0",dir},{"-run","[",dir}}{
+  var out,err bytes.Buffer
+  if Main(args,&out,&err)!=2{t.Fatalf("expected error for %v",args)}
+ }
+}

--- a/testrunner/runner_test.go
+++ b/testrunner/runner_test.go
@@ -1,55 +1,72 @@
 package testrunner
 
 import (
- "bytes"
- "encoding/json"
- "os"
- "os/exec"
- "path/filepath"
- "strings"
- "testing"
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
 )
 
 func fixture(t *testing.T, files map[string]string) string {
- t.Helper()
- dir:=t.TempDir()
- for path,src:=range files{
-  full:=filepath.Join(dir,path)
-  if err:=os.MkdirAll(filepath.Dir(full),0755);err!=nil{t.Fatal(err)}
-  if err:=os.WriteFile(full,[]byte(src),0600);err!=nil{t.Fatal(err)}
- }
- return dir
+	t.Helper()
+	dir := t.TempDir()
+	for path, src := range files {
+		full := filepath.Join(dir, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(src), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
 }
-func runCLI(t *testing.T,args ...string)(int,[]Result,string){
- t.Helper()
- if _,err:=exec.LookPath("cc");err!=nil{t.Skip("requires cc")}
- var stdout,stderr bytes.Buffer
- args=append([]string{"-json"},args...)
- code:=Main(args,&stdout,&stderr)
- var results []Result
- for _,line:=range strings.Split(strings.TrimSpace(stdout.String()),"\n"){
-  if line==""{continue};var r Result
-  if err:=json.Unmarshal([]byte(line),&r);err!=nil{t.Fatalf("invalid JSON: %v\n%s",err,line)}
-  results=append(results,r)
- }
- return code,results,stderr.String()
+func runCLI(t *testing.T, args ...string) (int, []Result, string) {
+	t.Helper()
+	if _, err := exec.LookPath("cc"); err != nil {
+		t.Skip("requires cc")
+	}
+	var stdout, stderr bytes.Buffer
+	args = append([]string{"-json"}, args...)
+	code := Main(args, &stdout, &stderr)
+	var results []Result
+	for _, line := range strings.Split(strings.TrimSpace(stdout.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var r Result
+		if err := json.Unmarshal([]byte(line), &r); err != nil {
+			t.Fatalf("invalid JSON: %v\n%s", err, line)
+		}
+		results = append(results, r)
+	}
+	return code, results, stderr.String()
 }
-func TestDiscoveryAndValidation(t *testing.T){
- dir:=fixture(t,map[string]string{
-  "production.oak":"TestNotRegistered: (): () {}",
-  "a_test.oak":"TestOne: (): () {}\nPropertyTwo: (data: []u8): () {}\nTesthelper: (): () {}",
-  "testdata/broken_test.oak":"not valid Oak",
- })
- packages,err:=Discover([]string{dir,filepath.Join(dir,"...")})
- if err!=nil{t.Fatal(err)}
- if len(packages)!=1 || len(packages[0].Tests)!=2{t.Fatalf("discovery: %+v",packages)}
- bad:=fixture(t,map[string]string{"a_test.oak":"TestWrong: (x: u32): () {}"})
- if _,err:=Discover([]string{bad});err==nil{t.Fatal("accepted invalid signature")}
+func TestDiscoveryAndValidation(t *testing.T) {
+	dir := fixture(t, map[string]string{
+		"production.oak":           "TestNotRegistered: (): () {}",
+		"a_test.oak":               "TestOne: (): () {}\nPropertyTwo: (data: []u8): () {}\nTesthelper: (): () {}",
+		"testdata/broken_test.oak": "not valid Oak",
+	})
+	packages, err := Discover([]string{dir, filepath.Join(dir, "...")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(packages) != 1 || len(packages[0].Tests) != 2 {
+		t.Fatalf("discovery: %+v", packages)
+	}
+	bad := fixture(t, map[string]string{"a_test.oak": "TestWrong: (x: u32): () {}"})
+	if _, err := Discover([]string{bad}); err == nil {
+		t.Fatal("accepted invalid signature")
+	}
 }
-func TestNativeUnitPropertyFuzzAndSim(t *testing.T){
- dir:=fixture(t,map[string]string{
-  "production.oak":"double: (x: u32): u32 = x + x\nmain: (): i32 = 42",
-  "a_test.oak":`import(testing)
+func TestNativeUnitPropertyFuzzAndSim(t *testing.T) {
+	dir := fixture(t, map[string]string{
+		"production.oak": "double: (x: u32): u32 = x + x\nmain: (): i32 = 42",
+		"a_test.oak": `import(testing)
 TestArithmetic: (): () { test_check(double(u32(3)) == u32(6), u32(1)) }
 PropertyRange: (data: []u8): () {
  state: [1]TestChoices
@@ -75,19 +92,31 @@ SimOrder: (data: []u8): () {
  second: SimEvent = sim_next(queue, events, clock, choices, data)
  test_check(second.kind == u32(1) && clock[0].now == u64(20), u32(7))
 }`,
- })
- code,results,stderr:=runCLI(t,"-runs","8",dir)
- if code!=0 || len(results)!=4{t.Fatalf("code %d: %+v\n%s",code,results,stderr)}
- for _,r:=range results{if r.Status!="pass"{t.Fatalf("%+v",r)}}
- code,results,stderr=runCLI(t,"-fuzz","FuzzBytes","-runs","20",dir)
- if code!=0 || len(results)!=1 || results[0].Cases!=20{t.Fatalf("fuzz: %d %+v %s",code,results,stderr)}
- code,results,stderr=runCLI(t,"-run","PropertyRange","-runs","5","-cover","12:5",dir)
- if code!=0{t.Fatalf("coverage: %d %+v %s",code,results,stderr)}
- code,results,_=runCLI(t,"-run","PropertyRange","-runs","5","-cover","13:1",dir)
- if code!=1 || !strings.Contains(results[0].Failure,"class 13"){t.Fatalf("missed vacuous property: %d %+v",code,results)}
+	})
+	code, results, stderr := runCLI(t, "-runs", "8", dir)
+	if code != 0 || len(results) != 4 {
+		t.Fatalf("code %d: %+v\n%s", code, results, stderr)
+	}
+	for _, r := range results {
+		if r.Status != "pass" {
+			t.Fatalf("%+v", r)
+		}
+	}
+	code, results, stderr = runCLI(t, "-fuzz", "FuzzBytes", "-runs", "20", dir)
+	if code != 0 || len(results) != 1 || results[0].Cases != 20 {
+		t.Fatalf("fuzz: %d %+v %s", code, results, stderr)
+	}
+	code, results, stderr = runCLI(t, "-run", "PropertyRange", "-runs", "5", "-cover", "12:5", dir)
+	if code != 0 {
+		t.Fatalf("coverage: %d %+v %s", code, results, stderr)
+	}
+	code, results, _ = runCLI(t, "-run", "PropertyRange", "-runs", "5", "-cover", "13:1", dir)
+	if code != 1 || !strings.Contains(results[0].Failure, "class 13") {
+		t.Fatalf("missed vacuous property: %d %+v", code, results)
+	}
 }
-func TestFailureShrinkReplayAndCorpus(t *testing.T){
- dir:=fixture(t,map[string]string{"a_test.oak":`import(testing)
+func TestFailureShrinkReplayAndCorpus(t *testing.T) {
+	dir := fixture(t, map[string]string{"a_test.oak": `import(testing)
 TestOther: (): () {}
 PropertyFails: (data: []u8): () {
  state: [1]TestChoices
@@ -95,39 +124,69 @@ PropertyFails: (data: []u8): () {
  value: u8 = test_byte(choices, data)
  test_check(value < u8(7), u32(7001))
 }`})
- code,results,stderr:=runCLI(t,"-runs","4",dir)
- if code!=1 || len(results)!=2{t.Fatalf("%d %+v %s",code,results,stderr)}
- var failure Result
- for _,r:=range results{if r.Name=="PropertyFails"{failure=r}}
- if failure.Artifact=="" || failure.Failure!="invariant:7001"{t.Fatalf("%+v",failure)}
- a,err:=readArtifact(failure.Artifact,256);if err!=nil{t.Fatal(err)}
- if !bytes.Equal(a.Input,[]byte{7}){t.Fatalf("not minimized: %v",a.Input)}
- code,results,stderr=runCLI(t,"-replay",failure.Artifact,dir)
- if code!=1 || len(results)!=1 || results[0].Failure!="reproduced invariant:7001"{t.Fatalf("replay: %d %+v %s",code,results,stderr)}
- // Corpus runs even with a different root seed and before the empty input.
- code,results,stderr=runCLI(t,"-run","PropertyFails","-runs","1","-seed","999",dir)
- if code!=1 || results[0].Cases!=1{t.Fatalf("corpus: %d %+v %s",code,results,stderr)}
- // Source drift must not silently masquerade as exact replay.
- f:=filepath.Join(dir,"a_test.oak");data,_:=os.ReadFile(f);os.WriteFile(f,append(data,[]byte("\nTestAdded: (): () {}\n")...),0600)
- code,results,_=runCLI(t,"-replay",failure.Artifact,dir)
- if code==0 || !strings.Contains(results[0].Failure,"build mismatch"){t.Fatalf("drift: %d %+v",code,results)}
+	code, results, stderr := runCLI(t, "-runs", "4", dir)
+	if code != 1 || len(results) != 2 {
+		t.Fatalf("%d %+v %s", code, results, stderr)
+	}
+	var failure Result
+	for _, r := range results {
+		if r.Name == "PropertyFails" {
+			failure = r
+		}
+	}
+	if failure.Artifact == "" || failure.Failure != "invariant:7001" {
+		t.Fatalf("%+v", failure)
+	}
+	a, err := readArtifact(failure.Artifact, 256)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(a.Input, []byte{7}) {
+		t.Fatalf("not minimized: %v", a.Input)
+	}
+	code, results, stderr = runCLI(t, "-replay", failure.Artifact, dir)
+	if code != 1 || len(results) != 1 || results[0].Failure != "reproduced invariant:7001" {
+		t.Fatalf("replay: %d %+v %s", code, results, stderr)
+	}
+	// Corpus runs even with a different root seed and before the empty input.
+	code, results, stderr = runCLI(t, "-run", "PropertyFails", "-runs", "1", "-seed", "999", dir)
+	if code != 1 || results[0].Cases != 1 {
+		t.Fatalf("corpus: %d %+v %s", code, results, stderr)
+	}
+	// Source drift must not silently masquerade as exact replay.
+	f := filepath.Join(dir, "a_test.oak")
+	data, _ := os.ReadFile(f)
+	os.WriteFile(f, append(data, []byte("\nTestAdded: (): () {}\n")...), 0600)
+	code, results, _ = runCLI(t, "-replay", failure.Artifact, dir)
+	if code == 0 || !strings.Contains(results[0].Failure, "build mismatch") {
+		t.Fatalf("drift: %d %+v", code, results)
+	}
 }
-func TestDiscardTimeoutAndCrashIsolation(t *testing.T){
- dir:=fixture(t,map[string]string{"a_test.oak":`import(testing)
+func TestDiscardTimeoutAndCrashIsolation(t *testing.T) {
+	dir := fixture(t, map[string]string{"a_test.oak": `import(testing)
 PropertyDiscard: (data: []u8): () { test_assume(false) }
 TestCrash: (): () { assert(false) }
 TestTimeout: (): () { while true {} }
 TestSurvives: (): () { test_check(true, u32(1)) }
 `})
- code,results,stderr:=runCLI(t,"-runs","1","-max-discards","2","-timeout","100ms","-shrink","0",dir)
- if code!=1 || len(results)!=4{t.Fatalf("%d %+v %s",code,results,stderr)}
- states:=map[string]Result{};for _,r:=range results{states[r.Name]=r}
- if states["TestSurvives"].Status!="pass" || states["TestTimeout"].Failure!="timeout" || states["TestCrash"].Status!="fail" || states["PropertyDiscard"].Discards!=3{t.Fatalf("%+v",states)}
+	code, results, stderr := runCLI(t, "-runs", "1", "-max-discards", "2", "-timeout", "100ms", "-shrink", "0", dir)
+	if code != 1 || len(results) != 4 {
+		t.Fatalf("%d %+v %s", code, results, stderr)
+	}
+	states := map[string]Result{}
+	for _, r := range results {
+		states[r.Name] = r
+	}
+	if states["TestSurvives"].Status != "pass" || states["TestTimeout"].Failure != "timeout" || states["TestCrash"].Status != "fail" || states["PropertyDiscard"].Discards != 3 {
+		t.Fatalf("%+v", states)
+	}
 }
-func TestNoTestsAndInvalidFlagsFail(t *testing.T){
- dir:=t.TempDir()
- for _,args:=range [][]string{{dir},{"-runs","0",dir},{"-run","[",dir}}{
-  var out,err bytes.Buffer
-  if Main(args,&out,&err)!=2{t.Fatalf("expected error for %v",args)}
- }
+func TestNoTestsAndInvalidFlagsFail(t *testing.T) {
+	dir := t.TempDir()
+	for _, args := range [][]string{{dir}, {"-runs", "0", dir}, {"-run", "[", dir}} {
+		var out, err bytes.Buffer
+		if Main(args, &out, &err) != 2 {
+			t.Fatalf("expected error for %v", args)
+		}
+	}
 }


### PR DESCRIPTION
Oak could execute checked systems code through its C backend but had no native test runner. This adds `oak test` and connects generated testing to real OS components.

Changes:
- Discover unit, property, fuzz and simulation tests in `*_test.oak`; support filtering, JSON results, watchdogs, semantic coverage counts and optional sanitizers.
- Add `import(testing)` assertions with stable invariant IDs, assumptions, composable choice-tape generators and bounded virtual-time event queues.
- Minimize failures, save versioned regression corpora and strictly replay the original build/configuration/failure signature.
- Provide portable mutation fuzzing and checked C/libFuzzer harness export.
- Enforce conservative whole-package simulation boundaries before specialization: reject unsafe blocks, machine/atomic operations and unlisted FFI, including hidden helpers and generic templates.
- Link explicit trusted native adapter manifests with exact scalar ABI declarations and hash-pinned, snapshotted object files. Include adapter identities in replay fingerprints; allow adapter-backed fuzz exports.

Validation:
- [Dedicated testing CI passed](https://github.com/SCKelemen/oak/actions/runs/34240622894): native end-to-end runner tests, adapter hash/ABI/source drift and strict replay, Oak examples, libFuzzer, and Go reducer/mutation fuzz targets.
- The IRQ pilot mutation test requires the four-command lost-edge counterexample.
- [OS integration PR](https://github.com/SCKelemen/os/pull/19) executes canonical Zig IRQ/timer/router modules. Its [CI passed](https://github.com/SCKelemen/os/actions/runs/34240449894): 1,000 properties, 2,000 simulations across two seeds with required fault coverage, 1,000 mutation-fuzz cases, a 1,000-run libFuzzer smoke campaign, and an injected production lost-edge bug minimized to 11 bytes and strictly replayed.
- Merged current specification changes, preserving JSON decoding, resource semantics, and freestanding compiler work. Golden, library, AArch64, formal, snapshot and generalization checks pass. The longer full compiler/stdlib race suites are still running.

Scope: this is bounded component simulation, not whole-machine emulation or an ARM weak-memory model. The compiler enforces the Oak boundary restrictions; native adapter determinism remains an explicit trusted contract, not a proven effect closure or syscall sandbox. Automatic ADT/refinement generators and debugger-schema integration remain future work. See `docs/spec/110-testing.md` and `testrunner/README.md` for contracts and commands.