### PR TITLE
Protocols: data fields may not shadow the projection's names

### DIFF
--- a/compiler/e2e_protocol_data_test.go
+++ b/compiler/e2e_protocol_data_test.go
@@ -65,6 +65,7 @@ func TestProtocolDataShapeDiagnostics(t *testing.T) {
 		"init extra field":  "P: protocol = { data { x: u32 }\n init { x: u32(1), z: u32(2) }\n initial X\n a: X -> Y }\nmain: (): i32 = 0",
 		"data w/o record":   "P: protocol = { initial X\n a: X -> Y when data.x > u32(0) }\nmain: (): i32 = 0",
 		"unguarded twins":   "P: protocol = { data { x: u32 }\n init { x: u32(0) }\n initial X\n a: X -> Y when data.x > u32(0)\n a: X -> X }\nmain: (): i32 = 0",
+		"reserved field":    "P: protocol = { data { state: u32 }\n init { state: u32(0) }\n initial X\n a: X -> Y }\nmain: (): i32 = 0",
 	}
 	for name, src := range cases {
 		_, err := New().WithSource(name+".oak", "import(std)\n"+src).EmitC().Get()

--- a/compiler/protocols.go
+++ b/compiler/protocols.go
@@ -111,6 +111,13 @@ func analyzeProtocol(decl *ast.ProtocolDeclaration, report func(code string, nod
 		fields := map[string]bool{}
 		for _, f := range decl.Data.FieldOrder {
 			fields[f.Name] = true
+			// The control state is the module's `state` variable and the
+			// projection's `state` parameter; a field of that name would
+			// shadow both.
+			if f.Name == "state" || f.Name == "step" || f.Name == "data" {
+				report(CodeProtocolShape, decl.Data, "protocol %s: data field %s is reserved by the projection (the control state, the step, the record)", decl.Name.Value, f.Name)
+				ok = false
+			}
 		}
 		for _, f := range decl.Init.FieldOrder {
 			if !fields[f.Name] {

--- a/docs/spec/112-protocols.md
+++ b/docs/spec/112-protocols.md
@@ -72,7 +72,7 @@ Shape errors (`OAK-M0301`): no `initial`, no transitions, a lowercase state,
 a payload that is not a scalar, a payload that changes between lines of one
 step, a `(name, from)` pair declared twice without guards, `data` without
 `init` or `init` without `data`, an `init` that misses or invents a field, a
-guard or effect that names `data` when none is declared, a `via` without a
+guard or effect that names `data` when none is declared, a data field named `state`, `step` or `data` (the projection's own names), a `via` without a
 `resource`, an initial state no transition leaves, and a projection whose
 name the program already declares.
 


### PR DESCRIPTION
A data field called `state` collided with the generated TLA+ module's control variable and with the projection's `state` parameter (found declaring the OS scheduler). `state`, `step` and `data` as data field names are now `OAK-M0301` shape errors naming the reason; spec 112-protocols.md lists them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)