### PR TITLE
Expose the EL2 physical timer for Oak-owned interrupts

### DIFF
--- a/codegen/aarch64_sysreg_test.go
+++ b/codegen/aarch64_sysreg_test.go
@@ -11,6 +11,18 @@ import (
 const aarch64SysRegSource = `
 package main
 
+fn sysreg_read_physical_count() -> u64
+  arm64.read_cntpct_el0()
+fn sysreg_read_frequency() -> u64
+  arm64.read_cntfrq_el0()
+fn sysreg_read_hyp_control() -> u64
+  arm64.read_cnthp_ctl_el2()
+fn sysreg_write_hyp_control(value: u64) -> ()
+  arm64.write_cnthp_ctl_el2(value)
+fn sysreg_read_hyp_compare() -> u64
+  arm64.read_cnthp_cval_el2()
+fn sysreg_write_hyp_compare(value: u64) -> ()
+  arm64.write_cnthp_cval_el2(value)
 fn sysreg_read_hcr() -> u64
   arm64.read_hcr_el2()
 fn sysreg_write_hcr(value: u64) -> ()
@@ -68,6 +80,12 @@ func TestAArch64SystemRegisterInstructionRefinement(t *testing.T) {
 		mnemonic string
 		reg      string
 	}{
+		{"sysreg_read_physical_count", "mrs", "cntpct_el0"},
+		{"sysreg_read_frequency", "mrs", "cntfrq_el0"},
+		{"sysreg_read_hyp_control", "mrs", "cnthp_ctl_el2"},
+		{"sysreg_write_hyp_control", "msr", "cnthp_ctl_el2"},
+		{"sysreg_read_hyp_compare", "mrs", "cnthp_cval_el2"},
+		{"sysreg_write_hyp_compare", "msr", "cnthp_cval_el2"},
 		{"sysreg_read_hcr", "mrs", "hcr_el2"},
 		{"sysreg_write_hcr", "msr", "hcr_el2"},
 		{"sysreg_read_esr", "mrs", "esr_el2"},

--- a/docs/notes/el2-timer.md
+++ b/docs/notes/el2-timer.md
@@ -1,0 +1,23 @@
+# EL2 physical timer register surface
+
+Oak now exposes read_cntpct_el0 and read_cntfrq_el0 as read-only u64
+operations, plus read/write_cnthp_ctl_el2 and read/write_cnthp_cval_el2.
+These use the existing system-register semantic authority and explicit
+AArch64 MRS/MSR lowering. No portable timer emulation or hidden barriers
+are added.
+
+CNTPCT is the physical counter; CNTFRQ gives its frequency in Hz. Oak
+exposes CNTFRQ as read-only deliberately, although privileged firmware
+can architecturally write it. CNTHP_CTL and CNTHP_CVAL require EL2 and
+control the non-secure hypervisor physical timer. Control bit 0 enables
+the timer, bit 1 masks its output, and read-only bit 2 reports the timer
+condition. The timer is a level interrupt source. Software must disable,
+mask, or reprogram it before completing interrupt-controller service.
+
+The caller owns privilege configuration, GIC routing, barriers, deadline
+overflow policy, and interrupt entry/return. Reads/writes alone neither
+enable IRQ delivery nor preserve an interrupted ABI frame. Tests verify
+all six transfer instructions and exact register names with no added
+barriers; catalog tests reject write access to the two counter inputs.
+
+Consumer: SCKelemen/os's single-core QEMU EL2 timer interrupt pilot.

--- a/semir/sysreg.go
+++ b/semir/sysreg.go
@@ -52,6 +52,10 @@ var arm64SysRegs = [...]SysRegSpec{
 	{Name: "far_el2", Asm: "FAR_EL2", Access: SysRegReadOnly},
 	{Name: "hpfar_el2", Asm: "HPFAR_EL2", Access: SysRegReadOnly},
 	{Name: "cntvct_el0", Asm: "CNTVCT_EL0", Access: SysRegReadOnly},
+	{Name: "cntpct_el0", Asm: "CNTPCT_EL0", Access: SysRegReadOnly},
+	{Name: "cntfrq_el0", Asm: "CNTFRQ_EL0", Access: SysRegReadOnly},
+	{Name: "cnthp_ctl_el2", Asm: "CNTHP_CTL_EL2", Access: SysRegReadWrite},
+	{Name: "cnthp_cval_el2", Asm: "CNTHP_CVAL_EL2", Access: SysRegReadWrite},
 
 	{Name: "hcr_el2", Asm: "HCR_EL2", Access: SysRegReadWrite},
 	{Name: "vttbr_el2", Asm: "VTTBR_EL2", Access: SysRegReadWrite},

--- a/semir/sysreg_test.go
+++ b/semir/sysreg_test.go
@@ -4,8 +4,8 @@ import "testing"
 
 func TestArm64SysRegCatalogIsLegalAndUnique(t *testing.T) {
 	regs := Arm64SysRegs()
-	if len(regs) != 20 {
-		t.Fatalf("system-register catalog has %d entries, want 20", len(regs))
+	if len(regs) != 24 {
+		t.Fatalf("system-register catalog has %d entries, want 24", len(regs))
 	}
 	seenReg := map[string]bool{}
 	seenMember := map[string]bool{}
@@ -37,7 +37,7 @@ func TestArm64SysRegCatalogIsLegalAndUnique(t *testing.T) {
 }
 
 func TestReadOnlySysRegsHaveNoWriteSurface(t *testing.T) {
-	for _, name := range []string{"currentel", "esr_el2", "far_el2", "hpfar_el2", "cntvct_el0"} {
+	for _, name := range []string{"currentel", "esr_el2", "far_el2", "hpfar_el2", "cntvct_el0", "cntpct_el0", "cntfrq_el0"} {
 		if _, found, _ := LookupArm64SysRegMember("write_" + name); found {
 			t.Fatalf("read-only register %s unexpectedly exposes a write member", name)
 		}


### PR DESCRIPTION
The OS needs a real EL2 timer source to progress from deliberate BRK returns to asynchronous interrupts.

Add read-only CNTPCT_EL0 and CNTFRQ_EL0 inputs and read/write CNTHP_CTL_EL2 and CNTHP_CVAL_EL2 through the existing system-register catalog. No hidden barriers or portable emulation. The OS owns GIC routing, IRQ masking, and deadline policy.

Extend catalog permission tests and cross-compiled AArch64 instruction tests for all six transfers. AArch64 refinement checks passed. Consumer SCKelemen/os#20 pins ad7ac31cbd8a2379009b4e28a8023aee2dafaca5 and all its CI jobs passed: https://github.com/SCKelemen/os/actions/runs/34241118543. Actual QEMU execution verified masked suppression, three timer IRQ returns with GPR/SP/flag preservation, rearming, and clean shutdown. The normal collection and fatal BRK regressions also passed.

All eight compiler workflows passed, including the two full compiler suites: https://github.com/SCKelemen/oak/actions/runs/34240510323 and https://github.com/SCKelemen/oak/actions/runs/34240510142.