### PR TITLE
Enforce resource call authority exclusivity

### DIFF
--- a/compiler/resource_call_exclusivity_test.go
+++ b/compiler/resource_call_exclusivity_test.go
@@ -1,0 +1,75 @@
+package compiler
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/SCKelemen/oak/typechecker"
+)
+
+func compilerResourceCallExclusivityDeclarations() []typechecker.ResourceProtocolDeclaration {
+	return []typechecker.ResourceProtocolDeclaration{{
+		Name:          "HandleAccess",
+		ResourceTypes: []string{"Handle"},
+		States:        []string{"Open"},
+		Initial:       "Open",
+		Transitions: []typechecker.ResourceTransitionDeclaration{{
+			Name:     "update-pair",
+			Callable: "update_pair",
+			From:     "Open",
+			To:       "Open",
+			Parameters: []typechecker.ResourceParameterDeclaration{
+				{Index: 0, Mode: typechecker.ResourceParameterBorrowedMut},
+				{Index: 1, Mode: typechecker.ResourceParameterBorrowed},
+			},
+		}},
+	}}
+}
+
+func TestDefaultCheckRejectsAliasedMutableResourceArguments(t *testing.T) {
+	const source = `
+Handle: type = struct { id: u32 }
+update_pair: (left: Handle, right: Handle): () = {}
+f: (h: Handle): u32 {
+  alias: Handle = h
+  update_pair(h, alias)
+  h.id
+}
+`
+
+	_, err := New().
+		WithSource("resource-call-alias.oak", source).
+		WithResourceProtocols(compilerResourceCallExclusivityDeclarations()).
+		Check().
+		Get()
+	if err == nil {
+		t.Fatal("expected aliased mutable resource call rejection")
+	}
+	var diagnosticErr *DiagnosticError
+	if !errors.As(err, &diagnosticErr) {
+		t.Fatalf("expected DiagnosticError, got %T: %v", err, err)
+	}
+	if diagnosticErr.Phase != "resource" {
+		t.Fatalf("expected resource phase rejection, got %q", diagnosticErr.Phase)
+	}
+
+	aliasConflicts := 0
+	consumedErrors := 0
+	for _, diagnostic := range diagnosticErr.Diagnostics {
+		if diagnostic == nil {
+			continue
+		}
+		switch diagnostic.Code {
+		case typechecker.CodeResourceCallAliasConflict:
+			aliasConflicts++
+		case typechecker.CodeResourceUsedAfterConsume:
+			consumedErrors++
+		}
+	}
+	if aliasConflicts != 1 {
+		t.Fatalf("expected one %s diagnostic, got %#v", typechecker.CodeResourceCallAliasConflict, diagnosticErr.Diagnostics)
+	}
+	if consumedErrors != 0 {
+		t.Fatalf("call-local alias conflict must not cascade into %s: %#v", typechecker.CodeResourceUsedAfterConsume, diagnosticErr.Diagnostics)
+	}
+}

--- a/docs/spec/15-diagnostics.md
+++ b/docs/spec/15-diagnostics.md
@@ -217,6 +217,7 @@ The first stable borrow-conflict family is:
 | `OAK-B0109` | a view/span escapes the lifetime currently established for its owner |
 | `OAK-B0110` | unsafe code assumes mutable-region disjointness that safe analysis could not prove |
 | `OAK-B0111` | a resource or alias is used after its authority was consumed |
+| `OAK-B0112` | a resource call requires exclusive authority but two mode-marked arguments alias the same resource |
 
 For `OAK-B0106`, known regions use half-open interval semantics. The diagnostic
 should show the requested region and one earliest causal conflicting span. If a
@@ -229,6 +230,14 @@ a secondary label. If the later name is not the syntactic name consumed directly
 the diagnostic must include the shortest useful programmer-visible alias or
 provenance chain connecting it to the consumed authority. It should not dump an
 internal alias-set identifier.
+
+For `OAK-B0112`, the primary label is the argument whose semantic parameter mode
+requires exclusive authority. The conflicting argument is a secondary label.
+When the two arguments use different names, include the shortest useful alias or
+provenance chain showing why they identify one resource authority class. A call
+rejected for this conflict has not occurred semantically, so the diagnostic must
+not trigger a derivative use-after-consume error merely because one of its
+parameters was marked consuming.
 
 When several active borrows or aliases could explain the same conflict, the
 compiler should choose causal context deterministically, preferring the earliest

--- a/docs/spec/50-borrowing.md
+++ b/docs/spec/50-borrowing.md
@@ -173,6 +173,26 @@ Exact surface syntax is not frozen. The normative semantics are:
 - consumption does not imply allocation, copying, or destruction unless the operation separately specifies those effects;
 - safe control flow must establish that every reachable use occurs before consumption or on a path where consumption did not occur.
 
