### PR TITLE
Derive typed test commands from a command sum type

### DIFF
--- a/compiler/derive.go
+++ b/compiler/derive.go
@@ -152,15 +152,29 @@ func (d *deriver) lowerRequest(fn *ast.FunctionStatement) {
 			d.report(CodeDeriveSignature, fn.Name, "derive.compare requires the signature (a: T, b: T): Ordering, with Ordering: type = Less | Equal | Greater in scope")
 			return
 		}
+	case "test_generate", "test_encode", "test_decode":
+		// Signature and target type are checked together: the type is the
+		// return type (generate), the parameter (encode), or Option's
+		// argument (decode).
 	default:
 		diag := d.report(CodeDeriveUnknown, fn.Body, "derive.%s is not a derivable operation", kind)
-		diag.AddHelp("derivable operations: derive.equal, derive.hash, derive.compare")
+		diag.AddHelp("derivable operations: derive.equal, derive.hash, derive.compare, derive.test_generate, derive.test_encode, derive.test_decode")
 		return
 	}
-	typeName, ok := fn.Parameters[0].Type.(*ast.Identifier)
-	if !ok {
-		d.report(CodeDeriveUnsupported, fn.Parameters[0].Type, "derive.%s: the parameter type must be a declared record or ADT", kind)
-		return
+	var typeName *ast.Identifier
+	if strings.HasPrefix(kind, "test_") {
+		ident, ok := d.testCommandType(kind, fn)
+		if !ok {
+			return
+		}
+		typeName = ident
+	} else {
+		ident, ok := fn.Parameters[0].Type.(*ast.Identifier)
+		if !ok {
+			d.report(CodeDeriveUnsupported, fn.Parameters[0].Type, "derive.%s: the parameter type must be a declared record or ADT", kind)
+			return
+		}
+		typeName = ident
 	}
 	decl, declared := d.types[typeName.Value]
 	if !declared {
@@ -176,7 +190,7 @@ func (d *deriver) lowerRequest(fn *ast.FunctionStatement) {
 		diag.AddNote("derivation reads the type's definition; only its own package may do that (opaque types stay opaque)")
 		return
 	}
-	helper, ok := d.helper(kind, typeName.Value, fn.Parameters[0].Type)
+	helper, ok := d.helper(kind, typeName.Value, typeName)
 	if !ok {
 		return
 	}
@@ -221,6 +235,12 @@ func (d *deriver) helper(kind, typeName string, node ast.Node) (string, bool) {
 		text, ok = d.hashHelper(name, typeName, decl, node)
 	case "compare":
 		text, ok = d.compareHelper(name, typeName, decl, node)
+	case "test_generate":
+		text, ok = d.testGenerateHelper(name, typeName, decl, node)
+	case "test_encode":
+		text, ok = d.testEncodeHelper(name, typeName, decl, node)
+	case "test_decode":
+		text, ok = d.testDecodeHelper(name, typeName, decl, node)
 	}
 	if !ok {
 		return "", false
@@ -230,7 +250,7 @@ func (d *deriver) helper(kind, typeName string, node ast.Node) (string, bool) {
 }
 
 func (d *deriver) helperOwner(helper string) (string, bool) {
-	for _, prefix := range []string{"__derive_equal_", "__derive_hash_", "__derive_compare_"} {
+	for _, prefix := range []string{"__derive_equal_", "__derive_hash_", "__derive_compare_", "__derive_test_generate_", "__derive_test_encode_", "__derive_test_decode_"} {
 		if strings.HasPrefix(helper, prefix) {
 			if decl := d.types[strings.TrimPrefix(helper, prefix)]; decl != nil {
 				return decl.Name.Token.SemanticContext, true

--- a/compiler/derive_testing.go
+++ b/compiler/derive_testing.go
@@ -1,0 +1,276 @@
+package compiler
+
+// Typed test commands (docs/spec/110-testing.md, "Typed commands"): a
+// command sum type whose variants carry Unit, one fixed-width scalar, or a
+// closed record of at most two scalars derives its generator over the choice
+// tape, its packing into the three-word TestCommand carrier, and its
+// range-checked decoder. Three kinds, one fact (the declaration), the same
+// mechanism as derive.equal: generated Oak text, ordinary parser, every gate.
+//
+//   cmd_generate: (choices: [*]TestChoices, data: []u8): Cmd = derive.test_generate
+//   cmd_encode:   (v: Cmd): TestCommand = derive.test_encode
+//   cmd_decode:   (command: TestCommand): Option[Cmd] = derive.test_decode
+//
+// Encoding is injective and canonical: kind is the variant index, the first
+// scalar is target, the second is value, and unused words are zero, so the
+// runner's command reducer (delete whole commands, shrink words toward zero)
+// moves through decodable commands toward the smallest variant payloads.
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/SCKelemen/oak/ast"
+)
+
+// commandScalars are the payload scalar types that fit one u32 carrier word.
+var commandScalars = map[string]uint64{"u8": 255, "u16": 65535, "u32": 4294967295, "Bool": 1}
+
+type commandField struct {
+	name string // "" for a bare scalar payload
+	typ  string
+}
+
+type commandVariant struct {
+	name   string
+	record string // payload record type name, "" for Unit or a bare scalar
+	fields []commandField
+}
+
+// testCommandType returns the command type of a testing derive request after
+// checking the signature of its kind.
+func (d *deriver) testCommandType(kind string, fn *ast.FunctionStatement) (*ast.Identifier, bool) {
+	bad := func(want string) (*ast.Identifier, bool) {
+		d.report(CodeDeriveSignature, fn.Name, "derive.%s requires the signature %s", kind, want)
+		return nil, false
+	}
+	if fn.Receiver != nil || len(fn.TypeParams) != 0 {
+		return bad("a non-generic top-level function")
+	}
+	switch kind {
+	case "test_generate":
+		if len(fn.Parameters) != 2 || !isSpanOf(fn.Parameters[0].Type, "TestChoices") || !isViewOf(fn.Parameters[1].Type, "u8") {
+			return bad("(choices: [*]TestChoices, data: []u8): T")
+		}
+		ident, ok := fn.ReturnType.(*ast.Identifier)
+		if !ok {
+			return bad("(choices: [*]TestChoices, data: []u8): T")
+		}
+		return ident, true
+	case "test_encode":
+		if len(fn.Parameters) != 1 || !isIdentifierType(fn.ReturnType, "TestCommand") {
+			return bad("(v: T): TestCommand")
+		}
+		ident, ok := fn.Parameters[0].Type.(*ast.Identifier)
+		if !ok {
+			return bad("(v: T): TestCommand")
+		}
+		return ident, true
+	case "test_decode":
+		if len(fn.Parameters) != 1 || !isIdentifierType(fn.Parameters[0].Type, "TestCommand") {
+			return bad("(command: TestCommand): Option[T]")
+		}
+		option, ok := fn.ReturnType.(*ast.IndexExpression)
+		if !ok || option.Dot || !isIdentifierType(option.Left, "Option") {
+			return bad("(command: TestCommand): Option[T]")
+		}
+		ident, ok := option.Index.(*ast.Identifier)
+		if !ok {
+			return bad("(command: TestCommand): Option[T]")
+		}
+		return ident, true
+	}
+	return nil, false
+}
+
+func isSpanOf(expr ast.Expression, element string) bool {
+	index, ok := expr.(*ast.IndexExpression)
+	if !ok || index.Dot {
+		return false
+	}
+	marker, ok := index.Index.(*ast.Identifier)
+	return ok && marker.Value == "*" && isIdentifierType(index.Left, element)
+}
+
+func isViewOf(expr ast.Expression, element string) bool {
+	index, ok := expr.(*ast.IndexExpression)
+	if !ok || index.Dot {
+		return false
+	}
+	marker, ok := index.Index.(*ast.Identifier)
+	return ok && marker.Value == "" && isIdentifierType(index.Left, element)
+}
+
+// commandVariants reads a command sum type: every variant carries Unit, one
+// carrier scalar, or a closed record of at most two carrier scalars.
+func (d *deriver) commandVariants(kind, typeName string, decl *ast.ADTType, node ast.Node) ([]commandVariant, bool) {
+	unsupported := func(format string, args ...interface{}) ([]commandVariant, bool) {
+		diag := d.report(CodeDeriveUnsupported, node, "derive.%s for %s: "+format, append([]interface{}{kind, typeName}, args...)...)
+		diag.AddHelp("command variants carry Unit, one of u8/u16/u32/Bool, or a record of at most two of those")
+		return nil, false
+	}
+	if _, isRecord := recordShape(decl); isRecord || len(decl.Variants) == 0 {
+		return unsupported("expected a sum type of command variants")
+	}
+	var variants []commandVariant
+	for _, variant := range decl.Variants {
+		if variant.Name == nil || variant.Literal != nil || variant.Result != nil {
+			return unsupported("variants must be plain constructors")
+		}
+		v := commandVariant{name: variant.Name.Value}
+		if variant.Payload != nil {
+			ident, ok := variant.Payload.(*ast.Identifier)
+			if !ok {
+				return unsupported("variant %s has a payload the generator cannot carry", v.name)
+			}
+			if _, scalar := commandScalars[ident.Value]; scalar {
+				v.fields = []commandField{{"", ident.Value}}
+			} else {
+				payload := d.types[ident.Value]
+				if payload == nil || len(payload.TypeParams) != 0 {
+					return unsupported("variant %s needs a closed record payload of at most two carrier scalars", v.name)
+				}
+				shape, isRecord := recordShape(payload)
+				if !isRecord || len(shape.FieldOrder) > 2 {
+					return unsupported("variant %s needs a closed record payload of at most two carrier scalars", v.name)
+				}
+				v.record = ident.Value
+				for _, field := range shape.FieldOrder {
+					typ, ok := field.Value.(*ast.Identifier)
+					if !ok {
+						return unsupported("field %s.%s has a type the carrier cannot hold", v.record, field.Name)
+					}
+					if _, scalar := commandScalars[typ.Value]; !scalar {
+						return unsupported("field %s.%s has type %s; carrier scalars are u8, u16, u32 and Bool", v.record, field.Name, typ.Value)
+					}
+					v.fields = append(v.fields, commandField{field.Name, typ.Value})
+				}
+			}
+		}
+		variants = append(variants, v)
+	}
+	return variants, true
+}
+
+// scalarGenerate draws one scalar of the given type from the choice tape.
+func scalarGenerate(typ string) string {
+	switch typ {
+	case "u8":
+		return "u8_trunc_u32(test_range(choices, data, u32(0), u32(255)))"
+	case "u16":
+		return "u16_trunc_u32(test_range(choices, data, u32(0), u32(65535)))"
+	case "Bool":
+		return "test_bool(choices, data)"
+	}
+	return "test_u32(choices, data)"
+}
+
+// scalarToWord widens one scalar to a carrier word.
+func scalarToWord(typ, expr string) string {
+	if typ == "Bool" {
+		return "(" + expr + " ? u32(1) | u32(0))"
+	}
+	return "u32(" + expr + ")"
+}
+
+// scalarFromWord narrows one carrier word to a scalar; the caller has already
+// checked the range.
+func scalarFromWord(typ, word string) string {
+	switch typ {
+	case "u8":
+		return "u8_trunc_u32(" + word + ")"
+	case "u16":
+		return "u16_trunc_u32(" + word + ")"
+	case "Bool":
+		return word + " == u32(1)"
+	}
+	return word
+}
+
+func (v commandVariant) construct(typeName string, fields []string) string {
+	switch {
+	case len(v.fields) == 0:
+		return typeName + "." + v.name
+	case v.record == "":
+		return fmt.Sprintf("%s.%s(%s)", typeName, v.name, fields[0])
+	}
+	var parts []string
+	for i, field := range v.fields {
+		parts = append(parts, field.name+": "+fields[i])
+	}
+	return fmt.Sprintf("%s.%s(%s { %s })", typeName, v.name, v.record, strings.Join(parts, ", "))
+}
+
+func (d *deriver) testGenerateHelper(name, typeName string, decl *ast.ADTType, node ast.Node) (string, bool) {
+	variants, ok := d.commandVariants("test_generate", typeName, decl, node)
+	if !ok {
+		return "", false
+	}
+	var body strings.Builder
+	fmt.Fprintf(&body, "%s: (choices: [*]TestChoices, data: []u8): %s {\n  variant: u32 = test_range(choices, data, u32(0), u32(%d))\n", name, typeName, len(variants)-1)
+	for i, v := range variants {
+		var fields []string
+		for _, field := range v.fields {
+			fields = append(fields, scalarGenerate(field.typ))
+		}
+		value := v.construct(typeName, fields)
+		if i == len(variants)-1 {
+			fmt.Fprintf(&body, "  { %s }\n}", value)
+		} else {
+			fmt.Fprintf(&body, "  variant == u32(%d) ? { %s } |\n", i, value)
+		}
+	}
+	return body.String(), true
+}
+
+func (d *deriver) testEncodeHelper(name, typeName string, decl *ast.ADTType, node ast.Node) (string, bool) {
+	variants, ok := d.commandVariants("test_encode", typeName, decl, node)
+	if !ok {
+		return "", false
+	}
+	var body strings.Builder
+	fmt.Fprintf(&body, "%s: (v: %s): TestCommand = v ?", name, typeName)
+	for i, v := range variants {
+		words := []string{"u32(0)", "u32(0)"}
+		pattern := "." + v.name
+		if len(v.fields) != 0 {
+			pattern += "(x)"
+		}
+		for j, field := range v.fields {
+			access := "x"
+			if v.record != "" {
+				access = "x." + field.name
+			}
+			words[j] = scalarToWord(field.typ, access)
+		}
+		fmt.Fprintf(&body, "\n | %s => TestCommand { kind: u32(%d), target: %s, value: %s }", pattern, i, words[0], words[1])
+	}
+	return body.String(), true
+}
+
+func (d *deriver) testDecodeHelper(name, typeName string, decl *ast.ADTType, node ast.Node) (string, bool) {
+	variants, ok := d.commandVariants("test_decode", typeName, decl, node)
+	if !ok {
+		return "", false
+	}
+	var body strings.Builder
+	fmt.Fprintf(&body, "%s: (command: TestCommand): Option[%s] {\n", name, typeName)
+	for i, v := range variants {
+		words := []string{"command.target", "command.value"}
+		conditions := []string{fmt.Sprintf("command.kind == u32(%d)", i)}
+		var fields []string
+		for j, word := range words {
+			if j < len(v.fields) {
+				if bound := commandScalars[v.fields[j].typ]; bound < 4294967295 {
+					conditions = append(conditions, fmt.Sprintf("%s <= u32(%d)", word, bound))
+				}
+				fields = append(fields, scalarFromWord(v.fields[j].typ, word))
+			} else {
+				conditions = append(conditions, word+" == u32(0)")
+			}
+		}
+		fmt.Fprintf(&body, "  %s ? { .Some(%s) } |\n", strings.Join(conditions, " && "), v.construct(typeName, fields))
+	}
+	body.WriteString("  { .None }\n}")
+	return body.String(), true
+}

--- a/docs/spec/110-testing.md
+++ b/docs/spec/110-testing.md
@@ -348,6 +348,33 @@ JSON corpus entries must match the input format. Trace replay retains the same
 build and semantic-trace checks as byte properties. A generator failure is a
 harness error, not a minimized target counterexample.
 
+### Typed commands
+
+A command sum type derives its generator, carrier encoding, and decoder
+(`83-modules.md` section 6.6): each variant carries Unit, one carrier scalar
+(`u8`, `u16`, `u32`, `Bool`), or a closed record of at most two carrier
+scalars. The type's own package declares:
+
+```oak
+SleepArg: type = struct { task: u8, ticks: u8 }
+Cmd: type = Admit: u8 | Sleep: SleepArg | Tick
+cmd_generate: (choices: [*]TestChoices, data: []u8): Cmd = derive.test_generate
+cmd_encode: (v: Cmd): TestCommand = derive.test_encode
+cmd_decode: (command: TestCommand): Option[Cmd] = derive.test_decode
+```
+
+`test_generate` draws the variant with `test_range` and each scalar from its
+full range; `test_encode` packs the variant index as `kind`, the first scalar
+as `target`, the second as `value`, with unused words zero; `test_decode`
+accepts exactly the encodings `test_encode` produces (range-checked, unused
+words zero) and returns `None` otherwise. The encoding is injective and
+canonical, so the command reducer moves through decodable commands toward the
+smallest payloads, and a target that rejects `None` with `test_assume` never
+executes an undecodable history. `Option` requires `import(std)`. Any other
+payload shape rejects (`OAK-M0203`); a wrong signature rejects (`OAK-M0202`).
+Model preconditions and legality remain the author's: derivation supplies the
+plumbing, not the semantics.
+
 `examples/testing/irq_test.oak` contains `PropertyIrqCommands`: acknowledgement
 is legal only in a deliverable model state and EOI only in an active one. The
 Go mutation test injects the lost-edge bug into a nine-command legal history and

--- a/docs/spec/83-modules.md
+++ b/docs/spec/83-modules.md
@@ -366,6 +366,11 @@ point_hash: (v: Point): u64 = derive.hash
 - `derive.compare` requires `(a: T, b: T): Ordering` with
   `Ordering: type = Less | Equal | Greater` in scope, and orders records
   lexicographically by field and ADTs by variant index then payload.
+- `derive.test_generate`, `derive.test_encode`, and `derive.test_decode`
+  derive a test-command sum type's tape generator, `TestCommand` packing, and
+  range-checked decoder (`110-testing.md`, "Typed commands"); the type is the
+  return type, the parameter, or `Option`'s argument respectively, and they
+  require `import(testing)` (and `import(std)` for `Option`).
 - Members may be fixed-width integers, `Bool`, and declared records or ADTs,
   recursively (helpers are generated once per type); anything else is
   rejected (`OAK-M0203`). Generic types are not derivable over (`OAK-M0203`).

--- a/testrunner/README.md
+++ b/testrunner/README.md
@@ -80,6 +80,21 @@ Failures shrink by deleting whole commands and reducing their fields; a pop
 whose push was deleted is rejected by the precondition instead of becoming a
 misleading counterexample. Results and artifacts carry the decoded commands.
 
+Declare commands as a sum type and derive the plumbing instead of packing
+words by hand:
+
+```oak
+Cmd: type = Push: u8 | Pop
+cmd_generate: (choices: [*]TestChoices, data: []u8): Cmd = derive.test_generate
+cmd_encode: (v: Cmd): TestCommand = derive.test_encode
+cmd_decode: (command: TestCommand): Option[Cmd] = derive.test_decode
+```
+
+The generator emits `cmd_encode(cmd_generate(choices, data))`; the target
+decodes each carrier command, rejects `None` with `test_assume`, and works
+with `Cmd` values. Variants may carry Unit, one of `u8`/`u16`/`u32`/`Bool`, or
+a record of at most two of those.
+
 Describe your trace events in `oak-trace.json` beside the tests and failures
 print named operations and fields (`command kind=tick target=1 ticks=9`)
 instead of raw payloads; JSON results add `trace_text`, and a diverging replay

--- a/testrunner/typed_test.go
+++ b/testrunner/typed_test.go
@@ -1,0 +1,83 @@
+package testrunner
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const typedFixture = `import(std)
+import(testing)
+
+SleepArg: type = struct { task: u8, ticks: u8 }
+Cmd: type = Admit: u8 | Sleep: SleepArg | Tick | Flag: Bool
+
+cmd_generate: (choices: [*]TestChoices, data: []u8): Cmd = derive.test_generate
+cmd_encode: (v: Cmd): TestCommand = derive.test_encode
+cmd_decode: (command: TestCommand): Option[Cmd] = derive.test_decode
+
+sleep_ticks: (v: Cmd): u8 = v ? | .Sleep(s) => s.ticks | .Admit(t) => u8(0) | .Tick => u8(0) | .Flag(f) => u8(0)
+
+GeneratePropertyTyped: (data: []u8): () {
+  tape: [1]TestChoices
+  choices: [*]TestChoices = span(&tape)
+  i: u32 = u32(0)
+  while i < u32(6) {
+    testing_command(cmd_encode(cmd_generate(choices, data)))
+    i = i + u32(1)
+  }
+}
+
+PropertyTyped: (data: []u8): () {
+  count: u32 = test_command_count(data)
+  i: u32 = u32(0)
+  while i < count {
+    raw: TestCommand = test_command_at(data, i)
+    decoded: Option[Cmd] = cmd_decode(raw)
+    present: Bool = decoded ? | .Some(v) => true | .None => false
+    test_assume(present)
+    value: Cmd = decoded ? | .Some(v) => v | .None => Cmd.Tick
+    back: TestCommand = cmd_encode(value)
+    test_check(back.kind == raw.kind && back.target == raw.target && back.value == raw.value, u32(9001))
+    test_check(sleep_ticks(value) < u8(3), u32(9002))
+    i = i + u32(1)
+  }
+}
+`
+
+// Typed commands round-trip through the carrier, the generator drives them,
+// and a failing history shrinks to the single smallest decodable command.
+func TestDerivedTypedCommands(t *testing.T) {
+	dir := fixture(t, map[string]string{"a_test.oak": typedFixture})
+	code, results, stderr := runCLI(t, "-runs", "200", "-seed", "3", "-timeout", "10s", dir)
+	if code != 1 || len(results) != 1 || results[0].Failure != "invariant:9002" {
+		t.Fatalf("%d %+v %s", code, results, stderr)
+	}
+	want := []Command{{Kind: 1, Target: 0, Value: 3}}
+	if !reflect.DeepEqual(results[0].Commands, want) {
+		t.Fatalf("minimized typed history: %+v", results[0].Commands)
+	}
+	code, replay, _ := runCLI(t, "-replay", results[0].Artifact, dir)
+	if code != 1 || replay[0].Failure != "reproduced invariant:9002" {
+		t.Fatalf("replay: %d %+v", code, replay)
+	}
+}
+
+func TestDerivedTypedCommandsRejectBadShapes(t *testing.T) {
+	for _, bad := range []struct{ source, code string }{
+		{"import(std)\nimport(testing)\nCmd: type = Tick | Go: u32\nbad: (v: Cmd): u32 = derive.test_encode\nTestX: (): () {}\n", "OAK-M0202"},
+		{"import(std)\nimport(testing)\nCmd: type = Tick | Go: u64\ngen: (choices: [*]TestChoices, data: []u8): Cmd = derive.test_generate\nTestX: (): () {}\n", "OAK-M0203"},
+		{"import(std)\nimport(testing)\nBig: type = struct { a: u32, b: u32, c: u32 }\nCmd: type = Tick | Go: Big\ngen: (choices: [*]TestChoices, data: []u8): Cmd = derive.test_generate\nTestX: (): () {}\n", "OAK-M0203"},
+		{"import(std)\nimport(testing)\nP: type = struct { a: u32 }\ngen: (choices: [*]TestChoices, data: []u8): P = derive.test_generate\nTestX: (): () {}\n", "OAK-M0203"},
+	} {
+		dir := fixture(t, map[string]string{"a_test.oak": bad.source})
+		code, results, stderr := runCLI(t, dir)
+		text := stderr
+		for _, r := range results {
+			text += r.Failure
+		}
+		if code == 0 || !strings.Contains(text, bad.code) {
+			t.Fatalf("accepted or misreported %q: %d %+v %s", bad.source, code, results, stderr)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Three new `derive.<kind>`s on the existing derivation mechanism: `derive.test_generate` (`(choices: [*]TestChoices, data: []u8): T`), `derive.test_encode` (`(v: T): TestCommand`), `derive.test_decode` (`(command: TestCommand): Option[T]`). `T` is a sum type whose variants carry Unit, one carrier scalar (`u8`/`u16`/`u32`/`Bool`), or a closed record of at most two carrier scalars.
- Encoding is injective and canonical (variant index → kind, scalars → target/value, unused words zero) so the command reducer moves through decodable commands toward the smallest payloads; the decoder range-checks and returns `None` otherwise. Bad signatures reject with `OAK-M0202`, unsupported shapes with `OAK-M0203`, undeclared payload types no longer crash the deriver.
- Runner tests: a typed generator/target round-trips through the carrier and a failing history shrinks to exactly one `Sleep{task:0, ticks:3}`; four negative shapes are rejected. Spec (`110-testing.md` "Typed commands", `83-modules.md` 6.6) and README updated.
- Removes the hand-packed `kind/target/value` boilerplate from future stateful harnesses; the OS scheduler and vGIC harnesses can adopt it next.

## Test plan
- [x] `go test ./testrunner -run 'TestDerivedTypedCommands|Command|Module'`
- [x] `go test ./compiler -run 'Derive|derive'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)