### PR TITLE
testrunner: an uncreatable report file is a runner error, not a case failure

### DIFF
--- a/testrunner/native.go
+++ b/testrunner/native.go
@@ -193,6 +193,7 @@ func (p *nativeProgram) run(index int, input []byte) (result outcome) {
 	reportFile, err := os.CreateTemp(p.dir, "report-*")
 	if err != nil {
 		result.signature = "harness:report-file"
+		result.output = err.Error()
 		return result
 	}
 	reportPath := reportFile.Name()

--- a/testrunner/native_test.go
+++ b/testrunner/native_test.go
@@ -1,0 +1,20 @@
+package testrunner
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestReportFileFailureCarriesTheError(t *testing.T) {
+	// A missing working directory makes the report file uncreatable; the
+	// outcome must name the harness failure and carry the OS error text.
+	p := &nativeProgram{bin: "/nonexistent/test", dir: t.TempDir() + "/gone", maxBytes: 64, timeout: time.Second}
+	out := p.run(0, nil)
+	if out.status != "fail" || out.signature != "harness:report-file" {
+		t.Fatalf("outcome = %q/%q, want fail/harness:report-file", out.status, out.signature)
+	}
+	if !strings.Contains(out.output, "gone") {
+		t.Fatalf("output %q does not name the report path", out.output)
+	}
+}

--- a/testrunner/runner.go
+++ b/testrunner/runner.go
@@ -388,6 +388,13 @@ func runTest(pkg Package, test Test, index int, native *nativeProgram, cfg Confi
 			}
 			return true
 		}
+		// A report file that could not be created is the runner's failure,
+		// not the case's: nothing ran. Report it as an error and stop
+		// instead of saving an unreproducible artifact.
+		if out.signature == "harness:report-file" {
+			result.Status, result.Failure = "error", "cannot create report file: "+out.output
+			return false
+		}
 		result.Status = "fail"
 		result.Failure = out.signature
 		result.Output = out.output


### PR DESCRIPTION
## Summary

- A case whose per-execution report file cannot be created never ran. The runner recorded it as a test failure (`harness:report-file`), saved an artifact, and then reported a replay divergence when the artifact passed. It now stops with `status: error` and the operating system's message, before any artifact is written.
- The native outcome carries the error text in its output; a test pins that.

Seen on a shared workstation where another process was cleaning temporary directories during a `-workers 4` campaign of the OS two-vCPU simulation; the case-level failure was not reproducible and pointed at the harness rather than the environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