+Resource callable metadata may additionally classify parameters as shared-borrowed,
+mutable-borrowed, or consumed without freezing source syntax. These modes impose a
+call-local alias compatibility rule over explicitly mode-marked resource arguments:
+
+- two shared-borrowed arguments may identify the same resource authority class;
+- if either marked argument is mutable-borrowed or consumed, those two arguments
+  must identify distinct resource authority classes;
+- mutable-borrowed exclusivity ends when the call ends and does not consume the
+  caller's resource authority;
+- a consuming parameter invalidates its authority class only after the call has
+  passed all call-local authority checks;
+- a call rejected because marked arguments alias has not occurred semantically,
+  so it must not consume any argument or cause derivative use-after-consume errors.
+
+This rule is defined over resource provenance/alias classes rather than variable
+spelling: passing two different names for one authority is still an alias conflict.
+Unmarked resource parameters retain their ordinary semantics until a semantic or
+ABI contract explicitly assigns an authority mode. `OAK-B0112` reports violations
+of this call-local exclusivity rule.
+
 The checker should track alias classes or equivalent provenance so that consumption invalidates the relevant authority rather than merely one variable name. Copyable values remain outside this rule unless their type/protocol explicitly opts into resource semantics.
 
 `OAK-B0111` is reserved for use after consumption. Its diagnostic must show the consume site, the later use, and any relevant alias/provenance chain that explains why the later name lost authority (`15-diagnostics` section 6).
@@ -249,8 +269,13 @@ The core borrow/resource model must prove:
 - consumption permanently removes the consumed resource authority on that control-flow path;
 - live aliases in the consumed alias class cannot retain resource authority;
 - temporary `UniqueWrite` borrowing and permanent consumption remain distinct transitions;
+- shared resource-call parameters are alias-compatible while mutable-borrowed and consumed parameters require exclusive authority classes;
+- rejecting a resource-call alias conflict leaves permanent resource authority unchanged;
 - extent propagation preserves the semantic length equations introduced by array views, slices, and proved splits.
 
-`spec/lean/Oak/Borrowing.lean` models the local borrow-state laws. Consumption/alias-class and symbolic-extent lemmas should extend that proof surface as the checker representation lands. Temporal ownership transfer across asynchronous actors may additionally use TLA+ when introduced.
-
+`spec/lean/Oak/Borrowing.lean` models the local borrow-state laws. `Oak.ResourceFlow`
+models consumption and alias classes, while `Oak.ResourceCall` models call-local
+parameter-mode compatibility. Symbolic-extent lemmas should extend that proof
+surface as the checker representation lands. Temporal ownership transfer across
+asynchronous actors may additionally use TLA+ when introduced.
 

--- a/spec/lean/Oak.lean
+++ b/spec/lean/Oak.lean
@@ -12,6 +12,7 @@ import Oak.AArch64ControlTransfer
 import Oak.AArch64ColdEntry
 import Oak.Borrowing
 import Oak.ResourceFlow
+import Oak.ResourceCall
 import Oak.BorrowRegions
 import Oak.Reborrow
 import Oak.ReborrowRefinement

--- a/spec/lean/Oak/ResourceCall.lean
+++ b/spec/lean/Oak/ResourceCall.lean
@@ -1,0 +1,68 @@
+import Oak.ResourceFlow
+
+namespace Oak.ResourceCall
+
+/-- Resource parameter access modes are semantic callable facts. They do not
+freeze any source spelling. Shared borrowing preserves authority and may alias;
+mutable borrowing and consumption require call-local exclusivity. -/
+inductive ParameterMode where
+  | borrowed
+  | borrowedMut
+  | consumed
+  deriving DecidableEq, Repr
+
+/-- Two mode-marked arguments may carry the same resource authority class only
+when both accesses are shared borrows. -/
+def Compatible : ParameterMode -> ParameterMode -> Prop
+  | .borrowed, .borrowed => True
+  | _, _ => False
+
+theorem borrowed_alias_compatible :
+    Compatible .borrowed .borrowed := by
+  simp [Compatible]
+
+theorem borrowedMut_requires_exclusive (other : ParameterMode) :
+    ¬ Compatible .borrowedMut other := by
+  cases other <;> simp [Compatible]
+
+theorem consumed_requires_exclusive (other : ParameterMode) :
+    ¬ Compatible .consumed other := by
+  cases other <;> simp [Compatible]
+
+theorem compatibility_symmetric (left right : ParameterMode) :
+    Compatible left right ↔ Compatible right left := by
+  cases left <;> cases right <;> simp [Compatible]
+
+theorem compatible_iff_shared (left right : ParameterMode) :
+    Compatible left right ↔ left = .borrowed ∧ right = .borrowed := by
+  cases left <;> cases right <;> simp [Compatible]
+
+/-- `commit` models the permanent resource effect after call-local authority
+checks have completed. Rejected calls are identity transitions; shared and
+mutable borrows are temporary and also preserve permanent authority. -/
+def commit : Bool -> ParameterMode -> Oak.ResourceFlow.State -> Oak.ResourceFlow.Name -> Oak.ResourceFlow.State
+  | false, _, s, _ => s
+  | true, .consumed, s, name => Oak.ResourceFlow.consume s name
+  | true, _, s, _ => s
+
+theorem rejected_call_preserves_state (mode : ParameterMode)
+    (s : Oak.ResourceFlow.State) (name : Oak.ResourceFlow.Name) :
+    commit false mode s name = s := by
+  rfl
+
+theorem shared_call_preserves_state (s : Oak.ResourceFlow.State)
+    (name : Oak.ResourceFlow.Name) :
+    commit true .borrowed s name = s := by
+  rfl
+
+theorem mutable_call_preserves_state (s : Oak.ResourceFlow.State)
+    (name : Oak.ResourceFlow.Name) :
+    commit true .borrowedMut s name = s := by
+  rfl
+
+theorem consumed_call_commits_consumption (s : Oak.ResourceFlow.State)
+    (name : Oak.ResourceFlow.Name) :
+    commit true .consumed s name = Oak.ResourceFlow.consume s name := by
+  rfl
+
+end Oak.ResourceCall

