### PR TITLE
oak test: parallel workers and resumable campaigns

### DIFF
--- a/docs/spec/110-testing.md
+++ b/docs/spec/110-testing.md
@@ -112,6 +112,28 @@ the reduction budget and each uses the ordinary per-case watchdog.
 A generic signal signature cannot distinguish two unrelated traps with the same
 signal; stable invariant IDs are preferred for stateful properties.
 
+## Campaigns
+
+Every generated attempt is a pure function of the root seed, the test name and
+the attempt index, so a campaign is the prefix of one deterministic sequence.
+`-workers N` (1..64) prepares and executes up to `N` attempts concurrently and
+then consumes their outcomes in attempt order: counts, discards, coverage, the
+failing attempt and its minimized input are identical for every worker count.
+Attempts prepared beyond the stopping point are executed but never counted.
+Each execution writes its own control report, so concurrent cases never share a
+file. Minimization and corpus replay remain sequential.
+
+`-campaign dir` makes a campaign resumable. After every batch the runner writes
+`<dir>/<Test>-<package digest>.json` with the engine and build identity, seed,
+input limit, sanitizer mode, next attempt, and the accepted, case, discard and
+class counts. A later invocation with the same identity continues from the next
+attempt with those counts, so `-runs 1000000` can be split across many jobs
+over time; a satisfied campaign does no new work. State from a different build,
+test, seed or configuration rejects rather than mixing sequences. Results report
+`attempts`, the consumed prefix length including resumed attempts. Sharding
+across machines needs no extra mechanism: give each shard a distinct `-seed`.
+`-replay` never combines with a campaign.
+
 ## Corpus and replay
 
 Failures are atomically saved in `testdata/oak/<TestName>/<digest>.json` with:

--- a/testrunner/README.md
+++ b/testrunner/README.md
@@ -85,6 +85,11 @@ print named operations and fields (`command kind=tick target=1 ticks=9`)
 instead of raw payloads; JSON results add `trace_text`, and a diverging replay
 names the first event that differed. See the specification for the format.
 
+Long campaigns: `-workers 8` runs cases in parallel with results identical to a
+sequential run; `-campaign build/campaign -runs 1000000` checkpoints progress
+per test so the next invocation continues where the last one stopped; distinct
+`-seed` values shard a campaign across machines.
+
 `-timeout`, `-max-bytes`, `-max-discards`, `-shrink`, and `-shrink-timeout` make
 campaign costs explicit. `-cover 1:10,2:1` requires sample counts for IDs emitted
 by `testing_classify`. Rejected inputs never count as passes. Use `-sanitize`

