### PR TITLE
oak test: trace schema decoding and replay divergence reports

### DIFF
--- a/docs/spec/110-testing.md
+++ b/docs/spec/110-testing.md
@@ -148,6 +148,29 @@ Strict replay requires the same trace prefix and truncation flag, even when the
 invariant ID matches. This detects observed divergence; it does not prove that
 unrecorded behavior or a truncated suffix was identical. Legacy artifacts with
 no trace version retain their original input/build/signature replay contract.
+A diverging replay reports the index of the first recorded event the observed
+trace did not reproduce, with both events; a trace that ends early reports the
+missing side. JSON results carry it as `trace_divergence`.
+
+## Trace schema
+
+A package may describe its events in `oak-trace.json` next to its tests:
+
+```json
+{"version": 1, "events": {"401": {"name": "command",
+  "a": [{"name": "kind", "shift": 32, "bits": 32, "names": {"0": "admit"}},
+        {"name": "target", "shift": 16, "bits": 16}],
+  "b": [{"name": "ticks"}]}}}
+```
+
+Each field selects `(payload >> shift) & mask(bits)`; omitting both takes the
+whole payload, and `names` maps decimal values to labels. The schema decodes
+terminal output, the `trace_text` array of JSON results, and divergence
+reports. It never changes what is recorded, compared, or replayed: artifacts
+keep raw events, unknown IDs print raw, and a package without a schema behaves
+as before. A present schema must be valid (version 1, u32 event keys,
+identifier names, fields inside 64 bits, at most 1 MiB), because decoded output
+that silently fell back to raw values would mislead.
 
 Ordinary test runs replay corpus inputs before generating new ones and do not
 require the historical build fingerprint: checked-in regressions must survive

--- a/testrunner/README.md
+++ b/testrunner/README.md
@@ -80,6 +80,11 @@ Failures shrink by deleting whole commands and reducing their fields; a pop
 whose push was deleted is rejected by the precondition instead of becoming a
 misleading counterexample. Results and artifacts carry the decoded commands.
 
+Describe your trace events in `oak-trace.json` beside the tests and failures
+print named operations and fields (`command kind=tick target=1 ticks=9`)
+instead of raw payloads; JSON results add `trace_text`, and a diverging replay
+names the first event that differed. See the specification for the format.
+
 `-timeout`, `-max-bytes`, `-max-discards`, `-shrink`, and `-shrink-timeout` make
 campaign costs explicit. `-cover 1:10,2:1` requires sample counts for IDs emitted
 by `testing_classify`. Rejected inputs never count as passes. Use `-sanitize`

--- a/testrunner/discover.go
+++ b/testrunner/discover.go
@@ -32,6 +32,9 @@ type Package struct {
 	Source   string
 	Tests    []Test
 	Registry []Test
+	// Schema decodes semantic trace events for people and tools; nil when the
+	// directory has no oak-trace.json.
+	Schema *TraceSchema
 }
 
 // symbol is the C name the generated translation unit gives a top-level
@@ -125,6 +128,11 @@ func Discover(paths []string) ([]Package, error) {
 		}
 		var pkg Package
 		pkg.Dir = dir
+		schema, err := loadTraceSchema(dir)
+		if err != nil {
+			return nil, err
+		}
+		pkg.Schema = schema
 		generators := map[string]*ast.FunctionStatement{}
 		var src strings.Builder
 		clauses := 0

