### PR TITLE
Add resource parameter authority modes

### DIFF
--- a/compiler/resource_parameter_modes_test.go
+++ b/compiler/resource_parameter_modes_test.go
@@ -1,0 +1,135 @@
+package compiler
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/SCKelemen/oak/semir"
+	"github.com/SCKelemen/oak/typechecker"
+)
+
+func compilerParameterModeDeclarations() []typechecker.ResourceProtocolDeclaration {
+	return []typechecker.ResourceProtocolDeclaration{{
+		Name:          "HandleLifecycle",
+		ResourceTypes: []string{"Handle"},
+		States:        []string{"Open", "Closed"},
+		Initial:       "Open",
+		Transitions: []typechecker.ResourceTransitionDeclaration{
+			{
+				Name:       "inspect-transition",
+				Callable:   "inspect",
+				From:       "Open",
+				To:         "Open",
+				Parameters: []typechecker.ResourceParameterDeclaration{{Index: 0, Mode: typechecker.ResourceParameterBorrowed}},
+			},
+			{
+				Name:       "update-transition",
+				Callable:   "update",
+				From:       "Open",
+				To:         "Open",
+				Parameters: []typechecker.ResourceParameterDeclaration{{Index: 0, Mode: typechecker.ResourceParameterBorrowedMut}},
+			},
+			{
+				Name:       "close-transition",
+				Callable:   "close",
+				From:       "Open",
+				To:         "Closed",
+				Parameters: []typechecker.ResourceParameterDeclaration{{Index: 0, Mode: typechecker.ResourceParameterConsumed}},
+			},
+		},
+	}}
+}
+
+func TestResourceSemIREmitsCanonicalParameterModes(t *testing.T) {
+	const source = `
+Handle: type = struct { id: u32 }
+inspect: (h: Handle): () = {}
+update: (h: Handle): () = {}
+close: (h: Handle): () = {}
+`
+
+	result, err := New().
+		WithSource("resource-modes.oak", source).
+		ResourceSemIR(compilerParameterModeDeclarations()).
+		Get()
+	if err != nil {
+		t.Fatalf("resource SemIR stage failed: %v", err)
+	}
+	transitions := result.Module.Protocols[0].Transitions
+	if len(transitions) != 3 {
+		t.Fatalf("unexpected transitions: %#v", transitions)
+	}
+
+	inspect, _, err := transitions[0].ResourceSemantics()
+	if err != nil || len(inspect.Borrowed) != 1 || inspect.Borrowed[0] != 0 {
+		t.Fatalf("inspect mode was not emitted canonically: %#v err=%v", inspect, err)
+	}
+	update, _, err := transitions[1].ResourceSemantics()
+	if err != nil || len(update.BorrowedMut) != 1 || update.BorrowedMut[0] != 0 {
+		t.Fatalf("update mode was not emitted canonically: %#v err=%v", update, err)
+	}
+	close, _, err := transitions[2].ResourceSemantics()
+	if err != nil || len(close.Consumes) != 1 || close.Consumes[0] != 0 {
+		t.Fatalf("close mode was not emitted canonically: %#v err=%v", close, err)
+	}
+
+	if transitions[0].Effects[0].Name != semir.ResourceEffectBorrow ||
+		transitions[1].Effects[0].Name != semir.ResourceEffectBorrowMut ||
+		transitions[2].Effects[0].Name != semir.ResourceEffectConsume {
+		t.Fatalf("unexpected canonical effects: %#v", transitions)
+	}
+}
+
+func TestDefaultCheckPreservesAuthorityAcrossBorrowModes(t *testing.T) {
+	const source = `
+Handle: type = struct { id: u32 }
+inspect: (h: Handle): () = {}
+update: (h: Handle): () = {}
+close: (h: Handle): () = {}
+f: (h: Handle): u32 {
+  inspect(h)
+  update(h)
+  h.id
+}
+`
+
+	if _, err := New().
+		WithSource("borrowed-resource.oak", source).
+		WithResourceProtocols(compilerParameterModeDeclarations()).
+		Check().
+		Get(); err != nil {
+		t.Fatalf("borrowed resource authority should remain live: %v", err)
+	}
+}
+
+func TestDefaultCheckConsumesOnlyConsumedMode(t *testing.T) {
+	const source = `
+Handle: type = struct { id: u32 }
+inspect: (h: Handle): () = {}
+update: (h: Handle): () = {}
+close: (h: Handle): () = {}
+f: (h: Handle): u32 {
+  close(h)
+  h.id
+}
+`
+
+	_, err := New().
+		WithSource("consumed-resource-mode.oak", source).
+		WithResourceProtocols(compilerParameterModeDeclarations()).
+		Check().
+		Get()
+	if err == nil {
+		t.Fatal("expected consumed resource rejection")
+	}
+	var diagnosticErr *DiagnosticError
+	if !errors.As(err, &diagnosticErr) {
+		t.Fatalf("expected DiagnosticError, got %T: %v", err, err)
+	}
+	for _, diagnostic := range diagnosticErr.Diagnostics {
+		if diagnostic != nil && diagnostic.Code == typechecker.CodeResourceUsedAfterConsume {
+			return
+		}
+	}
+	t.Fatalf("expected %s, got %#v", typechecker.CodeResourceUsedAfterConsume, diagnosticErr.Diagnostics)
+}