--- a/typechecker/resource_call_exclusivity.go
+++ b/typechecker/resource_call_exclusivity.go
@@ -1,0 +1,155 @@
+package typechecker
+
+import (
+	"fmt"
+
+	"github.com/SCKelemen/oak/ast"
+	"github.com/SCKelemen/oak/diagnostic"
+)
+
+type resourceCallArgument struct {
+	index   int
+	mode    ResourceParameterMode
+	name    string
+	node    ast.Node
+	tracked bool
+}
+
+func resourceParameterModesCompatible(left, right ResourceParameterMode) bool {
+	if left == ResourceParameterUnspecified || right == ResourceParameterUnspecified {
+		return true
+	}
+	return left == ResourceParameterBorrowed && right == ResourceParameterBorrowed
+}
+
+func (a *typedResourceAnalysis) checkCallResourceExclusivity(expr *ast.InvocationExpression, op ResourceOperation) bool {
+	if a == nil || a.flow == nil || expr == nil || len(op.Parameters) == 0 {
+		return true
+	}
+
+	participants := make([]resourceCallArgument, 0, len(op.Parameters))
+	for _, parameter := range op.Parameters {
+		if parameter.Index < 0 || parameter.Index >= len(expr.Arguments) {
+			continue
+		}
+		argument := expr.Arguments[parameter.Index]
+		if !a.isResourceValue(argument) {
+			continue
+		}
+
+		participant := resourceCallArgument{
+			index: parameter.Index,
+			mode:  parameter.Mode,
+			node:  argument,
+		}
+		if ident, ok := argument.(*ast.Identifier); ok && ident != nil && a.flow.Registered(ident.Value) && a.flow.CanUse(ident.Value) {
+			participant.name = ident.Value
+			participant.tracked = true
+		}
+		participants = append(participants, participant)
+
+		// Permanent consumption must identify the authority class that becomes
+		// unavailable after the call. Until aggregate/field resource provenance
+		// is modeled, consuming an untracked resource expression would silently
+		// fail to invalidate anything, so reject it rather than weaken authority.
+		if parameter.Mode == ResourceParameterConsumed && !participant.tracked {
+			a.reportUntrackedResourceArgument(expr, participant, "consuming")
+			return false
+		}
+	}
+
+	for i := 0; i < len(participants); i++ {
+		for j := i + 1; j < len(participants); j++ {
+			left, right := participants[i], participants[j]
+			if resourceParameterModesCompatible(left.mode, right.mode) {
+				continue
+			}
+			if left.tracked && right.tracked {
+				if !a.flow.Aliases(left.name, right.name) {
+					continue
+				}
+				a.reportCallAliasConflict(expr, left, right)
+				return false
+			}
+
+			// An exclusive mode paired with resource-valued expressions whose
+			// authority classes are not tracked cannot prove the arguments distinct.
+			// Fail closed instead of accepting field projections or other expressions
+			// that may denote the same underlying resource.
+			primary := left
+			if left.mode == ResourceParameterBorrowed && right.mode != ResourceParameterBorrowed {
+				primary = right
+			}
+			a.reportUntrackedResourceArgument(expr, primary, resourceParameterModeAccess(primary.mode))
+			return false
+		}
+	}
+	return true
+}
+
+func (a *typedResourceAnalysis) isResourceValue(expr ast.Expression) bool {
+	if a == nil || a.tc == nil || a.tc.env == nil || expr == nil {
+		return false
+	}
+	typ := a.tc.env.CheckedExpressionType(expr)
+	name := nominalTypeName(typ)
+	return name != "" && a.model.ResourceTypes[name]
+}
+
+func (a *typedResourceAnalysis) reportCallAliasConflict(expr *ast.InvocationExpression, left, right resourceCallArgument) {
+	primary, other := left, right
+	if left.mode == ResourceParameterBorrowed && right.mode != ResourceParameterBorrowed {
+		primary, other = right, left
+	}
+
+	callable, _ := a.callableIdentity(expr)
+	title := fmt.Sprintf(
+		"resource argument %d to %q requires %s authority, but argument %d aliases the same resource",
+		primary.index+1,
+		callable,
+		resourceParameterModeAccess(primary.mode),
+		other.index+1,
+	)
+	d := a.tc.addResourceDiagnosticWithCode(primary.node, CodeResourceCallAliasConflict, title)
+	d.AddSecondary(diagnostic.NodeToRange(other.node), fmt.Sprintf(
+		"argument %d uses the same authority through %q",
+		other.index+1,
+		other.name,
+	))
+	for _, edge := range a.flow.AliasPath(primary.name, other.name) {
+		message := fmt.Sprintf("resource alias %q derives authority from %q", edge.Child, edge.Parent)
+		if edge.Origin != nil {
+			d.AddSecondary(diagnostic.NodeToRange(edge.Origin), message)
+		} else {
+			d.AddNote(message)
+		}
+	}
+	d.AddNote("shared resource borrows may alias; mutable borrows and consuming parameters require exclusive authority for the duration of the call")
+	d.AddHelp("pass distinct resource authority classes, or use shared-borrowed parameters when aliasing is intended and semantically valid")
+}
+
+func (a *typedResourceAnalysis) reportUntrackedResourceArgument(expr *ast.InvocationExpression, argument resourceCallArgument, access string) {
+	callable, _ := a.callableIdentity(expr)
+	title := fmt.Sprintf(
+		"resource argument %d to %q requires %s authority, but its resource provenance is not traceable",
+		argument.index+1,
+		callable,
+		access,
+	)
+	d := a.tc.addResourceDiagnosticWithCode(argument.node, CodeResourceCallAliasConflict, title)
+	d.AddNote("Oak must know the resource authority class to prove call-local exclusivity and to record permanent consumption")
+	d.AddHelp("pass a resource whose authority class is already tracked, or obtain a fresh resource from an operation declared to return fresh authority")
+}
+
+func resourceParameterModeAccess(mode ResourceParameterMode) string {
+	switch mode {
+	case ResourceParameterBorrowedMut:
+		return "exclusive mutable"
+	case ResourceParameterConsumed:
+		return "exclusive consuming"
+	case ResourceParameterBorrowed:
+		return "shared borrowed"
+	default:
+		return "resource"
+	}
+}