--- a/testrunner/runner.go
+++ b/testrunner/runner.go
@@ -31,18 +31,29 @@ func Defaults() Config {
 
 type Result struct {
 	Test
-	Commands       []Command      `json:"commands,omitempty"`
-	Trace          []TraceEvent   `json:"trace,omitempty"`
-	TraceTruncated bool           `json:"trace_truncated,omitempty"`
-	Package        string         `json:"package"`
-	Status         string         `json:"status"`
-	Cases          int            `json:"cases"`
-	Discards       int            `json:"discards"`
-	Seed           uint64         `json:"seed"`
-	Failure        string         `json:"failure,omitempty"`
-	Artifact       string         `json:"artifact,omitempty"`
-	Output         string         `json:"output,omitempty"`
-	Classes        map[uint32]int `json:"classes,omitempty"`
+	Commands       []Command    `json:"commands,omitempty"`
+	Trace          []TraceEvent `json:"trace,omitempty"`
+	TraceText      []string     `json:"trace_text,omitempty"`
+	TraceTruncated bool         `json:"trace_truncated,omitempty"`
+	// Divergence is set when a strict replay reproduced the failure signature
+	// but not the recorded semantic trace.
+	Divergence *TraceDivergence `json:"trace_divergence,omitempty"`
+	Package    string           `json:"package"`
+	Status     string           `json:"status"`
+	Cases      int              `json:"cases"`
+	Discards   int              `json:"discards"`
+	Seed       uint64           `json:"seed"`
+	Failure    string           `json:"failure,omitempty"`
+	Artifact   string           `json:"artifact,omitempty"`
+	Output     string           `json:"output,omitempty"`
+	Classes    map[uint32]int   `json:"classes,omitempty"`
+	schema     *TraceSchema
+}
+
+// setTrace records a trace with its decoded text when the package has a schema.
+func (r *Result) setTrace(trace []TraceEvent, truncated bool) {
+	r.Trace, r.TraceTruncated = trace, truncated
+	r.TraceText = r.schema.describeAll(trace)
 }
 
 // Main is usable without os.Exit, including by CLI integration tests.
@@ -208,8 +219,17 @@ func Main(args []string, stdout, stderr io.Writer) int {
 				start = 0
 			}
 			for i := start; i < len(result.Trace); i++ {
-				e := result.Trace[i]
-				fmt.Fprintf(stdout, "  trace[%d] id=%d a=%d b=%d\n", i, e.ID, e.A, e.B)
+				fmt.Fprintf(stdout, "  trace[%d] %s\n", i, result.schema.Describe(result.Trace[i]))
+			}
+			if d := result.Divergence; d != nil {
+				recorded, observed := "trace ended", "trace ended"
+				if d.Recorded != nil {
+					recorded = result.schema.Describe(*d.Recorded)
+				}
+				if d.Observed != nil {
+					observed = result.schema.Describe(*d.Observed)
+				}
+				fmt.Fprintf(stdout, "  diverged at trace[%d]: recorded %s; observed %s\n", d.Index, recorded, observed)
 			}
 			if result.TraceTruncated {
 				fmt.Fprintln(stdout, "  trace truncated after 256 events; later events were not recorded")
@@ -278,7 +298,7 @@ func parseCover(raw string) (map[uint32]int, error) {
 }
 
 func runTest(pkg Package, test Test, index int, native *nativeProgram, cfg Config, cover map[uint32]int, replay *Artifact) Result {
-	result := Result{Test: test, Package: pkg.Dir, Status: "pass", Seed: cfg.Seed, Classes: map[uint32]int{}}
+	result := Result{Test: test, Package: pkg.Dir, Status: "pass", Seed: cfg.Seed, Classes: map[uint32]int{}, schema: pkg.Schema}
 	format := ""
 	generator := -1
 	if test.Generator != "" {
@@ -308,7 +328,7 @@ func runTest(pkg Package, test Test, index int, native *nativeProgram, cfg Confi
 		out := native.run(index, replay.Input)
 		result.Cases = 1
 		result.Output = out.output
-		result.Trace, result.TraceTruncated = out.trace, out.traceTruncated
+		result.setTrace(out.trace, out.traceTruncated)
 		if format != "" {
 			result.Commands = decodeCommands(replay.Input)
 		}
@@ -317,7 +337,12 @@ func runTest(pkg Package, test Test, index int, native *nativeProgram, cfg Confi
 			result.Failure = "reproduced " + out.signature
 			if replay.TraceVersion == traceVersion && !sameTrace(out, outcome{trace: replay.Trace, traceTruncated: replay.TraceTruncated}) {
 				result.Status = "error"
-				result.Failure = "replay trace diverged despite matching failure signature"
+				result.Divergence = divergence(replay.Trace, out.trace)
+				if result.Divergence != nil {
+					result.Failure = fmt.Sprintf("replay trace diverged at event %d despite matching failure signature", result.Divergence.Index)
+				} else {
+					result.Failure = "replay trace truncation flag diverged despite matching failure signature"
+				}
 			}
 		} else {
 			result.Status = "error"
@@ -390,7 +415,7 @@ func runTest(pkg Package, test Test, index int, native *nativeProgram, cfg Confi
 				}
 			}
 		}
-		result.Trace, result.TraceTruncated = out.trace, out.traceTruncated
+		result.setTrace(out.trace, out.traceTruncated)
 		result.Output = out.output
 		if format != "" {
 			result.Commands = decodeCommands(best)
@@ -445,7 +470,7 @@ func runTest(pkg Package, test Test, index int, native *nativeProgram, cfg Confi
 				}
 				if generated.status != "pass" {
 					result.Status, result.Failure, result.Output = "error", "command generator failed: "+generated.signature, generated.output
-					result.Trace, result.TraceTruncated = generated.trace, generated.traceTruncated
+					result.setTrace(generated.trace, generated.traceTruncated)
 					return result
 				}
 				input = encodeCommands(generated.commands)

--- a/testrunner/schema.go
+++ b/testrunner/schema.go
@@ -1,0 +1,205 @@
+package testrunner
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// A package may describe its semantic trace events in oak-trace.json so
+// failures, artifacts and replay divergence read as named operations and
+// fields instead of raw 64-bit payloads. The schema is documentation for
+// tools: it never changes what is recorded, compared, or replayed.
+const traceSchemaFile = "oak-trace.json"
+const traceSchemaLimit = 1 << 20
+
+type TraceField struct {
+	Name string `json:"name"`
+	// Shift and Bits select (payload >> Shift) & mask(Bits). Both zero means
+	// the whole 64-bit payload.
+	Shift uint              `json:"shift,omitempty"`
+	Bits  uint              `json:"bits,omitempty"`
+	Names map[string]string `json:"names,omitempty"`
+}
+
+type TraceEventSchema struct {
+	Name string       `json:"name"`
+	A    []TraceField `json:"a,omitempty"`
+	B    []TraceField `json:"b,omitempty"`
+}
+
+type TraceSchema struct {
+	Version int                         `json:"version"`
+	Events  map[string]TraceEventSchema `json:"events"`
+	byID    map[uint32]TraceEventSchema
+}
+
+// TraceDivergence names the first recorded event a strict replay did not
+// reproduce. A nil side means that trace ended first.
+type TraceDivergence struct {
+	Index    int         `json:"index"`
+	Recorded *TraceEvent `json:"recorded,omitempty"`
+	Observed *TraceEvent `json:"observed,omitempty"`
+}
+
+var fieldName = regexp.MustCompile(`^[A-Za-z_][A-Za-z_0-9]*$`)
+
+// loadTraceSchema returns nil without error when the package has no schema.
+// A present schema must be valid: silently ignoring a broken one would make
+// decoded output lie.
+func loadTraceSchema(dir string) (*TraceSchema, error) {
+	path := filepath.Join(dir, traceSchemaFile)
+	f, err := os.Open(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	data, err := io.ReadAll(io.LimitReader(f, traceSchemaLimit+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > traceSchemaLimit {
+		return nil, fmt.Errorf("%s: schema exceeds %d bytes", path, traceSchemaLimit)
+	}
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	decoder.DisallowUnknownFields()
+	var schema TraceSchema
+	if err := decoder.Decode(&schema); err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+	if schema.Version != 1 {
+		return nil, fmt.Errorf("%s: unsupported trace schema version %d", path, schema.Version)
+	}
+	schema.byID = map[uint32]TraceEventSchema{}
+	for key, event := range schema.Events {
+		id, err := strconv.ParseUint(key, 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("%s: event key %q is not a u32", path, key)
+		}
+		if !fieldName.MatchString(event.Name) {
+			return nil, fmt.Errorf("%s: event %s has an invalid name %q", path, key, event.Name)
+		}
+		for _, fields := range [][]TraceField{event.A, event.B} {
+			for _, field := range fields {
+				if !fieldName.MatchString(field.Name) {
+					return nil, fmt.Errorf("%s: event %s has an invalid field name %q", path, key, field.Name)
+				}
+				if field.Bits > 64 || field.Shift > 63 || field.Shift+field.Bits > 64 || (field.Bits == 0 && field.Shift != 0) {
+					return nil, fmt.Errorf("%s: event %s field %s selects bits outside a 64-bit payload", path, key, field.Name)
+				}
+				if len(field.Names) > 4096 {
+					return nil, fmt.Errorf("%s: event %s field %s has too many names", path, key, field.Name)
+				}
+				for value := range field.Names {
+					if _, err := strconv.ParseUint(value, 10, 64); err != nil {
+						return nil, fmt.Errorf("%s: event %s field %s name key %q is not a u64", path, key, field.Name, value)
+					}
+				}
+			}
+		}
+		schema.byID[uint32(id)] = event
+	}
+	return &schema, nil
+}
+
+func (f TraceField) extract(payload uint64) uint64 {
+	if f.Bits == 0 {
+		return payload
+	}
+	value := payload >> f.Shift
+	if f.Bits < 64 {
+		value &= (1 << f.Bits) - 1
+	}
+	return value
+}
+
+func describeFields(fields []TraceField, payload uint64) string {
+	var parts []string
+	for _, field := range fields {
+		value := field.extract(payload)
+		text := strconv.FormatUint(value, 10)
+		if name, ok := field.Names[text]; ok {
+			text = name
+		}
+		parts = append(parts, field.Name+"="+text)
+	}
+	return strings.Join(parts, " ")
+}
+
+// Describe renders one event. Unknown IDs, or a nil schema, keep the raw form
+// so decoded and undecoded events are both unambiguous.
+func (s *TraceSchema) Describe(e TraceEvent) string {
+	raw := fmt.Sprintf("id=%d a=%d b=%d", e.ID, e.A, e.B)
+	if s == nil {
+		return raw
+	}
+	event, ok := s.byID[e.ID]
+	if !ok {
+		return raw
+	}
+	text := event.Name
+	if a := describeFields(event.A, e.A); a != "" {
+		text += " " + a
+	} else if len(event.A) == 0 && e.A != 0 {
+		text += fmt.Sprintf(" a=%d", e.A)
+	}
+	if b := describeFields(event.B, e.B); b != "" {
+		text += " " + b
+	} else if len(event.B) == 0 && e.B != 0 {
+		text += fmt.Sprintf(" b=%d", e.B)
+	}
+	return text
+}
+
+func (s *TraceSchema) describeAll(events []TraceEvent) []string {
+	if s == nil {
+		return nil
+	}
+	out := make([]string, len(events))
+	for i, e := range events {
+		out[i] = s.Describe(e)
+	}
+	return out
+}
+
+// eventIDs lists the schema's event IDs in ascending order, for -list output.
+func (s *TraceSchema) eventIDs() []uint32 {
+	if s == nil {
+		return nil
+	}
+	ids := make([]uint32, 0, len(s.byID))
+	for id := range s.byID {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids
+}
+
+// divergence finds the first position where the observed trace differs from
+// the recorded one, including one trace ending early.
+func divergence(recorded, observed []TraceEvent) *TraceDivergence {
+	for i := 0; i < len(recorded) || i < len(observed); i++ {
+		d := &TraceDivergence{Index: i}
+		if i < len(recorded) {
+			r := recorded[i]
+			d.Recorded = &r
+		}
+		if i < len(observed) {
+			o := observed[i]
+			d.Observed = &o
+		}
+		if d.Recorded == nil || d.Observed == nil || *d.Recorded != *d.Observed {
+			return d
+		}
+	}
+	return nil
+}

--- a/testrunner/schema_test.go
+++ b/testrunner/schema_test.go
@@ -1,0 +1,105 @@
+package testrunner
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const schedSchema = `{
+  "version": 1,
+  "events": {
+    "401": {"name": "command",
+            "a": [{"name": "kind", "shift": 32, "bits": 32, "names": {"0": "admit", "5": "tick"}},
+                  {"name": "target", "shift": 16, "bits": 16},
+                  {"name": "value", "shift": 0, "bits": 16}],
+            "b": [{"name": "ticks"}]},
+    "402": {"name": "state", "a": [{"name": "packed"}]}
+  }
+}`
+
+func TestTraceSchemaDescribe(t *testing.T) {
+	dir := fixture(t, map[string]string{traceSchemaFile: schedSchema})
+	schema, err := loadTraceSchema(dir)
+	if err != nil || schema == nil {
+		t.Fatal(err)
+	}
+	got := schema.Describe(TraceEvent{ID: 401, A: 5<<32 | 1<<16 | 7, B: 9})
+	if got != "command kind=tick target=1 value=7 ticks=9" {
+		t.Fatalf("decoded %q", got)
+	}
+	if got := schema.Describe(TraceEvent{ID: 402, A: 3}); got != "state packed=3" {
+		t.Fatalf("decoded %q", got)
+	}
+	if got := schema.Describe(TraceEvent{ID: 999, A: 1, B: 2}); got != "id=999 a=1 b=2" {
+		t.Fatalf("unknown event %q", got)
+	}
+	if (*TraceSchema)(nil).Describe(TraceEvent{ID: 1}) != "id=1 a=0 b=0" {
+		t.Fatal("nil schema must keep the raw form")
+	}
+	for _, bad := range []string{
+		`{"version": 2, "events": {}}`,
+		`{"version": 1, "events": {"x": {"name": "e"}}}`,
+		`{"version": 1, "events": {"1": {"name": "e", "a": [{"name": "f", "shift": 60, "bits": 8}]}}}`,
+		`{"version": 1, "events": {"1": {"name": "e", "a": [{"name": "f", "names": {"x": "y"}}]}}}`,
+		`{"version": 1, "events": {"1": {"name": "bad name"}}}`,
+		`{"version": 1, "events": {}, "extra": true}`,
+	} {
+		dir := fixture(t, map[string]string{traceSchemaFile: bad})
+		if _, err := loadTraceSchema(dir); err == nil {
+			t.Fatalf("accepted invalid schema %s", bad)
+		}
+	}
+	if schema, err := loadTraceSchema(t.TempDir()); err != nil || schema != nil {
+		t.Fatalf("missing schema: %v %v", schema, err)
+	}
+}
+
+// Failures and artifacts print decoded events; a tampered artifact's replay
+// names the first recorded event the observed trace did not reproduce.
+func TestTraceSchemaInResultsAndDivergence(t *testing.T) {
+	dir := fixture(t, map[string]string{
+		traceSchemaFile: schedSchema,
+		"a_test.oak": `import(testing)
+TestDecoded: (): () {
+  testing_trace(u32(401), (u64(5) << u64(32)) | u64(3), u64(1))
+  testing_trace(u32(402), u64(8), u64(0))
+  test_check(false, u32(7100))
+}
+`})
+	code, results, stderr := runCLI(t, "-shrink", "0", dir)
+	if code != 1 || len(results) != 1 || results[0].Failure != "invariant:7100" {
+		t.Fatalf("%d %+v %s", code, results, stderr)
+	}
+	want := []string{"command kind=tick target=0 value=3 ticks=1", "state packed=8"}
+	if strings.Join(results[0].TraceText, "|") != strings.Join(want, "|") {
+		t.Fatalf("trace text %v", results[0].TraceText)
+	}
+	raw, err := os.ReadFile(results[0].Artifact)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var a Artifact
+	if err := json.Unmarshal(raw, &a); err != nil {
+		t.Fatal(err)
+	}
+	a.Trace[1].A = 9
+	tampered := filepath.Join(dir, "tampered.json")
+	raw, _ = json.Marshal(a)
+	if err := os.WriteFile(tampered, raw, 0600); err != nil {
+		t.Fatal(err)
+	}
+	code, replay, _ := runCLI(t, "-replay", tampered, dir)
+	if code != 2 || replay[0].Status != "error" || replay[0].Divergence == nil {
+		t.Fatalf("divergence not reported: %d %+v", code, replay)
+	}
+	d := replay[0].Divergence
+	if d.Index != 1 || d.Recorded == nil || d.Recorded.A != 9 || d.Observed == nil || d.Observed.A != 8 {
+		t.Fatalf("divergence %+v", d)
+	}
+	if !strings.Contains(replay[0].Failure, "diverged at event 1") {
+		t.Fatalf("failure text %q", replay[0].Failure)
+	}
+}


### PR DESCRIPTION
## Summary
- A package may describe its semantic trace events in `oak-trace.json` (version 1): event names plus payload fields selected by `shift`/`bits` with optional value `names`. Failures print decoded events (`command kind=tick target=1 ticks=9`), JSON results add `trace_text`, unknown IDs and schema-less packages keep the raw form. Present schemas must be valid (fail closed); the schema never changes what is recorded, compared, or replayed.
- Strict replay that reproduces the failure signature but not the trace now reports the first recorded event the observed trace did not reproduce (`trace_divergence` with index, recorded, observed; either side nil when a trace ended early) and prints both decoded.
- Tests: schema decoding and validation; a decoded failure through the CLI; a tampered artifact's replay reporting divergence at the changed event. Spec and README updated.
- This is the first debugger-integration slice: the OS scheduler and wakeup harnesses will ship schemas so minimized histories read as named operations.

## Test plan
- [x] `go test ./testrunner -run 'TestTraceSchema|TestTraceBounds|TestModulePackages|TestNativeCommands'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)