### PR TITLE
oak test: build module packages through the module loader

### DIFF
--- a/docs/spec/110-testing.md
+++ b/docs/spec/110-testing.md
@@ -33,8 +33,16 @@ simulation campaigns. No matching tests is an error, including empty discovery.
 Bootstrap package source is concatenated in filename order with source-boundary
 comments. Test registrations retain original filename and line. Compiler errors
 currently refer to positions in the assembled `<oak-test-package>` source.
-General package resolution and fully source-mapped multi-file diagnostics are
-separate compiler work; this runner does not invent a second module system.
+
+A directory whose `.oak` files all open with the same package clause is a
+module package (`83-modules.md`). It compiles through the module loader with
+the root package's `*_test.oak` files included, so tests may use `pub` members,
+imported packages resolved through the enclosing `oak.mod`, and the simulation
+profile. Mixing files with and without a clause in one directory rejects. The
+root package's C symbols carry the package prefix (`oak_<package>_<Name>`)
+unless it is `package main`; the harness uses the same renaming as
+`compiler/modules.go`. Only the root package's test files join the build:
+imported packages are compiled as their clients see them.
 
 ## Isolation, outcomes, and reporting
 

--- a/testrunner/README.md
+++ b/testrunner/README.md
@@ -13,7 +13,10 @@ compiler (`cc` by default) is required. Then:
 ```
 
 Flags precede directory arguments. Put tests in `*_test.oak` alongside the
-production `.oak` sources they exercise:
+production `.oak` sources they exercise. A directory whose files begin with a
+`package` clause is built as a module package through its `oak.mod`, so tests
+can import sibling packages and use `pub` members; a directory without clauses
+is a bootstrap package assembled by concatenation:
 
 ```oak
 import(testing)