--- a/typechecker/resource_call_exclusivity_test.go
+++ b/typechecker/resource_call_exclusivity_test.go
@@ -1,0 +1,240 @@
+package typechecker
+
+import (
+	"strings"
+	"testing"
+)
+
+func resourceCallModel(name string, parameters ...ResourceParameterDeclaration) ResourceModel {
+	model := NewResourceModel()
+	model.MarkResourceType("Handle")
+	operation := ResourceOperation{Parameters: parameters}
+	for _, parameter := range parameters {
+		if parameter.Mode == ResourceParameterConsumed {
+			operation.Consumes = append(operation.Consumes, parameter.Index)
+		}
+	}
+	model.MarkOperation(name, operation)
+	return model
+}
+
+func resourceCallDiagnostics(tc *TypeChecker, code string) []string {
+	out := []string{}
+	for _, d := range tc.Diagnostics() {
+		if d.Code == code {
+			out = append(out, d.PlainText())
+		}
+	}
+	return out
+}
+
+func TestResourceCallSharedBorrowsMayAlias(t *testing.T) {
+	input := `
+Handle: type = struct { id: u32 }
+inspect_pair: (left: Handle, right: Handle): () = {}
+f: (h: Handle): u32 {
+  alias: Handle = h
+  inspect_pair(h, alias)
+  h.id
+}`
+	model := resourceCallModel("inspect_pair",
+		ResourceParameterDeclaration{Index: 0, Mode: ResourceParameterBorrowed},
+		ResourceParameterDeclaration{Index: 1, Mode: ResourceParameterBorrowed},
+	)
+	tc := setupTypeChecker(input)
+	tc.CheckProgramWithResources(parseProgram(input), model)
+
+	if got := resourceCallDiagnostics(tc, CodeResourceCallAliasConflict); len(got) != 0 {
+		t.Fatalf("shared resource borrows should be alias-compatible: %v", got)
+	}
+	if got := resourceCallDiagnostics(tc, CodeResourceUsedAfterConsume); len(got) != 0 {
+		t.Fatalf("shared resource borrows must preserve permanent authority: %v", got)
+	}
+}
+
+func TestResourceCallMutableBorrowRejectsAliasedParticipant(t *testing.T) {
+	input := `
+Handle: type = struct { id: u32 }
+update_pair: (left: Handle, right: Handle): () = {}
+f: (h: Handle): u32 {
+  alias: Handle = h
+  update_pair(h, alias)
+  h.id
+}`
+	model := resourceCallModel("update_pair",
+		ResourceParameterDeclaration{Index: 0, Mode: ResourceParameterBorrowedMut},
+		ResourceParameterDeclaration{Index: 1, Mode: ResourceParameterBorrowed},
+	)
+	tc := setupTypeChecker(input)
+	tc.CheckProgramWithResources(parseProgram(input), model)
+
+	got := resourceCallDiagnostics(tc, CodeResourceCallAliasConflict)
+	if len(got) != 1 {
+		t.Fatalf("expected one %s diagnostic, got %v (all errors: %v)", CodeResourceCallAliasConflict, got, tc.Errors())
+	}
+	if !strings.Contains(got[0], "exclusive mutable") || !strings.Contains(got[0], `alias "alias" derives authority from "h"`) {
+		t.Fatalf("expected exclusivity and alias provenance, got %q", got[0])
+	}
+}
+
+func TestResourceCallConsumeAliasConflictDoesNotMutateAuthority(t *testing.T) {
+	input := `
+Handle: type = struct { id: u32 }
+consume_and_read: (owned: Handle, read: Handle): () = {}
+f: (h: Handle): u32 {
+  alias: Handle = h
+  consume_and_read(h, alias)
+  h.id
+}`
+	model := resourceCallModel("consume_and_read",
+		ResourceParameterDeclaration{Index: 0, Mode: ResourceParameterConsumed},
+		ResourceParameterDeclaration{Index: 1, Mode: ResourceParameterBorrowed},
+	)
+	tc := setupTypeChecker(input)
+	tc.CheckProgramWithResources(parseProgram(input), model)
+
+	if got := resourceCallDiagnostics(tc, CodeResourceCallAliasConflict); len(got) != 1 {
+		t.Fatalf("expected one call-alias conflict, got %v (all errors: %v)", got, tc.Errors())
+	}
+	if got := resourceCallDiagnostics(tc, CodeResourceUsedAfterConsume); len(got) != 0 {
+		t.Fatalf("invalid call must not consume and cascade into %s: %v", CodeResourceUsedAfterConsume, got)
+	}
+}
+
+func TestResourceCallDistinctConsumedArgumentsAreAllowed(t *testing.T) {
+	input := `
+Handle: type = struct { id: u32 }
+consume_pair: (left: Handle, right: Handle): () = {}
+f: (left: Handle, right: Handle): u32 {
+  consume_pair(left, right)
+  0
+}`
+	model := resourceCallModel("consume_pair",
+		ResourceParameterDeclaration{Index: 0, Mode: ResourceParameterConsumed},
+		ResourceParameterDeclaration{Index: 1, Mode: ResourceParameterConsumed},
+	)
+	tc := setupTypeChecker(input)
+	tc.CheckProgramWithResources(parseProgram(input), model)
+
+	if got := resourceCallDiagnostics(tc, CodeResourceCallAliasConflict); len(got) != 0 {
+		t.Fatalf("distinct authority classes should satisfy consuming exclusivity: %v", got)
+	}
+}
+
+func TestResourceCallSameBindingConflictsWithMutableBorrow(t *testing.T) {
+	input := `
+Handle: type = struct { id: u32 }
+touch_pair: (left: Handle, right: Handle): () = {}
+f: (h: Handle): u32 {
+  touch_pair(h, h)
+  h.id
+}`
+	model := resourceCallModel("touch_pair",
+		ResourceParameterDeclaration{Index: 0, Mode: ResourceParameterBorrowedMut},
+		ResourceParameterDeclaration{Index: 1, Mode: ResourceParameterBorrowed},
+	)
+	tc := setupTypeChecker(input)
+	tc.CheckProgramWithResources(parseProgram(input), model)
+
+	if got := resourceCallDiagnostics(tc, CodeResourceCallAliasConflict); len(got) != 1 {
+		t.Fatalf("same binding must conflict with mutable call access: %v", got)
+	}
+}
+
+func TestResourceCallMutableBorrowFailsClosedForFieldProjection(t *testing.T) {
+	input := `
+Handle: type = struct { id: u32 }
+Holder: type = struct { handle: Handle }
+update_pair: (left: Handle, right: Handle): () = {}
+f: (holder: Holder): u32 {
+  update_pair(holder.handle, holder.handle)
+  holder.handle.id
+}`
+	model := resourceCallModel("update_pair",
+		ResourceParameterDeclaration{Index: 0, Mode: ResourceParameterBorrowedMut},
+		ResourceParameterDeclaration{Index: 1, Mode: ResourceParameterBorrowed},
+	)
+	tc := setupTypeChecker(input)
+	tc.CheckProgramWithResources(parseProgram(input), model)
+
+	got := resourceCallDiagnostics(tc, CodeResourceCallAliasConflict)
+	if len(got) != 1 {
+		t.Fatalf("untracked field projections must fail closed for exclusive access: %v (all errors: %v)", got, tc.Errors())
+	}
+	if !strings.Contains(got[0], "provenance is not traceable") {
+		t.Fatalf("expected traceability diagnostic, got %q", got[0])
+	}
+}
+
+func TestResourceCallConsumedFieldProjectionFailsClosed(t *testing.T) {
+	input := `
+Handle: type = struct { id: u32 }
+Holder: type = struct { handle: Handle }
+close: (h: Handle): () = {}
+f: (holder: Holder): u32 {
+  close(holder.handle)
+  holder.handle.id
+}`
+	model := resourceCallModel("close",
+		ResourceParameterDeclaration{Index: 0, Mode: ResourceParameterConsumed},
+	)
+	tc := setupTypeChecker(input)
+	tc.CheckProgramWithResources(parseProgram(input), model)
+
+	if got := resourceCallDiagnostics(tc, CodeResourceCallAliasConflict); len(got) != 1 {
+		t.Fatalf("untracked consumed resource expression must fail closed: %v (all errors: %v)", got, tc.Errors())
+	}
+	if got := resourceCallDiagnostics(tc, CodeResourceUsedAfterConsume); len(got) != 0 {
+		t.Fatalf("rejected untracked consumption must not invent permanent invalidation: %v", got)
+	}
+}
+
+func TestResourceCallProjectionBindingsRetainUnknownProvenance(t *testing.T) {
+	input := `
+Handle: type = struct { id: u32 }
+Holder: type = struct { handle: Handle }
+update_pair: (left: Handle, right: Handle): () = {}
+f: (holder: Holder): u32 {
+  left: Handle = holder.handle
+  right: Handle = holder.handle
+  update_pair(left, right)
+  holder.handle.id
+}`
+	model := resourceCallModel("update_pair",
+		ResourceParameterDeclaration{Index: 0, Mode: ResourceParameterBorrowedMut},
+		ResourceParameterDeclaration{Index: 1, Mode: ResourceParameterBorrowed},
+	)
+	tc := setupTypeChecker(input)
+	tc.CheckProgramWithResources(parseProgram(input), model)
+
+	got := resourceCallDiagnostics(tc, CodeResourceCallAliasConflict)
+	if len(got) != 1 {
+		t.Fatalf("bound untraceable projections must remain unknown: %v (all errors: %v)", got, tc.Errors())
+	}
+	if !strings.Contains(got[0], "provenance is not traceable") {
+		t.Fatalf("expected retained unknown-provenance diagnostic, got %q", got[0])
+	}
+}
+
+func TestResourceCallFreshReturnRemainsTrackedForExclusiveAccess(t *testing.T) {
+	input := `
+Handle: type = struct { id: u32 }
+renew: (h: Handle): Handle = h
+update_pair: (left: Handle, right: Handle): () = {}
+f: (left: Handle, right: Handle): u32 {
+  next: Handle = renew(left)
+  update_pair(next, right)
+  next.id
+}`
+	model := resourceCallModel("update_pair",
+		ResourceParameterDeclaration{Index: 0, Mode: ResourceParameterBorrowedMut},
+		ResourceParameterDeclaration{Index: 1, Mode: ResourceParameterBorrowed},
+	)
+	model.MarkOperation("renew", ResourceOperation{ReturnsFresh: true})
+	tc := setupTypeChecker(input)
+	tc.CheckProgramWithResources(parseProgram(input), model)
+
+	if got := resourceCallDiagnostics(tc, CodeResourceCallAliasConflict); len(got) != 0 {
+		t.Fatalf("explicit fresh return must introduce tracked independent authority: %v", got)
+	}
+}