--- a/testrunner/campaign.go
+++ b/testrunner/campaign.go
@@ -1,0 +1,104 @@
+package testrunner
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// A campaign file lets one long exploration continue across invocations and
+// CI jobs. It records how far the attempt sequence of one (package, test,
+// seed, build) has been consumed and what was counted; resuming continues at
+// the next attempt with the same counts, so a campaign of N accepted cases is
+// the same sequence of inputs whether it ran in one sitting or ten.
+type campaignState struct {
+	Version     int            `json:"version"`
+	Engine      string         `json:"engine"`
+	Build       string         `json:"build"`
+	Test        string         `json:"test"`
+	Kind        string         `json:"kind"`
+	Seed        uint64         `json:"seed"`
+	MaxBytes    int            `json:"max_bytes"`
+	Sanitize    bool           `json:"sanitize"`
+	NextAttempt int            `json:"next_attempt"`
+	Accepted    int            `json:"accepted"`
+	Cases       int            `json:"cases"`
+	Discards    int            `json:"discards"`
+	Classes     map[string]int `json:"classes,omitempty"`
+}
+
+const campaignLimit = 1 << 20
+
+func campaignPath(dir string, pkg Package, test Test) string {
+	sum := sha256.Sum256([]byte(pkg.Dir))
+	return filepath.Join(dir, test.Name+"-"+hex.EncodeToString(sum[:8])+".json")
+}
+
+// loadCampaign returns nil without error when no state exists yet. Existing
+// state must belong to exactly this build and configuration: continuing an
+// attempt sequence against different code would report counts nobody ran.
+func loadCampaign(path string, want campaignState) (*campaignState, error) {
+	f, err := os.Open(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	data, err := io.ReadAll(io.LimitReader(f, campaignLimit+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > campaignLimit {
+		return nil, fmt.Errorf("oversized campaign state %s", path)
+	}
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	decoder.DisallowUnknownFields()
+	var state campaignState
+	if err := decoder.Decode(&state); err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+	if state.Version != 1 || state.Engine != want.Engine || state.Build != want.Build || state.Test != want.Test || state.Kind != want.Kind || state.Seed != want.Seed || state.MaxBytes != want.MaxBytes || state.Sanitize != want.Sanitize {
+		return nil, fmt.Errorf("campaign state %s belongs to a different build, test, seed or configuration; use a new campaign directory", path)
+	}
+	if state.NextAttempt < 0 || state.Accepted < 0 || state.Cases < 0 || state.Discards < 0 || state.Accepted > state.Cases || state.Cases+state.Discards > state.NextAttempt {
+		return nil, fmt.Errorf("inconsistent campaign state %s", path)
+	}
+	for key := range state.Classes {
+		if _, err := strconv.ParseUint(key, 10, 32); err != nil {
+			return nil, fmt.Errorf("invalid class id in %s", path)
+		}
+	}
+	return &state, nil
+}
+
+func saveCampaign(path string, state campaignState) error {
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	f, err := os.CreateTemp(filepath.Dir(path), ".campaign-*")
+	if err != nil {
+		return err
+	}
+	temp := f.Name()
+	defer os.Remove(temp)
+	if _, err := f.Write(append(data, '\n')); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	return os.Rename(temp, path)
+}

--- a/testrunner/campaign_test.go
+++ b/testrunner/campaign_test.go
@@ -1,0 +1,80 @@
+package testrunner
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const campaignFixture = `import(testing)
+PropertyNibble: (data: []u8): () {
+  test_assume(len(data) > u32(0))
+  test_check((data[0] & u8(15)) != u8(7) || len(data) < u32(2), u32(7200))
+}
+PropertyAlwaysPasses: (data: []u8): () { testing_classify(u32(1)) }
+`
+
+// The worker count changes wall-clock time only: the failing attempt, its
+// minimized input, and every count are identical.
+func TestWorkersDeterministic(t *testing.T) {
+	var reference Result
+	var referenceInput []byte
+	for _, workers := range []string{"1", "4"} {
+		dir := fixture(t, map[string]string{"a_test.oak": campaignFixture})
+		code, results, stderr := runCLI(t, "-run", "^PropertyNibble$", "-workers", workers, "-runs", "500", dir)
+		if code != 1 || len(results) != 1 || results[0].Failure != "invariant:7200" {
+			t.Fatalf("workers %s: %d %+v %s", workers, code, results, stderr)
+		}
+		a, err := readArtifact(results[0].Artifact, 256)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if workers == "1" {
+			reference, referenceInput = results[0], a.Input
+			continue
+		}
+		r := results[0]
+		if r.Cases != reference.Cases || r.Discards != reference.Discards || r.Attempts != reference.Attempts || a.Attempt != reference.Attempts-1 || !bytes.Equal(a.Input, referenceInput) {
+			t.Fatalf("worker count changed the outcome:\n%+v %v\n%+v %v", reference, referenceInput, r, a.Input)
+		}
+	}
+}
+
+// A campaign continues the same attempt sequence across invocations and
+// refuses state from a different configuration.
+func TestCampaignResume(t *testing.T) {
+	dir := fixture(t, map[string]string{"a_test.oak": campaignFixture})
+	campaign := filepath.Join(t.TempDir(), "campaign")
+	code, results, stderr := runCLI(t, "-run", "^PropertyAlwaysPasses$", "-runs", "5", "-campaign", campaign, dir)
+	if code != 0 || results[0].Cases != 5 || results[0].Attempts != 5 {
+		t.Fatalf("first run: %d %+v %s", code, results, stderr)
+	}
+	code, results, stderr = runCLI(t, "-run", "^PropertyAlwaysPasses$", "-runs", "12", "-workers", "3", "-campaign", campaign, dir)
+	if code != 0 || results[0].Cases != 12 || results[0].Attempts != 12 || results[0].Classes[1] != 12 {
+		t.Fatalf("resumed run: %d %+v %s", code, results, stderr)
+	}
+	// Already satisfied campaigns do no new work.
+	code, results, _ = runCLI(t, "-run", "^PropertyAlwaysPasses$", "-runs", "12", "-campaign", campaign, dir)
+	if code != 0 || results[0].Cases != 12 || results[0].Attempts != 12 {
+		t.Fatalf("satisfied run: %d %+v", code, results)
+	}
+	entries, err := os.ReadDir(campaign)
+	if err != nil || len(entries) != 1 || !strings.HasPrefix(entries[0].Name(), "PropertyAlwaysPasses-") {
+		t.Fatalf("campaign state files: %v %v", entries, err)
+	}
+	code, results, _ = runCLI(t, "-run", "^PropertyAlwaysPasses$", "-runs", "12", "-seed", "2", "-campaign", campaign, dir)
+	if code != 2 || results[0].Status != "error" || !strings.Contains(results[0].Failure, "different build, test, seed") {
+		t.Fatalf("mismatched campaign accepted: %d %+v", code, results)
+	}
+	// A failing campaign checkpoints the consumed attempts before reporting.
+	failing := filepath.Join(t.TempDir(), "failing")
+	code, results, _ = runCLI(t, "-run", "^PropertyNibble$", "-runs", "500", "-shrink", "0", "-campaign", failing, dir)
+	if code != 1 || results[0].Failure != "invariant:7200" || results[0].Attempts == 0 {
+		t.Fatalf("failing campaign: %d %+v", code, results)
+	}
+	if code, _, _ := runCLI(t, "-replay", results[0].Artifact, "-campaign", failing, dir); code != 2 {
+		t.Fatal("replay must not combine with a campaign")
+	}
+}

--- a/testrunner/native.go
+++ b/testrunner/native.go
@@ -189,8 +189,15 @@ func (p *nativeProgram) run(index int, input []byte) (result outcome) {
 		result.signature = "harness:input-too-large"
 		return result
 	}
-	reportPath := filepath.Join(p.dir, "report")
-	_ = os.Remove(reportPath)
+	// One report file per execution: workers run cases concurrently.
+	reportFile, err := os.CreateTemp(p.dir, "report-*")
+	if err != nil {
+		result.signature = "harness:report-file"
+		return result
+	}
+	reportPath := reportFile.Name()
+	_ = reportFile.Close()
+	defer os.Remove(reportPath)
 	ctx, cancel := context.WithTimeout(context.Background(), p.timeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, p.bin, strconv.Itoa(index), reportPath)
@@ -199,7 +206,7 @@ func (p *nativeProgram) run(index int, input []byte) (result outcome) {
 	cmd.Stdout, cmd.Stderr = &output, &output
 	// Bound pipe draining too: a descendant must not keep the runner waiting.
 	cmd.WaitDelay = 100 * time.Millisecond
-	err := cmd.Run()
+	err = cmd.Run()
 	result.output = output.text()
 	timedOut := ctx.Err() != nil
 	// Read the flushed prefix even when a watchdog killed the process. A

--- a/testrunner/runner.go
+++ b/testrunner/runner.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -23,10 +24,12 @@ type Config struct {
 	Run, Fuzz, Sim, Replay               string
 	JSON, List, Verbose, Sanitize        bool
 	Cover                                string
+	Workers                              int
+	Campaign                             string
 }
 
 func Defaults() Config {
-	return Config{CC: "cc", Runs: 100, MaxBytes: 256, Shrink: 200, Seed: 1, Timeout: 2 * time.Second, BuildTimeout: time.Minute, ShrinkTimeout: 10 * time.Second, MaxDiscards: 1000}
+	return Config{CC: "cc", Runs: 100, MaxBytes: 256, Shrink: 200, Seed: 1, Timeout: 2 * time.Second, BuildTimeout: time.Minute, ShrinkTimeout: 10 * time.Second, MaxDiscards: 1000, Workers: 1}
 }
 
 type Result struct {
@@ -47,7 +50,10 @@ type Result struct {
 	Artifact   string           `json:"artifact,omitempty"`
 	Output     string           `json:"output,omitempty"`
 	Classes    map[uint32]int   `json:"classes,omitempty"`
-	schema     *TraceSchema
+	// Attempts is how far the deterministic attempt sequence was consumed,
+	// including attempts carried over from a resumed campaign.
+	Attempts int `json:"attempts,omitempty"`
+	schema   *TraceSchema
 }
 
 // setTrace records a trace with its decoded text when the package has a schema.
@@ -77,6 +83,8 @@ func Main(args []string, stdout, stderr io.Writer) int {
 	flags.StringVar(&cfg.Sim, "sim", "", "simulation name regular expression")
 	flags.StringVar(&cfg.Replay, "replay", "", "replay one saved artifact against its exact build")
 	flags.StringVar(&cfg.Cover, "cover", "", "required class sample counts, e.g. 10:5,20:1 (per selected generated test)")
+	flags.IntVar(&cfg.Workers, "workers", cfg.Workers, "concurrent case executions (1..64); results are identical for every value")
+	flags.StringVar(&cfg.Campaign, "campaign", "", "directory of resumable campaign state per test; rerun with a larger -runs to continue")
 	flags.BoolVar(&cfg.JSON, "json", false, "emit one JSON result per test")
 	flags.BoolVar(&cfg.List, "list", false, "list matching tests without compilation")
 	flags.BoolVar(&cfg.Verbose, "v", false, "include successful test output")
@@ -91,7 +99,7 @@ func Main(args []string, stdout, stderr io.Writer) int {
 		}
 		return 2
 	}
-	if cfg.Runs < 1 || cfg.Runs > 1000000 || cfg.MaxBytes < 0 || cfg.MaxBytes > 1<<20 || cfg.Shrink < 0 || cfg.MaxDiscards < 0 || cfg.Timeout <= 0 || cfg.BuildTimeout <= 0 || cfg.ShrinkTimeout <= 0 || cfg.Fuzz != "" && cfg.Sim != "" || cfg.Replay != "" && (cfg.Fuzz != "" || cfg.Sim != "" || cfg.Run != "" || cfg.List || cfg.Cover != "") {
+	if cfg.Workers < 1 || cfg.Workers > 64 || cfg.Campaign != "" && cfg.Replay != "" || cfg.Runs < 1 || cfg.Runs > 1000000 || cfg.MaxBytes < 0 || cfg.MaxBytes > 1<<20 || cfg.Shrink < 0 || cfg.MaxDiscards < 0 || cfg.Timeout <= 0 || cfg.BuildTimeout <= 0 || cfg.ShrinkTimeout <= 0 || cfg.Fuzz != "" && cfg.Sim != "" || cfg.Replay != "" && (cfg.Fuzz != "" || cfg.Sim != "" || cfg.Run != "" || cfg.List || cfg.Cover != "") {
 		fmt.Fprintln(stderr, "invalid test configuration")
 		return 2
 	}
@@ -356,12 +364,11 @@ func runTest(pkg Package, test Test, index int, native *nativeProgram, cfg Confi
 		result.Failure = err.Error()
 		return result
 	}
-	execute := func(input []byte, attempt int) bool {
-		if format != "" && (len(input)%commandWidth != 0 || len(input)/commandWidth > commandLimit) {
-			result.Status, result.Failure = "error", "invalid concrete command corpus: expected at most 256 complete 12-byte commands"
-			return false
-		}
-		out := native.run(index, input)
+	// consume records one executed case in attempt order; execute runs and
+	// consumes sequentially (unit tests, corpus). Generated attempts are
+	// prepared by workers and consumed in order, so the reported outcome,
+	// counts and minimized failure are the same for every worker count.
+	consume := func(input []byte, out outcome, attempt int) bool {
 		if out.status == "discard" {
 			result.Discards++
 			if test.Kind == "unit" || result.Discards > cfg.MaxDiscards {
@@ -431,6 +438,13 @@ func runTest(pkg Package, test Test, index int, native *nativeProgram, cfg Confi
 		}
 		return false
 	}
+	execute := func(input []byte, attempt int) bool {
+		if format != "" && (len(input)%commandWidth != 0 || len(input)/commandWidth > commandLimit) {
+			result.Status, result.Failure = "error", "invalid concrete command corpus: expected at most 256 complete 12-byte commands"
+			return false
+		}
+		return consume(input, native.run(index, input), attempt)
+	}
 	if test.Kind == "unit" {
 		execute(nil, 0)
 		return result
@@ -454,24 +468,18 @@ func runTest(pkg Package, test Test, index int, native *nativeProgram, cfg Confi
 			}
 		}
 	} else {
-		accepted := 0
-		for attempt := 0; accepted < cfg.Runs; attempt++ {
+		type prepared struct {
+			input     []byte
+			out       outcome
+			generated *outcome
+		}
+		prepare := func(attempt int) prepared {
 			r := randomFor(cfg.Seed, test.Name, attempt)
 			input := generate(&r, attempt, cfg.MaxBytes)
 			if generator >= 0 {
 				generated := native.run(generator, input)
-				if generated.status == "discard" {
-					result.Discards++
-					if result.Discards > cfg.MaxDiscards {
-						result.Status, result.Failure = "fail", "generator discard budget exhausted"
-						return result
-					}
-					continue
-				}
 				if generated.status != "pass" {
-					result.Status, result.Failure, result.Output = "error", "command generator failed: "+generated.signature, generated.output
-					result.setTrace(generated.trace, generated.traceTruncated)
-					return result
+					return prepared{generated: &generated}
 				}
 				input = encodeCommands(generated.commands)
 			}
@@ -480,14 +488,90 @@ func runTest(pkg Package, test Test, index int, native *nativeProgram, cfg Confi
 			} else if test.Kind == "fuzz" {
 				input = seeds[attempt]
 			}
-			before := result.Cases
-			if !execute(input, attempt) {
+			return prepared{input: input, out: native.run(index, input)}
+		}
+		accepted := 0
+		attempt := 0
+		state := campaignState{Version: 1, Engine: engineVersion, Build: native.build, Test: test.Name, Kind: test.Kind, Seed: cfg.Seed, MaxBytes: cfg.MaxBytes, Sanitize: cfg.Sanitize}
+		statePath := ""
+		if cfg.Campaign != "" {
+			statePath = campaignPath(cfg.Campaign, pkg, test)
+			saved, err := loadCampaign(statePath, state)
+			if err != nil {
+				result.Status, result.Failure = "error", err.Error()
 				return result
 			}
-			if result.Cases > before {
-				accepted++
+			if saved != nil {
+				attempt, accepted = saved.NextAttempt, saved.Accepted
+				result.Cases, result.Discards = saved.Cases, saved.Discards
+				for key, count := range saved.Classes {
+					id, _ := strconv.ParseUint(key, 10, 32)
+					result.Classes[uint32(id)] += count
+				}
 			}
 		}
+		checkpoint := func() {
+			result.Attempts = attempt
+			if statePath == "" {
+				return
+			}
+			state.NextAttempt, state.Accepted, state.Cases, state.Discards = attempt, accepted, result.Cases, result.Discards
+			state.Classes = map[string]int{}
+			for id, count := range result.Classes {
+				state.Classes[strconv.FormatUint(uint64(id), 10)] = count
+			}
+			if err := saveCampaign(statePath, state); err != nil {
+				result.Status, result.Failure = "error", "cannot save campaign state: "+err.Error()
+			}
+		}
+		for accepted < cfg.Runs && result.Status != "error" {
+			batch := make([]prepared, cfg.Workers)
+			var wg sync.WaitGroup
+			for i := range batch {
+				wg.Add(1)
+				go func(i int) {
+					defer wg.Done()
+					batch[i] = prepare(attempt + i)
+				}(i)
+			}
+			wg.Wait()
+			stop := false
+			for i := range batch {
+				if accepted >= cfg.Runs {
+					break
+				}
+				item := batch[i]
+				attempt++
+				if item.generated != nil {
+					if item.generated.status == "discard" {
+						result.Discards++
+						if result.Discards > cfg.MaxDiscards {
+							result.Status, result.Failure = "fail", "generator discard budget exhausted"
+							stop = true
+							break
+						}
+						continue
+					}
+					result.Status, result.Failure, result.Output = "error", "command generator failed: "+item.generated.signature, item.generated.output
+					result.setTrace(item.generated.trace, item.generated.traceTruncated)
+					stop = true
+					break
+				}
+				before := result.Cases
+				if !consume(item.input, item.out, attempt-1) {
+					stop = true
+					break
+				}
+				if result.Cases > before {
+					accepted++
+				}
+			}
+			checkpoint()
+			if stop {
+				return result
+			}
+		}
+		result.Attempts = attempt
 	}
 	if result.Cases == 0 {
 		result.Status = "fail"


### PR DESCRIPTION
## Summary
- `-workers N` (1..64): attempts are prepared and executed concurrently, then consumed in attempt order. Counts, discards, coverage, the failing attempt and its minimized input are identical for every worker count (test compares 1 vs 4 workers on a randomly failing property). Each child execution now has its own control report file.
- `-campaign dir`: after every batch the runner checkpoints `<Test>-<package digest>.json` with engine/build/seed/limits identity, next attempt and counts; a later run continues the same deterministic sequence (`-runs 5` then `-runs 12 -workers 3` yields exactly 12 cases, all classes counted), a satisfied campaign does no work, and state from a different seed or build rejects. Results report `attempts`.
- Sharding across machines stays `-seed` per shard; documented. `-replay` cannot combine with a campaign.
- Spec and README updated.

## Test plan
- [x] `go test ./testrunner -run 'TestWorkersDeterministic|TestCampaignResume'`
- [x] full `go test ./testrunner` (only the known macOS-only environment failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)