### PR TITLE
fix(test): portable warning flags in the match-binding C test

### DIFF
--- a/compiler/e2e_ml_feedback_test.go
+++ b/compiler/e2e_ml_feedback_test.go
@@ -178,7 +178,10 @@ main: (): i32 {
 	if err := os.WriteFile(cPath, []byte(output), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	build := exec.Command(cc, "-std=c99", "-O1", "-Wall", "-Wextra", "-Wuninitialized", "-Wsometimes-uninitialized", "-Wmaybe-uninitialized", "-Wno-unknown-warning-option", "-c", cPath, "-o", filepath.Join(dir, "pick.o"))
+	// Portable flags only: gcc rejects clang's -Wsometimes-uninitialized as an
+	// error, and -Wall already enables each compiler's own uninitialized-use
+	// analysis (-Wmaybe-uninitialized on gcc, -Wsometimes-uninitialized on clang).
+	build := exec.Command(cc, "-std=c99", "-O1", "-Wall", "-Wextra", "-Wuninitialized", "-c", cPath, "-o", filepath.Join(dir, "pick.o"))
 	out, err := build.CombinedOutput()
 	if err != nil {
 		t.Fatalf("cc failed: %v\n%s", err, out)


### PR DESCRIPTION
Follow-up to #94. The new `TestE2EMatchValuedBindingIsWarningFreeC` passed the clang-only flag `-Wsometimes-uninitialized`, which gcc rejects as an error, so the Linux "Run Tests" job failed after the squash landed. Use portable flags only; `-Wall` already enables each compiler's own uninitialized-use analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)