### PR TITLE
Repair resource call contracts and scope borrowed result semantics

### DIFF
--- a/docs/resource-contracts-and-results.md
+++ b/docs/resource-contracts-and-results.md
@@ -1,0 +1,146 @@
+# Resource contracts and borrowed results
+
+Design and implementation audit following resource parameter modes and call-local
+exclusivity. This document proposes the next semantic increments; it does not
+enable borrowed returns or freeze source syntax. The normative borrowing rules
+remain in `spec/50-borrowing.md`.
+
+## Current implementation audit
+
+Audited against specification commit `0c086683a8a02fa9bb96a5a6e0d856942bbe0321`.
+PR #69 merged as `906bff7b575dd114e08a27e7ed9acdad4ef15d80`. Its resource-flow
+files still match the reviewed head `99423a1` at this specification revision.
+
+| Boundary | Evidence | Finding |
+| --- | --- | --- |
+| Declarations to resolved facts | `typechecker/resource_resolution.go`, `resolveResourceParameters` | Validates nominal resource parameters, modes, indices, and cross-protocol agreement; derives the consumption projection. |
+| Resolved facts to SemIR | `compiler/resource_semir.go`, `emitResourceSemIR` | Emits canonical borrow, mutable-borrow, consume, and fresh-return effects. |
+| SemIR to executable model | `typechecker/resource_semir.go`, `resourceParametersFromSemIR` | Preserves modes and consumption. Direct model construction needs the same canonicalization guarantees. |
+| Ordinary global calls | `typechecker/resource_flow.go`, `callableIdentity` | Resolves the global function identity, provided it is not lexically shadowed. |
+| Nominal method calls | The same resolver and `resource_callable_test.go` | Resolves `Receiver::method`. Parameter indices describe explicit arguments; the receiver is not an implicit consumed argument. A separate receiver authority contract is still needed. |
+| Function values | `FunctionType` in `typechecker/typechecker.go`; `callableIdentity` | Function types carry parameter types, result type, and variadic status, but no resource contract. Local callable bindings are deliberately excluded from global-name resolution. Contract preservation through function values is not established. |
+| Generic specialization | `typechecker/genericfn.go`, `invokeInstantiated` | Calls are rewritten to concrete mangled identities and specialized bodies are checked. There is no resource-contract projection in this specialization path. Rechecking bodies is not evidence that a template's external contract survives renaming. |
+| Interfaces and wrappers | Nominal-only resource resolution and callable lookup | Interface-level ownership substitutability and wrapper effect summaries are not implemented by this path. A wrapper's call to a consuming function does not itself establish the wrapper's caller-facing contract. |
+
+These are source-audit findings, not claims of executed end-to-end regression
+coverage for every boundary. In particular, do not treat an unresolved callable
+as proof that its resource effects are empty.
+
+## Repair of the existing call checker
+
+The accompanying repair normalizes direct resource operations in both directions:
+legacy consumption adds consumed modes, and consumed modes generate consumption.
+Matching duplicated representations are accepted for SemIR compatibility;
+contradictory representations fail closed. The checking entry point normalizes
+direct map construction too.
+
+A successful fresh-return invocation supplies independent result authority even
+when used directly as an argument. A source temporary is not required. Rejected
+inner calls cannot certify fresh results or authorize outer-call consumption.
+Unknown projections remain unknown after naming them. Already-consumed arguments
+retain their causal use-after-consume diagnostic, rather than acquiring a second
+unknown-provenance diagnosis.
+
+Resource reassignment is conservatively rejected pending destination provenance
+tracking. This is an acceptance restriction, not a complete reassignment model.
+Future support must handle shadowing, reassignment through blocks, control-flow
+joins, loop fixed points, and old aliases without reviving consumed authority.
+
+## Callable contract preservation
+
+Introduce one checked semantic callable contract, referenced by stable declaration
+identity rather than inferred from source names or mangled-name prefixes. It must
+describe explicit parameter modes, any receiver mode, result provenance, and
+retention/escape obligations. Syntax and ABI projection remain separate choices.
+
+Initially require exact normalized resource-contract agreement when substituting
+function values or interface implementations. Do not invent ownership variance
+until its substitutability laws are specified and proved. Missing information is
+unknown, not an empty-effect contract. When a boundary cannot preserve a required
+contract, reject that boundary with a diagnostic identifying where it would be
+lost.
+
+Specialization must project the template contract under the same type substitution
+that produces the specialized signature. Wrappers must either have a checked
+explicit contract or acquire a sound inferred summary. Borrowed parameters cannot
+be forwarded to consuming operations merely because their local bindings are
+live. A borrowed parameter's authority is also a callee-body obligation.
+
+Acceptance cases:
+
+1. Calling a consuming operation through a local function value still invalidates
+   the caller's resource aliases.
+2. A consuming implementation cannot satisfy a shared-borrow callable contract.
+3. Two concrete specializations preserve the same template authority modes.
+4. A wrapper that consumes its input cannot expose a borrow-only contract.
+5. Receiver modes survive method resolution without shifting explicit indices.
+6. Unknown contract information cannot erase an already-known obligation.
+
+## Result provenance and lifetime dependencies
+
+Result identity, access permission, and lifetime dependency are separate facts.
+The following names are explanatory semantic categories, not proposed keywords.
+
+| Result category | Authority identity | Lifetime/access obligation |
+| --- | --- | --- |
+| Fresh | New independent authority class, established by the callable contract | Freshness alone does not establish allocation, ownership of backing memory, or an unlimited lifetime. |
+| Alias of input | Same authority class as a specified input or projection | Cannot widen the input's access permission; consumption of that class invalidates its dependent aliases. |
+| Shared borrow of input | Proven dependency on the input's authority or storage origin | Read permission; result must stay within the proven owner lifetime and prohibit incompatible owner access while live. |
+| Mutable reborrow of input | Proven dependency on an exclusive input access | Parent access is suspended for the result's lifetime and restored on release; the result cannot outlive its source. |
+| Unknown | No established identity relationship | Cannot prove independence, permit exclusive use that requires it, or justify escape. |
+
+For storage views, retain owner and absolute region facts. For opaque resources,
+retain resource authority identity. Relate the two only when an operation's
+contract establishes that relationship; do not manufacture a storage borrow for
+an opaque handle.
+
+Returning an alias or borrow of consumed input authority is invalid unless a
+separately specified transfer contract establishes new valid authority. Merely
+marking the return fresh is not proof of backing-storage liveness. The compiler
+must validate declared result relationships against bodies, or admit them only
+at an explicit trusted external boundary.
+
+At control-flow joins, preserve every possible dependency. Conflicting origins
+must become a conservative dependency set or unknown provenance, never fresh
+authority. Field names alone do not prove resource independence: two different
+fields may contain handles to the same resource.
+
+Keep `OAK-B0109` in force until these relationships are implemented end to end.
+The first useful positive case is a read-only result derived from one caller-owned
+input with no local owner escape. Tests must include owner destruction, mutation,
+consumption, wrapper storage, branch-dependent origins, and invalid nested calls.
+
+## Call duration and future callbacks
+
+Specify evaluation and access admission as separate phases. Evaluate the callee
+and arguments in the language's defined order, preserving effects of nested calls;
+validate resource arguments at the call boundary; admit temporary access; perform
+the call; end temporary access. Consumption affects only accepted operations.
+Rejecting an outer call does not undo valid nested calls already evaluated.
+
+This pairwise call checker is not an interprocedural exclusivity proof. Before
+capturing callbacks are enabled, contracts must account for retained authority,
+reentrant access, globals, and overlapping callback execution. A returned borrow
+extends a dependency beyond call completion and therefore cannot use the current
+"all temporary access ends at return" rule without an explicit result contract.
+
+## Generic resource ergonomics
+
+Exercise `Option[Handle]`, `Result[Handle, E]`, and Oak's existing match expression
+early. Inspection should borrow a payload; extraction should transfer authority
+and invalidate the previous owning location. Copyability is a capability, not an
+assumption that every type variable satisfies. Ownership-aware matching should
+extend the existing match semantics without introducing a second branching form.
+
+Editor information should expose parameter and result contracts. Diagnostics
+should distinguish proven aliasing, unknown provenance, and already-unavailable
+authority, showing both conflicting uses where applicable. A suggested temporary
+binding must never be presented as a way to manufacture authority.
+
+## Swift references
+
+- [SE-0377: Parameter ownership modifiers](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0377-parameter-ownership-modifiers.md): contracts on declarations and function types. Swift consuming calls on copyable values are not Oak resource invalidation.
+- [SE-0176: Exclusive access to memory](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0176-enforce-exclusive-access-to-memory.md): access duration and callbacks. Storage exclusivity does not establish unique resource authority; Swift's dynamic enforcement is not a proposed Oak runtime requirement.
+- [SE-0437: Noncopyable standard-library primitives](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0437-noncopyable-stdlib-primitives.md): make optional/result APIs usable without assuming copying.
+- [SE-0447: Span](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0447-span-access-shared-contiguous-storage.md): safe borrowed contiguous access and lifetime dependencies. Swift's read-only Span corresponds more closely to Oak's view.
+- [Swift API design guidelines](https://www.swift.org/documentation/api-design-guidelines/): evaluate actual call sites and use consistent operation naming.

--- a/docs/spec/50-borrowing.md
+++ b/docs/spec/50-borrowing.md
@@ -193,6 +193,23 @@ Unmarked resource parameters retain their ordinary semantics until a semantic or
 ABI contract explicitly assigns an authority mode. `OAK-B0112` reports violations
 of this call-local exclusivity rule.
 
+The executable model normalizes consumed modes and legacy consumption metadata to
+one contract. Conflicting metadata is rejected. A successfully checked call whose
+contract establishes fresh result authority may be passed directly as a resource
+argument; naming that result first does not change its exclusivity semantics.
+Rejected calls do not establish fresh results. Valid nested-call effects are not
+rolled back when a surrounding call is rejected.
+
+Resource reassignment is currently rejected with `OAK-B0112` until destination
+provenance is tracked; it must not retain a stale independent alias class. Unknown
+provenance and known consumed authority are distinct diagnostic causes. A conflict
+involving an unknown argument must identify that argument, including when it is a
+shared participant paired with a tracked exclusive participant.
+
+The callable-boundary audit and proposed result provenance/lifetime relationships
+are recorded in [`../resource-contracts-and-results.md`](../resource-contracts-and-results.md).
+These proposals do not relax the current borrowed-return restriction.
+
 The checker should track alias classes or equivalent provenance so that consumption invalidates the relevant authority rather than merely one variable name. Copyable values remain outside this rule unless their type/protocol explicitly opts into resource semantics.
 
 `OAK-B0111` is reserved for use after consumption. Its diagnostic must show the consume site, the later use, and any relevant alias/provenance chain that explains why the later name lost authority (`15-diagnostics` section 6).
@@ -278,4 +295,5 @@ models consumption and alias classes, while `Oak.ResourceCall` models call-local
 parameter-mode compatibility. Symbolic-extent lemmas should extend that proof
 surface as the checker representation lands. Temporal ownership transfer across
 asynchronous actors may additionally use TLA+ when introduced.
+
 

--- a/typechecker/resource_call_exclusivity.go
+++ b/typechecker/resource_call_exclusivity.go
@@ -13,6 +13,7 @@ type resourceCallArgument struct {
 	name    string
 	node    ast.Node
 	tracked bool
+	fresh   bool
 }
 
 func resourceParameterModesCompatible(left, right ResourceParameterMode) bool {
@@ -30,7 +31,9 @@ func (a *typedResourceAnalysis) checkCallResourceExclusivity(expr *ast.Invocatio
 	participants := make([]resourceCallArgument, 0, len(op.Parameters))
 	for _, parameter := range op.Parameters {
 		if parameter.Index < 0 || parameter.Index >= len(expr.Arguments) {
-			continue
+			a.tc.addResourceDiagnosticWithCode(expr, CodeResourceCallAliasConflict,
+				"resource contract refers to an argument outside this call")
+			return false
 		}
 		argument := expr.Arguments[parameter.Index]
 		if !a.isResourceValue(argument) {
@@ -42,9 +45,20 @@ func (a *typedResourceAnalysis) checkCallResourceExclusivity(expr *ast.Invocatio
 			mode:  parameter.Mode,
 			node:  argument,
 		}
-		if ident, ok := argument.(*ast.Identifier); ok && ident != nil && a.flow.Registered(ident.Value) && a.flow.CanUse(ident.Value) {
+		if ident, ok := argument.(*ast.Identifier); ok && ident != nil && a.flow.Registered(ident.Value) {
+			if !a.flow.CanUse(ident.Value) {
+				// Ordinary argument evaluation owns the use-after-consume diagnostic.
+				a.use(ident.Value, ident)
+				return false
+			}
 			participant.name = ident.Value
+			participant.tracked = !a.unknownResources[ident.Value]
+		}
+		if call, ok := argument.(*ast.InvocationExpression); ok && a.freshCalls[call] {
+			// Each successfully evaluated fresh result has independent authority.
+			// It needs no source binding and cannot revive an input authority class.
 			participant.tracked = true
+			participant.fresh = true
 		}
 		participants = append(participants, participant)
 
@@ -65,7 +79,7 @@ func (a *typedResourceAnalysis) checkCallResourceExclusivity(expr *ast.Invocatio
 				continue
 			}
 			if left.tracked && right.tracked {
-				if !a.flow.Aliases(left.name, right.name) {
+				if left.fresh || right.fresh || !a.flow.Aliases(left.name, right.name) {
 					continue
 				}
 				a.reportCallAliasConflict(expr, left, right)
@@ -80,7 +94,11 @@ func (a *typedResourceAnalysis) checkCallResourceExclusivity(expr *ast.Invocatio
 			if left.mode == ResourceParameterBorrowed && right.mode != ResourceParameterBorrowed {
 				primary = right
 			}
-			a.reportUntrackedResourceArgument(expr, primary, resourceParameterModeAccess(primary.mode))
+			unknown := left
+			if left.tracked {
+				unknown = right
+			}
+			a.reportUntrackedResourcePair(expr, primary, unknown)
 			return false
 		}
 	}
@@ -152,4 +170,16 @@ func resourceParameterModeAccess(mode ResourceParameterMode) string {
 	default:
 		return "resource"
 	}
+}
+
+
+func (a *typedResourceAnalysis) reportUntrackedResourcePair(expr *ast.InvocationExpression, exclusive, unknown resourceCallArgument) {
+	callable, _ := a.callableIdentity(expr)
+	d := a.tc.addResourceDiagnosticWithCode(exclusive.node, CodeResourceCallAliasConflict,
+		fmt.Sprintf("resource argument %d to %q requires %s authority, but argument %d resource provenance is not traceable",
+			exclusive.index+1, callable, resourceParameterModeAccess(exclusive.mode), unknown.index+1))
+	d.AddSecondary(diagnostic.NodeToRange(unknown.node),
+		fmt.Sprintf("argument %d has unknown resource provenance", unknown.index+1))
+	d.AddNote("unknown provenance cannot establish distinct resource authority classes")
+	d.AddHelp("provide traceable resource provenance; introducing a local name alone does not establish independence")
 }

--- a/typechecker/resource_call_exclusivity.go
+++ b/typechecker/resource_call_exclusivity.go
@@ -78,8 +78,14 @@ func (a *typedResourceAnalysis) checkCallResourceExclusivity(expr *ast.Invocatio
 			if resourceParameterModesCompatible(left.mode, right.mode) {
 				continue
 			}
+			// A checked fresh result establishes independent authority even when
+			// the other participant's provenance is unknown. Unknown consuming
+			// participants have already been rejected above.
+			if left.fresh || right.fresh {
+				continue
+			}
 			if left.tracked && right.tracked {
-				if left.fresh || right.fresh || !a.flow.Aliases(left.name, right.name) {
+				if !a.flow.Aliases(left.name, right.name) {
 					continue
 				}
 				a.reportCallAliasConflict(expr, left, right)

--- a/typechecker/resource_call_exclusivity_test.go
+++ b/typechecker/resource_call_exclusivity_test.go
@@ -380,3 +380,52 @@ func TestResourceModelConflictingModesFailClosed(t *testing.T) {
 		t.Fatalf("conflicting legacy and canonical metadata must fail closed: %v", got)
 	}
 }
+
+func TestResourceCallFreshResultIsDistinctFromUnknownBorrow(t *testing.T) {
+	for _, arguments := range []string{"renew(h), holder.handle", "holder.handle, renew(h)"} {
+		t.Run(arguments, func(t *testing.T) {
+			input := `
+Handle: type = struct { id: u32 }
+Holder: type = struct { handle: Handle }
+renew: (h: Handle): Handle = h
+update_pair: (left: Handle, right: Handle): () = {}
+f: (h: Handle, holder: Holder): u32 {
+  update_pair(` + arguments + `)
+  h.id
+}`
+			model := resourceCallModel("update_pair",
+				ResourceParameterDeclaration{Index: 0, Mode: ResourceParameterBorrowedMut},
+				ResourceParameterDeclaration{Index: 1, Mode: ResourceParameterBorrowed})
+			model.MarkOperation("renew", ResourceOperation{ReturnsFresh: true})
+			tc := setupTypeChecker(input)
+			tc.CheckProgramWithResources(parseProgram(input), model)
+			if len(tc.Errors()) != 0 {
+				t.Fatalf("fresh authority must be distinct from unknown borrowed authority: %v", tc.Errors())
+			}
+		})
+	}
+}
+
+func TestResourceCallFreshResultDoesNotAuthorizeUnknownConsumption(t *testing.T) {
+	input := `
+Handle: type = struct { id: u32 }
+Holder: type = struct { handle: Handle }
+renew: (h: Handle): Handle = h
+close_pair: (left: Handle, right: Handle): () = {}
+f: (h: Handle, holder: Holder): u32 {
+  close_pair(renew(h), holder.handle)
+  h.id
+}`
+	model := resourceCallModel("close_pair",
+		ResourceParameterDeclaration{Index: 0, Mode: ResourceParameterConsumed},
+		ResourceParameterDeclaration{Index: 1, Mode: ResourceParameterConsumed})
+	model.MarkOperation("renew", ResourceOperation{ReturnsFresh: true})
+	tc := setupTypeChecker(input)
+	tc.CheckProgramWithResources(parseProgram(input), model)
+	if got := resourceCallDiagnostics(tc, CodeResourceCallAliasConflict); len(got) != 1 {
+		t.Fatalf("fresh peer must not permit consumption of an unknown class: %v", got)
+	}
+	if got := resourceCallDiagnostics(tc, CodeResourceUsedAfterConsume); len(got) != 0 {
+		t.Fatalf("rejected call must preserve input authority: %v", got)
+	}
+}

--- a/typechecker/resource_call_exclusivity_test.go
+++ b/typechecker/resource_call_exclusivity_test.go
@@ -8,13 +8,7 @@ import (
 func resourceCallModel(name string, parameters ...ResourceParameterDeclaration) ResourceModel {
 	model := NewResourceModel()
 	model.MarkResourceType("Handle")
-	operation := ResourceOperation{Parameters: parameters}
-	for _, parameter := range parameters {
-		if parameter.Mode == ResourceParameterConsumed {
-			operation.Consumes = append(operation.Consumes, parameter.Index)
-		}
-	}
-	model.MarkOperation(name, operation)
+	model.MarkOperation(name, ResourceOperation{Parameters: parameters})
 	return model
 }
 
@@ -236,5 +230,153 @@ f: (left: Handle, right: Handle): u32 {
 
 	if got := resourceCallDiagnostics(tc, CodeResourceCallAliasConflict); len(got) != 0 {
 		t.Fatalf("explicit fresh return must introduce tracked independent authority: %v", got)
+	}
+}
+
+
+func TestResourceCallConsumedModeInvalidatesAliases(t *testing.T) {
+	input := `
+Handle: type = struct { id: u32 }
+close: (h: Handle): () = {}
+f: (h: Handle): u32 {
+  alias: Handle = h
+  close(h)
+  alias.id
+}`
+	model := resourceCallModel("close", ResourceParameterDeclaration{Index: 0, Mode: ResourceParameterConsumed})
+	tc := setupTypeChecker(input)
+	tc.CheckProgramWithResources(parseProgram(input), model)
+	if got := resourceCallDiagnostics(tc, CodeResourceUsedAfterConsume); len(got) != 1 {
+		t.Fatalf("consumed mode must invalidate aliases without legacy metadata: %v (all: %v)", got, tc.Errors())
+	}
+}
+
+func TestResourceCallDirectFreshResultMatchesBinding(t *testing.T) {
+	for _, invocation := range []string{"update_pair(renew(left), right)", "next: Handle = renew(left)\n  update_pair(next, right)", "update_pair(renew(left), renew(left))"} {
+		t.Run(invocation, func(t *testing.T) {
+			input := `
+Handle: type = struct { id: u32 }
+renew: (h: Handle): Handle = h
+update_pair: (left: Handle, right: Handle): () = {}
+f: (left: Handle, right: Handle): u32 {
+  ` + invocation + `
+  left.id
+}`
+			model := resourceCallModel("update_pair",
+				ResourceParameterDeclaration{Index: 0, Mode: ResourceParameterBorrowedMut},
+				ResourceParameterDeclaration{Index: 1, Mode: ResourceParameterBorrowed})
+			model.MarkOperation("renew", ResourceOperation{ReturnsFresh: true})
+			tc := setupTypeChecker(input)
+			tc.CheckProgramWithResources(parseProgram(input), model)
+			if len(tc.Errors()) != 0 {
+				t.Fatalf("fresh expression and binding forms must both be valid: %v", tc.Errors())
+			}
+		})
+	}
+}
+
+func TestResourceCallUnknownDiagnosticNamesSharedArgument(t *testing.T) {
+	input := `
+Handle: type = struct { id: u32 }
+Holder: type = struct { handle: Handle }
+update_pair: (left: Handle, right: Handle): () = {}
+f: (h: Handle, holder: Holder): u32 {
+  update_pair(h, holder.handle)
+  h.id
+}`
+	model := resourceCallModel("update_pair",
+		ResourceParameterDeclaration{Index: 0, Mode: ResourceParameterBorrowedMut},
+		ResourceParameterDeclaration{Index: 1, Mode: ResourceParameterBorrowed})
+	tc := setupTypeChecker(input)
+	tc.CheckProgramWithResources(parseProgram(input), model)
+	got := resourceCallDiagnostics(tc, CodeResourceCallAliasConflict)
+	if len(got) != 1 || !strings.Contains(got[0], "argument 2 resource provenance is not traceable") {
+		t.Fatalf("diagnostic must identify the unknown shared argument: %v", got)
+	}
+}
+
+func TestResourceCallAlreadyConsumedDoesNotCascade(t *testing.T) {
+	input := `
+Handle: type = struct { id: u32 }
+close: (h: Handle): () = {}
+f: (h: Handle): u32 {
+  close(h)
+  close(h)
+  0
+}`
+	model := resourceCallModel("close", ResourceParameterDeclaration{Index: 0, Mode: ResourceParameterConsumed})
+	tc := setupTypeChecker(input)
+	tc.CheckProgramWithResources(parseProgram(input), model)
+	if got := resourceCallDiagnostics(tc, CodeResourceUsedAfterConsume); len(got) != 1 {
+		t.Fatalf("expected one use-after-consume: %v", got)
+	}
+	if got := resourceCallDiagnostics(tc, CodeResourceCallAliasConflict); len(got) != 0 {
+		t.Fatalf("known consumed authority is not unknown provenance: %v", got)
+	}
+}
+
+func TestResourceReassignmentFailsClosed(t *testing.T) {
+	input := `
+Handle: type = struct { id: u32 }
+update_pair: (left: Handle, right: Handle): () = {}
+f: (h: Handle, other: Handle): u32 {
+  alias: Handle = other
+  alias = h
+  update_pair(h, alias)
+  0
+}`
+	model := resourceCallModel("update_pair",
+		ResourceParameterDeclaration{Index: 0, Mode: ResourceParameterBorrowedMut},
+		ResourceParameterDeclaration{Index: 1, Mode: ResourceParameterBorrowed})
+	tc := setupTypeChecker(input)
+	tc.CheckProgramWithResources(parseProgram(input), model)
+	got := resourceCallDiagnostics(tc, CodeResourceCallAliasConflict)
+	if len(got) == 0 || !strings.Contains(got[0], "resource reassignment") {
+		t.Fatalf("unsupported reassignment must not retain trusted distinctness: %v (all: %v)", got, tc.Errors())
+	}
+}
+
+func TestRejectedFreshCallDoesNotConsumeOuterArgument(t *testing.T) {
+	input := `
+Handle: type = struct { id: u32 }
+renew: (left: Handle, right: Handle): Handle = left
+close_pair: (left: Handle, right: Handle): () = {}
+f: (h: Handle, other: Handle): u32 {
+  close_pair(renew(h, h), other)
+  other.id
+}`
+	model := resourceCallModel("close_pair",
+		ResourceParameterDeclaration{Index: 0, Mode: ResourceParameterConsumed},
+		ResourceParameterDeclaration{Index: 1, Mode: ResourceParameterConsumed})
+	model.MarkOperation("renew", ResourceOperation{
+		Parameters: []ResourceParameterDeclaration{
+			{Index: 0, Mode: ResourceParameterBorrowedMut},
+			{Index: 1, Mode: ResourceParameterBorrowed},
+		},
+		ReturnsFresh: true,
+	})
+	tc := setupTypeChecker(input)
+	tc.CheckProgramWithResources(parseProgram(input), model)
+	if got := resourceCallDiagnostics(tc, CodeResourceCallAliasConflict); len(got) != 1 {
+		t.Fatalf("expected only inner call conflict: %v", got)
+	}
+	if got := resourceCallDiagnostics(tc, CodeResourceUsedAfterConsume); len(got) != 0 {
+		t.Fatalf("invalid inner call cannot authorize outer consumption: %v", got)
+	}
+}
+
+func TestResourceModelConflictingModesFailClosed(t *testing.T) {
+	input := `Handle: type = struct { id: u32 }`
+	model := NewResourceModel()
+	model.MarkResourceType("Handle")
+	// Populate the map directly to exercise the checking entry-point boundary.
+	model.Operations["close"] = ResourceOperation{
+		Parameters: []ResourceParameterDeclaration{{Index: 0, Mode: ResourceParameterBorrowed}},
+		Consumes: []int{0},
+	}
+	tc := setupTypeChecker(input)
+	tc.CheckProgramWithResources(parseProgram(input), model)
+	if got := resourceCallDiagnostics(tc, CodeResourceCallAliasConflict); len(got) != 1 {
+		t.Fatalf("conflicting legacy and canonical metadata must fail closed: %v", got)
 	}
 }

--- a/typechecker/resource_flow.go
+++ b/typechecker/resource_flow.go
@@ -49,23 +49,16 @@ func (m *ResourceModel) MarkOperation(name string, operation ResourceOperation) 
 	if m.Operations == nil {
 		m.Operations = make(map[string]ResourceOperation)
 	}
-	copyOperation := operation
-	copyOperation.Parameters = append([]ResourceParameterDeclaration(nil), operation.Parameters...)
-	copyOperation.Consumes = append([]int(nil), operation.Consumes...)
-	// Compatibility for pre-parameter-mode callers: a legacy consume list is
-	// equivalent to explicit consumed parameters when no richer modes exist.
-	if len(copyOperation.Parameters) == 0 {
-		for _, index := range copyOperation.Consumes {
-			copyOperation.Parameters = append(copyOperation.Parameters, ResourceParameterDeclaration{
-				Index: index,
-				Mode:  ResourceParameterConsumed,
-			})
-		}
+	normalized, err := normalizeResourceOperation(operation)
+	if err != nil {
+		// Keep malformed input for the checking entry point to diagnose. Never
+		// silently replace a conflicting contract with an empty operation.
+		operation.Parameters = append([]ResourceParameterDeclaration(nil), operation.Parameters...)
+		operation.Consumes = append([]int(nil), operation.Consumes...)
+		m.Operations[name] = operation
+		return
 	}
-	sort.Slice(copyOperation.Parameters, func(i, j int) bool {
-		return copyOperation.Parameters[i].Index < copyOperation.Parameters[j].Index
-	})
-	m.Operations[name] = copyOperation
+	m.Operations[name] = normalized
 }
 
 // CheckProgramWithResources is the integrated typed-program entrypoint for the
@@ -83,6 +76,24 @@ func (tc *TypeChecker) CheckResourceFlow(program *ast.Program, model ResourceMod
 	if tc == nil || program == nil {
 		return
 	}
+	// Normalize here too: callers can populate Operations without MarkOperation.
+	normalized := NewResourceModel()
+	normalized.ResourceTypes = model.ResourceTypes
+	names := make([]string, 0, len(model.Operations))
+	for name := range model.Operations {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		op, err := normalizeResourceOperation(model.Operations[name])
+		if err != nil {
+			tc.addResourceDiagnosticWithCode(nil, CodeResourceCallAliasConflict,
+				fmt.Sprintf("invalid resource contract for %q: %v", name, err))
+			return
+		}
+		normalized.Operations[name] = op
+	}
+	model = normalized
 	for _, statement := range program.Statements {
 		fn, ok := statement.(*ast.FunctionStatement)
 		if !ok || fn == nil || fn.ExternSymbol != "" {
@@ -122,6 +133,7 @@ type typedResourceAnalysis struct {
 	reported         map[string]bool
 	unknownResources map[string]bool
 	scopes           []map[string]struct{}
+	freshCalls       map[*ast.InvocationExpression]bool
 }
 
 func (m ResourceModel) isResourceType(expr ast.Expression) bool {
@@ -260,6 +272,10 @@ func (a *typedResourceAnalysis) statement(stmt ast.Statement) {
 		a.variable(s)
 	case *ast.AssignmentStatement:
 		a.expression(s.Value)
+		if a.isResourceValue(s.Value) || (s.Name != nil && (a.flow.Registered(s.Name.Value) || a.unknownResources[s.Name.Value])) {
+			a.tc.addResourceDiagnosticWithCode(s, CodeResourceCallAliasConflict,
+				"resource reassignment requires tracked destination provenance")
+		}
 	case *ast.IndexAssignmentStatement:
 		if s.Target != nil {
 			a.expression(s.Target.Left)
@@ -308,7 +324,7 @@ func (a *typedResourceAnalysis) variable(stmt *ast.VariableDeclaration) {
 
 	fresh := false
 	if call, ok := stmt.Value.(*ast.InvocationExpression); ok {
-		if op, exists := a.operation(call); exists && op.ReturnsFresh {
+		if a.freshCalls[call] {
 			fresh = true
 		}
 	}
@@ -481,6 +497,11 @@ func (a *typedResourceAnalysis) invocation(expr *ast.InvocationExpression) {
 	if expr == nil {
 		return
 	}
+	if a.freshCalls == nil {
+		a.freshCalls = make(map[*ast.InvocationExpression]bool)
+	}
+	delete(a.freshCalls, expr)
+	diagnosticsBefore := len(a.tc.Diagnostics())
 	// The callee identifier is not a resource value. Non-identifier callees
 	// may themselves evaluate expressions, so preserve their effects.
 	if _, simple := expr.Function.(*ast.Identifier); !simple {
@@ -497,7 +518,7 @@ func (a *typedResourceAnalysis) invocation(expr *ast.InvocationExpression) {
 	// Call-local resource modes are checked after ordinary argument uses and
 	// before permanent consumption. Invalid calls therefore do not mutate
 	// authority state and cannot create cascading use-after-consume errors.
-	if !a.checkCallResourceExclusivity(expr, op) {
+	if len(a.tc.Diagnostics()) != diagnosticsBefore || !a.checkCallResourceExclusivity(expr, op) {
 		return
 	}
 	for _, index := range op.Consumes {
@@ -514,6 +535,7 @@ func (a *typedResourceAnalysis) invocation(expr *ast.InvocationExpression) {
 			a.flow.Consume(ident.Value, expr)
 		}
 	}
+	a.freshCalls[expr] = op.ReturnsFresh
 }
 
 func (a *typedResourceAnalysis) match(expr *ast.MatchExpression) {
@@ -575,3 +597,4 @@ func (a *typedResourceAnalysis) use(name string, node ast.Node) {
 	}
 	d.AddHelp("use the fresh resource value returned by the consuming operation, if the protocol returns one")
 }
+

--- a/typechecker/resource_operation.go
+++ b/typechecker/resource_operation.go
@@ -1,0 +1,47 @@
+package typechecker
+
+import (
+	"fmt"
+	"sort"
+)
+
+// normalizeResourceOperation keeps the legacy consumption projection and the
+// parameter contract in agreement. Matching legacy entries are accepted because
+// SemIR projection supplies both representations; conflicting entries fail closed.
+func normalizeResourceOperation(op ResourceOperation) (ResourceOperation, error) {
+	modes := make(map[int]ResourceParameterMode)
+	for _, parameter := range op.Parameters {
+		if parameter.Index < 0 || parameter.Mode < ResourceParameterBorrowed || parameter.Mode > ResourceParameterConsumed {
+			return ResourceOperation{}, fmt.Errorf("invalid resource parameter %d mode %d", parameter.Index, parameter.Mode)
+		}
+		if _, exists := modes[parameter.Index]; exists {
+			return ResourceOperation{}, fmt.Errorf("duplicate resource parameter %d", parameter.Index)
+		}
+		modes[parameter.Index] = parameter.Mode
+	}
+	legacy := make(map[int]bool)
+	for _, index := range op.Consumes {
+		if index < 0 || legacy[index] {
+			return ResourceOperation{}, fmt.Errorf("invalid or duplicate consumed argument %d", index)
+		}
+		legacy[index] = true
+		if mode, exists := modes[index]; exists && mode != ResourceParameterConsumed {
+			return ResourceOperation{}, fmt.Errorf("argument %d has conflicting resource modes", index)
+		}
+		modes[index] = ResourceParameterConsumed
+	}
+	indices := make([]int, 0, len(modes))
+	for index := range modes {
+		indices = append(indices, index)
+	}
+	sort.Ints(indices)
+	out := ResourceOperation{ReturnsFresh: op.ReturnsFresh}
+	for _, index := range indices {
+		mode := modes[index]
+		out.Parameters = append(out.Parameters, ResourceParameterDeclaration{Index: index, Mode: mode})
+		if mode == ResourceParameterConsumed {
+			out.Consumes = append(out.Consumes, index)
+		}
+	}
+	return out, nil
+}


### PR DESCRIPTION
Resource calls can currently retain authority after a consumed-mode call when direct model metadata omits the legacy Consumes projection. The final #69 review also found that fresh results require unnecessary temporary bindings and unknown-provenance diagnostics can blame the wrong argument.

This follow-up normalizes the executable contract at registration and checking boundaries, rejects contradictory metadata, recognizes successfully checked direct fresh-return arguments, identifies the unknown participant, and suppresses derivative use-after-consume diagnostics. It also fails closed on resource reassignment until destination provenance is modeled, addressing the older stale-alias finding.

Regression tests cover consumed-mode alias invalidation, direct/bound fresh-result equivalence, independent fresh calls, unknown shared participants, double-consume diagnostics, unsupported reassignment, invalid nested calls, and conflicting metadata.

The accompanying source audit documents callable contract gaps at function-value, specialization, wrapper, interface, and receiver boundaries. It proposes separate result identity, permission, and lifetime relationships informed by Swift. Borrowed returns remain restricted and no source grammar is frozen.

Validation: local Go execution is unavailable in this workspace; repository CI and review must validate this head before merge. Based on specification 0c086683a8a02fa9bb96a5a6e0d856942bbe0321. PR #69 was already merged; this is a new follow-up, not a change to that merge.