### PR TITLE
Record semantic failure traces and check them during strict replay

### DIFF
--- a/compiler/simulation.go
+++ b/compiler/simulation.go
@@ -60,6 +60,7 @@ func checkSimulation(root *ast.Program, bindings []SimulationBinding) error {
 		{Name: "testing_fail_host", Symbol: "oak_test_host_fail", Parameters: []string{"c.UInt32"}, Return: "()"},
 		{Name: "testing_discard", Symbol: "oak_test_host_discard", Return: "()"},
 		{Name: "testing_classify_host", Symbol: "oak_test_host_classify", Parameters: []string{"c.UInt32"}, Return: "()"},
+		{Name: "testing_trace_host", Symbol: "oak_test_host_trace", Parameters: []string{"c.UInt32", "c.UInt64", "c.UInt64"}, Return: "()"},
 	}
 	return walkSimulation(reflect.ValueOf(root), func(value any) error {
 		switch n := value.(type) {

--- a/docs/spec/110-testing.md
+++ b/docs/spec/110-testing.md
@@ -57,6 +57,9 @@ Tests may use the host permissions available to them. Sanitizers are opt-in via
   cases; exceeding `-max-discards` fails. A unit test cannot discard.
 - `testing_classify(id)`: mark a class reached in this execution. Each accepted
   execution counts once per class, even if a loop emits it repeatedly.
+- `testing_trace(id, a, b)`: record an author-defined semantic event with a
+  stable `u32` ID and two `u64` payloads. Values are observations, not choices:
+  the call consumes no choice-tape bytes and does not affect scheduling.
 - `-cover 10:5,20:1`: require minimum accepted-case counts for these class IDs in
   each selected non-unit test. These are semantic labels, not code coverage.
 
@@ -93,6 +96,11 @@ same failure signature. Both an execution budget and a time budget apply. One
 in-flight execution may extend the shrink deadline by at most its case timeout.
 An initial repeat checks failure stability. Timeouts and harness failures are
 saved but not minimized. The result is budget-minimized, not globally minimal.
+Stability confirmation compares recorded traces too. A final execution confirms
+the minimized input and supplies its trace and output; it must match the last
+accepted reduction's trace. If it diverges, retain the original input/evidence
+and report instability. Initial/final confirmation executions are additional to
+the reduction budget and each uses the ordinary per-case watchdog.
 A generic signal signature cannot distinguish two unrelated traps with the same
 signal; stable invariant IDs are preferred for stateful properties.
 
@@ -106,6 +114,7 @@ Failures are atomically saved in `testdata/oak/<TestName>/<digest>.json` with:
 - root seed and attempt;
 - maximum input size, execution timeout, and sanitizer mode;
 - failure signature and concrete minimized input (JSON base64).
+- optional trace schema version, recorded semantic events and truncation flag.
 
 The build fingerprint covers generated C, the harness, native compilation flags,
 C compiler version output, and any adapter manifest and object hashes. It is a useful drift check, not an attestation of
@@ -117,6 +126,20 @@ both the build fingerprint and failure signature. A reproduced failure exits
 nonzero. Divergence is reported explicitly, including a now-passing input.
 Filtering does not change the compiled registration table, so selecting one test
 for replay does not itself invalidate a multi-test failure artifact.
+
+New artifacts carry trace version 1. The first 256 events are retained in order;
+an additional event sets `trace_truncated` without changing the test outcome.
+Each event has `id`, `a`, and `b`; the 64-bit payloads are JSON decimal strings
+to avoid precision loss in JavaScript tooling. Events are flushed immediately,
+preserving an available prefix after a trap or watchdog termination. Trace
+storage shares the existing bounded control report. The terminal prints the
+last eight retained events; the artifact and JSON result contain the entire
+retained prefix. Successful/discarded cases do not expose traces in results.
+
+Strict replay requires the same trace prefix and truncation flag, even when the
+invariant ID matches. This detects observed divergence; it does not prove that
+unrecorded behavior or a truncated suffix was identical. Legacy artifacts with
+no trace version retain their original input/build/signature replay contract.
 
 Ordinary test runs replay corpus inputs before generating new ones and do not
 require the historical build fingerprint: checked-in regressions must survive
@@ -139,6 +162,9 @@ harness preserves invariant IDs, skips oversized input, and translates rejected
 inputs to a return to libFuzzer. libFuzzer owns its corpus, crash files and
 minimization. Copy useful raw crash files into the runner's `.bin` corpus to
 reproduce and reduce them with `oak test`.
+
+Trace calls are no-ops in persistent libFuzzer exports. Replay a raw crash input
+through the isolated runner to collect a bounded semantic history.
 
 libFuzzer is persistent: all tested state must be constructed/reset inside the
 fuzz function. Target-side state must not escape across calls. Avoid nontrivial

--- a/examples/testing/irq_test.oak
+++ b/examples/testing/irq_test.oak
@@ -39,6 +39,7 @@ PropertyIrqHistory: (data: []u8): () {
   while step < u32(64) {
     action: u32 = u32(test_byte(choices, data)) % u32(8)
     before: Irq = state[0]
+    testing_trace(u32(200), u64(action), u64(step))
     irq_apply(state, action)
     model = irq_model(model, action)
     after: Irq = state[0]
@@ -87,6 +88,7 @@ SimTimerIrq: (data: []u8): () {
   while queue[0].count > u32(0) {
     previous: u64 = clock[0].now
     event: SimEvent = sim_next(queue, events, clock, choices, data)
+    testing_trace(u32(201), (u64(event.kind) << u64(32)) | u64(event.value), clock[0].now)
     test_check(clock[0].now >= previous, u32(2021))
     event.kind == u32(0) ? { compare = u64(event.value) }
     event.kind == u32(1) ? { masked = true }

--- a/stdlib/testing.oak
+++ b/stdlib/testing.oak
@@ -3,9 +3,16 @@
 testing_fail_host: (id: c.UInt32): () = c.extern("oak_test_host_fail")
 testing_discard: (): () = c.extern("oak_test_host_discard")
 testing_classify_host: (id: c.UInt32): () = c.extern("oak_test_host_classify")
+testing_trace_host: (id: c.UInt32, a: c.UInt64, b: c.UInt64): () = c.extern("oak_test_host_trace")
 
 testing_fail: (id: u32): () { testing_fail_host(c.UInt32(id)) }
 testing_classify: (id: u32): () { testing_classify_host(c.UInt32(id)) }
+
+// Bounded semantic trace: stable event ID and two domain-defined payloads.
+// The native runner retains the first 256 events and marks truncation.
+testing_trace: (id: u32, a: u64, b: u64): () {
+  testing_trace_host(c.UInt32(id), c.UInt64(a), c.UInt64(b))
+}
 
 test_check: (condition: Bool, id: u32): () {
   !condition ? { testing_fail(id) }

--- a/testrunner/README.md
+++ b/testrunner/README.md
@@ -36,6 +36,14 @@ A failure prints an exact replay command and saves its minimized input under
 runs execute the corpus before exploring new inputs. `-replay` checks the exact
 build and expected failure; a reproduced failure still exits nonzero.
 
+Use `testing_trace(id, a, b)` to record semantic actions or observations with a
+stable `u32` event ID and two `u64` payloads. Failures retain the first 256 events
+with an explicit truncation flag; the terminal prints the last eight retained
+events. The saved trace describes the **minimized** input, and exact replay
+compares both the failure and its recorded trace. JSON payloads are decimal
+strings so tools can preserve every 64-bit value. Trace calls are no-ops in
+libFuzzer exports; rerun a raw crash input with `oak test` to collect its trace.
+
 `-timeout`, `-max-bytes`, `-max-discards`, `-shrink`, and `-shrink-timeout` make
 campaign costs explicit. `-cover 1:10,2:1` requires sample counts for IDs emitted
 by `testing_classify`. Rejected inputs never count as passes. Use `-sanitize`

--- a/testrunner/engine.go
+++ b/testrunner/engine.go
@@ -133,18 +133,21 @@ func Minimize(ctx context.Context, input []byte, budget int, fails func([]byte) 
 }
 
 type Artifact struct {
-	TimeoutNanos int64  `json:"timeout_nanos"`
-	Version      int    `json:"version"`
-	Engine       string `json:"engine"`
-	Test         string `json:"test"`
-	Kind         string `json:"kind"`
-	Build        string `json:"build"`
-	Seed         uint64 `json:"seed"`
-	Attempt      int    `json:"attempt"`
-	MaxBytes     int    `json:"max_bytes"`
-	Sanitize     bool   `json:"sanitize"`
-	Signature    string `json:"signature"`
-	Input        []byte `json:"input"` // JSON base64, including arbitrary invalid UTF-8.
+	TraceVersion   int          `json:"trace_version,omitempty"`
+	Trace          []TraceEvent `json:"trace,omitempty"`
+	TraceTruncated bool         `json:"trace_truncated,omitempty"`
+	TimeoutNanos   int64        `json:"timeout_nanos"`
+	Version        int          `json:"version"`
+	Engine         string       `json:"engine"`
+	Test           string       `json:"test"`
+	Kind           string       `json:"kind"`
+	Build          string       `json:"build"`
+	Seed           uint64       `json:"seed"`
+	Attempt        int          `json:"attempt"`
+	MaxBytes       int          `json:"max_bytes"`
+	Sanitize       bool         `json:"sanitize"`
+	Signature      string       `json:"signature"`
+	Input          []byte       `json:"input"` // JSON base64, including arbitrary invalid UTF-8.
 }
 
 func readArtifact(path string, max int) (Artifact, error) {
@@ -175,6 +178,9 @@ func readArtifact(path string, max int) (Artifact, error) {
 	}
 	if _, err := hex.DecodeString(a.Build); err != nil {
 		return a, fmt.Errorf("invalid build fingerprint in %s", path)
+	}
+	if a.TraceVersion != 0 && a.TraceVersion != traceVersion || len(a.Trace) > traceLimit || a.TraceTruncated && len(a.Trace) != traceLimit || a.TraceVersion == 0 && (len(a.Trace) != 0 || a.TraceTruncated) {
+		return a, fmt.Errorf("invalid or unsupported trace in %s", path)
 	}
 	return a, nil
 }

--- a/testrunner/fuzz.go
+++ b/testrunner/fuzz.go
@@ -38,6 +38,7 @@ void oak_test_host_fail(uint32_t id) {
 }
 void oak_test_host_discard(void) { longjmp(oak_fuzz_discard, 1); }
 void oak_test_host_classify(uint32_t id) { (void)id; }
+void oak_test_host_trace(uint32_t id, uint64_t a, uint64_t b) { (void)id; (void)a; (void)b; }
 #define main oak_fuzz_application_entry
 `)
 	out.WriteString(generated)

--- a/testrunner/native.go
+++ b/testrunner/native.go
@@ -49,6 +49,8 @@ type nativeProgram struct {
 type outcome struct {
 	status, signature, output string
 	classes                   map[uint32]bool
+	trace                     []TraceEvent
+	traceTruncated            bool
 }
 
 func buildNative(pkg Package, cfg Config) (*nativeProgram, error) {
@@ -144,6 +146,18 @@ const nativePreamble = `
 #include <stdlib.h>
 #include <stdint.h>
 static FILE *oak_test_report;
+static unsigned oak_test_trace_count;
+void oak_test_host_trace(uint32_t id, uint64_t a, uint64_t b) {
+ if (!oak_test_report) return;
+ if (oak_test_trace_count < 256) {
+  fprintf(oak_test_report, "trace %u %llu %llu\n", (unsigned)id, (unsigned long long)a, (unsigned long long)b);
+  oak_test_trace_count++;
+ } else if (oak_test_trace_count == 256) {
+  fputs("trace-truncated\n", oak_test_report);
+  oak_test_trace_count++;
+ }
+ fflush(oak_test_report);
+}
 void oak_test_host_fail(uint32_t id) {
  if (oak_test_report) { fprintf(oak_test_report, "fail %u\n", (unsigned)id); fflush(oak_test_report); }
  exit(101);
@@ -157,8 +171,8 @@ void oak_test_host_classify(uint32_t id) {
 }
 `
 
-func (p *nativeProgram) run(index int, input []byte) outcome {
-	result := outcome{status: "fail", classes: map[uint32]bool{}}
+func (p *nativeProgram) run(index int, input []byte) (result outcome) {
+	result = outcome{status: "fail", classes: map[uint32]bool{}}
 	if len(input) > p.maxBytes {
 		result.signature = "harness:input-too-large"
 		return result
@@ -175,10 +189,14 @@ func (p *nativeProgram) run(index int, input []byte) outcome {
 	cmd.WaitDelay = 100 * time.Millisecond
 	err := cmd.Run()
 	result.output = output.text()
-	if ctx.Err() != nil {
-		result.signature = "timeout"
-		return result
-	}
+	timedOut := ctx.Err() != nil
+	// Read the flushed prefix even when a watchdog killed the process. A
+	// partial final report line must not hide the original timeout outcome.
+	defer func() {
+		if timedOut {
+			result.status, result.signature = "fail", "timeout"
+		}
+	}()
 	var report []byte
 	if f, openErr := os.Open(reportPath); openErr == nil {
 		report, _ = io.ReadAll(io.LimitReader(f, outputLimit+1))
@@ -194,7 +212,22 @@ func (p *nativeProgram) run(index int, input []byte) outcome {
 		if len(fields) == 0 {
 			continue
 		}
-		if len(fields) == 2 && (fields[0] == "class" || fields[0] == "fail") {
+		if len(fields) == 4 && fields[0] == "trace" {
+			id, e1 := strconv.ParseUint(fields[1], 10, 32)
+			a, e2 := strconv.ParseUint(fields[2], 10, 64)
+			b, e3 := strconv.ParseUint(fields[3], 10, 64)
+			if e1 != nil || e2 != nil || e3 != nil || len(result.trace) >= traceLimit || result.traceTruncated {
+				result.signature = "harness:bad-report"
+				return result
+			}
+			result.trace = append(result.trace, TraceEvent{ID: uint32(id), A: a, B: b})
+		} else if len(fields) == 1 && fields[0] == "trace-truncated" {
+			if len(result.trace) != traceLimit || result.traceTruncated {
+				result.signature = "harness:bad-report"
+				return result
+			}
+			result.traceTruncated = true
+		} else if len(fields) == 2 && (fields[0] == "class" || fields[0] == "fail") {
 			id, e := strconv.ParseUint(fields[1], 10, 32)
 			if e != nil {
 				result.signature = "harness:bad-report"

--- a/testrunner/runner.go
+++ b/testrunner/runner.go
@@ -31,15 +31,17 @@ func Defaults() Config {
 
 type Result struct {
 	Test
-	Package  string         `json:"package"`
-	Status   string         `json:"status"`
-	Cases    int            `json:"cases"`
-	Discards int            `json:"discards"`
-	Seed     uint64         `json:"seed"`
-	Failure  string         `json:"failure,omitempty"`
-	Artifact string         `json:"artifact,omitempty"`
-	Output   string         `json:"output,omitempty"`
-	Classes  map[uint32]int `json:"classes,omitempty"`
+	Trace          []TraceEvent   `json:"trace,omitempty"`
+	TraceTruncated bool           `json:"trace_truncated,omitempty"`
+	Package        string         `json:"package"`
+	Status         string         `json:"status"`
+	Cases          int            `json:"cases"`
+	Discards       int            `json:"discards"`
+	Seed           uint64         `json:"seed"`
+	Failure        string         `json:"failure,omitempty"`
+	Artifact       string         `json:"artifact,omitempty"`
+	Output         string         `json:"output,omitempty"`
+	Classes        map[uint32]int `json:"classes,omitempty"`
 }
 
 // Main is usable without os.Exit, including by CLI integration tests.
@@ -197,6 +199,17 @@ func Main(args []string, stdout, stderr io.Writer) int {
 			if result.Output != "" {
 				fmt.Fprintln(stdout, result.Output)
 			}
+			start := len(result.Trace) - 8
+			if start < 0 {
+				start = 0
+			}
+			for i := start; i < len(result.Trace); i++ {
+				e := result.Trace[i]
+				fmt.Fprintf(stdout, "  trace[%d] id=%d a=%d b=%d\n", i, e.ID, e.A, e.B)
+			}
+			if result.TraceTruncated {
+				fmt.Fprintln(stdout, "  trace truncated after 256 events; later events were not recorded")
+			}
 		}
 	}
 	for _, pkg := range packages {
@@ -272,9 +285,14 @@ func runTest(pkg Package, test Test, index int, native *nativeProgram, cfg Confi
 		out := native.run(index, replay.Input)
 		result.Cases = 1
 		result.Output = out.output
+		result.Trace, result.TraceTruncated = out.trace, out.traceTruncated
 		if out.status == "fail" && out.signature == replay.Signature {
 			result.Status = "fail"
 			result.Failure = "reproduced " + out.signature
+			if replay.TraceVersion == traceVersion && !sameTrace(out, outcome{trace: replay.Trace, traceTruncated: replay.TraceTruncated}) {
+				result.Status = "error"
+				result.Failure = "replay trace diverged despite matching failure signature"
+			}
 		} else {
 			result.Status = "error"
 			result.Failure = fmt.Sprintf("replay diverged: expected %s, got %s %s", replay.Signature, out.status, out.signature)
@@ -315,18 +333,33 @@ func runTest(pkg Package, test Test, index int, native *nativeProgram, cfg Confi
 		// Timeouts and infrastructure failures are not stable shrink predicates.
 		if test.Kind != "unit" && cfg.Shrink > 0 && out.signature != "timeout" && !strings.HasPrefix(out.signature, "harness:") {
 			confirmation := native.run(index, input)
-			if confirmation.status != "fail" || confirmation.signature != out.signature {
+			if confirmation.status != "fail" || confirmation.signature != out.signature || !sameTrace(confirmation, out) {
 				result.Failure = "non-reproducible failure: " + out.signature
 			} else {
 				ctx, cancel := context.WithTimeout(context.Background(), cfg.ShrinkTimeout)
+				bestOutcome := confirmation
 				best = Minimize(ctx, input, cfg.Shrink, func(candidate []byte) bool {
 					r := native.run(index, candidate)
-					return r.status == "fail" && r.signature == out.signature
+					matches := r.status == "fail" && r.signature == out.signature
+					if matches {
+						bestOutcome = r
+					}
+					return matches
 				})
 				cancel()
+				final := native.run(index, best)
+				if final.status == "fail" && final.signature == out.signature && sameTrace(final, bestOutcome) {
+					out = final
+				} else {
+					best = input
+					result.Failure = "non-reproducible minimized failure: " + out.signature
+				}
 			}
 		}
+		result.Trace, result.TraceTruncated = out.trace, out.traceTruncated
+		result.Output = out.output
 		artifact := Artifact{TimeoutNanos: int64(cfg.Timeout), Version: 1, Engine: engineVersion, Test: test.Name, Kind: test.Kind, Build: native.build, Seed: cfg.Seed, Attempt: attempt, MaxBytes: cfg.MaxBytes, Sanitize: cfg.Sanitize, Signature: out.signature, Input: best}
+		artifact.TraceVersion, artifact.Trace, artifact.TraceTruncated = traceVersion, out.trace, out.traceTruncated
 		path, err := saveArtifact(pkg, test, artifact)
 		if err != nil {
 			result.Failure += "; cannot save failure: " + err.Error()

--- a/testrunner/trace.go
+++ b/testrunner/trace.go
@@ -1,0 +1,18 @@
+package testrunner
+
+import "slices"
+
+const traceLimit = 256
+const traceVersion = 1
+
+// TraceEvent records a domain-defined action or observation. Payloads use
+// decimal strings in JSON so JavaScript tools cannot round 64-bit values.
+type TraceEvent struct {
+	ID uint32 `json:"id"`
+	A  uint64 `json:"a,string"`
+	B  uint64 `json:"b,string"`
+}
+
+func sameTrace(a, b outcome) bool {
+	return a.traceTruncated == b.traceTruncated && slices.Equal(a.trace, b.trace)
+}

--- a/testrunner/trace_test.go
+++ b/testrunner/trace_test.go
@@ -1,0 +1,117 @@
+package testrunner
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMinimizedTraceAndExactReplay(t *testing.T) {
+	dir := fixture(t, map[string]string{"trace_test.oak": `import(testing)
+SimTrace: (data: []u8): () {
+  storage: [1]TestChoices
+  choices: [*]TestChoices = span(&storage)
+  value: u8 = test_byte(choices, data)
+  testing_trace(u32(42), u64(value), u64(len(data)))
+  testing_trace(u32(43), ^u64(0), u64(9007199254740993))
+  test_check(value < u8(7), u32(7003))
+}
+`})
+	code, results, stderr := runCLI(t, "-runs", "4", dir)
+	if code != 1 || len(results) != 1 || results[0].Failure != "invariant:7003" {
+		t.Fatalf("%d %+v %s", code, results, stderr)
+	}
+	result := results[0]
+	a, err := readArtifact(result.Artifact, 256)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(a.Input, []byte{7}) || a.TraceVersion != traceVersion || len(a.Trace) != 2 || a.Trace[0] != (TraceEvent{ID: 42, A: 7, B: 1}) || a.Trace[1].A != ^uint64(0) || a.Trace[1].B != 9007199254740993 || !sameTrace(outcome{trace: a.Trace}, outcome{trace: result.Trace}) {
+		t.Fatalf("trace does not describe minimized input: %+v", a)
+	}
+	raw, _ := os.ReadFile(result.Artifact)
+	if !bytes.Contains(raw, []byte(`"18446744073709551615"`)) {
+		t.Fatalf("64-bit payload not lossless JSON: %s", raw)
+	}
+	code, results, stderr = runCLI(t, "-replay", result.Artifact, dir)
+	if code != 1 || results[0].Failure != "reproduced invariant:7003" {
+		t.Fatalf("%d %+v %s", code, results, stderr)
+	}
+	// Same concrete input/build/invariant, but a different observed history.
+	a.Trace[0].A++
+	tampered := filepath.Join(t.TempDir(), "trace.json")
+	raw, _ = json.Marshal(a)
+	os.WriteFile(tampered, raw, 0600)
+	code, results, stderr = runCLI(t, "-replay", tampered, dir)
+	if code != 2 || !strings.Contains(results[0].Failure, "trace diverged") {
+		t.Fatalf("%d %+v %s", code, results, stderr)
+	}
+	// Old artifacts are valid regression inputs and have no trace contract.
+	a.TraceVersion, a.Trace, a.TraceTruncated = 0, nil, false
+	raw, _ = json.Marshal(a)
+	os.WriteFile(tampered, raw, 0600)
+	code, results, _ = runCLI(t, "-replay", tampered, dir)
+	if code != 1 || results[0].Failure != "reproduced invariant:7003" {
+		t.Fatalf("legacy replay: %d %+v", code, results)
+	}
+}
+
+func TestTraceBoundsCrashAndTimeout(t *testing.T) {
+	dir := fixture(t, map[string]string{"trace_test.oak": `import(testing)
+TestTraceBound: (): () {
+  i: u32 = u32(0)
+  while i < u32(300) {
+    testing_trace(u32(44), u64(i), u64(0))
+    i = i + u32(1)
+  }
+  test_check(false, u32(7004))
+}
+TestTraceCrash: (): () { testing_trace(u32(45), u64(1), u64(2)); assert(false) }
+TestTraceTimeout: (): () { testing_trace(u32(46), u64(3), u64(4)); while true {} }
+`})
+	code, results, stderr := runCLI(t, "-timeout", "100ms", "-shrink", "0", dir)
+	if code != 1 || len(results) != 3 {
+		t.Fatalf("%d %+v %s", code, results, stderr)
+	}
+	for _, r := range results {
+		if r.Name == "TestTraceBound" {
+			if r.Failure != "invariant:7004" || len(r.Trace) != traceLimit || !r.TraceTruncated || r.Trace[traceLimit-1].A != traceLimit-1 {
+				t.Fatalf("trace bound: %+v", r)
+			}
+			code, replay, _ := runCLI(t, "-replay", r.Artifact, dir)
+			if code != 1 || replay[0].Failure != "reproduced invariant:7004" {
+				t.Fatalf("truncated replay: %d %+v", code, replay)
+			}
+		} else if len(r.Trace) != 1 || r.TraceTruncated || r.Status != "fail" {
+			t.Fatalf("lost crash/timeout prefix: %+v", r)
+		}
+		if r.Name == "TestTraceTimeout" && r.Failure != "timeout" {
+			t.Fatalf("timeout changed: %+v", r)
+		}
+	}
+}
+
+func TestTraceSchemaRejectsInvalidHistories(t *testing.T) {
+	a := Artifact{TimeoutNanos: 1, Version: 1, Engine: engineVersion, Test: "TestTrace", Kind: "unit", Build: strings.Repeat("a", 64), Signature: "invariant:1"}
+	for _, bad := range []Artifact{
+		func() Artifact { b := a; b.TraceVersion = 2; return b }(),
+		func() Artifact { b := a; b.Trace = []TraceEvent{{ID: 1}}; return b }(),
+		func() Artifact { b := a; b.TraceVersion = traceVersion; b.TraceTruncated = true; return b }(),
+		func() Artifact {
+			b := a
+			b.TraceVersion = traceVersion
+			b.Trace = make([]TraceEvent, traceLimit+1)
+			return b
+		}(),
+	} {
+		path := filepath.Join(t.TempDir(), "invalid.json")
+		raw, _ := json.Marshal(bad)
+		os.WriteFile(path, raw, 0600)
+		if _, err := readArtifact(path, 256); err == nil {
+			t.Fatalf("accepted invalid trace: %+v", bad)
+		}
+	}
+}


### PR DESCRIPTION
A minimized choice tape identifies a failing input, but it does not explain the actions leading to failure. Matching only the invariant ID can also miss divergent behavior during replay.

Adds `testing_trace(id, a, b)` with a bounded 256-event prefix and explicit truncation. Failed cases and artifacts retain semantic events, including the flushed prefix before traps/watchdog termination. Payloads use decimal strings in JSON to preserve full 64-bit values. Human output shows the last eight retained events.

The reducer now confirms its final candidate and saves that candidate's trace/output. Strict replay compares the trace prefix and truncation flag as well as build/input/failure identity. Legacy artifacts retain their existing contract. libFuzzer trace calls are no-ops; raw crash files can be rerun through `oak test` for tracing.

Tests cover minimized-versus-original histories, matching-invariant trace divergence, 64-bit JSON precision, truncation, traps, watchdogs, and invalid trace schemas. IRQ and timer examples emit semantic actions. [Dedicated testing CI passed](https://github.com/SCKelemen/oak/actions/runs/34260238789), including native replay/trace tests, examples, libFuzzer export and reducer/mutation fuzzing. [OS integration CI also passed](https://github.com/SCKelemen/os/actions/runs/34260440740): production IRQ/timer/router scenarios and the exact four-command minimized mutation history. The full compiler/stdlib race suites are still running.