### PR TITLE
Expose VBAR_EL2 for Oak-owned exception setup

### DIFF
--- a/codegen/aarch64_sysreg_test.go
+++ b/codegen/aarch64_sysreg_test.go
@@ -23,6 +23,10 @@ fn sysreg_write_vttbr(value: u64) -> ()
   arm64.write_vttbr_el2(value)
 fn sysreg_write_vtcr(value: u64) -> ()
   arm64.write_vtcr_el2(value)
+fn sysreg_read_vbar() -> u64
+  arm64.read_vbar_el2()
+fn sysreg_write_vbar(value: u64) -> ()
+  arm64.write_vbar_el2(value)
 `
 
 func compileSysRegAArch64Assembly(t *testing.T) (generated, assembly string) {
@@ -70,6 +74,8 @@ func TestAArch64SystemRegisterInstructionRefinement(t *testing.T) {
 		{"sysreg_read_counter", "mrs", "cntvct_el0"},
 		{"sysreg_write_vttbr", "msr", "vttbr_el2"},
 		{"sysreg_write_vtcr", "msr", "vtcr_el2"},
+		{"sysreg_read_vbar", "mrs", "vbar_el2"},
+		{"sysreg_write_vbar", "msr", "vbar_el2"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.fn, func(t *testing.T) {

--- a/docs/notes/el2-vectors.md
+++ b/docs/notes/el2-vectors.md
@@ -1,0 +1,18 @@
+# EL2 exception vector base
+
+Oak exposes `arm64.read_vbar_el2() -> u64` and
+`arm64.write_vbar_el2(value: u64) -> ()`. These are privileged AArch64
+register operations, with no hidden allocation or barrier. The OS must supply
+a valid 2 KiB-aligned executable vector table for its translation regime and
+execute an explicit ISB after installation. The write intrinsic does not
+validate mappings or establish a vector table.
+
+The OS collection payload uses these operations to install a fatal exception
+diagnostic path. ESR_EL2, ELR_EL2, SPSR_EL2 and FAR_EL2 reads were already
+available. FAR is meaningful only for exception classes that define it.
+
+Reference: [Arm VBAR_EL2](https://support.arm.com/documentation/ddi0601/2023-12/AArch64-Registers/VBAR-EL2--Vector-Base-Address-Register--EL2-?lang=en).
+
+The instruction-refinement tests require exact MRS/MSR VBAR_EL2 operations and
+verify that neither introduces a barrier. Runtime vector alignment, dispatch,
+and exception diagnostics are exercised in the OS QEMU suite.

--- a/semir/sysreg.go
+++ b/semir/sysreg.go
@@ -60,6 +60,7 @@ var arm64SysRegs = [...]SysRegSpec{
 	{Name: "cntvoff_el2", Asm: "CNTVOFF_EL2", Access: SysRegReadWrite},
 	{Name: "elr_el2", Asm: "ELR_EL2", Access: SysRegReadWrite},
 	{Name: "spsr_el2", Asm: "SPSR_EL2", Access: SysRegReadWrite},
+	{Name: "vbar_el2", Asm: "VBAR_EL2", Access: SysRegReadWrite},
 
 	{Name: "cntv_ctl_el0", Asm: "CNTV_CTL_EL0", Access: SysRegReadWrite},
 	{Name: "cntv_cval_el0", Asm: "CNTV_CVAL_EL0", Access: SysRegReadWrite},

--- a/semir/sysreg_test.go
+++ b/semir/sysreg_test.go
@@ -4,8 +4,8 @@ import "testing"
 
 func TestArm64SysRegCatalogIsLegalAndUnique(t *testing.T) {
 	regs := Arm64SysRegs()
-	if len(regs) != 19 {
-		t.Fatalf("system-register catalog has %d entries, want 19", len(regs))
+	if len(regs) != 20 {
+		t.Fatalf("system-register catalog has %d entries, want 20", len(regs))
 	}
 	seenReg := map[string]bool{}
 	seenMember := map[string]bool{}


### PR DESCRIPTION
The OS Oak payload can read exception state but cannot install its EL2 vector base through Oak. Add VBAR_EL2 to the typed read/write register catalog.

Cross-compilation tests require exact MRS/MSR VBAR_EL2 operations and no hidden barriers. Update the catalog cardinality check and document alignment, mapping and explicit-ISB obligations. This does not add a generic assembly escape hatch.

Validation: all eight workflows passed on 5dfdc833f25445e7723b8e9c54136e545921131e, including both full race suites, exact AArch64 instruction refinement, golden, formal, API and library checks. OS PR #17 passed ReleaseSafe QEMU vector installation, normal collection execution and a fatal BRK diagnostic whose reported PC and syndrome were matched against the exact ELF.