### PR TITLE
CI: model-check the generated protocol modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,23 @@ jobs:
     - name: Verify dependencies
       run: go mod verify
 
+    # The protocol tests model-check their generated TLA+ modules when a TLC
+    # jar is present (compiler/e2e_protocol_array_test.go); give them one.
+    - name: Set up Java for TLC
+      uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: '21'
+
+    - name: Install TLC
+      run: curl -fsSL -o /tmp/tla2tools.jar https://github.com/tlaplus/tlaplus/releases/latest/download/tla2tools.jar
+
     - name: Check nested array store regression
       run: go test -v ./compiler -run '^TestE2ENestedArrayFieldStores$' -count=1
 
     - name: Run tests
+      env:
+        OAK_TLA2TOOLS_JAR: /tmp/tla2tools.jar
       run: go test -v -race -timeout 40m ./...
 
   aarch64-memory-refinement:


### PR DESCRIPTION
The protocol array test (`compiler/e2e_protocol_array_test.go`) runs TLC on its generated module when `OAK_TLA2TOOLS_JAR` is set and skips otherwise. The test job now installs Java 21 and the TLC jar and sets the variable, so the generator's TLA+ output is checked on every CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)