--- a/typechecker/resource_diagnostics.go
+++ b/typechecker/resource_diagnostics.go
@@ -6,14 +6,20 @@ import (
 	"github.com/SCKelemen/oak/lsp"
 )
 
-// addResourceDiagnostic keeps OAK-B0111 in the borrow/resource diagnostic
-// category even though typed resource analysis is hosted by typechecker.
+const CodeResourceCallAliasConflict = "OAK-B0112"
+
+// addResourceDiagnostic keeps resource authority failures in the borrow/resource
+// diagnostic category even though typed resource analysis is hosted by typechecker.
 func (tc *TypeChecker) addResourceDiagnostic(node ast.Node, title string) *diagnostic.Diagnostic {
+	return tc.addResourceDiagnosticWithCode(node, CodeResourceUsedAfterConsume, title)
+}
+
+func (tc *TypeChecker) addResourceDiagnosticWithCode(node ast.Node, code, title string) *diagnostic.Diagnostic {
 	var d *diagnostic.Diagnostic
 	if node != nil {
-		d = diagnostic.NewDiagnosticFromNodeWithCode(node, "borrow", CodeResourceUsedAfterConsume, title)
+		d = diagnostic.NewDiagnosticFromNodeWithCode(node, "borrow", code, title)
 	} else {
-		d = diagnostic.NewDiagnosticWithCode(lsp.Range{}, "borrow", CodeResourceUsedAfterConsume, title)
+		d = diagnostic.NewDiagnosticWithCode(lsp.Range{}, "borrow", code, title)
 	}
 	tc.diagnostics.AddDiagnostic(d)
 	return d

--- a/typechecker/resource_flow.go
+++ b/typechecker/resource_flow.go
@@ -15,16 +15,17 @@ import (
 const CodeResourceUsedAfterConsume = "OAK-B0111"
 
 // ResourceOperation is internal semantic metadata for a callable. It freezes
-// no source syntax: frontends/protocol lowering can mark which arguments lose
-// old authority, and whether the result denotes fresh authority.
+// no source syntax: frontends/protocol lowering can describe call-local
+// authority modes, permanent consumption, and fresh result authority.
 type ResourceOperation struct {
+	Parameters   []ResourceParameterDeclaration
 	Consumes     []int
 	ReturnsFresh bool
 }
 
 // ResourceModel is the syntax-independent bridge from resolved types/callables
 // to resource-flow analysis. ResourceTypes contains nominal source type names;
-// Operations contains semantic consuming operations by resolved callable name.
+// Operations contains semantic resource operations by resolved callable name.
 type ResourceModel struct {
 	ResourceTypes map[string]bool
 	Operations    map[string]ResourceOperation
@@ -49,7 +50,21 @@ func (m *ResourceModel) MarkOperation(name string, operation ResourceOperation) 
 		m.Operations = make(map[string]ResourceOperation)
 	}
 	copyOperation := operation
+	copyOperation.Parameters = append([]ResourceParameterDeclaration(nil), operation.Parameters...)
 	copyOperation.Consumes = append([]int(nil), operation.Consumes...)
+	// Compatibility for pre-parameter-mode callers: a legacy consume list is
+	// equivalent to explicit consumed parameters when no richer modes exist.
+	if len(copyOperation.Parameters) == 0 {
+		for _, index := range copyOperation.Consumes {
+			copyOperation.Parameters = append(copyOperation.Parameters, ResourceParameterDeclaration{
+				Index: index,
+				Mode:  ResourceParameterConsumed,
+			})
+		}
+	}
+	sort.Slice(copyOperation.Parameters, func(i, j int) bool {
+		return copyOperation.Parameters[i].Index < copyOperation.Parameters[j].Index
+	})
 	m.Operations[name] = copyOperation
 }
 
@@ -74,10 +89,11 @@ func (tc *TypeChecker) CheckResourceFlow(program *ast.Program, model ResourceMod
 			continue
 		}
 		analysis := &typedResourceAnalysis{
-			tc:       tc,
-			model:    model,
-			flow:     resourceflow.New(),
-			reported: make(map[string]bool),
+			tc:               tc,
+			model:            model,
+			flow:             resourceflow.New(),
+			reported:         make(map[string]bool),
+			unknownResources: make(map[string]bool),
 		}
 		analysis.pushScope()
 		if fn.Receiver != nil && fn.Receiver.Name != nil {
@@ -100,11 +116,12 @@ func (tc *TypeChecker) CheckResourceFlow(program *ast.Program, model ResourceMod
 }
 
 type typedResourceAnalysis struct {
-	tc       *TypeChecker
-	model    ResourceModel
-	flow     *resourceflow.Flow
-	reported map[string]bool
-	scopes   []map[string]struct{}
+	tc               *TypeChecker
+	model            ResourceModel
+	flow             *resourceflow.Flow
+	reported         map[string]bool
+	unknownResources map[string]bool
+	scopes           []map[string]struct{}
 }
 
 func (m ResourceModel) isResourceType(expr ast.Expression) bool {
@@ -165,6 +182,16 @@ func (a *typedResourceAnalysis) isLocalBinding(name string) bool {
 		}
 	}
 	return false
+}
+
+func cloneResourceProvenance(source map[string]bool) map[string]bool {
+	cloned := make(map[string]bool, len(source))
+	for name, unknown := range source {
+		if unknown {
+			cloned[name] = true
+		}
+	}
+	return cloned
 }
 
 // callableIdentity resolves a checked invocation to the semantic callable key
@@ -256,8 +283,12 @@ func (a *typedResourceAnalysis) block(block *ast.BlockStatement) {
 	if block == nil {
 		return
 	}
+	incomingProvenance := cloneResourceProvenance(a.unknownResources)
 	a.pushScope()
-	defer a.popScope()
+	defer func() {
+		a.popScope()
+		a.unknownResources = incomingProvenance
+	}()
 	for _, stmt := range block.Statements {
 		a.statement(stmt)
 	}
@@ -274,25 +305,49 @@ func (a *typedResourceAnalysis) variable(stmt *ast.VariableDeclaration) {
 	if stmt.Value != nil {
 		a.expression(stmt.Value)
 	}
-	isResource := a.model.isResourceType(stmt.Type)
+
+	fresh := false
+	if call, ok := stmt.Value.(*ast.InvocationExpression); ok {
+		if op, exists := a.operation(call); exists && op.ReturnsFresh {
+			fresh = true
+		}
+	}
+	isResource := a.model.isResourceType(stmt.Type) || fresh
 	if !isResource {
-		if call, ok := stmt.Value.(*ast.InvocationExpression); ok {
-			if op, exists := a.operation(call); exists && op.ReturnsFresh {
-				isResource = true
+		return
+	}
+
+	if source, ok := stmt.Value.(*ast.Identifier); ok {
+		if a.flow.Registered(source.Value) {
+			if a.flow.CanUse(source.Value) {
+				a.flow.Alias(stmt.Name.Value, source.Value, stmt.Name)
 			}
+			return
+		}
+		if a.unknownResources[source.Value] {
+			a.unknownResources[stmt.Name.Value] = true
+			return
 		}
 	}
-	if !isResource {
+
+	if fresh {
+		// Only an explicit semantic fresh-return fact introduces a new authority
+		// class for an initialized local resource. This is never revival of an
+		// input resource consumed by the operation.
+		a.flow.Register(stmt.Name.Value, stmt.Name)
 		return
 	}
-	if source, ok := stmt.Value.(*ast.Identifier); ok && a.flow.Registered(source.Value) {
-		if a.flow.CanUse(source.Value) {
-			a.flow.Alias(stmt.Name.Value, source.Value, stmt.Name)
-		}
+
+	if stmt.Value != nil && a.isResourceValue(stmt.Value) {
+		// A projection or other resource-valued expression without a tracked
+		// authority source is not fresh merely because it receives a new name.
+		// Preserve unknown provenance so a later exclusive/consuming call fails
+		// closed instead of synthesizing a distinct authority class.
+		a.unknownResources[stmt.Name.Value] = true
 		return
 	}
-	// A resource-returning transition/constructor creates a new authority
-	// class. This is never revival of the consumed input binding.
+
+	// An uninitialized resource binding is an independent local authority root.
 	a.flow.Register(stmt.Name.Value, stmt.Name)
 }
 
@@ -405,8 +460,10 @@ func (a *typedResourceAnalysis) expression(expr ast.Expression) {
 		// are still checked without lending outer authority to the closure.
 		outerFlow := a.flow
 		outerScopes := a.scopes
+		outerUnknown := a.unknownResources
 		a.flow = resourceflow.New()
 		a.scopes = nil
+		a.unknownResources = make(map[string]bool)
 		a.pushScope()
 		for _, argument := range e.Arguments {
 			if argument != nil {
@@ -416,6 +473,7 @@ func (a *typedResourceAnalysis) expression(expr ast.Expression) {
 		a.block(e.Body)
 		a.flow = outerFlow
 		a.scopes = outerScopes
+		a.unknownResources = outerUnknown
 	}
 }
 
@@ -432,8 +490,14 @@ func (a *typedResourceAnalysis) invocation(expr *ast.InvocationExpression) {
 		a.expression(argument)
 	}
 
-	op, consuming := a.operation(expr)
-	if !consuming {
+	op, present := a.operation(expr)
+	if !present {
+		return
+	}
+	// Call-local resource modes are checked after ordinary argument uses and
+	// before permanent consumption. Invalid calls therefore do not mutate
+	// authority state and cannot create cascading use-after-consume errors.
+	if !a.checkCallResourceExclusivity(expr, op) {
 		return
 	}
 	for _, index := range op.Consumes {

--- a/typechecker/resource_semir.go
+++ b/typechecker/resource_semir.go
@@ -2,6 +2,7 @@ package typechecker
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/SCKelemen/oak/ast"
 	"github.com/SCKelemen/oak/semir"
@@ -9,8 +10,8 @@ import (
 
 // ResourceModelFromSemIR derives the typechecker's executable resource model
 // from checked semantic facts. Resource-bearing definitions are identified by
-// their Authority.Resource axis; consuming/fresh-return operations come from
-// structured resource effects bound to resolved protocol callables.
+// their Authority.Resource axis; parameter authority modes and fresh-return
+// semantics come from structured resource effects bound to resolved callables.
 func ResourceModelFromSemIR(module semir.Module) (ResourceModel, error) {
 	if err := module.Validate(); err != nil {
 		return ResourceModel{}, fmt.Errorf("invalid semantic module: %w", err)
@@ -66,6 +67,7 @@ func ResourceModelFromSemIR(module semir.Module) (ResourceModel, error) {
 			fullSemantics[callable] = semantics
 
 			model.MarkOperation(callable, ResourceOperation{
+				Parameters:   resourceParametersFromSemIR(semantics),
 				Consumes:     append([]int(nil), semantics.Consumes...),
 				ReturnsFresh: semantics.ReturnsFresh,
 			})
@@ -73,6 +75,22 @@ func ResourceModelFromSemIR(module semir.Module) (ResourceModel, error) {
 	}
 
 	return model, nil
+}
+
+func resourceParametersFromSemIR(semantics semir.ResourceTransitionSemantics) []ResourceParameterDeclaration {
+	parameters := make([]ResourceParameterDeclaration, 0,
+		len(semantics.Borrowed)+len(semantics.BorrowedMut)+len(semantics.Consumes))
+	for _, index := range semantics.Borrowed {
+		parameters = append(parameters, ResourceParameterDeclaration{Index: index, Mode: ResourceParameterBorrowed})
+	}
+	for _, index := range semantics.BorrowedMut {
+		parameters = append(parameters, ResourceParameterDeclaration{Index: index, Mode: ResourceParameterBorrowedMut})
+	}
+	for _, index := range semantics.Consumes {
+		parameters = append(parameters, ResourceParameterDeclaration{Index: index, Mode: ResourceParameterConsumed})
+	}
+	sort.Slice(parameters, func(i, j int) bool { return parameters[i].Index < parameters[j].Index })
+	return parameters
 }
 
 // CheckProgramWithSemIR is the semantic-pipeline resource-checking entrypoint.
@@ -88,8 +106,15 @@ func (tc *TypeChecker) CheckProgramWithSemIR(program *ast.Program, module semir.
 }
 
 func sameResourceOperation(left, right ResourceOperation) bool {
-	if left.ReturnsFresh != right.ReturnsFresh || len(left.Consumes) != len(right.Consumes) {
+	if left.ReturnsFresh != right.ReturnsFresh ||
+		len(left.Parameters) != len(right.Parameters) ||
+		len(left.Consumes) != len(right.Consumes) {
 		return false
+	}
+	for i := range left.Parameters {
+		if left.Parameters[i] != right.Parameters[i] {
+			return false
+		}
 	}
 	for i := range left.Consumes {
 		if left.Consumes[i] != right.Consumes[i] {

--- a/typechecker/resource_semir_modes_projection_test.go
+++ b/typechecker/resource_semir_modes_projection_test.go
@@ -1,0 +1,45 @@
+package typechecker
+
+import (
+	"testing"
+
+	"github.com/SCKelemen/oak/semir"
+)
+
+func TestResourceModelFromSemIRPreservesParameterModes(t *testing.T) {
+	module := resourceSemanticModule()
+	module.Protocols[0].Transitions = append(module.Protocols[0].Transitions, semir.Transition{
+		Name:     "AccessPairTransition",
+		Callable: "access_pair",
+		From:     "Open",
+		To:       "Open",
+		Effects: []semir.Effect{
+			semir.ResourceBorrowMutArgument(1),
+			semir.ResourceBorrowArgument(0),
+		},
+	})
+
+	model, err := ResourceModelFromSemIR(module)
+	if err != nil {
+		t.Fatalf("resource model derivation failed: %v", err)
+	}
+	op, ok := model.Operations["access_pair"]
+	if !ok {
+		t.Fatal("expected resource operation for resolved callable")
+	}
+	want := []ResourceParameterDeclaration{
+		{Index: 0, Mode: ResourceParameterBorrowed},
+		{Index: 1, Mode: ResourceParameterBorrowedMut},
+	}
+	if len(op.Parameters) != len(want) {
+		t.Fatalf("unexpected parameter modes: %#v", op.Parameters)
+	}
+	for i := range want {
+		if op.Parameters[i] != want[i] {
+			t.Fatalf("parameter modes were not preserved and sorted: got %#v want %#v", op.Parameters, want)
+		}
+	}
+	if len(op.Consumes) != 0 {
+		t.Fatalf("borrow modes must not invent permanent consumption: %#v", op)
+	}
+}


### PR DESCRIPTION
## Summary

- preserve full resource parameter modes from SemIR into executable resource-flow analysis
- enforce alias-class compatibility for explicitly mode-marked resource call arguments
- allow shared-borrowed arguments to alias each other
- require mutable-borrowed and consumed arguments to have exclusive resource authority classes
- leave permanent authority unchanged when a call is rejected for an alias conflict
- retain legacy `Consumes` metadata compatibility
- add stable `OAK-B0112` diagnostics with alias provenance
- add production/compiler, SemIR projection, typechecker, normative spec, and Lean proof coverage

## Semantics

This is call-local authority checking. Mutable borrowing does not consume authority; consumption commits only after all call-local authority checks succeed. Unmarked resource parameters keep their existing semantics.

## Syntax

No parser or grammar changes. Resource parameter modes remain semantic/ABI-facing facts; source ownership and consume spelling remain unfrozen.