--- a/compiler/resource_semir.go
+++ b/compiler/resource_semir.go
@@ -79,6 +79,7 @@ func cloneResourceProtocolDeclarations(declarations []typechecker.ResourceProtoc
 		cloned[i].Transitions = make([]typechecker.ResourceTransitionDeclaration, len(declaration.Transitions))
 		for j, transition := range declaration.Transitions {
 			cloned[i].Transitions[j] = transition
+			cloned[i].Transitions[j].Parameters = append([]typechecker.ResourceParameterDeclaration(nil), transition.Parameters...)
 			cloned[i].Transitions[j].Consumes = append([]int(nil), transition.Consumes...)
 		}
 	}
@@ -116,8 +117,17 @@ func emitResourceSemIR(resources typechecker.ResolvedResourceProgram) (semir.Mod
 				From:     resourceTransition.From,
 				To:       resourceTransition.To,
 			}
-			for _, index := range resourceTransition.Consumes {
-				transition.Effects = append(transition.Effects, semir.ResourceConsumeArgument(index))
+			for _, parameter := range resourceTransition.Parameters {
+				switch parameter.Mode {
+				case typechecker.ResourceParameterBorrowed:
+					transition.Effects = append(transition.Effects, semir.ResourceBorrowArgument(parameter.Index))
+				case typechecker.ResourceParameterBorrowedMut:
+					transition.Effects = append(transition.Effects, semir.ResourceBorrowMutArgument(parameter.Index))
+				case typechecker.ResourceParameterConsumed:
+					transition.Effects = append(transition.Effects, semir.ResourceConsumeArgument(parameter.Index))
+				default:
+					return semir.Module{}, fmt.Errorf("resource callable %q has unresolved parameter mode %d", resourceTransition.Callable, parameter.Mode)
+				}
 			}
 			if resourceTransition.ReturnsFresh {
 				transition.Effects = append(transition.Effects, semir.ResourceReturnFresh())

--- a/semir/resource_effects.go
+++ b/semir/resource_effects.go
@@ -8,29 +8,53 @@ import (
 )
 
 const (
-	// ResourceEffectNamespace owns semantic effects that change resource
-	// authority. These are SemIR facts, not source syntax.
-	ResourceEffectNamespace   = "resource"
+	// ResourceEffectNamespace owns semantic effects that describe or change
+	// resource authority. These are SemIR facts, not source syntax.
+	ResourceEffectNamespace = "resource"
+
+	// Parameter effects describe how a callable may use one resource argument.
+	// Borrowed and borrowed-mutable parameters preserve permanent authority;
+	// consumed parameters permanently invalidate the old authority class.
+	ResourceEffectBorrow      = "borrow"
+	ResourceEffectBorrowMut   = "borrow-mut"
 	ResourceEffectConsume     = "consume"
 	ResourceEffectReturnFresh = "return-fresh"
 )
 
 // ResourceTransitionSemantics is the resource-authority projection of one
-// protocol transition. Consumes contains zero-based callable argument indices;
-// ReturnsFresh means the transition's result carries new live authority rather
-// than reviving any consumed input value.
+// protocol transition. Parameter index lists are zero-based callable argument
+// indices and are sorted deterministically. ReturnsFresh means the result
+// carries a new live authority class rather than reviving any consumed input.
 type ResourceTransitionSemantics struct {
+	Borrowed     []int
+	BorrowedMut  []int
 	Consumes     []int
 	ReturnsFresh bool
+}
+
+// ResourceBorrowArgument constructs the canonical semantic effect for a shared
+// borrowed resource parameter.
+func ResourceBorrowArgument(index int) Effect {
+	return resourceArgumentEffect(ResourceEffectBorrow, index)
+}
+
+// ResourceBorrowMutArgument constructs the canonical semantic effect for a
+// mutable borrowed resource parameter.
+func ResourceBorrowMutArgument(index int) Effect {
+	return resourceArgumentEffect(ResourceEffectBorrowMut, index)
 }
 
 // ResourceConsumeArgument constructs the canonical semantic effect for a
 // consuming parameter. Negative indices are retained so validation can reject
 // malformed generated SemIR instead of silently rewriting it.
 func ResourceConsumeArgument(index int) Effect {
+	return resourceArgumentEffect(ResourceEffectConsume, index)
+}
+
+func resourceArgumentEffect(name string, index int) Effect {
 	return Effect{
 		Namespace:  ResourceEffectNamespace,
-		Name:       ResourceEffectConsume,
+		Name:       name,
 		Parameters: []string{"arg:" + strconv.Itoa(index)},
 	}
 }
@@ -43,10 +67,10 @@ func ResourceReturnFresh() Effect {
 
 // ResourceSemantics decodes structured resource effects from a transition.
 // Effects outside the resource namespace are ignored. Unknown/malformed
-// resource effects are rejected so typos cannot silently weaken consumption.
+// resource effects are rejected so typos cannot silently weaken authority.
 func (t Transition) ResourceSemantics() (ResourceTransitionSemantics, bool, error) {
 	result := ResourceTransitionSemantics{}
-	seenConsume := make(map[int]bool)
+	seenParameter := make(map[int]string)
 	seenFresh := false
 	present := false
 
@@ -56,27 +80,24 @@ func (t Transition) ResourceSemantics() (ResourceTransitionSemantics, bool, erro
 		}
 		present = true
 		switch effect.Name {
-		case ResourceEffectConsume:
-			if len(effect.Parameters) != 1 {
-				return ResourceTransitionSemantics{}, true,
-					fmt.Errorf("resource.consume expects exactly one arg:<index> parameter")
+		case ResourceEffectBorrow, ResourceEffectBorrowMut, ResourceEffectConsume:
+			index, err := decodeResourceArgument(effect)
+			if err != nil {
+				return ResourceTransitionSemantics{}, true, err
 			}
-			parameter := effect.Parameters[0]
-			if !strings.HasPrefix(parameter, "arg:") {
+			if previous, exists := seenParameter[index]; exists {
 				return ResourceTransitionSemantics{}, true,
-					fmt.Errorf("resource.consume parameter %q must be arg:<index>", parameter)
+					fmt.Errorf("resource argument %d has both %s and %s modes", index, previous, effect.Name)
 			}
-			index, err := strconv.Atoi(strings.TrimPrefix(parameter, "arg:"))
-			if err != nil || index < 0 {
-				return ResourceTransitionSemantics{}, true,
-					fmt.Errorf("resource.consume parameter %q has invalid argument index", parameter)
+			seenParameter[index] = effect.Name
+			switch effect.Name {
+			case ResourceEffectBorrow:
+				result.Borrowed = append(result.Borrowed, index)
+			case ResourceEffectBorrowMut:
+				result.BorrowedMut = append(result.BorrowedMut, index)
+			case ResourceEffectConsume:
+				result.Consumes = append(result.Consumes, index)
 			}
-			if seenConsume[index] {
-				return ResourceTransitionSemantics{}, true,
-					fmt.Errorf("resource.consume duplicates argument %d", index)
-			}
-			seenConsume[index] = true
-			result.Consumes = append(result.Consumes, index)
 
 		case ResourceEffectReturnFresh:
 			if len(effect.Parameters) != 0 {
@@ -96,8 +117,25 @@ func (t Transition) ResourceSemantics() (ResourceTransitionSemantics, bool, erro
 		}
 	}
 
+	sort.Ints(result.Borrowed)
+	sort.Ints(result.BorrowedMut)
 	sort.Ints(result.Consumes)
 	return result, present, nil
+}
+
+func decodeResourceArgument(effect Effect) (int, error) {
+	if len(effect.Parameters) != 1 {
+		return 0, fmt.Errorf("resource.%s expects exactly one arg:<index> parameter", effect.Name)
+	}
+	parameter := effect.Parameters[0]
+	if !strings.HasPrefix(parameter, "arg:") {
+		return 0, fmt.Errorf("resource.%s parameter %q must be arg:<index>", effect.Name, parameter)
+	}
+	index, err := strconv.Atoi(strings.TrimPrefix(parameter, "arg:"))
+	if err != nil || index < 0 {
+		return 0, fmt.Errorf("resource.%s parameter %q has invalid argument index", effect.Name, parameter)
+	}
+	return index, nil
 }
 
 // ValidateResourceSemantics validates every resource-specific transition fact

--- a/semir/resource_parameter_modes_test.go
+++ b/semir/resource_parameter_modes_test.go
@@ -1,0 +1,66 @@
+package semir
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResourceTransitionSemanticsDecodesParameterModes(t *testing.T) {
+	transition := Transition{
+		Callable: "operate",
+		Effects: []Effect{
+			ResourceBorrowArgument(2),
+			ResourceConsumeArgument(0),
+			ResourceBorrowMutArgument(1),
+			ResourceReturnFresh(),
+		},
+	}
+
+	semantics, present, err := transition.ResourceSemantics()
+	if err != nil || !present {
+		t.Fatalf("resource parameter modes did not decode: present=%v err=%v", present, err)
+	}
+	if len(semantics.Borrowed) != 1 || semantics.Borrowed[0] != 2 {
+		t.Fatalf("borrowed arguments = %v", semantics.Borrowed)
+	}
+	if len(semantics.BorrowedMut) != 1 || semantics.BorrowedMut[0] != 1 {
+		t.Fatalf("mutable borrowed arguments = %v", semantics.BorrowedMut)
+	}
+	if len(semantics.Consumes) != 1 || semantics.Consumes[0] != 0 {
+		t.Fatalf("consumed arguments = %v", semantics.Consumes)
+	}
+	if !semantics.ReturnsFresh {
+		t.Fatal("fresh result authority was lost")
+	}
+}
+
+func TestResourceTransitionSemanticsRejectsConflictingParameterModes(t *testing.T) {
+	transition := Transition{
+		Callable: "operate",
+		Effects: []Effect{
+			ResourceBorrowArgument(0),
+			ResourceConsumeArgument(0),
+		},
+	}
+
+	_, present, err := transition.ResourceSemantics()
+	if !present || err == nil || !strings.Contains(err.Error(), "both borrow and consume modes") {
+		t.Fatalf("expected conflicting parameter-mode rejection, got present=%v err=%v", present, err)
+	}
+}
+
+func TestResourceTransitionSemanticsRejectsMalformedBorrowIndex(t *testing.T) {
+	transition := Transition{
+		Callable: "inspect",
+		Effects: []Effect{{
+			Namespace:  ResourceEffectNamespace,
+			Name:       ResourceEffectBorrow,
+			Parameters: []string{"arg:nope"},
+		}},
+	}
+
+	_, present, err := transition.ResourceSemantics()
+	if !present || err == nil || !strings.Contains(err.Error(), "invalid argument index") {
+		t.Fatalf("expected malformed borrow rejection, got present=%v err=%v", present, err)
+	}
+}

--- a/typechecker/resource_parameter_modes_test.go
+++ b/typechecker/resource_parameter_modes_test.go
@@ -1,0 +1,115 @@
+package typechecker
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveResourceDeclarationsNormalizesParameterModes(t *testing.T) {
+	const input = `
+Handle: type = struct { id: u32 }
+operate: (read: Handle, write: Handle, close: Handle): Handle = read
+`
+	tc := checkedResourceProgram(t, input)
+	declarations := []ResourceProtocolDeclaration{{
+		Name:          "HandleLifecycle",
+		ResourceTypes: []string{"Handle"},
+		States:        []string{"Open", "Closed"},
+		Initial:       "Open",
+		Transitions: []ResourceTransitionDeclaration{{
+			Name:     "operate-transition",
+			Callable: "operate",
+			From:     "Open",
+			To:       "Open",
+			Parameters: []ResourceParameterDeclaration{
+				{Index: 2, Mode: ResourceParameterConsumed},
+				{Index: 0, Mode: ResourceParameterBorrowed},
+				{Index: 1, Mode: ResourceParameterBorrowedMut},
+			},
+			ReturnsFresh: true,
+		}},
+	}}
+
+	resolved, err := tc.ResolveResourceDeclarations(declarations)
+	if err != nil {
+		t.Fatalf("resource resolution failed: %v", err)
+	}
+	transition := resolved.Protocols[0].Transitions[0]
+	if len(transition.Parameters) != 3 {
+		t.Fatalf("resolved parameter modes = %#v", transition.Parameters)
+	}
+	want := []ResolvedResourceParameter{
+		{Index: 0, Mode: ResourceParameterBorrowed},
+		{Index: 1, Mode: ResourceParameterBorrowedMut},
+		{Index: 2, Mode: ResourceParameterConsumed},
+	}
+	for i := range want {
+		if transition.Parameters[i] != want[i] {
+			t.Fatalf("parameter %d = %#v, want %#v", i, transition.Parameters[i], want[i])
+		}
+	}
+	if len(transition.Consumes) != 1 || transition.Consumes[0] != 2 {
+		t.Fatalf("permanent-authority projection = %v", transition.Consumes)
+	}
+}
+
+func TestResolveResourceDeclarationsKeepsLegacyConsumesCompatible(t *testing.T) {
+	const input = `
+Handle: type = struct { id: u32 }
+close: (h: Handle): () = {}
+`
+	tc := checkedResourceProgram(t, input)
+	declarations := handleResourceDeclarations()
+	declarations[0].Transitions = declarations[0].Transitions[:1]
+
+	resolved, err := tc.ResolveResourceDeclarations(declarations)
+	if err != nil {
+		t.Fatalf("legacy consume input failed: %v", err)
+	}
+	transition := resolved.Protocols[0].Transitions[0]
+	if len(transition.Parameters) != 1 || transition.Parameters[0].Mode != ResourceParameterConsumed || transition.Parameters[0].Index != 0 {
+		t.Fatalf("legacy consume was not normalized: %#v", transition.Parameters)
+	}
+}
+
+func TestResolveResourceDeclarationsRejectsLegacyModeOverlap(t *testing.T) {
+	const input = `
+Handle: type = struct { id: u32 }
+close: (h: Handle): () = {}
+`
+	tc := checkedResourceProgram(t, input)
+	declarations := handleResourceDeclarations()
+	declarations[0].Transitions = declarations[0].Transitions[:1]
+	declarations[0].Transitions[0].Parameters = []ResourceParameterDeclaration{{Index: 0, Mode: ResourceParameterBorrowed}}
+
+	_, err := tc.ResolveResourceDeclarations(declarations)
+	if err == nil || !strings.Contains(err.Error(), "both parameter modes and legacy consumes") {
+		t.Fatalf("expected compatibility-overlap rejection, got %v", err)
+	}
+}
+
+func TestResolveResourceDeclarationsRejectsBorrowedNonResourceArgument(t *testing.T) {
+	const input = `
+Handle: type = struct { id: u32 }
+inspect_id: (id: u32): () = {}
+`
+	tc := checkedResourceProgram(t, input)
+	declarations := []ResourceProtocolDeclaration{{
+		Name:          "HandleLifecycle",
+		ResourceTypes: []string{"Handle"},
+		States:        []string{"Open"},
+		Initial:       "Open",
+		Transitions: []ResourceTransitionDeclaration{{
+			Name:       "inspect-transition",
+			Callable:   "inspect_id",
+			From:       "Open",
+			To:         "Open",
+			Parameters: []ResourceParameterDeclaration{{Index: 0, Mode: ResourceParameterBorrowed}},
+		}},
+	}}
+
+	_, err := tc.ResolveResourceDeclarations(declarations)
+	if err == nil || !strings.Contains(err.Error(), "non-resource type") {
+		t.Fatalf("expected non-resource borrowed argument rejection, got %v", err)
+	}
+}

--- a/typechecker/resource_resolution.go
+++ b/typechecker/resource_resolution.go
@@ -17,13 +17,47 @@ type ResourceProtocolDeclaration struct {
 	Transitions   []ResourceTransitionDeclaration
 }
 
+// ResourceParameterMode describes how one callable parameter participates in
+// resource authority. These are semantic/ABI facts, not source-level syntax.
+type ResourceParameterMode uint8
+
+const (
+	ResourceParameterUnspecified ResourceParameterMode = iota
+	ResourceParameterBorrowed
+	ResourceParameterBorrowedMut
+	ResourceParameterConsumed
+)
+
+func (mode ResourceParameterMode) String() string {
+	switch mode {
+	case ResourceParameterBorrowed:
+		return "borrowed"
+	case ResourceParameterBorrowedMut:
+		return "borrowed-mut"
+	case ResourceParameterConsumed:
+		return "consumed"
+	default:
+		return "unspecified"
+	}
+}
+
+// ResourceParameterDeclaration assigns one resource-authority mode to a
+// zero-based callable parameter.
+type ResourceParameterDeclaration struct {
+	Index int
+	Mode  ResourceParameterMode
+}
+
 // ResourceTransitionDeclaration binds one protocol-local transition label to
 // an explicit callable identity. Callable is never inferred from Name.
 type ResourceTransitionDeclaration struct {
-	Name         string
-	Callable     string
-	From         string
-	To           string
+	Name       string
+	Callable   string
+	From       string
+	To         string
+	Parameters []ResourceParameterDeclaration
+	// Consumes is the compatibility input for callers that predate explicit
+	// parameter modes. Resolution normalizes it to ResourceParameterConsumed.
 	Consumes     []int
 	ReturnsFresh bool
 }
@@ -47,12 +81,24 @@ type ResolvedResourceProtocol struct {
 	Transitions []ResolvedResourceTransition
 }
 
+type ResolvedResourceParameter struct {
+	Index int
+	Mode  ResourceParameterMode
+}
+
 type ResolvedResourceTransition struct {
-	Name         string
-	Callable     string
-	From         string
-	To           string
+	Name       string
+	Callable   string
+	From       string
+	To         string
+	Parameters []ResolvedResourceParameter
+	// Consumes is retained as the executable permanent-authority projection.
 	Consumes     []int
+	ReturnsFresh bool
+}
+
+type resolvedCallableResourceSemantics struct {
+	Parameters   []ResolvedResourceParameter
 	ReturnsFresh bool
 }
 
@@ -109,8 +155,6 @@ func (tc *TypeChecker) ResolveResourceDeclarations(declarations []ResourceProtoc
 		}
 	}
 
-	// A stable type order makes emitted semantic modules independent of map
-	// iteration and of later resolver implementation details.
 	sort.Slice(resolved.Types, func(i, j int) bool {
 		if resolved.Types[i].Name != resolved.Types[j].Name {
 			return resolved.Types[i].Name < resolved.Types[j].Name
@@ -118,7 +162,7 @@ func (tc *TypeChecker) ResolveResourceDeclarations(declarations []ResourceProtoc
 		return resolved.Types[i].Protocol < resolved.Types[j].Protocol
 	})
 
-	callableSemantics := make(map[string]ResourceOperation)
+	callableSemantics := make(map[string]resolvedCallableResourceSemantics)
 	for _, declaration := range declarations {
 		stateNames := make(map[string]bool, len(declaration.States))
 		states := make([]string, 0, len(declaration.States))
@@ -139,11 +183,7 @@ func (tc *TypeChecker) ResolveResourceDeclarations(declarations []ResourceProtoc
 			return ResolvedResourceProgram{}, fmt.Errorf("resource protocol %q initial state %q does not exist", declaration.Name, declaration.Initial)
 		}
 
-		protocol := ResolvedResourceProtocol{
-			Name:    declaration.Name,
-			States:  states,
-			Initial: declaration.Initial,
-		}
+		protocol := ResolvedResourceProtocol{Name: declaration.Name, States: states, Initial: declaration.Initial}
 		transitionNames := make(map[string]bool, len(declaration.Transitions))
 		for _, transition := range declaration.Transitions {
 			if transition.Name == "" {
@@ -172,19 +212,9 @@ func (tc *TypeChecker) ResolveResourceDeclarations(declarations []ResourceProtoc
 				return ResolvedResourceProgram{}, fmt.Errorf("resource protocol %q transition %q binds %q, which is not a function", declaration.Name, transition.Name, transition.Callable)
 			}
 
-			consumes := append([]int(nil), transition.Consumes...)
-			sort.Ints(consumes)
-			for i, index := range consumes {
-				if index < 0 || index >= len(function.Parameters) {
-					return ResolvedResourceProgram{}, fmt.Errorf("resource callable %q consumes argument %d outside its %d parameters", transition.Callable, index, len(function.Parameters))
-				}
-				if i > 0 && consumes[i-1] == index {
-					return ResolvedResourceProgram{}, fmt.Errorf("resource callable %q consumes argument %d more than once", transition.Callable, index)
-				}
-				parameterName := nominalTypeName(function.Parameters[index])
-				if !resourceTypes[parameterName] {
-					return ResolvedResourceProgram{}, fmt.Errorf("resource callable %q argument %d has non-resource type %s", transition.Callable, index, function.Parameters[index])
-				}
+			parameters, consumes, err := resolveResourceParameters(transition, function, resourceTypes)
+			if err != nil {
+				return ResolvedResourceProgram{}, err
 			}
 			if transition.ReturnsFresh {
 				returnName := nominalTypeName(function.ReturnType)
@@ -193,16 +223,17 @@ func (tc *TypeChecker) ResolveResourceDeclarations(declarations []ResourceProtoc
 				}
 			}
 
-			operation := ResourceOperation{Consumes: consumes, ReturnsFresh: transition.ReturnsFresh}
-			if previous, exists := callableSemantics[transition.Callable]; exists && !sameResourceOperation(previous, operation) {
+			semantics := resolvedCallableResourceSemantics{Parameters: parameters, ReturnsFresh: transition.ReturnsFresh}
+			if previous, exists := callableSemantics[transition.Callable]; exists && !sameResolvedCallableResourceSemantics(previous, semantics) {
 				return ResolvedResourceProgram{}, fmt.Errorf("resource callable %q has conflicting semantics across protocols", transition.Callable)
 			}
-			callableSemantics[transition.Callable] = operation
+			callableSemantics[transition.Callable] = semantics
 			protocol.Transitions = append(protocol.Transitions, ResolvedResourceTransition{
 				Name:         transition.Name,
 				Callable:     transition.Callable,
 				From:         transition.From,
 				To:           transition.To,
+				Parameters:   parameters,
 				Consumes:     consumes,
 				ReturnsFresh: transition.ReturnsFresh,
 			})
@@ -211,6 +242,75 @@ func (tc *TypeChecker) ResolveResourceDeclarations(declarations []ResourceProtoc
 	}
 
 	return resolved, nil
+}
+
+func resolveResourceParameters(
+	transition ResourceTransitionDeclaration,
+	function *FunctionType,
+	resourceTypes map[string]bool,
+) ([]ResolvedResourceParameter, []int, error) {
+	seen := make(map[int]ResourceParameterMode)
+	parameters := make([]ResolvedResourceParameter, 0, len(transition.Parameters)+len(transition.Consumes))
+
+	validate := func(index int, mode ResourceParameterMode) error {
+		if mode == ResourceParameterUnspecified || mode > ResourceParameterConsumed {
+			return fmt.Errorf("resource callable %q argument %d has invalid parameter mode %d", transition.Callable, index, mode)
+		}
+		if index < 0 || index >= len(function.Parameters) {
+			return fmt.Errorf("resource callable %q marks argument %d outside its %d parameters", transition.Callable, index, len(function.Parameters))
+		}
+		if previous, exists := seen[index]; exists {
+			return fmt.Errorf("resource callable %q argument %d has both %s and %s modes", transition.Callable, index, previous, mode)
+		}
+		parameterName := nominalTypeName(function.Parameters[index])
+		if !resourceTypes[parameterName] {
+			return fmt.Errorf("resource callable %q argument %d has non-resource type %s", transition.Callable, index, function.Parameters[index])
+		}
+		seen[index] = mode
+		parameters = append(parameters, ResolvedResourceParameter{Index: index, Mode: mode})
+		return nil
+	}
+
+	for _, parameter := range transition.Parameters {
+		if err := validate(parameter.Index, parameter.Mode); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	legacyConsumes := append([]int(nil), transition.Consumes...)
+	sort.Ints(legacyConsumes)
+	for i, index := range legacyConsumes {
+		if i > 0 && legacyConsumes[i-1] == index {
+			return nil, nil, fmt.Errorf("resource callable %q consumes argument %d more than once", transition.Callable, index)
+		}
+		if _, exists := seen[index]; exists {
+			return nil, nil, fmt.Errorf("resource callable %q argument %d is specified by both parameter modes and legacy consumes", transition.Callable, index)
+		}
+		if err := validate(index, ResourceParameterConsumed); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	sort.Slice(parameters, func(i, j int) bool { return parameters[i].Index < parameters[j].Index })
+	consumes := make([]int, 0, len(parameters))
+	for _, parameter := range parameters {
+		if parameter.Mode == ResourceParameterConsumed {
+			consumes = append(consumes, parameter.Index)
+		}
+	}
+	return parameters, consumes, nil
+}
+
+func sameResolvedCallableResourceSemantics(left, right resolvedCallableResourceSemantics) bool {
+	if left.ReturnsFresh != right.ReturnsFresh || len(left.Parameters) != len(right.Parameters) {
+		return false
+	}
+	for i := range left.Parameters {
+		if left.Parameters[i] != right.Parameters[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // nominalTypeName returns the authority-bearing nominal base. Structural

--- a/typechecker/resource_semir.go
+++ b/typechecker/resource_semir.go
@@ -37,6 +37,7 @@ func ResourceModelFromSemIR(module semir.Module) (ResourceModel, error) {
 		}
 	}
 
+	fullSemantics := make(map[string]semir.ResourceTransitionSemantics)
 	for _, protocol := range module.Protocols {
 		for _, transition := range protocol.Transitions {
 			semantics, present, err := transition.ResourceSemantics()
@@ -52,13 +53,9 @@ func ResourceModelFromSemIR(module semir.Module) (ResourceModel, error) {
 				continue
 			}
 
-			operation := ResourceOperation{
-				Consumes:     append([]int(nil), semantics.Consumes...),
-				ReturnsFresh: semantics.ReturnsFresh,
-			}
 			callable := transition.Callable
-			if existing, exists := model.Operations[callable]; exists {
-				if !sameResourceOperation(existing, operation) {
+			if existing, exists := fullSemantics[callable]; exists {
+				if !sameResourceTransitionSemantics(existing, semantics) {
 					return ResourceModel{}, fmt.Errorf(
 						"resource callable %q has conflicting semantics across protocols",
 						callable,
@@ -66,7 +63,12 @@ func ResourceModelFromSemIR(module semir.Module) (ResourceModel, error) {
 				}
 				continue
 			}
-			model.MarkOperation(callable, operation)
+			fullSemantics[callable] = semantics
+
+			model.MarkOperation(callable, ResourceOperation{
+				Consumes:     append([]int(nil), semantics.Consumes...),
+				ReturnsFresh: semantics.ReturnsFresh,
+			})
 		}
 	}
 
@@ -91,6 +93,27 @@ func sameResourceOperation(left, right ResourceOperation) bool {
 	}
 	for i := range left.Consumes {
 		if left.Consumes[i] != right.Consumes[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func sameResourceTransitionSemantics(left, right semir.ResourceTransitionSemantics) bool {
+	if left.ReturnsFresh != right.ReturnsFresh {
+		return false
+	}
+	return sameIntSlice(left.Borrowed, right.Borrowed) &&
+		sameIntSlice(left.BorrowedMut, right.BorrowedMut) &&
+		sameIntSlice(left.Consumes, right.Consumes)
+}
+
+func sameIntSlice(left, right []int) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
 			return false
 		}
 	}


### PR DESCRIPTION
## Summary

- add syntax-independent resource parameter modes: borrowed, borrowed-mutable, and consumed
- keep legacy `Consumes` metadata as a compatibility input and normalize it during semantic resolution
- validate marked parameters against checked nominal resource types and reject overlapping/conflicting modes
- emit canonical `resource.borrow`, `resource.borrow-mut`, and `resource.consume` SemIR effects
- reject conflicting full resource semantics across protocols, including externally supplied SemIR
- preserve permanent authority across borrow modes; only consumed parameters invalidate old authority

## Coverage

- SemIR decoding, malformed metadata, and conflicting parameter modes
- resolver normalization, legacy compatibility, overlap rejection, and resource-type validation
- compiler emission and default `Check()` behavior for borrowed/mutable/consumed parameters

## Syntax

No parser or grammar changes. These are semantic/ABI-facing facts only; source ownership/consume spelling remains unfrozen.