--- a/testrunner/adapter.go
+++ b/testrunner/adapter.go
@@ -124,6 +124,11 @@ func loadAdapter(path string) (*nativeAdapter, error) {
 
 func packageCompilation(pkg Package, adapter *nativeAdapter) compiler.Compilation {
 	comp := compiler.New().WithSource(filepath.Join(pkg.Dir, "<oak-test-package>"), pkg.Source)
+	if pkg.Module {
+		// Module packages resolve imports through the enclosing oak.mod; the
+		// root package's *_test.oak files join it only in this test build.
+		comp = compiler.New().WithPackageDir(pkg.Dir).WithTestFiles(true)
+	}
 	// All invocations of a package containing Sim tests use the same profile,
 	// preserving fingerprints across test selection and exact replay.
 	for _, test := range pkg.Registry {

--- a/testrunner/discover.go
+++ b/testrunner/discover.go
@@ -24,10 +24,40 @@ type Test struct {
 }
 
 type Package struct {
-	Dir      string
+	Dir string
+	// Name is the package clause of a module package (docs/spec/83-modules.md);
+	// empty for a bootstrap package assembled by concatenation.
+	Name     string
+	Module   bool
 	Source   string
 	Tests    []Test
 	Registry []Test
+}
+
+// symbol is the C name the generated translation unit gives a top-level
+// function: the root package of a module build is injectively renamed unless
+// it is package main, matching compiler/modules.go.
+func (p Package) symbol(name string) string {
+	if p.Module && p.Name != "main" {
+		return "oak_" + p.Name + "_" + name
+	}
+	return "oak_" + name
+}
+
+// packageClause returns the package name declared by the first statement of
+// an Oak source file, or "" when the file has no package clause.
+func packageClause(source string) string {
+	for _, line := range strings.Split(source, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "//") {
+			continue
+		}
+		if name, ok := strings.CutPrefix(trimmed, "package "); ok {
+			return strings.TrimSpace(name)
+		}
+		return ""
+	}
+	return ""
 }
 
 var cIdentifier = regexp.MustCompile(`^[A-Za-z_][A-Za-z_0-9]*$`)
@@ -97,6 +127,8 @@ func Discover(paths []string) ([]Package, error) {
 		pkg.Dir = dir
 		generators := map[string]*ast.FunctionStatement{}
 		var src strings.Builder
+		clauses := 0
+		files := 0
 		for _, entry := range entries {
 			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".oak") || strings.HasPrefix(entry.Name(), ".") {
 				continue
@@ -105,6 +137,16 @@ func Discover(paths []string) ([]Package, error) {
 			data, err := os.ReadFile(path)
 			if err != nil {
 				return nil, err
+			}
+			// A directory whose files open with package clauses is a module
+			// package: the compiler's loader assembles it, not concatenation.
+			files++
+			if name := packageClause(string(data)); name != "" {
+				if clauses != 0 && name != pkg.Name {
+					return nil, fmt.Errorf("%s: package clause %q disagrees with %q", path, name, pkg.Name)
+				}
+				pkg.Name, pkg.Module = name, true
+				clauses++
 			}
 			// Newlines prevent final comments/layout blocks from eating the next file.
 			fmt.Fprintf(&src, "\n// oak test source: %s\n%s\n", entry.Name(), data)
@@ -135,6 +177,9 @@ func Discover(paths []string) ([]Package, error) {
 				}
 				pkg.Tests = append(pkg.Tests, Test{Name: fn.Name.Value, File: entry.Name(), Line: fn.Token.Line, Kind: kind})
 			}
+		}
+		if clauses != 0 && clauses != files {
+			return nil, fmt.Errorf("%s: every file of a module package must begin with the same package clause", dir)
 		}
 		pkg.Source = src.String()
 		sort.Slice(pkg.Tests, func(i, j int) bool { return pkg.Tests[i].Name < pkg.Tests[j].Name })

--- a/testrunner/fuzz.go
+++ b/testrunner/fuzz.go
@@ -49,10 +49,10 @@ void oak_test_host_command(uint32_t kind, uint32_t target, uint32_t value) { (vo
 	fmt.Fprintf(&out, `int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
  if (size > %d) return 0;
  if (setjmp(oak_fuzz_discard)) return 0;
- oak_%s((oak_view_u8){data, (u32)size});
+ %s((oak_view_u8){data, (u32)size});
  return 0;
 }
-`, maxBytes, test.Name)
+`, maxBytes, pkg.symbol(test.Name))
 	return out.String(), nil
 }
 

--- a/testrunner/module_test.go
+++ b/testrunner/module_test.go
@@ -1,0 +1,101 @@
+package testrunner
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A directory whose files open with package clauses is compiled through the
+// module loader with its *_test.oak files, so tests can exercise pub members,
+// imported packages, and the simulation profile with mangled root symbols.
+func TestModulePackages(t *testing.T) {
+	dir := fixture(t, map[string]string{
+		"oak.mod": "module example.com/os\noak 0.1.0\n",
+		"sched/queue.oak": `package sched
+
+pub Queue: type = struct { count: u32 }
+
+pub queue_push: (q: [*]Queue): Bool {
+  q[0].count < u32(2) ? { q[0].count = q[0].count + u32(1); true } | { false }
+}
+`,
+		"sched/queue_test.oak": `package sched
+
+import(testing)
+
+TestPush: (): () {
+  storage: [1]Queue
+  q: [*]Queue = span(&storage)
+  q[0] = Queue { count: u32(0) }
+  test_check(queue_push(q), u32(1))
+  test_check(queue_push(q), u32(2))
+  test_check(!queue_push(q), u32(3))
+}
+
+PropertyPushBound: (data: []u8): () {
+  storage: [1]Queue
+  q: [*]Queue = span(&storage)
+  q[0] = Queue { count: u32(0) }
+  i: u32 = u32(0)
+  while i < len(data) { pushed: Bool = queue_push(q); i = i + u32(1) }
+  test_check(q[0].count <= u32(2), u32(4))
+  test_check(len(data) < u32(3), u32(5))
+}
+
+SimQueueClock: (data: []u8): () {
+  clock_storage: [1]SimClock
+  clock: [*]SimClock = span(&clock_storage)
+  clock[0] = SimClock { now: u64(len(data)) }
+  test_check(clock[0].now < u64(300), u32(6))
+}
+`,
+		"app/app.oak": `package main
+
+import("example.com/os/sched")
+
+pub fill: (): u32 {
+  storage: [1]sched.Queue
+  q: [*]sched.Queue = span(&storage)
+  q[0] = sched.Queue { count: u32(0) }
+  first: Bool = sched.queue_push(q)
+  second: Bool = sched.queue_push(q)
+  q[0].count
+}
+`,
+		"app/app_test.oak": `package main
+
+import(testing)
+
+TestFillUsesImportedPackage: (): () { test_check(fill() == u32(2), u32(7)) }
+`,
+	})
+	code, results, stderr := runCLI(t, "-runs", "8", filepath.Join(dir, "app"), filepath.Join(dir, "sched"))
+	if code != 1 || len(results) != 4 {
+		t.Fatalf("%d %+v %s", code, results, stderr)
+	}
+	byName := map[string]Result{}
+	for _, r := range results {
+		byName[r.Name] = r
+	}
+	for _, name := range []string{"TestPush", "SimQueueClock", "TestFillUsesImportedPackage"} {
+		if byName[name].Status != "pass" {
+			t.Fatalf("%s: %+v", name, byName[name])
+		}
+	}
+	bound := byName["PropertyPushBound"]
+	if bound.Status != "fail" || bound.Failure != "invariant:5" {
+		t.Fatalf("property: %+v", bound)
+	}
+	a, err := readArtifact(bound.Artifact, 256)
+	if err != nil || len(a.Input) != 3 {
+		t.Fatalf("minimized module failure: %+v %v", a, err)
+	}
+	code, replay, _ := runCLI(t, "-replay", bound.Artifact, filepath.Join(dir, "sched"))
+	if code != 1 || replay[0].Failure != "reproduced invariant:5" {
+		t.Fatalf("module replay: %d %+v", code, replay)
+	}
+	if _, err := Discover([]string{fixture(t, map[string]string{"a.oak": "package a\n", "a_test.oak": "TestA: (): () {}"})}); err == nil || !strings.Contains(err.Error(), "package clause") {
+		t.Fatalf("mixed package clauses accepted: %v", err)
+	}
+}

--- a/testrunner/native.go
+++ b/testrunner/native.go
@@ -91,7 +91,7 @@ int main(int argc, char **argv) {
  switch (strtol(argv[1], NULL, 10)) {
 `, cfg.MaxBytes, cfg.MaxBytes, cfg.MaxBytes)
 	for i, test := range pkg.Registry {
-		fmt.Fprintf(&source, "case %d: oak_test_generating = %d; oak_%s(", i, map[bool]int{true: 1, false: 0}[test.Kind == "generator"], test.Name)
+		fmt.Fprintf(&source, "case %d: oak_test_generating = %d; %s(", i, map[bool]int{true: 1, false: 0}[test.Kind == "generator"], pkg.symbol(test.Name))
 		if test.Kind != "unit" {
 			source.WriteString("(oak_view_u8){data, (u32)size}")
 		}


### PR DESCRIPTION
## Summary
- A test directory whose `.oak` files all begin with the same `package` clause is now compiled with `WithPackageDir(dir).WithTestFiles(true)` instead of bootstrap concatenation, so tests can use `pub` members and packages imported through the enclosing `oak.mod`, with the simulation profile still applied.
- The native harness and fuzz export use the loader's root-symbol renaming (`oak_<package>_<Name>`, unmangled for `package main`).
- Mixed directories (some files with a clause, some without) reject at discovery.
- Go test covers a two-package module: a `pub` queue package with unit, property, and simulation tests (failure minimized and strictly replayed) and a `package main` client whose test calls the imported package.
- Spec and README updated. Needed so the OS can move its Oak scheduler into a pure `sched` package tested by `oak test`.

## Test plan
- [x] `go test ./testrunner -run 'TestModulePackages|Command|TestDiscovery|TestIRQ|TestNative'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)