### PR TITLE
Simulated block storage with tape-driven faults for deterministic simulation (#109)

### DIFF
--- a/docs/spec/110-testing.md
+++ b/docs/spec/110-testing.md
@@ -253,10 +253,48 @@ Only the actual imported testing reporter declarations are automatically
 trusted. User declarations cannot obtain that trust by copying a reporter name
 or symbol. Other foreign boundaries require an explicit native adapter.
 No arbitrary clocks, entropy, MMIO, threads or atomics are automatically
-intercepted. Storage persistence/fault models, general scheduling adapters, and
-integration with the OS's replay/debug event schema remain future work.
+intercepted. General scheduling adapters and integration with the OS's
+replay/debug event schema remain future work; simulated storage is below.
 Single-thread event interleavings are not an ARM weak-memory model and do not
 replace the existing memory-model litmus tests or hardware validation.
+
+## Simulated storage
+
+`SimDisk` and the `sim_disk_*` functions are a deterministic block device for
+simulation scenarios: pure Oak in the testing module, over caller-owned
+storage, with no native adapter. A device has `blocks × words` `u64` words in
+two copies — the volatile copy that reads see while the device is running and
+the durable copy that survives a crash — and two provenance flag words per
+block, one per copy. `sim_disk_init` sizes and zeroes it; `sim_disk_write`
+writes one block from a caller span and marks it dirty; `sim_disk_fsync`
+persists every dirty block; `sim_disk_read` copies one block into a caller
+span and reports failure; `sim_disk_crash` drops every unpersisted write and
+reverts each block to its durable copy and provenance; `sim_disk_restart`
+brings the device back.
+
+Faults are explicit actions drawn from the choice tape, never ambient. A
+`faults` mask enables them per operation: torn write (a prefix of the block
+persists), misdirected write (it lands in another block; the target keeps its
+content), dropped write (acknowledged, never landed), lost fsync (acknowledged,
+one dirty block stays undurable), bit flip on read (one bit, both copies), and
+latent sector error (the read fails until the block is rewritten). One roll in
+eight injects a fault, chosen among the enabled kinds that apply; the tape's
+exhaustion value never injects one, so a shrunk tape is a run with fewer
+faults and strict replay reproduces each one. Every fault increments its
+counter on the device and marks the copies it touched: 2 torn, 4 misdirected,
+8 stale (an acknowledged write never landed here), 16 corrupted, 32 latent,
+with 1 for dirty. `sim_disk_trusted` and `sim_disk_durable_trusted` report a
+block with no fault mark on the volatile or durable copy. A clean rewrite
+heals the volatile copy; an fsync that acknowledges a stale block makes its
+durable copy stale too.
+
+The ledger is the scenario's contract. Durability obligations apply to trusted
+blocks; detection obligations — checksums, sequence numbers, epochs — apply to
+the rest. The bundled write-ahead-log scenario (`examples/testing`) states the
+three a single-disk log can honestly keep: no phantom record unless its block
+is untrusted, recovery is a prefix of what was appended, and every acknowledged
+record on a trusted block is recovered up to the first untrusted acknowledged
+block. Without faults the device is exact against a two-copy model.
 
 ## Trusted native adapters
 

--- a/docs/spec/STATUS.md
+++ b/docs/spec/STATUS.md
@@ -162,7 +162,10 @@ Do not mark a feature **R** merely because Go/Zig tests mirror theorem examples.
 
 `oak test` and `import(testing)` implement the bootstrap contract in
 `110-testing.md`: native isolated cases, choice-tape properties/minimization,
-mutation fuzzing, libFuzzer export, persistent corpus/replay, and bounded
-discrete-event simulation. These are execution-tested tools, not a formal
+mutation fuzzing, libFuzzer export, persistent corpus/replay, bounded
+discrete-event simulation, and simulated storage (a deterministic two-copy
+block device with tape-driven torn, misdirected, dropped, lost-fsync, bit-flip
+and latent-error faults and a per-block provenance ledger; exercised by a
+write-ahead-log recovery scenario). These are execution-tested tools, not a formal
 refinement claim. Whole-machine simulation, compiler-enforced effect closure,
 and automatic generator derivation remain unimplemented.

--- a/examples/testing/sim_storage_test.oak
+++ b/examples/testing/sim_storage_test.oak
@@ -1,0 +1,351 @@
+import(testing)
+
+// Simulated storage (stdlib sim_storage.oak): a four-block, four-word device.
+// Unit histories pin the crash contract and the fault ledger; the property
+// checks the device against an exact model with no faults enabled; the
+// simulation drives a write-ahead log through every fault kind and asks only
+// what a real WAL can promise: no phantom records, a prefix, and durability
+// of every acknowledged block the ledger calls trusted.
+
+sim_disk_fill: (rec: [*]u64, seq: u64, a: u64, b: u64): () {
+  rec[0] = seq
+  rec[1] = a
+  rec[2] = b
+  rec[3] = wal_checksum(seq, a, b)
+}
+
+wal_checksum: (seq: u64, a: u64, b: u64): u64 {
+  h: u64 = u64(0x2545F4914F6CDD1D)
+  h = (h ^ seq) * u64(0x3F58476D1CE4E5B9)
+  h = (h ^ a) * u64(0x14D049BB133111EB)
+  h = (h ^ b) * u64(0x3F58476D1CE4E5B9)
+  h ^ (h >> u64(31))
+}
+
+TestSimDiskCrashContract: (): () {
+  d: [1]SimDisk
+  dur: [16]u64
+  vol: [16]u64
+  fl: [8]u32
+  tape: [1]TestChoices
+  zeros: [4]u8
+  rec: [4]u64
+  out: [4]u64
+  disk: [*]SimDisk = span(&d)
+  durable: [*]u64 = span(&dur)
+  volatile: [*]u64 = span(&vol)
+  flags: [*]u32 = span(&fl)
+  choices: [*]TestChoices = span(&tape)
+  data: []u8 = view(&zeros)
+  record: [*]u64 = span(&rec)
+  read: [*]u64 = span(&out)
+  sim_disk_init(disk, durable, volatile, flags, u32(4), u32(4))
+  sim_disk_fill(record, u64(1), u64(10), u64(20))
+  ignored: u32 = sim_disk_write(disk, durable, volatile, flags, u32(1), record, choices, data, u32(0))
+  test_check(sim_disk_dirty(flags, u32(1)) && sim_disk_trusted(flags, u32(1)), u32(5000))
+  // Visible before fsync, gone after a crash without one.
+  ok: Bool = sim_disk_read(disk, durable, volatile, flags, u32(1), read, choices, data, u32(0))
+  test_check(ok && read[0] == u64(1) && read[3] == wal_checksum(u64(1), u64(10), u64(20)), u32(5001))
+  sim_disk_crash(disk, durable, volatile, flags)
+  sim_disk_restart(disk)
+  ok = sim_disk_read(disk, durable, volatile, flags, u32(1), read, choices, data, u32(0))
+  test_check(ok && read[0] == u64(0) && read[3] == u64(0), u32(5002))
+  test_check(!sim_disk_dirty(flags, u32(1)), u32(5003))
+  // Persisted, it survives the crash.
+  ignored = sim_disk_write(disk, durable, volatile, flags, u32(1), record, choices, data, u32(0))
+  ignored = sim_disk_fsync(disk, durable, volatile, flags, choices, data, u32(0))
+  test_check(!sim_disk_dirty(flags, u32(1)), u32(5004))
+  sim_disk_crash(disk, durable, volatile, flags)
+  sim_disk_restart(disk)
+  ok = sim_disk_read(disk, durable, volatile, flags, u32(1), read, choices, data, u32(0))
+  test_check(ok && read[0] == u64(1) && read[1] == u64(10) && read[2] == u64(20), u32(5005))
+  test_check(sim_disk_trusted(flags, u32(1)) && sim_disk_durable_trusted(flags, u32(1)), u32(5006))
+}
+
+// A tape that forces one fault: roll 7 (fault), pick 0 (the only enabled
+// kind), then the fault's own choices.
+TestSimDiskTornWriteIsLedgered: (): () {
+  d: [1]SimDisk
+  dur: [16]u64
+  vol: [16]u64
+  fl: [8]u32
+  tape: [1]TestChoices
+  bytes: [12]u8
+  rec: [4]u64
+  out: [4]u64
+  disk: [*]SimDisk = span(&d)
+  durable: [*]u64 = span(&dur)
+  volatile: [*]u64 = span(&vol)
+  flags: [*]u32 = span(&fl)
+  choices: [*]TestChoices = span(&tape)
+  record: [*]u64 = span(&rec)
+  read: [*]u64 = span(&out)
+  bytes[0] = u8(7)
+  bytes[8] = u8(2)
+  data: []u8 = view(&bytes)
+  sim_disk_init(disk, durable, volatile, flags, u32(4), u32(4))
+  sim_disk_fill(record, u64(3), u64(30), u64(60))
+  fault: u32 = sim_disk_write(disk, durable, volatile, flags, u32(2), record, choices, data, u32(1))
+  test_check(fault == u32(1) && disk[0].torn == u32(1), u32(5010))
+  test_check(!sim_disk_trusted(flags, u32(2)) && sim_disk_dirty(flags, u32(2)), u32(5011))
+  ok: Bool = sim_disk_read(disk, durable, volatile, flags, u32(2), read, choices, data, u32(0))
+  // Two words kept, two words still zero: the checksum no longer matches.
+  test_check(ok && read[0] == u64(3) && read[1] == u64(30) && read[2] == u64(0) && read[3] == u64(0), u32(5012))
+  test_check(wal_checksum(read[0], read[1], read[2]) != read[3], u32(5013))
+  // A clean rewrite heals the provenance.
+  ignored: u32 = sim_disk_write(disk, durable, volatile, flags, u32(2), record, choices, data, u32(0))
+  test_check(sim_disk_trusted(flags, u32(2)), u32(5014))
+}
+
+TestSimDiskLostFsyncIsLedgered: (): () {
+  d: [1]SimDisk
+  dur: [16]u64
+  vol: [16]u64
+  fl: [8]u32
+  tape: [1]TestChoices
+  bytes: [12]u8
+  rec: [4]u64
+  out: [4]u64
+  disk: [*]SimDisk = span(&d)
+  durable: [*]u64 = span(&dur)
+  volatile: [*]u64 = span(&vol)
+  flags: [*]u32 = span(&fl)
+  choices: [*]TestChoices = span(&tape)
+  record: [*]u64 = span(&rec)
+  read: [*]u64 = span(&out)
+  bytes[0] = u8(7)
+  data: []u8 = view(&bytes)
+  sim_disk_init(disk, durable, volatile, flags, u32(4), u32(4))
+  sim_disk_fill(record, u64(5), u64(50), u64(100))
+  // The write is clean (faults mask excludes write faults) and consumes no
+  // fault choices beyond its roll; the fsync rolls next.
+  zeros: [4]u8
+  quiet: []u8 = view(&zeros)
+  ignored: u32 = sim_disk_write(disk, durable, volatile, flags, u32(0), record, choices, quiet, u32(0))
+  choices[0].offset = u32(0)
+  fault: u32 = sim_disk_fsync(disk, durable, volatile, flags, choices, data, u32(8))
+  test_check(fault == u32(8) && disk[0].lost == u32(1), u32(5020))
+  test_check(!sim_disk_dirty(flags, u32(0)) && !sim_disk_trusted(flags, u32(0)) && !sim_disk_durable_trusted(flags, u32(0)), u32(5021))
+  sim_disk_crash(disk, durable, volatile, flags)
+  sim_disk_restart(disk)
+  ok: Bool = sim_disk_read(disk, durable, volatile, flags, u32(0), read, choices, quiet, u32(0))
+  test_check(ok && read[0] == u64(0), u32(5022))
+}
+
+// Without faults the device is exact: reads see the last write, a crash
+// reverts every block to its last persisted content.
+PropertySimDiskExact: (data: []u8): () {
+  d: [1]SimDisk
+  dur: [16]u64
+  vol: [16]u64
+  fl: [8]u32
+  mvol: [16]u64
+  mdur: [16]u64
+  tape: [1]TestChoices
+  rec: [4]u64
+  out: [4]u64
+  disk: [*]SimDisk = span(&d)
+  durable: [*]u64 = span(&dur)
+  volatile: [*]u64 = span(&vol)
+  flags: [*]u32 = span(&fl)
+  choices: [*]TestChoices = span(&tape)
+  record: [*]u64 = span(&rec)
+  read: [*]u64 = span(&out)
+  sim_disk_init(disk, durable, volatile, flags, u32(4), u32(4))
+  step: u32 = u32(0)
+  while step < u32(48) {
+    op: u32 = test_range(choices, data, u32(0), u32(4))
+    block: u32 = test_range(choices, data, u32(0), u32(3))
+    testing_trace(u32(500), u64(op), u64(block))
+    op <= u32(1) ? {
+      value: u64 = u64(test_u32(choices, data))
+      sim_disk_fill(record, u64(step), value, u64(block))
+      ignored: u32 = sim_disk_write(disk, durable, volatile, flags, block, record, choices, data, u32(0))
+      w: u32 = u32(0)
+      while w < u32(4) {
+        mvol[block * u32(4) + w] = record[w]
+        w = w + u32(1)
+      }
+      testing_classify(u32(50))
+    }
+    op == u32(2) ? {
+      ignored2: u32 = sim_disk_fsync(disk, durable, volatile, flags, choices, data, u32(0))
+      i: u32 = u32(0)
+      while i < u32(16) {
+        mdur[i] = mvol[i]
+        i = i + u32(1)
+      }
+      testing_classify(u32(51))
+    }
+    op == u32(3) ? {
+      sim_disk_crash(disk, durable, volatile, flags)
+      sim_disk_restart(disk)
+      j: u32 = u32(0)
+      while j < u32(16) {
+        mvol[j] = mdur[j]
+        j = j + u32(1)
+      }
+      testing_classify(u32(52))
+    }
+    op == u32(4) ? {
+      ok: Bool = sim_disk_read(disk, durable, volatile, flags, block, read, choices, data, u32(0))
+      test_check(ok, u32(5030))
+      k: u32 = u32(0)
+      while k < u32(4) {
+        test_check(read[k] == mvol[block * u32(4) + k], u32(5031))
+        k = k + u32(1)
+      }
+      testing_classify(u32(53))
+    }
+    test_check(sim_disk_trusted(flags, block), u32(5032))
+    step = step + u32(1)
+  }
+  test_check(disk[0].torn + disk[0].misdirected + disk[0].dropped + disk[0].lost + disk[0].flipped + disk[0].latent == u32(0), u32(5033))
+}
+
+// A write-ahead log over the device: block i holds record i (seq, a, b,
+// checksum). Appends are unacknowledged until an fsync; recovery after a
+// crash scans blocks in order and stops at the first unreadable or invalid
+// record, then truncates by invalidating the tail durably (the simulation
+// found the alternative: a stale valid record beyond the truncation point
+// resurfaces after a later unacknowledged append vanishes). Every fault kind
+// may be enabled; the invariants are the ones a single-disk WAL can honestly
+// keep:
+//   5040 no phantom: a recovered record is what was written for that
+//        sequence number, unless the ledger marks its block untrusted (a
+//        dropped or misdirected write can leave an old valid record in
+//        place — the silent case only replication repairs; class 92);
+//   5041 prefix: recovery never yields more records than were appended;
+//   5042 durability: every acknowledged record on a trusted block is
+//        recovered, up to the first untrusted acknowledged block — a
+//        prefix scan cannot see past a record it cannot validate (class 93
+//        when a fault truncated acknowledged history).
+SimWalRecovery: (data: []u8): () {
+  d: [1]SimDisk
+  dur: [32]u64
+  vol: [32]u64
+  fl: [16]u32
+  tape: [1]TestChoices
+  rec: [4]u64
+  out: [4]u64
+  expected_a: [8]u64
+  expected_b: [8]u64
+  blank: [4]u64
+  disk: [*]SimDisk = span(&d)
+  durable: [*]u64 = span(&dur)
+  volatile: [*]u64 = span(&vol)
+  flags: [*]u32 = span(&fl)
+  choices: [*]TestChoices = span(&tape)
+  record: [*]u64 = span(&rec)
+  read: [*]u64 = span(&out)
+  blank_record: [*]u64 = span(&blank)
+  faults: u32 = u32(test_byte(choices, data)) & u32(63)
+  sim_disk_init(disk, durable, volatile, flags, u32(8), u32(4))
+  next: u32 = u32(0)
+  acked: u32 = u32(0)
+  epoch: u64 = u64(0)
+  step: u32 = u32(0)
+  while step < u32(32) {
+    op: u32 = test_range(choices, data, u32(0), u32(5))
+    testing_trace(u32(510), u64(op), (u64(next) << u64(32)) | u64(acked))
+    op <= u32(2) && next < u32(8) ? {
+      a: u64 = u64(test_u32(choices, data))
+      b: u64 = epoch
+      sim_disk_fill(record, u64(next), a, b)
+      expected_a[next] = a
+      expected_b[next] = b
+      f: u32 = sim_disk_write(disk, durable, volatile, flags, next, record, choices, data, faults)
+      f != u32(0) ? { testing_classify(u32(80) + f) }
+      next = next + u32(1)
+    }
+    op == u32(3) ? {
+      f2: u32 = sim_disk_fsync(disk, durable, volatile, flags, choices, data, faults)
+      f2 != u32(0) ? { testing_classify(u32(88)) }
+      acked = next
+    }
+    op == u32(4) && next > u32(0) ? {
+      // A read of a random appended record: the device may corrupt or fail.
+      which: u32 = test_range(choices, data, u32(0), next - u32(1))
+      before_flip: u32 = disk[0].flipped
+      before_latent: u32 = disk[0].latent
+      ignored: Bool = sim_disk_read(disk, durable, volatile, flags, which, read, choices, data, faults)
+      disk[0].flipped > before_flip ? { testing_classify(u32(89)) }
+      disk[0].latent > before_latent ? { testing_classify(u32(90)) }
+    }
+    op == u32(5) ? {
+      sim_disk_crash(disk, durable, volatile, flags)
+      sim_disk_restart(disk)
+      epoch = epoch + u64(1)
+      recovered: u32 = u32(0)
+      scanning: Bool = true
+      while scanning && recovered < u32(8) {
+        ok: Bool = sim_disk_read(disk, durable, volatile, flags, recovered, read, choices, data, u32(0))
+        valid: Bool = ok && read[0] == u64(recovered) && read[3] == wal_checksum(read[0], read[1], read[2])
+        valid ? {
+          matches: Bool = read[1] == expected_a[recovered] && read[2] == expected_b[recovered]
+          trusted: Bool = sim_disk_trusted(flags, recovered)
+          test_check(matches || !trusted, u32(5040))
+          !matches ? { testing_classify(u32(92)) }
+          recovered = recovered + u32(1)
+        } | { scanning = false }
+      }
+      testing_trace(u32(511), u64(recovered), (u64(next) << u64(32)) | u64(acked))
+      test_check(recovered <= next, u32(5041))
+      clean: Bool = true
+      i: u32 = u32(0)
+      while i < acked {
+        !sim_disk_trusted(flags, i) ? { clean = false }
+        clean ? { test_check(i < recovered, u32(5042)) }
+        i = i + u32(1)
+      }
+      recovered < acked ? { testing_classify(u32(93)) }
+      recovered < next && recovered >= acked ? { testing_classify(u32(94)) }
+      // Truncate: invalidate every block past the recovered prefix, durably.
+      q: u32 = recovered
+      while q < u32(8) {
+        fz: u32 = sim_disk_write(disk, durable, volatile, flags, q, blank_record, choices, data, faults)
+        fz != u32(0) ? { testing_classify(u32(80) + fz) }
+        q = q + u32(1)
+      }
+      fs: u32 = sim_disk_fsync(disk, durable, volatile, flags, choices, data, faults)
+      fs != u32(0) ? { testing_classify(u32(88)) }
+      next = recovered
+      acked = recovered
+      testing_classify(u32(95))
+    }
+    step = step + u32(1)
+  }
+  faults == u32(0) ? { testing_classify(u32(96)) }
+}
+
+// A nonzero fault mask with no fault roll is a clean write and fsync.
+TestSimDiskCleanUnderFaultMask: (): () {
+  d: [1]SimDisk
+  dur: [32]u64
+  vol: [32]u64
+  fl: [16]u32
+  tape: [1]TestChoices
+  zeros: [64]u8
+  rec: [4]u64
+  out: [4]u64
+  disk: [*]SimDisk = span(&d)
+  durable: [*]u64 = span(&dur)
+  volatile: [*]u64 = span(&vol)
+  flags: [*]u32 = span(&fl)
+  choices: [*]TestChoices = span(&tape)
+  data: []u8 = view(&zeros)
+  record: [*]u64 = span(&rec)
+  read: [*]u64 = span(&out)
+  sim_disk_init(disk, durable, volatile, flags, u32(8), u32(4))
+  sim_disk_fill(record, u64(0), u64(77), u64(0))
+  test_check(record[3] != u64(0), u32(5900))
+  f0: u32 = sim_disk_write(disk, durable, volatile, flags, u32(0), record, choices, data, u32(0))
+  test_check(f0 == u32(0) && volatile[3] == record[3], u32(5901))
+  sim_disk_fill(record, u64(1), u64(78), u64(0))
+  f4: u32 = sim_disk_write(disk, durable, volatile, flags, u32(1), record, choices, data, u32(4))
+  test_check(f4 == u32(0), u32(5902))
+  test_check(volatile[7] == record[3], u32(5903))
+  test_check(volatile[4] == u64(1), u32(5904))
+  ff: u32 = sim_disk_fsync(disk, durable, volatile, flags, choices, data, u32(4))
+  test_check(durable[3] == volatile[3] && durable[7] == volatile[7], u32(5905))
+}

--- a/stdlib/sim_storage.oak
+++ b/stdlib/sim_storage.oak
@@ -1,0 +1,233 @@
+// Simulated block storage for deterministic simulation (docs/spec/110-testing.md,
+// "Simulated storage"). A fixed-capacity device over caller-owned storage with
+// two copies of every block — the volatile copy reads see while the device is
+// running, and the durable copy that survives a crash — plus a provenance flag
+// word per copy that records which injected fault touched it. Every fault is
+// an explicit, tape-driven action, so shrinking removes faults and strict replay
+// reproduces them; the tape's exhaustion value (zero) never injects one.
+//
+// Fault kinds (the `faults` mask enables them; the ledger counts them):
+//   1 torn        a write persists only a prefix of the block (crash mid-write)
+//   2 misdirected a write lands in another block; the target keeps its content
+//   4 dropped     a write is acknowledged but never lands
+//   8 lost        an fsync is acknowledged but one dirty block stays undurable
+//  16 flipped     a read flips one bit of the block, in both copies
+//  32 latent      a read fails; the block reads as failed until rewritten
+//
+// Provenance flags, one word per copy (`flags[2 * block]` volatile,
+// `flags[2 * block + 1]` durable): 1 dirty (written since last persisted),
+// 2 torn, 4 misdirected (holds another block's write), 8 stale (an
+// acknowledged write never landed here), 16 corrupted, 32 latent. A block is
+// trusted when no fault bit is set on the copy in question; a scenario's
+// durability obligations apply to trusted blocks, and its detection
+// obligations (checksums, sequence numbers) to the others.
+pub SimDisk: type = struct {
+  blocks: u32
+  words: u32
+  running: Bool
+  torn: u32
+  misdirected: u32
+  dropped: u32
+  lost: u32
+  flipped: u32
+  latent: u32
+}
+
+pub sim_disk_init: (disk: [*]SimDisk, durable: [*]u64, volatile: [*]u64, flags: [*]u32, blocks: u32, words: u32): () {
+  assert(len(disk) == u32(1))
+  assert(blocks > u32(0) && words > u32(0))
+  assert(len(durable) == blocks * words && len(volatile) == blocks * words)
+  assert(len(flags) == blocks * u32(2))
+  disk[0] = SimDisk { blocks: blocks, words: words, running: true, torn: u32(0), misdirected: u32(0), dropped: u32(0), lost: u32(0), flipped: u32(0), latent: u32(0) }
+  i: u32 = u32(0)
+  while i < blocks * words {
+    durable[i] = u64(0)
+    volatile[i] = u64(0)
+    i = i + u32(1)
+  }
+  i = u32(0)
+  while i < blocks * u32(2) {
+    flags[i] = u32(0)
+    i = i + u32(1)
+  }
+}
+
+// No fault bit on the volatile copy (dirty is not a fault).
+pub sim_disk_trusted: (flags: [*]u32, block: u32): Bool = (flags[block * u32(2)] & u32(62)) == u32(0)
+
+// No fault bit on the durable copy: what a crash would leave behind.
+pub sim_disk_durable_trusted: (flags: [*]u32, block: u32): Bool = (flags[block * u32(2) + u32(1)] & u32(62)) == u32(0)
+
+pub sim_disk_dirty: (flags: [*]u32, block: u32): Bool = (flags[block * u32(2)] & u32(1)) != u32(0)
+
+// One roll in eight injects a fault, chosen uniformly among the enabled kinds
+// that apply to the operation. Zero (tape exhausted, or a shrunk tape) never
+// injects: a shorter tape is a run with fewer faults.
+sim_disk_pick_fault: (choices: [*]TestChoices, data: []u8, faults: u32, applicable: u32): u32 {
+  enabled: u32 = faults & applicable
+  roll: u32 = test_range(choices, data, u32(0), u32(7))
+  count: u32 = u32(0)
+  bit: u32 = u32(1)
+  while bit <= u32(32) {
+    (enabled & bit) != u32(0) ? { count = count + u32(1) }
+    bit = bit << u32(1)
+  }
+  chosen: u32 = u32(0)
+  roll == u32(7) && count > u32(0) ? {
+    pick: u32 = test_range(choices, data, u32(0), count - u32(1))
+    seen: u32 = u32(0)
+    bit = u32(1)
+    while bit <= u32(32) {
+      (enabled & bit) != u32(0) ? {
+        seen == pick ? { chosen = bit }
+        seen = seen + u32(1)
+      }
+      bit = bit << u32(1)
+    }
+  }
+  chosen
+}
+
+sim_disk_copy: (dst: [*]u64, dst_base: u32, src: [*]u64, src_base: u32, count: u32): () {
+  i: u32 = u32(0)
+  while i < count {
+    dst[dst_base + i] = src[src_base + i]
+    i = i + u32(1)
+  }
+}
+
+// Write one block from `src` (exactly `words` words). Returns the injected
+// fault (0 none, 1 torn, 2 misdirected, 4 dropped). A clean write heals every
+// fault bit on the volatile copy; the block is dirty until the next fsync.
+pub sim_disk_write: (disk: [*]SimDisk, durable: [*]u64, volatile: [*]u64, flags: [*]u32, block: u32, src: [*]u64, choices: [*]TestChoices, data: []u8, faults: u32): u32 {
+  assert(len(disk) == u32(1) && disk[0].running)
+  assert(block < disk[0].blocks && len(src) == disk[0].words)
+  words: u32 = disk[0].words
+  fault: u32 = sim_disk_pick_fault(choices, data, faults, u32(7))
+  fault == u32(0) ? {
+    sim_disk_copy(volatile, block * words, src, u32(0), words)
+    flags[block * u32(2)] = u32(1)
+  }
+  fault == u32(1) ? {
+    kept: u32 = test_range(choices, data, u32(0), words - u32(1))
+    sim_disk_copy(volatile, block * words, src, u32(0), kept)
+    flags[block * u32(2)] = u32(3)
+    disk[0].torn = disk[0].torn + u32(1)
+  }
+  fault == u32(2) ? {
+    victim: u32 = test_range(choices, data, u32(0), disk[0].blocks - u32(1))
+    victim == block ? { victim = (victim + u32(1)) % disk[0].blocks }
+    victim == block ? {
+      // A one-block device has nowhere else to land: the write is dropped.
+      fault = u32(4)
+    } | {
+      sim_disk_copy(volatile, victim * words, src, u32(0), words)
+      flags[victim * u32(2)] = u32(5)
+      flags[block * u32(2)] = flags[block * u32(2)] | u32(8)
+      disk[0].misdirected = disk[0].misdirected + u32(1)
+    }
+  }
+  fault == u32(4) ? {
+    flags[block * u32(2)] = flags[block * u32(2)] | u32(8)
+    disk[0].dropped = disk[0].dropped + u32(1)
+  }
+  fault
+}
+
+// Persist every dirty block. Returns the injected fault (0 none, 8 lost: one
+// dirty block is acknowledged but stays undurable, its durable copy marked
+// stale — the volatile copy too, since the acknowledgement is a lie).
+pub sim_disk_fsync: (disk: [*]SimDisk, durable: [*]u64, volatile: [*]u64, flags: [*]u32, choices: [*]TestChoices, data: []u8, faults: u32): u32 {
+  assert(len(disk) == u32(1) && disk[0].running)
+  words: u32 = disk[0].words
+  dirty: u32 = u32(0)
+  b: u32 = u32(0)
+  while b < disk[0].blocks {
+    sim_disk_dirty(flags, b) ? { dirty = dirty + u32(1) }
+    b = b + u32(1)
+  }
+  fault: u32 = u32(0)
+  dirty > u32(0) ? { fault = sim_disk_pick_fault(choices, data, faults, u32(8)) }
+  lose: u32 = disk[0].blocks
+  fault == u32(8) ? {
+    pick: u32 = test_range(choices, data, u32(0), dirty - u32(1))
+    seen: u32 = u32(0)
+    b = u32(0)
+    while b < disk[0].blocks {
+      sim_disk_dirty(flags, b) ? {
+        seen == pick ? { lose = b }
+        seen = seen + u32(1)
+      }
+      b = b + u32(1)
+    }
+    disk[0].lost = disk[0].lost + u32(1)
+  }
+  b = u32(0)
+  while b < disk[0].blocks {
+    sim_disk_dirty(flags, b) ? {
+      b == lose ? {
+        flags[b * u32(2) + u32(1)] = flags[b * u32(2) + u32(1)] | u32(8)
+        flags[b * u32(2)] = (flags[b * u32(2)] & u32(62)) | u32(8)
+      } | {
+        sim_disk_copy(durable, b * words, volatile, b * words, words)
+        flags[b * u32(2) + u32(1)] = flags[b * u32(2)] & u32(62)
+        flags[b * u32(2)] = flags[b * u32(2)] & u32(62)
+      }
+    } | {
+      // A dropped or misdirected write left this block undirtied but stale:
+      // the fsync acknowledges it as durable, so the durable copy is stale
+      // too (found by the WAL simulation: the mark vanished at the crash).
+      flags[b * u32(2) + u32(1)] = flags[b * u32(2) + u32(1)] | (flags[b * u32(2)] & u32(8))
+    }
+    b = b + u32(1)
+  }
+  fault
+}
+
+// Read one block into `dst` (exactly `words` words). Returns false on a read
+// failure (a latent sector error, injected now or left by an earlier read);
+// `dst` is then untouched. A bit flip corrupts one bit in both copies before
+// the read and is reported through the flags, never through the result.
+pub sim_disk_read: (disk: [*]SimDisk, durable: [*]u64, volatile: [*]u64, flags: [*]u32, block: u32, dst: [*]u64, choices: [*]TestChoices, data: []u8, faults: u32): Bool {
+  assert(len(disk) == u32(1) && disk[0].running)
+  assert(block < disk[0].blocks && len(dst) == disk[0].words)
+  words: u32 = disk[0].words
+  fault: u32 = sim_disk_pick_fault(choices, data, faults, u32(48))
+  fault == u32(32) ? {
+    flags[block * u32(2)] = flags[block * u32(2)] | u32(32)
+    flags[block * u32(2) + u32(1)] = flags[block * u32(2) + u32(1)] | u32(32)
+    disk[0].latent = disk[0].latent + u32(1)
+  }
+  fault == u32(16) ? {
+    word: u32 = test_range(choices, data, u32(0), words - u32(1))
+    bit: u32 = test_range(choices, data, u32(0), u32(63))
+    mask: u64 = u64(1) << u64(bit)
+    volatile[block * words + word] = volatile[block * words + word] ^ mask
+    durable[block * words + word] = durable[block * words + word] ^ mask
+    flags[block * u32(2)] = flags[block * u32(2)] | u32(16)
+    flags[block * u32(2) + u32(1)] = flags[block * u32(2) + u32(1)] | u32(16)
+    disk[0].flipped = disk[0].flipped + u32(1)
+  }
+  ok: Bool = (flags[block * u32(2)] & u32(32)) == u32(0)
+  ok ? { sim_disk_copy(dst, u32(0), volatile, block * words, words) }
+  ok
+}
+
+// Power loss: every unpersisted write vanishes, each block reverts to its
+// durable copy and durable provenance. The device stays down until restart.
+pub sim_disk_crash: (disk: [*]SimDisk, durable: [*]u64, volatile: [*]u64, flags: [*]u32): () {
+  assert(len(disk) == u32(1) && disk[0].running)
+  words: u32 = disk[0].words
+  b: u32 = u32(0)
+  while b < disk[0].blocks {
+    sim_disk_copy(volatile, b * words, durable, b * words, words)
+    flags[b * u32(2)] = flags[b * u32(2) + u32(1)]
+    b = b + u32(1)
+  }
+  disk[0].running = false
+}
+
+pub sim_disk_restart: (disk: [*]SimDisk): () {
+  assert(len(disk) == u32(1) && !disk[0].running)
+  disk[0].running = true
+}

--- a/stdlib/source.go
+++ b/stdlib/source.go
@@ -64,11 +64,19 @@ func flatten(text string) string {
 	return qualification.ReplaceAllString(text, "")
 }
 
+//go:embed testing.oak
+var testingSource string
+
+// Simulated block storage with tape-driven faults (110-testing.md,
+// "Simulated storage"): pure Oak over caller-owned storage, part of the
+// testing module so simulation packages get it without a native adapter.
+//
+//go:embed sim_storage.oak
+var simStorageSource string
+
 // TestingSource is the opt-in import(testing) module. Its reporting boundary
 // is supplied by oak test; generated target helpers use caller-owned storage.
-//
-//go:embed testing.oak
-var TestingSource string
+var TestingSource = testingSource + "\n" + simStorageSource
 
 // Packages are the standard library files importable as qualified package
 // views (docs/spec/83-modules.md section 9): `import("strings")` exposes the


### PR DESCRIPTION
## Summary

First increment of #109: a deterministic block device for simulation scenarios, pure Oak in the testing module over caller-owned storage.

- **`SimDisk` and `sim_disk_*`**: volatile and durable copies of every block, a provenance flag word per copy, `init`/`write`/`fsync`/`read`/`crash`/`restart`.
- **Six fault actions, all explicit and tape-driven**: torn write (prefix persists), misdirected write (lands elsewhere, target unchanged), dropped write (acknowledged, never landed), lost fsync (one dirty block stays undurable), bit flip on read (both copies), latent sector error (reads fail until rewritten). One roll in eight injects; the tape's exhaustion value never does, so a shrunk tape is a run with fewer faults and strict replay reproduces each one. Every fault is counted on the device and marks the copies it touched; `sim_disk_trusted` / `sim_disk_durable_trusted` read the ledger.
- **Tests in `examples/testing`**: the crash contract, torn-write and lost-fsync ledgering, a clean write under a nonzero mask, an exact two-copy model property with no faults, and `SimWalRecovery`: a write-ahead log under every fault kind with the three invariants a single-disk log can honestly keep (no phantom record unless its block is untrusted; recovery is a prefix; every acknowledged record on a trusted block is recovered up to the first untrusted acknowledged block).
- **Found while writing it**: fsync forgot to carry a dropped write's stale mark into the durable copy, so the mark vanished at the crash and a zero block read as trusted (fixed in the device); and a log that truncates without invalidating its tail lets a stale valid record resurface after a later unacknowledged append vanishes (the scenario's log now invalidates the tail durably).
- Spec: `110-testing.md` "Simulated storage"; STATUS row.

## Verification

- `oak test -runs 20 examples/testing`: 13 pass (CI budget).
- `SimWalRecovery` 1000 cases at seeds 1, 5, 7, 42, 99; classes cover every fault kind, truncated acknowledged history, and fault-free runs. `PropertySimDiskExact` 3000 cases.
- `go test ./testrunner ./compiler` pass; `gofmt` clean on the touched Go file.

Follow-ups under #109: `sim.crash` as an event with recovery entry points and `sim.sched` scheduling adapters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
