### PR TITLE
Stateful command properties with model-aware shrinking

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -30,6 +30,7 @@ jobs:
         run: |
           go test ./testrunner -run '^$' -fuzz '^FuzzMinimize$' -fuzztime 5s
           go test ./testrunner -run '^$' -fuzz '^FuzzMutationBounds$' -fuzztime 5s
+          go test ./testrunner -run '^$' -fuzz '^FuzzMinimizeCommands$' -fuzztime 5s
       - name: Formatting patch
         if: always()
         run: |

--- a/compiler/simulation.go
+++ b/compiler/simulation.go
@@ -61,6 +61,8 @@ func checkSimulation(root *ast.Program, bindings []SimulationBinding) error {
 		{Name: "testing_discard", Symbol: "oak_test_host_discard", Return: "()"},
 		{Name: "testing_classify_host", Symbol: "oak_test_host_classify", Parameters: []string{"c.UInt32"}, Return: "()"},
 		{Name: "testing_trace_host", Symbol: "oak_test_host_trace", Parameters: []string{"c.UInt32", "c.UInt64", "c.UInt64"}, Return: "()"},
+		{Name: "testing_command_host", Symbol: "oak_test_host_command", Parameters: []string{"c.UInt32", "c.UInt32", "c.UInt32"}, Return: "()"},
+		{Name: "testing_command_limit_host", Symbol: "oak_test_host_command_limit", Return: "c.UInt32"},
 	}
 	return walkSimulation(reflect.ValueOf(root), func(value any) error {
 		switch n := value.(type) {

--- a/docs/spec/110-testing.md
+++ b/docs/spec/110-testing.md
@@ -254,3 +254,41 @@ pilot and requires the model to detect invariant 2011 with the four-command
 counterexample `enable, inject, acknowledge, inject`. Go fuzz targets exercise
 reducer invariants and mutation bounds. The dedicated workflow
 runs the native Oak examples and a coverage-guided libFuzzer smoke campaign.
+
+## Stateful command properties
+
+A `GeneratePropertyName(data: []u8): ()` companion in a `*_test.oak` file
+opts `PropertyName` into concrete command histories. `GenerateSimName` works the
+same way for `SimName`. Companions are not separately registered tests. Unit and
+fuzz targets cannot have companions in this version.
+
+Use `TestChoices` to select legal operations against an independent model, then
+emit each operation with `testing_command(TestCommand { kind: ..., target: ...,
+value: ... })`. Emit at most `testing_command_limit()` commands, which is
+`min(256, -max-bytes / 12)`. Exceeding the limit or emitting during execution is
+a harness error. Generation runs in its own isolated process; target execution
+starts in a fresh process. Generator discards consume the discard budget.
+
+The target receives concrete commands, not the generator's random tape.
+`test_command_count(data)` validates alignment; `test_command_at(data, index)`
+decodes a command. Validate the **entire** history against model preconditions
+with `test_assume` before exercising the implementation. Reject unknown kinds,
+invalid identifiers and missing prerequisites. Then reset the model and compare
+each real operation with its model transition. Domain structs/enums can be
+mapped to this fixed three-word carrier; arbitrary type derivation is not yet
+provided.
+
+Shrinking deletes whole commands and reduces unsigned target/value fields.
+Kinds remain fixed. A candidate is retained only when execution reports the
+same invariant. Model preconditions therefore preserve dependencies: deleting
+a create operation must invalidate a later use of that object. The reducer does
+not infer references or rewrite IDs. Its bounded greedy search does not promise
+a globally minimal history.
+
+Artifacts record `input_format: "commands-v1-u32x3le"` and the concrete input as
+three little-endian u32 words per command. JSON results include decoded commands;
+terminal failures print them. Corpus runs, shrinking and strict replay bypass
+generation entirely. Raw `.bin` corpus entries must already have this encoding;
+JSON corpus entries must match the input format. Trace replay retains the same
+build and semantic-trace checks as byte properties. A generator failure is a
+harness error, not a minimized target counterexample.

--- a/docs/spec/110-testing.md
+++ b/docs/spec/110-testing.md
@@ -276,7 +276,8 @@ with `test_assume` before exercising the implementation. Reject unknown kinds,
 invalid identifiers and missing prerequisites. Then reset the model and compare
 each real operation with its model transition. Domain structs/enums can be
 mapped to this fixed three-word carrier; arbitrary type derivation is not yet
-provided.
+provided. Share one legality predicate between the generator and the target so
+the generator never emits a history the target would reject.
 
 Shrinking deletes whole commands and reduces unsigned target/value fields.
 Kinds remain fixed. A candidate is retained only when execution reports the
@@ -292,3 +293,12 @@ generation entirely. Raw `.bin` corpus entries must already have this encoding;
 JSON corpus entries must match the input format. Trace replay retains the same
 build and semantic-trace checks as byte properties. A generator failure is a
 harness error, not a minimized target counterexample.
+
+`examples/testing/irq_test.oak` contains `PropertyIrqCommands`: acknowledgement
+is legal only in a deliverable model state and EOI only in an active one. The
+Go mutation test injects the lost-edge bug into a nine-command legal history and
+requires the reducer to reach exactly `enable, inject, acknowledge, inject`;
+every intermediate candidate that removed the enabling command was rejected by
+the target's preconditions rather than accepted as a spurious shorter failure.
+A Go fuzz target checks that command minimization preserves alignment, never
+introduces a command kind, never grows, and never loses a reported failure.

--- a/examples/testing/irq_test.oak
+++ b/examples/testing/irq_test.oak
@@ -112,3 +112,73 @@ SimTimerIrq: (data: []u8): () {
   irq_apply(state, u32(6))
   test_check(irq_deliverable(state[0]), u32(2032))
 }
+
+// Model preconditions for command histories: acknowledgement requires a
+// deliverable model state and EOI requires an active one. Everything else is
+// always legal. The generator and the target share this single definition, so
+// shrinking cannot produce a history the target would not have accepted.
+irq_legal: (bits: u8, action: u32): Bool {
+  action == u32(5) ? { (bits & u8(5)) == u8(1) && (bits & u8(10)) != u8(0) } |
+  action == u32(6) ? { (bits & u8(4)) != u8(0) } |
+  { action <= u32(6) }
+}
+
+// Concrete command histories. The generator selects only legal operations
+// against the model; the emitted commands, not this tape, are the test input.
+GeneratePropertyIrqCommands: (data: []u8): () {
+  tape: [1]TestChoices
+  choices: [*]TestChoices = span(&tape)
+  limit: u32 = testing_command_limit()
+  limit > u32(32) ? { limit = u32(32) }
+  count: u32 = test_range(choices, data, u32(0), limit)
+  model: u8 = u8(0)
+  i: u32 = u32(0)
+  while i < count {
+    legal: [7]u32
+    options: u32 = u32(0)
+    action: u32 = u32(0)
+    while action <= u32(6) {
+      irq_legal(model, action) ? { legal[options] = action; options = options + u32(1) }
+      action = action + u32(1)
+    }
+    chosen: u32 = legal[test_range(choices, data, u32(0), options - u32(1))]
+    testing_command(TestCommand { kind: chosen, target: u32(0), value: u32(0) })
+    model = irq_model(model, chosen)
+    i = i + u32(1)
+  }
+}
+
+PropertyIrqCommands: (data: []u8): () {
+  count: u32 = test_command_count(data)
+  // Validate the entire history first: a shrunk history that deletes the
+  // enabling command must reject, which preserves dependencies.
+  model: u8 = u8(0)
+  i: u32 = u32(0)
+  while i < count {
+    command: TestCommand = test_command_at(data, i)
+    test_assume(command.target == u32(0) && command.value == u32(0))
+    test_assume(irq_legal(model, command.kind))
+    model = irq_model(model, command.kind)
+    i = i + u32(1)
+  }
+  storage: [1]Irq
+  state: [*]Irq = span(&storage)
+  model = u8(0)
+  i = u32(0)
+  while i < count {
+    action: u32 = test_command_at(data, i).kind
+    before: Irq = state[0]
+    testing_trace(u32(202), u64(action), u64(i))
+    irq_apply(state, action)
+    model = irq_model(model, action)
+    after: Irq = state[0]
+    test_check(after.enabled == ((model & u8(1)) != u8(0)), u32(2010))
+    test_check(after.latched == ((model & u8(2)) != u8(0)), u32(2011))
+    test_check(after.active == ((model & u8(4)) != u8(0)), u32(2012))
+    test_check(after.level == ((model & u8(8)) != u8(0)), u32(2013))
+    !before.active && after.active ? { test_check(irq_deliverable(before), u32(2015)) }
+    after.active ? { test_check(!irq_deliverable(after), u32(2016)) }
+    testing_classify(action)
+    i = i + u32(1)
+  }
+}

--- a/stdlib/testing.oak
+++ b/stdlib/testing.oak
@@ -4,6 +4,33 @@ testing_fail_host: (id: c.UInt32): () = c.extern("oak_test_host_fail")
 testing_discard: (): () = c.extern("oak_test_host_discard")
 testing_classify_host: (id: c.UInt32): () = c.extern("oak_test_host_classify")
 testing_trace_host: (id: c.UInt32, a: c.UInt64, b: c.UInt64): () = c.extern("oak_test_host_trace")
+testing_command_host: (kind: c.UInt32, target: c.UInt32, value: c.UInt32): () = c.extern("oak_test_host_command")
+testing_command_limit_host: (): c.UInt32 = c.extern("oak_test_host_command_limit")
+
+// A generator emits concrete commands; execution never reruns random choices.
+TestCommand: type = struct { kind: u32, target: u32, value: u32 }
+testing_command_limit: (): u32 = u32(testing_command_limit_host())
+testing_command: (command: TestCommand): () {
+  testing_command_host(c.UInt32(command.kind), c.UInt32(command.target), c.UInt32(command.value))
+}
+
+test_command_count: (data: []u8): u32 {
+  test_assume(len(data) % u32(12) == u32(0))
+  len(data) / u32(12)
+}
+
+test_command_word: (data: []u8, offset: u32): u32 {
+  assert(offset <= len(data) && len(data) - offset >= u32(4))
+  u32(data[offset]) | (u32(data[offset + u32(1)]) << u32(8)) |
+    (u32(data[offset + u32(2)]) << u32(16)) | (u32(data[offset + u32(3)]) << u32(24))
+}
+
+test_command_at: (data: []u8, index: u32): TestCommand {
+  count: u32 = test_command_count(data)
+  assert(index < count)
+  offset: u32 = index * u32(12)
+  TestCommand { kind: test_command_word(data, offset), target: test_command_word(data, offset + u32(4)), value: test_command_word(data, offset + u32(8)) }
+}
 
 testing_fail: (id: u32): () { testing_fail_host(c.UInt32(id)) }
 testing_classify: (id: u32): () { testing_classify_host(c.UInt32(id)) }

--- a/testrunner/README.md
+++ b/testrunner/README.md
@@ -44,6 +44,39 @@ compares both the failure and its recorded trace. JSON payloads are decimal
 strings so tools can preserve every 64-bit value. Trace calls are no-ops in
 libFuzzer exports; rerun a raw crash input with `oak test` to collect its trace.
 
+For stateful systems, add a `Generate<Name>` companion to a `Property` or `Sim`
+test. The generator selects legal operations against your model and emits
+concrete commands; the target validates the whole history with `test_assume`,
+then compares the implementation with the model step by step:
+
+```oak
+GeneratePropertyStack: (data: []u8): () {
+  tape: [1]TestChoices
+  choices: [*]TestChoices = span(&tape)
+  depth: u32 = u32(0)
+  i: u32 = u32(0)
+  while i < u32(16) {
+    depth > u32(0) && test_bool(choices, data) ? {
+      testing_command(TestCommand { kind: u32(1), target: u32(0), value: u32(0) })
+      depth = depth - u32(1)
+    } | {
+      testing_command(TestCommand { kind: u32(0), target: u32(0), value: test_range(choices, data, u32(0), u32(9)) })
+      depth = depth + u32(1)
+    }
+    i = i + u32(1)
+  }
+}
+
+PropertyStack: (data: []u8): () {
+  count: u32 = test_command_count(data)
+  // ... test_assume every pop has a matching earlier push, then execute ...
+}
+```
+
+Failures shrink by deleting whole commands and reducing their fields; a pop
+whose push was deleted is rejected by the precondition instead of becoming a
+misleading counterexample. Results and artifacts carry the decoded commands.
+
 `-timeout`, `-max-bytes`, `-max-discards`, `-shrink`, and `-shrink-timeout` make
 campaign costs explicit. `-cover 1:10,2:1` requires sample counts for IDs emitted
 by `testing_classify`. Rejected inputs never count as passes. Use `-sanitize`

--- a/testrunner/commands.go
+++ b/testrunner/commands.go
@@ -1,0 +1,89 @@
+package testrunner
+
+import (
+	"context"
+	"encoding/binary"
+)
+
+const commandWidth = 12
+const commandLimit = 256
+const commandFormat = "commands-v1-u32x3le"
+
+type Command struct {
+	Kind   uint32 `json:"kind"`
+	Target uint32 `json:"target"`
+	Value  uint32 `json:"value"`
+}
+
+func encodeCommands(commands []Command) []byte {
+	data := make([]byte, commandWidth*len(commands))
+	for i, c := range commands {
+		binary.LittleEndian.PutUint32(data[i*commandWidth:], c.Kind)
+		binary.LittleEndian.PutUint32(data[i*commandWidth+4:], c.Target)
+		binary.LittleEndian.PutUint32(data[i*commandWidth+8:], c.Value)
+	}
+	return data
+}
+
+func decodeCommands(data []byte) []Command {
+	var commands []Command
+	for i := 0; i+commandWidth <= len(data); i += commandWidth {
+		commands = append(commands, Command{Kind: binary.LittleEndian.Uint32(data[i:]), Target: binary.LittleEndian.Uint32(data[i+4:]), Value: binary.LittleEndian.Uint32(data[i+8:])})
+	}
+	return commands
+}
+
+// MinimizeCommands removes whole commands, then reduces target/value words.
+// Kinds never change. The target's model preconditions reject illegal histories
+// through test_assume; only a valid execution with the same invariant is kept.
+// Dependencies are semantic model obligations, not guessed from integer IDs.
+func MinimizeCommands(ctx context.Context, input []byte, budget int, fails func([]byte) bool) []byte {
+	best := append([]byte(nil), input...)
+	if len(best)%commandWidth != 0 {
+		return best
+	}
+	try := func(candidate []byte) bool {
+		if budget <= 0 || ctx.Err() != nil {
+			return false
+		}
+		budget--
+		if fails(candidate) {
+			best = append([]byte(nil), candidate...)
+			return true
+		}
+		return false
+	}
+	for chunk := len(best) / commandWidth; chunk > 0 && budget > 0 && ctx.Err() == nil; chunk /= 2 {
+		width := chunk * commandWidth
+		for start := 0; start+width <= len(best) && budget > 0 && ctx.Err() == nil; {
+			candidate := append(append([]byte(nil), best[:start]...), best[start+width:]...)
+			if !try(candidate) {
+				start += commandWidth
+			}
+		}
+	}
+	for i := 0; i < len(best) && budget > 0 && ctx.Err() == nil; i += commandWidth {
+		for _, field := range []int{4, 8} {
+			offset := i + field
+			original := binary.LittleEndian.Uint32(best[offset:])
+			if original == 0 {
+				continue
+			}
+			candidate := append([]byte(nil), best...)
+			binary.LittleEndian.PutUint32(candidate[offset:], 0)
+			if try(candidate) {
+				continue
+			}
+			for step := original / 2; step > 0 && budget > 0 && ctx.Err() == nil; step /= 2 {
+				for binary.LittleEndian.Uint32(best[offset:]) >= step && budget > 0 && ctx.Err() == nil {
+					candidate = append([]byte(nil), best...)
+					binary.LittleEndian.PutUint32(candidate[offset:], binary.LittleEndian.Uint32(best[offset:])-step)
+					if !try(candidate) {
+						break
+					}
+				}
+			}
+		}
+	}
+	return best
+}

--- a/testrunner/commands_test.go
+++ b/testrunner/commands_test.go
@@ -1,8 +1,12 @@
 package testrunner
 
 import (
+	"bytes"
 	"context"
+	"os"
+	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -91,4 +95,86 @@ PropertyCommands: (data: []u8): () {
 	if code != 1 || results[0].Cases != 1 {
 		t.Fatalf("corpus %d %+v %s", code, results, stderr)
 	}
+}
+
+// The command-generated IRQ example must reduce the injected lost-edge bug to
+// the four-command counterexample while every intermediate candidate stays a
+// legal history: deleting the enabling command invalidates the acknowledgement.
+func TestIRQCommandMutationDetected(t *testing.T) {
+	files := map[string]string{}
+	for _, name := range []string{"irq.oak", "irq_test.oak"} {
+		data, err := os.ReadFile(filepath.Join("..", "examples", "testing", name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		files[name] = string(data)
+	}
+	original := "action == u32(2) ? { state[0].latched = true }"
+	mutant := "action == u32(2) && !state[0].active ? { state[0].latched = true }"
+	if !strings.Contains(files["irq.oak"], original) {
+		t.Fatal("mutation site changed")
+	}
+	files["irq.oak"] = strings.Replace(files["irq.oak"], original, mutant, 1)
+	// enable, level up, inject, level down, ack, eoi, inject, ack, inject.
+	var history []Command
+	for _, kind := range []uint32{0, 3, 2, 4, 5, 6, 2, 5, 2} {
+		history = append(history, Command{Kind: kind})
+	}
+	files["testdata/oak/PropertyIrqCommands/lost-edge.bin"] = string(encodeCommands(history))
+	dir := fixture(t, files)
+	code, results, stderr := runCLI(t, "-run", "^PropertyIrqCommands$", "-runs", "1", dir)
+	if code != 1 || len(results) != 1 || results[0].Failure != "invariant:2011" {
+		t.Fatalf("mutation escaped: %d %+v %s", code, results, stderr)
+	}
+	want := []Command{{Kind: 0}, {Kind: 2}, {Kind: 5}, {Kind: 2}}
+	if !reflect.DeepEqual(results[0].Commands, want) {
+		t.Fatalf("unexpected minimized history: %+v", results[0].Commands)
+	}
+	if len(results[0].Trace) != 4 || results[0].Trace[3].ID != 202 || results[0].Trace[3].A != 2 {
+		t.Fatalf("trace does not describe the minimized history: %+v", results[0].Trace)
+	}
+	code, replay, _ := runCLI(t, "-replay", results[0].Artifact, dir)
+	if code != 1 || replay[0].Failure != "reproduced invariant:2011" || !reflect.DeepEqual(replay[0].Commands, want) {
+		t.Fatalf("replay: %d %+v", code, replay)
+	}
+}
+
+// Command minimization must keep every candidate aligned, never change a kind,
+// never grow, and never lose a failure the predicate still reports.
+func FuzzMinimizeCommands(t *testing.F) {
+	t.Add(encodeCommands([]Command{{1, 7, 0}, {2, 7, 100}, {9, 0, 0}}))
+	t.Fuzz(func(t *testing.T, input []byte) {
+		if len(input) > 24*commandWidth || len(input)%commandWidth != 0 {
+			t.Skip()
+		}
+		original := append([]byte(nil), input...)
+		kinds := map[uint32]int{}
+		for _, c := range decodeCommands(input) {
+			kinds[c.Kind]++
+		}
+		predicate := func(data []byte) bool {
+			if len(data)%commandWidth != 0 {
+				t.Fatal("unaligned candidate")
+			}
+			seen := map[uint32]int{}
+			failed := false
+			for _, c := range decodeCommands(data) {
+				seen[c.Kind]++
+				if kinds[c.Kind] < seen[c.Kind] {
+					t.Fatal("invented command kind")
+				}
+				if c.Kind == 2 && c.Value >= 3 {
+					failed = true
+				}
+			}
+			return failed
+		}
+		best := MinimizeCommands(context.Background(), input, 100, predicate)
+		if predicate(input) && !predicate(best) {
+			t.Fatal("lost failure")
+		}
+		if len(best) > len(input) || !bytes.Equal(input, original) {
+			t.Fatal("invalid shrink")
+		}
+	})
 }

--- a/testrunner/commands_test.go
+++ b/testrunner/commands_test.go
@@ -1,0 +1,94 @@
+package testrunner
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+func TestCommandShrinkPreservesDependencies(t *testing.T) {
+	input := encodeCommands([]Command{{9, 0, 0}, {1, 7, 0}, {2, 7, 100}, {9, 0, 0}})
+	calls := 0
+	fails := func(data []byte) bool {
+		calls++
+		if len(data)%12 != 0 {
+			t.Fatal("split command")
+		}
+		created := map[uint32]bool{}
+		failed := false
+		for _, c := range decodeCommands(data) {
+			switch c.Kind {
+			case 1:
+				created[c.Target] = true
+			case 2:
+				if !created[c.Target] {
+					return false
+				}
+				failed = c.Value >= 3
+			case 9:
+			default:
+				t.Fatal("changed command kind")
+			}
+		}
+		return failed
+	}
+	got := decodeCommands(MinimizeCommands(context.Background(), input, 200, fails))
+	want := []Command{{1, 7, 0}, {2, 7, 3}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+	if calls > 200 {
+		t.Fatal("exceeded budget")
+	}
+}
+
+func TestCommandGeneratorDiscovery(t *testing.T) {
+	for _, source := range []string{
+		"GeneratePropertyMissing: (data: []u8): () {}",
+		"GenerateFuzzBytes: (data: []u8): () {}\nFuzzBytes: (data: []u8): () {}",
+		"GeneratePropertyBad: (): () {}\nPropertyBad: (data: []u8): () {}",
+	} {
+		dir := fixture(t, map[string]string{"a_test.oak": source})
+		if _, err := Discover([]string{dir}); err == nil {
+			t.Fatalf("accepted %s", source)
+		}
+	}
+}
+
+func TestNativeCommandsShrinkReplay(t *testing.T) {
+	dir := fixture(t, map[string]string{"a_test.oak": `import(testing)
+GeneratePropertyCommands: (data: []u8): () {
+ testing_command(TestCommand { kind: u32(1), target: u32(7), value: u32(0) })
+ testing_command(TestCommand { kind: u32(2), target: u32(7), value: u32(100) })
+}
+PropertyCommands: (data: []u8): () {
+ count: u32 = test_command_count(data)
+ test_assume(count == u32(2))
+ first: TestCommand = test_command_at(data, u32(0))
+ second: TestCommand = test_command_at(data, u32(1))
+ test_assume(first.kind == u32(1) && second.kind == u32(2) && first.target == second.target)
+ testing_trace(u32(400), u64(first.target), u64(second.value))
+ test_check(second.value < u32(3), u32(8001))
+}`})
+	code, results, stderr := runCLI(t, "-runs", "1", dir)
+	if code != 1 || len(results) != 1 || results[0].Failure != "invariant:8001" {
+		t.Fatalf("%d %+v %s", code, results, stderr)
+	}
+	result := results[0]
+	want := []Command{{1, 7, 0}, {2, 7, 3}}
+	if !reflect.DeepEqual(result.Commands, want) {
+		t.Fatalf("commands: %+v", result)
+	}
+	a, err := readArtifact(result.Artifact, 256)
+	if err != nil || a.InputFormat != commandFormat {
+		t.Fatalf("artifact %+v %v", a, err)
+	}
+	code, results, stderr = runCLI(t, "-replay", result.Artifact, dir)
+	if code != 1 || results[0].Failure != "reproduced invariant:8001" || !reflect.DeepEqual(results[0].Commands, want) {
+		t.Fatalf("replay %d %+v %s", code, results, stderr)
+	}
+	code, results, stderr = runCLI(t, "-runs", "1", "-seed", "99", dir)
+	if code != 1 || results[0].Cases != 1 {
+		t.Fatalf("corpus %d %+v %s", code, results, stderr)
+	}
+}

--- a/testrunner/discover.go
+++ b/testrunner/discover.go
@@ -16,10 +16,11 @@ import (
 )
 
 type Test struct {
-	Name string `json:"name"`
-	File string `json:"file"`
-	Line int    `json:"line"`
-	Kind string `json:"kind"`
+	Generator string `json:"generator,omitempty"`
+	Name      string `json:"name"`
+	File      string `json:"file"`
+	Line      int    `json:"line"`
+	Kind      string `json:"kind"`
 }
 
 type Package struct {
@@ -94,6 +95,7 @@ func Discover(paths []string) ([]Package, error) {
 		}
 		var pkg Package
 		pkg.Dir = dir
+		generators := map[string]*ast.FunctionStatement{}
 		var src strings.Builder
 		for _, entry := range entries {
 			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".oak") || strings.HasPrefix(entry.Name(), ".") {
@@ -119,6 +121,12 @@ func Discover(paths []string) ([]Package, error) {
 					continue
 				}
 				kind := testKind(fn.Name.Value)
+				if strings.HasPrefix(fn.Name.Value, "Generate") && testKind(strings.TrimPrefix(fn.Name.Value, "Generate")) != "" {
+					if _, exists := generators[fn.Name.Value]; exists {
+						return nil, fmt.Errorf("duplicate generator %s", fn.Name.Value)
+					}
+					generators[fn.Name.Value] = fn
+				}
 				if kind == "" {
 					continue
 				}
@@ -135,7 +143,28 @@ func Discover(paths []string) ([]Package, error) {
 				return nil, fmt.Errorf("duplicate test %s in %s", pkg.Tests[i].Name, dir)
 			}
 		}
+		for i := range pkg.Tests {
+			name := "Generate" + pkg.Tests[i].Name
+			if fn := generators[name]; fn != nil {
+				if pkg.Tests[i].Kind != "property" && pkg.Tests[i].Kind != "simulation" {
+					return nil, fmt.Errorf("%s: command generators require a Property or Sim target", name)
+				}
+				if err := validateTest(fn, "generator"); err != nil {
+					return nil, err
+				}
+				pkg.Tests[i].Generator = name
+				delete(generators, name)
+			}
+		}
+		if len(generators) != 0 {
+			return nil, fmt.Errorf("command generator has no registered target in %s", dir)
+		}
 		pkg.Registry = append([]Test(nil), pkg.Tests...)
+		for _, test := range pkg.Tests {
+			if test.Generator != "" {
+				pkg.Registry = append(pkg.Registry, Test{Name: test.Generator, Kind: "generator"})
+			}
+		}
 		if len(pkg.Tests) != 0 {
 			packages = append(packages, pkg)
 		}

--- a/testrunner/engine.go
+++ b/testrunner/engine.go
@@ -133,6 +133,7 @@ func Minimize(ctx context.Context, input []byte, budget int, fails func([]byte) 
 }
 
 type Artifact struct {
+	InputFormat    string       `json:"input_format,omitempty"`
 	TraceVersion   int          `json:"trace_version,omitempty"`
 	Trace          []TraceEvent `json:"trace,omitempty"`
 	TraceTruncated bool         `json:"trace_truncated,omitempty"`
@@ -178,6 +179,9 @@ func readArtifact(path string, max int) (Artifact, error) {
 	}
 	if _, err := hex.DecodeString(a.Build); err != nil {
 		return a, fmt.Errorf("invalid build fingerprint in %s", path)
+	}
+	if a.InputFormat != "" && (a.InputFormat != commandFormat || len(a.Input)%commandWidth != 0 || len(a.Input)/commandWidth > commandLimit) {
+		return a, fmt.Errorf("invalid command input format in %s", path)
 	}
 	if a.TraceVersion != 0 && a.TraceVersion != traceVersion || len(a.Trace) > traceLimit || a.TraceTruncated && len(a.Trace) != traceLimit || a.TraceVersion == 0 && (len(a.Trace) != 0 || a.TraceTruncated) {
 		return a, fmt.Errorf("invalid or unsupported trace in %s", path)
@@ -237,7 +241,11 @@ func loadCorpus(pkg Package, test Test, max int) ([][]byte, error) {
 			if err != nil {
 				return nil, err
 			}
-			if a.Test != test.Name || a.Kind != test.Kind {
+			expectedFormat := ""
+			if test.Generator != "" {
+				expectedFormat = commandFormat
+			}
+			if a.Test != test.Name || a.Kind != test.Kind || a.InputFormat != expectedFormat {
 				return nil, fmt.Errorf("corpus identity mismatch: %s", path)
 			}
 			inputs = append(inputs, a.Input)

--- a/testrunner/fuzz.go
+++ b/testrunner/fuzz.go
@@ -23,6 +23,7 @@ func emitFuzzHarness(pkg Package, test Test, maxBytes int, adapter *nativeAdapte
 		return "", err
 	}
 	var out strings.Builder
+	fmt.Fprintf(&out, "#define OAK_COMMAND_LIMIT %d\n", min(commandLimit, maxBytes/commandWidth))
 	if adapter != nil {
 		fmt.Fprintf(&out, "/* Trusted adapter manifest identity SHA-256: %x; link its pinned objects explicitly. */\n", sha256.Sum256([]byte(adapter.identity)))
 	}
@@ -39,6 +40,8 @@ void oak_test_host_fail(uint32_t id) {
 void oak_test_host_discard(void) { longjmp(oak_fuzz_discard, 1); }
 void oak_test_host_classify(uint32_t id) { (void)id; }
 void oak_test_host_trace(uint32_t id, uint64_t a, uint64_t b) { (void)id; (void)a; (void)b; }
+uint32_t oak_test_host_command_limit(void) { return OAK_COMMAND_LIMIT; }
+void oak_test_host_command(uint32_t kind, uint32_t target, uint32_t value) { (void)kind; (void)target; (void)value; abort(); }
 #define main oak_fuzz_application_entry
 `)
 	out.WriteString(generated)

--- a/testrunner/native.go
+++ b/testrunner/native.go
@@ -51,6 +51,7 @@ type outcome struct {
 	classes                   map[uint32]bool
 	trace                     []TraceEvent
 	traceTruncated            bool
+	commands                  []Command
 }
 
 func buildNative(pkg Package, cfg Config) (*nativeProgram, error) {
@@ -73,6 +74,7 @@ func buildNative(pkg Package, cfg Config) (*nativeProgram, error) {
 		return nil, err
 	}
 	var source strings.Builder
+	fmt.Fprintf(&source, "#define OAK_COMMAND_LIMIT %d\n", min(commandLimit, cfg.MaxBytes/commandWidth))
 	source.WriteString(nativePreamble)
 	source.WriteString("\n#define main oak_test_application_entry\n")
 	source.WriteString(generated)
@@ -89,7 +91,7 @@ int main(int argc, char **argv) {
  switch (strtol(argv[1], NULL, 10)) {
 `, cfg.MaxBytes, cfg.MaxBytes, cfg.MaxBytes)
 	for i, test := range pkg.Registry {
-		fmt.Fprintf(&source, "case %d: oak_%s(", i, test.Name)
+		fmt.Fprintf(&source, "case %d: oak_test_generating = %d; oak_%s(", i, map[bool]int{true: 1, false: 0}[test.Kind == "generator"], test.Name)
 		if test.Kind != "unit" {
 			source.WriteString("(oak_view_u8){data, (u32)size}")
 		}
@@ -146,6 +148,16 @@ const nativePreamble = `
 #include <stdlib.h>
 #include <stdint.h>
 static FILE *oak_test_report;
+static unsigned oak_test_generating, oak_test_command_count;
+uint32_t oak_test_host_command_limit(void) { return OAK_COMMAND_LIMIT; }
+void oak_test_host_command(uint32_t kind, uint32_t target, uint32_t value) {
+ if (!oak_test_report) exit(125);
+ if (!oak_test_generating || oak_test_command_count >= OAK_COMMAND_LIMIT) {
+  fputs("error command-mode-or-limit\n", oak_test_report); fflush(oak_test_report); exit(125);
+ }
+ fprintf(oak_test_report, "command %u %u %u\n", (unsigned)kind, (unsigned)target, (unsigned)value);
+ oak_test_command_count++;
+}
 static unsigned oak_test_trace_count;
 void oak_test_host_trace(uint32_t id, uint64_t a, uint64_t b) {
  if (!oak_test_report) return;
@@ -212,7 +224,19 @@ func (p *nativeProgram) run(index int, input []byte) (result outcome) {
 		if len(fields) == 0 {
 			continue
 		}
-		if len(fields) == 4 && fields[0] == "trace" {
+		if len(fields) == 2 && fields[0] == "error" {
+			result.signature = "harness:" + fields[1]
+			return result
+		} else if len(fields) == 4 && fields[0] == "command" {
+			kind, e1 := strconv.ParseUint(fields[1], 10, 32)
+			target, e2 := strconv.ParseUint(fields[2], 10, 32)
+			value, e3 := strconv.ParseUint(fields[3], 10, 32)
+			if e1 != nil || e2 != nil || e3 != nil || len(result.commands) >= min(commandLimit, p.maxBytes/commandWidth) {
+				result.signature = "harness:bad-command-report"
+				return result
+			}
+			result.commands = append(result.commands, Command{Kind: uint32(kind), Target: uint32(target), Value: uint32(value)})
+		} else if len(fields) == 4 && fields[0] == "trace" {
 			id, e1 := strconv.ParseUint(fields[1], 10, 32)
 			a, e2 := strconv.ParseUint(fields[2], 10, 64)
 			b, e3 := strconv.ParseUint(fields[3], 10, 64)

--- a/testrunner/native.go
+++ b/testrunner/native.go
@@ -148,15 +148,15 @@ const nativePreamble = `
 #include <stdlib.h>
 #include <stdint.h>
 static FILE *oak_test_report;
-static unsigned oak_test_generating, oak_test_command_count;
+static unsigned oak_test_generating, oak_test_emitted_count;
 uint32_t oak_test_host_command_limit(void) { return OAK_COMMAND_LIMIT; }
 void oak_test_host_command(uint32_t kind, uint32_t target, uint32_t value) {
  if (!oak_test_report) exit(125);
- if (!oak_test_generating || oak_test_command_count >= OAK_COMMAND_LIMIT) {
+ if (!oak_test_generating || oak_test_emitted_count >= OAK_COMMAND_LIMIT) {
   fputs("error command-mode-or-limit\n", oak_test_report); fflush(oak_test_report); exit(125);
  }
  fprintf(oak_test_report, "command %u %u %u\n", (unsigned)kind, (unsigned)target, (unsigned)value);
- oak_test_command_count++;
+ oak_test_emitted_count++;
 }
 static unsigned oak_test_trace_count;
 void oak_test_host_trace(uint32_t id, uint64_t a, uint64_t b) {

--- a/testrunner/runner.go
+++ b/testrunner/runner.go
@@ -31,6 +31,7 @@ func Defaults() Config {
 
 type Result struct {
 	Test
+	Commands       []Command      `json:"commands,omitempty"`
 	Trace          []TraceEvent   `json:"trace,omitempty"`
 	TraceTruncated bool           `json:"trace_truncated,omitempty"`
 	Package        string         `json:"package"`
@@ -199,6 +200,9 @@ func Main(args []string, stdout, stderr io.Writer) int {
 			if result.Output != "" {
 				fmt.Fprintln(stdout, result.Output)
 			}
+			for i, c := range result.Commands {
+				fmt.Fprintf(stdout, "  command[%d] kind=%d target=%d value=%d\n", i, c.Kind, c.Target, c.Value)
+			}
 			start := len(result.Trace) - 8
 			if start < 0 {
 				start = 0
@@ -275,7 +279,26 @@ func parseCover(raw string) (map[uint32]int, error) {
 
 func runTest(pkg Package, test Test, index int, native *nativeProgram, cfg Config, cover map[uint32]int, replay *Artifact) Result {
 	result := Result{Test: test, Package: pkg.Dir, Status: "pass", Seed: cfg.Seed, Classes: map[uint32]int{}}
+	format := ""
+	generator := -1
+	if test.Generator != "" {
+		format = commandFormat
+		for i, t := range pkg.Registry {
+			if t.Name == test.Generator {
+				generator = i
+				break
+			}
+		}
+		if generator < 0 {
+			result.Status, result.Failure = "error", "missing command generator"
+			return result
+		}
+	}
 	if replay != nil {
+		if replay.InputFormat != format {
+			result.Status, result.Failure = "error", "replay input format mismatch"
+			return result
+		}
 		result.Seed = replay.Seed
 		if replay.Build != native.build {
 			result.Status = "error"
@@ -286,6 +309,9 @@ func runTest(pkg Package, test Test, index int, native *nativeProgram, cfg Confi
 		result.Cases = 1
 		result.Output = out.output
 		result.Trace, result.TraceTruncated = out.trace, out.traceTruncated
+		if format != "" {
+			result.Commands = decodeCommands(replay.Input)
+		}
 		if out.status == "fail" && out.signature == replay.Signature {
 			result.Status = "fail"
 			result.Failure = "reproduced " + out.signature
@@ -306,6 +332,10 @@ func runTest(pkg Package, test Test, index int, native *nativeProgram, cfg Confi
 		return result
 	}
 	execute := func(input []byte, attempt int) bool {
+		if format != "" && (len(input)%commandWidth != 0 || len(input)/commandWidth > commandLimit) {
+			result.Status, result.Failure = "error", "invalid concrete command corpus: expected at most 256 complete 12-byte commands"
+			return false
+		}
 		out := native.run(index, input)
 		if out.status == "discard" {
 			result.Discards++
@@ -338,7 +368,11 @@ func runTest(pkg Package, test Test, index int, native *nativeProgram, cfg Confi
 			} else {
 				ctx, cancel := context.WithTimeout(context.Background(), cfg.ShrinkTimeout)
 				bestOutcome := confirmation
-				best = Minimize(ctx, input, cfg.Shrink, func(candidate []byte) bool {
+				minimize := Minimize
+				if format != "" {
+					minimize = MinimizeCommands
+				}
+				best = minimize(ctx, input, cfg.Shrink, func(candidate []byte) bool {
 					r := native.run(index, candidate)
 					matches := r.status == "fail" && r.signature == out.signature
 					if matches {
@@ -358,7 +392,11 @@ func runTest(pkg Package, test Test, index int, native *nativeProgram, cfg Confi
 		}
 		result.Trace, result.TraceTruncated = out.trace, out.traceTruncated
 		result.Output = out.output
+		if format != "" {
+			result.Commands = decodeCommands(best)
+		}
 		artifact := Artifact{TimeoutNanos: int64(cfg.Timeout), Version: 1, Engine: engineVersion, Test: test.Name, Kind: test.Kind, Build: native.build, Seed: cfg.Seed, Attempt: attempt, MaxBytes: cfg.MaxBytes, Sanitize: cfg.Sanitize, Signature: out.signature, Input: best}
+		artifact.InputFormat = format
 		artifact.TraceVersion, artifact.Trace, artifact.TraceTruncated = traceVersion, out.trace, out.traceTruncated
 		path, err := saveArtifact(pkg, test, artifact)
 		if err != nil {
@@ -395,6 +433,23 @@ func runTest(pkg Package, test Test, index int, native *nativeProgram, cfg Confi
 		for attempt := 0; accepted < cfg.Runs; attempt++ {
 			r := randomFor(cfg.Seed, test.Name, attempt)
 			input := generate(&r, attempt, cfg.MaxBytes)
+			if generator >= 0 {
+				generated := native.run(generator, input)
+				if generated.status == "discard" {
+					result.Discards++
+					if result.Discards > cfg.MaxDiscards {
+						result.Status, result.Failure = "fail", "generator discard budget exhausted"
+						return result
+					}
+					continue
+				}
+				if generated.status != "pass" {
+					result.Status, result.Failure, result.Output = "error", "command generator failed: "+generated.signature, generated.output
+					result.Trace, result.TraceTruncated = generated.trace, generated.traceTruncated
+					return result
+				}
+				input = encodeCommands(generated.commands)
+			}
 			if test.Kind == "fuzz" && attempt >= len(seeds) {
 				input = mutate(&r, seeds, cfg.MaxBytes)
 			} else if test.Kind == "fuzz" {

--- a/testrunner/trace_test.go
+++ b/testrunner/trace_test.go
@@ -72,7 +72,7 @@ TestTraceBound: (): () {
 TestTraceCrash: (): () { testing_trace(u32(45), u64(1), u64(2)); assert(false) }
 TestTraceTimeout: (): () { testing_trace(u32(46), u64(3), u64(4)); while true {} }
 `})
-	code, results, stderr := runCLI(t, "-timeout", "100ms", "-shrink", "0", dir)
+	code, results, stderr := runCLI(t, "-timeout", "500ms", "-shrink", "0", dir)
 	if code != 1 || len(results) != 3 {
 		t.Fatalf("%d %+v %s", code, results, stderr)
 	}


### PR DESCRIPTION
## Summary
- Merge the stateful command testing work: `Generate<Property|Sim>Name` companions emit concrete `TestCommand` histories from an isolated generator process; targets validate the whole history against model preconditions and compare implementation with model.
- `MinimizeCommands` deletes whole commands and reduces target/value fields while kinds stay fixed; artifacts record `input_format: commands-v1-u32x3le`, results and terminal output decode the commands.
- New example `PropertyIrqCommands` shares one legality predicate between generator and target. A Go mutation test injects the lost-edge bug into a nine-command legal history and requires the reducer to reach exactly `enable, inject, acknowledge, inject` with a matching semantic trace and strict replay.
- `FuzzMinimizeCommands` checks alignment, no invented command kinds, monotone size, and no lost failures; wired into the testing workflow.
- Spec (`docs/spec/110-testing.md`) and runner README document the contract and its limits.

## Test plan
- [x] `go test ./testrunner` (Linux CI; on macOS the pre-existing adapter/libFuzzer/first-exec tests are environment-limited)
- [x] `go test ./testrunner -run '^$' -fuzz '^FuzzMinimizeCommands$' -fuzztime 5s`
- [x] `./build/oak test -runs 30 examples/testing`
- [x] OS harness (`pilots/oak/simulation`) runs against this build

🤖 Generated with [Claude Code](https://claude.com/claude-code)