### PR TITLE
stdlib strings: byte order marks, UTF-16 as bytes, Latin-1, signed and radix numbers

### DIFF
--- a/compiler/e2e_stdlib_text_encoding_test.go
+++ b/compiler/e2e_stdlib_text_encoding_test.go
@@ -1,0 +1,144 @@
+package compiler
+
+import "testing"
+
+// Byte order marks, UTF-16 as bytes in either order, Latin-1, and signed or
+// radix numbers (stdlib/strings.oak, STRINGS.md). Spans end with their block
+// before the owner is viewed again.
+func TestE2EStdlibTextByteOrderAndLatin1(t *testing.T) {
+	src := `
+import(std)
+same_bytes: (a: []u8, b: []u8): Bool {
+  same: Bool = len(a) == len(b)
+  i: u32 = 0
+  while same && i < len(a) { same = a[i] == b[i]
+    i = i + u32(1)
+  }
+  same
+}
+main: (): i32 {
+  bom8: [5]u8 = [5]u8{ 239, 187, 191, 104, 105 }
+  bom16le: [4]u8 = [4]u8{ 255, 254, 104, 0 }
+  bom32be: [4]u8 = [4]u8{ 0, 0, 254, 255 }
+  plain: []u8 = text_literal("hi")
+  assert(text_bom(view(&bom8)) == u32(1) && text_bom_width(u32(1)) == u32(3))
+  assert(text_bom(view(&bom16le)) == u32(2) && text_bom(view(&bom32be)) == u32(5) && text_bom(plain) == u32(0))
+  stripped: TextRange = text_strip_bom(view(&bom8))
+  assert(stripped.start == u32(3) && stripped.end == u32(5))
+
+  // UTF-16 LE and BE bytes of "A😀": 41 00 3D D8 00 DE / 00 41 D8 3D DE 00.
+  le: [6]u8 = [6]u8{ 65, 0, 61, 216, 0, 222 }
+  be: [6]u8 = [6]u8{ 0, 65, 216, 61, 222, 0 }
+  out: [5]u8
+  true ? {
+    dst: [*]u8 = span(&out)
+    assert(text_result_value(utf16_bytes_to_utf8_size(view(&le), false)) == u32(5))
+    assert(text_result_value(utf16_bytes_to_utf8(dst, view(&le), false)) == u32(5))
+  }
+  assert(text_equal(view(&out), text_literal("A😀")))
+  true ? {
+    dst: [*]u8 = span(&out)
+    assert(text_result_value(utf16_bytes_to_utf8(dst, view(&be), true)) == u32(5))
+  }
+  assert(text_equal(view(&out), text_literal("A😀")))
+  odd: [3]u8 = [3]u8{ 65, 0, 61 }
+  assert(!text_result_ok(utf16_bytes_to_utf8_size(view(&odd), false)))
+  lone: [2]u8 = [2]u8{ 61, 216 }
+  assert(!text_result_ok(utf16_bytes_to_utf8_size(view(&lone), false)))
+  back: [6]u8
+  assert(text_result_value(utf8_to_utf16_bytes_size(text_literal("A😀"))) == u32(6))
+  true ? {
+    bdst: [*]u8 = span(&back)
+    assert(text_result_value(utf8_to_utf16_bytes(bdst, text_literal("A😀"), true)) == u32(6))
+  }
+  assert(same_bytes(view(&back), view(&be)))
+  true ? {
+    bdst: [*]u8 = span(&back)
+    assert(text_result_value(utf8_to_utf16_bytes(bdst, text_literal("A😀"), false)) == u32(6))
+  }
+  assert(same_bytes(view(&back), view(&le)))
+
+  // Latin-1: "café" is 63 61 66 E9; UTF-8 needs five bytes.
+  latin: [4]u8 = [4]u8{ 99, 97, 102, 233 }
+  utf: [5]u8
+  assert(text_result_value(latin1_to_utf8_size(view(&latin))) == u32(5))
+  true ? {
+    udst: [*]u8 = span(&utf)
+    assert(text_result_value(latin1_to_utf8(udst, view(&latin))) == u32(5))
+  }
+  assert(text_equal(view(&utf), text_literal("café")))
+  again: [4]u8
+  true ? {
+    adst: [*]u8 = span(&again)
+    assert(text_result_value(utf8_to_latin1(adst, view(&utf))) == u32(4))
+  }
+  assert(same_bytes(view(&again), view(&latin)))
+  assert(!text_result_ok(utf8_to_latin1_size(text_literal("😀"))))
+  small: [2]u8
+  true ? {
+    sdst: [*]u8 = span(&small)
+    assert(!text_result_ok(latin1_to_utf8(sdst, view(&latin))))
+  }
+  assert(small[0] == u8(0) && small[1] == u8(0))
+  42
+}
+`
+	code, abnormal := buildAndRun(t, "text_byte_order", src)
+	if abnormal || code != 42 {
+		t.Fatalf("exit=(%d,%v)", code, abnormal)
+	}
+}
+
+func TestE2EStdlibTextSignedAndRadixNumbers(t *testing.T) {
+	src := `
+import(std)
+parsed_i64: (src: []u8): i64 = text_parse_i64(src, u32(10)) ? | .Ok(v) => v | .Err(e) => i64(0) - i64(1)
+parse_fails: (src: []u8, radix: u32): Bool = text_parse_i64(src, radix) ? | .Ok(v) => false | .Err(e) => true
+main: (): i32 {
+  assert(parsed_i64(text_literal("-42")) == i64(0) - i64(42))
+  assert(parsed_i64(text_literal("+7")) == i64(7))
+  assert(parsed_i64(text_literal("-0")) == i64(0))
+  assert(parsed_i64(text_literal("9223372036854775807")) == i64(9223372036854775807))
+  assert(parse_fails(text_literal("9223372036854775808"), u32(10)))
+  assert(parsed_i64(text_literal("-9223372036854775808")) == i64_bits_u64(u64(9223372036854775808)))
+  assert(parse_fails(text_literal("-9223372036854775809"), u32(10)))
+  assert(parse_fails(text_literal("-"), u32(10)) && parse_fails(text_literal(""), u32(10)))
+  assert(parse_fails(text_literal("1x"), u32(10)))
+  hex_parsed: i64 = text_parse_i64(text_literal("-ff"), u32(16)) ? | .Ok(v) => v | .Err(e) => i64(0)
+  assert(hex_parsed == i64(0) - i64(255))
+
+  buffer: [80]u8
+  n: u32 = 0
+  true ? {
+    dst: [*]u8 = span(&buffer)
+    b: TextBuilder = text_builder()
+    b = append_i64(b, dst, i64(0) - i64(42))
+    b = append_text(b, dst, text_literal(" "))
+    b = append_u64_radix(b, dst, u64(255), u32(16), true)
+    b = append_text(b, dst, text_literal(" "))
+    b = append_u64_radix(b, dst, u64(255), u32(16), false)
+    b = append_text(b, dst, text_literal(" "))
+    b = append_u64_radix(b, dst, u64(5), u32(2), false)
+    b = append_text(b, dst, text_literal(" "))
+    b = append_i64(b, dst, i64_bits_u64(u64(9223372036854775808)))
+    n = text_result_value(finish_text(b))
+    bad: TextBuilder = append_u64_radix(text_builder(), dst, u64(1), u32(37), false)
+    assert(!text_result_ok(finish_text(bad)))
+  }
+  whole: []u8 = view(&buffer)
+  written: []u8 = whole[u32(0):n]
+  assert(text_equal(written, text_literal("-42 FF ff 101 -9223372036854775808")))
+  tiny: [2]u8
+  true ? {
+    tdst: [*]u8 = span(&tiny)
+    short: TextBuilder = append_i64(text_builder(), tdst, i64(0) - i64(100))
+    assert(!text_result_ok(finish_text(short)))
+  }
+  42
+}
+`
+	code, abnormal := buildAndRun(t, "text_signed_radix", src)
+	if abnormal || code != 42 {
+		t.Fatalf("exit=(%d,%v)", code, abnormal)
+	}
+}

--- a/examples/testing/text_encoding_test.oak
+++ b/examples/testing/text_encoding_test.oak
@@ -1,0 +1,146 @@
+import(std)
+import(testing)
+
+// Round trips through the strings package's byte-order and Latin-1 codecs
+// and its signed/radix numbers (stdlib/STRINGS.md). The tape chooses the
+// bytes and numbers; every encode must decode to what went in.
+
+// Latin-1 bytes -> UTF-8 -> Latin-1 is the identity on any bytes (7000);
+// the UTF-8 is valid (7001) and as long as _size said (7002).
+PropertyLatin1RoundTrip: (data: []u8): () {
+  tape: [1]TestChoices
+  choices: [*]TestChoices = span(&tape)
+  source: [16]u8
+  utf: [32]u8
+  back: [16]u8
+  count: u32 = test_range(choices, data, u32(0), u32(16))
+  i: u32 = u32(0)
+  while i < count {
+    source[i] = test_byte(choices, data)
+    i = i + u32(1)
+  }
+  whole: []u8 = view(&source)
+  src: []u8 = whole[u32(0):count]
+  needed: u32 = text_result_value(latin1_to_utf8_size(src))
+  written: u32 = u32(0)
+  true ? {
+    dst: [*]u8 = span(&utf)
+    written = text_result_value(latin1_to_utf8(dst, src))
+  }
+  test_check(written == needed, u32(7002))
+  encoded_whole: []u8 = view(&utf)
+  encoded: []u8 = encoded_whole[u32(0):written]
+  test_check(utf8_validate(encoded), u32(7001))
+  returned: u32 = u32(0)
+  true ? {
+    bdst: [*]u8 = span(&back)
+    returned = text_result_value(utf8_to_latin1(bdst, encoded))
+  }
+  test_check(returned == count, u32(7000))
+  j: u32 = u32(0)
+  while j < count {
+    test_check(back[j] == source[j], u32(7000))
+    j = j + u32(1)
+  }
+  count == u32(0) ? { testing_classify(u32(150)) }
+  written > count ? { testing_classify(u32(151)) }
+}
+
+// Scalars -> UTF-8 -> UTF-16 bytes (tape-chosen byte order) -> UTF-8 is the
+// identity (7010); the byte length matches _size (7011); flipping the byte
+// order of the decode fails or differs (7012).
+PropertyUtf16BytesRoundTrip: (data: []u8): () {
+  tape: [1]TestChoices
+  choices: [*]TestChoices = span(&tape)
+  utf: [32]u8
+  units: [64]u8
+  back: [32]u8
+  count: u32 = test_range(choices, data, u32(0), u32(6))
+  length: u32 = u32(0)
+  true ? {
+    dst: [*]u8 = span(&utf)
+    i: u32 = u32(0)
+    while i < count {
+      raw: u32 = test_range(choices, data, u32(1), u32(1114111))
+      value: u32 = unicode_is_scalar(raw) ? raw | u32(65)
+      length = length + text_result_value(utf8_encode(dst, length, value))
+      i = i + u32(1)
+    }
+  }
+  whole: []u8 = view(&utf)
+  src: []u8 = whole[u32(0):length]
+  big: Bool = test_bool(choices, data)
+  needed: u32 = text_result_value(utf8_to_utf16_bytes_size(src))
+  written: u32 = u32(0)
+  true ? {
+    udst: [*]u8 = span(&units)
+    written = text_result_value(utf8_to_utf16_bytes(udst, src, big))
+  }
+  test_check(written == needed, u32(7011))
+  units_whole: []u8 = view(&units)
+  encoded: []u8 = units_whole[u32(0):written]
+  returned: u32 = u32(0)
+  true ? {
+    bdst: [*]u8 = span(&back)
+    returned = text_result_value(utf16_bytes_to_utf8(bdst, encoded, big))
+  }
+  true ? {
+    back_whole: []u8 = view(&back)
+    test_check(returned == length && text_equal(back_whole[u32(0):returned], src), u32(7010))
+  }
+  flipped: Result[u32, TextError] = utf16_bytes_to_utf8_size(encoded, !big)
+  text_result_ok(flipped) && length > u32(0) ? {
+    other_store: [32]u8
+    other: u32 = u32(0)
+    true ? {
+      odst: [*]u8 = span(&other_store)
+      other = text_result_value(utf16_bytes_to_utf8(odst, encoded, !big))
+    }
+    other_whole: []u8 = view(&other_store)
+    test_check(other != length || !text_equal(other_whole[u32(0):other], src), u32(7012))
+    testing_classify(u32(152))
+  }
+  big ? { testing_classify(u32(153)) }
+  written > length ? { testing_classify(u32(154)) }
+}
+
+// Format then parse is the identity for signed decimals (7020) and for
+// unsigned values in a tape-chosen radix and letter case (7021).
+PropertyNumberRoundTrip: (data: []u8): () {
+  tape: [1]TestChoices
+  choices: [*]TestChoices = span(&tape)
+  buffer: [80]u8
+  high: u64 = u64(test_u32(choices, data))
+  low: u64 = u64(test_u32(choices, data))
+  bits: u64 = (high << u64(32)) | low
+  signed: i64 = i64_bits_u64(bits)
+  n: u32 = u32(0)
+  true ? {
+    dst: [*]u8 = span(&buffer)
+    b: TextBuilder = append_i64(text_builder(), dst, signed)
+    n = text_result_value(finish_text(b))
+  }
+  true ? {
+    whole: []u8 = view(&buffer)
+    text: []u8 = whole[u32(0):n]
+    parsed: Result[i64, TextParseError] = text_parse_i64(text, u32(10))
+    value: i64 = parsed ? | .Ok(v) => v | .Err(e) => i64(0) - i64(1)
+    test_check(value == signed, u32(7020))
+  }
+  signed < i64(0) ? { testing_classify(u32(155)) }
+  radix: u32 = test_range(choices, data, u32(2), u32(36))
+  upper: Bool = test_bool(choices, data)
+  m: u32 = u32(0)
+  true ? {
+    rdst: [*]u8 = span(&buffer)
+    rb: TextBuilder = append_u64_radix(text_builder(), rdst, bits, radix, upper)
+    m = text_result_value(finish_text(rb))
+  }
+  radix_whole: []u8 = view(&buffer)
+  radix_text: []u8 = radix_whole[u32(0):m]
+  back: Result[u64, TextParseError] = text_parse_u64(radix_text, radix)
+  unsigned: u64 = back ? | .Ok(v) => v | .Err(e) => u64(0)
+  test_check(unsigned == bits, u32(7021))
+  radix == u32(16) ? { testing_classify(u32(156)) }
+  radix == u32(2) ? { testing_classify(u32(157)) }
+}

--- a/stdlib/README.md
+++ b/stdlib/README.md
@@ -470,7 +470,9 @@ segmented/disjoint storage; these are not implemented by this addition.
 The [strings API](STRINGS.md) is executable through `import(std)`: strict
 UTF-8/16/32 codecs, ASCII validation, Unicode 17 full casing and case folding,
 searching, trimming, split/fields iteration, range-based joining, replacement,
-repetition, unsigned parsing, and a bounded fluent text builder. All outputs use
+repetition, byte order marks, UTF-16 as bytes in either byte order, Latin-1,
+signed and radix number parsing and formatting, and a bounded fluent text
+builder. All outputs use
 caller-provided storage. `text_literal("hello")` supplies readable static UTF-8
 byte views through ordinary borrowing. The placeholder string examples have been
 replaced with compiled programs; see `examples/stdlib_strings.oak`.

--- a/stdlib/STRINGS.md
+++ b/stdlib/STRINGS.md
@@ -94,6 +94,21 @@ helpers such as `text_find_from`, `text_is_boundary`, `text_decoded` and
 `text_fold_next` require their caller to establish the relevant validity/state
 preconditions; use the public operations above at input boundaries.
 
+## Byte order, UTF-16 as bytes, Latin-1, and numbers
+
+| API | Contract |
+| --- | --- |
+| `text_bom(src)` | Leading mark: 0 none, 1 UTF-8, 2 UTF-16 LE, 3 UTF-16 BE, 4 UTF-32 LE, 5 UTF-32 BE (UTF-32 LE is checked before UTF-16 LE, whose mark it extends) |
+| `text_bom_width(kind)`, `text_strip_bom(src)` | The mark's byte length; the `TextRange` after any mark |
+| `utf16_bytes_decode(src, offset, big_endian)` | One scalar from UTF-16 stored as bytes; `next` is a byte offset; odd tails and lone surrogates reject |
+| `utf16_bytes_to_utf8(dst, src, big_endian)`, `_size(src, big_endian)` | UTF-16 bytes in either byte order to UTF-8 |
+| `utf8_to_utf16_bytes(dst, src, big_endian)`, `_size(src)` | UTF-8 to UTF-16 bytes in the requested byte order; no mark is written |
+| `latin1_to_utf8(dst, src)`, `_size(src)` | ISO-8859-1 bytes to UTF-8 (every byte is the scalar of its value) |
+| `utf8_to_latin1(dst, src)`, `_size(src)` | UTF-8 to ISO-8859-1; a scalar above U+00FF is `InvalidScalar` |
+| `text_parse_i64(src, radix)` | Optional leading `-` or `+`, then `text_parse_u64`'s digits; the magnitude must fit the sign |
+| `append_i64(builder, dst, value)` | Decimal with a leading `-` when negative |
+| `append_u64_radix(builder, dst, value, radix, upper)` | Radix 2..36, letters for digits above 9 in the requested case; an invalid radix records `InvalidScalar` |
+
 ## Splitting and construction
 
 | API | Contract |

--- a/stdlib/strings.oak
+++ b/stdlib/strings.oak
@@ -899,3 +899,253 @@ pub text_parse_u64: (src: []u8, radix: u32): Result[u64, TextParseError] {
     !valid ? { .Err(.InvalidDigit) } | overflowed ? { .Err(.NumberOverflow) } | { .Ok(value) }
   }
 }
+
+// ---------------------------------------------------------------------------
+// Byte order marks, UTF-16 as bytes, Latin-1, and signed/radix numbers.
+// The same contract as the rest of this file: caller-owned storage, every
+// input and destination validated before a byte is written, u32 code-unit
+// counts on success.
+
+// text_bom classifies a leading byte order mark: 0 none, 1 UTF-8 (EF BB BF),
+// 2 UTF-16 LE (FF FE), 3 UTF-16 BE (FE FF), 4 UTF-32 LE (FF FE 00 00),
+// 5 UTF-32 BE (00 00 FE FF). UTF-32 LE is checked before UTF-16 LE, whose
+// mark it extends.
+pub text_bom: (src: []u8): u32 {
+  n: u32 = len(src)
+  n >= u32(4) && src[0] == u8(255) && src[1] == u8(254) && src[2] == u8(0) && src[3] == u8(0) ? u32(4) |
+  n >= u32(4) && src[0] == u8(0) && src[1] == u8(0) && src[2] == u8(254) && src[3] == u8(255) ? u32(5) |
+  n >= u32(3) && src[0] == u8(239) && src[1] == u8(187) && src[2] == u8(191) ? u32(1) |
+  n >= u32(2) && src[0] == u8(255) && src[1] == u8(254) ? u32(2) |
+  n >= u32(2) && src[0] == u8(254) && src[1] == u8(255) ? u32(3) | u32(0)
+}
+
+// text_bom_width is the mark's length in bytes for a text_bom kind (0 for none).
+pub text_bom_width: (kind: u32): u32 = kind == u32(1) ? u32(3) | kind == u32(2) || kind == u32(3) ? u32(2) | kind == u32(4) || kind == u32(5) ? u32(4) | u32(0)
+
+// text_strip_bom is the range of src after any leading mark.
+pub text_strip_bom: (src: []u8): TextRange = TextRange { start: text_bom_width(text_bom(src)), end: len(src) }
+
+// utf16_unit_at reads one UTF-16 code unit from bytes at an even offset.
+utf16_unit_at: (src: []u8, offset: u32, big_endian: Bool): u32 {
+  big_endian ? { (u32(src[offset]) << u32(8)) | u32(src[offset + u32(1)]) } | { (u32(src[offset + u32(1)]) << u32(8)) | u32(src[offset]) }
+}
+
+// utf16_bytes_decode decodes one scalar from UTF-16 stored as bytes; `next`
+// is the next byte offset. An odd tail, a lone surrogate, or an offset past
+// the end rejects.
+pub utf16_bytes_decode: (src: []u8, offset: u32, big_endian: Bool): Result[TextScalar, TextError] {
+  offset > len(src) ? { .Err(.OutOfBounds) } | offset == len(src) ? { .Err(.Empty) } | len(src) - offset < u32(2) ? { .Err(.InvalidEncoding) } | {
+    first: u32 = utf16_unit_at(src, offset, big_endian)
+    first < u32(55296) || first > u32(57343) ? { .Ok(TextScalar { value: first, next: offset + u32(2) }) } | {
+      first > u32(56319) || len(src) - offset < u32(4) ? { .Err(.InvalidEncoding) } | {
+        second: u32 = utf16_unit_at(src, offset + u32(2), big_endian)
+        second < u32(56320) || second > u32(57343) ? { .Err(.InvalidEncoding) } | {
+          .Ok(TextScalar { value: u32(65536) + ((first - u32(55296)) << u32(10)) + second - u32(56320), next: offset + u32(4) })
+        }
+      }
+    }
+  }
+}
+
+// utf16_bytes_to_utf8_size validates UTF-16 bytes and measures the UTF-8.
+pub utf16_bytes_to_utf8_size: (src: []u8, big_endian: Bool): Result[u32, TextError] {
+  at: u32 = 0
+  total: u32 = 0
+  valid: Bool = true
+  while at < len(src) && valid {
+    decoded: Result[TextScalar, TextError] = utf16_bytes_decode(src, at, big_endian)
+    valid = text_decode_ok(decoded)
+    valid ? {
+      item: TextScalar = text_decoded(decoded)
+      at = item.next
+      total = total + utf8_width(item.value)
+    }
+  }
+  valid ? { .Ok(total) } | { .Err(.InvalidEncoding) }
+}
+
+pub utf16_bytes_to_utf8: (dst: [*]u8, src: []u8, big_endian: Bool): Result[u32, TextError] {
+  measured: Result[u32, TextError] = utf16_bytes_to_utf8_size(src, big_endian)
+  !text_result_ok(measured) ? { measured } | {
+    needed: u32 = text_result_value(measured)
+    needed > len(dst) ? { .Err(.DestinationTooSmall) } | {
+      at: u32 = 0
+      out: u32 = 0
+      while at < len(src) {
+        item: TextScalar = text_decoded(utf16_bytes_decode(src, at, big_endian))
+        written: Result[u32, TextError] = utf8_encode(dst, out, item.value)
+        assert(text_result_ok(written))
+        out = out + text_result_value(written)
+        at = item.next
+      }
+      .Ok(out)
+    }
+  }
+}
+
+// utf8_to_utf16_bytes_size is the byte length of the UTF-16 for valid UTF-8.
+pub utf8_to_utf16_bytes_size: (src: []u8): Result[u32, TextError] {
+  units: Result[u32, TextError] = utf8_to_utf16_size(src)
+  !text_result_ok(units) ? { units } | {
+    count: u32 = text_result_value(units)
+    count > u32(2147483647) ? { .Err(.SizeOverflow) } | { .Ok(count * u32(2)) }
+  }
+}
+
+pub utf8_to_utf16_bytes: (dst: [*]u8, src: []u8, big_endian: Bool): Result[u32, TextError] {
+  measured: Result[u32, TextError] = utf8_to_utf16_bytes_size(src)
+  !text_result_ok(measured) ? { measured } | {
+    needed: u32 = text_result_value(measured)
+    needed > len(dst) ? { .Err(.DestinationTooSmall) } | {
+      at: u32 = 0
+      out: u32 = 0
+      while at < len(src) {
+        item: TextScalar = text_decoded(utf8_decode(src, at))
+        units: [2]u16
+        pair: [*]u16 = span(&units)
+        width: u32 = text_result_value(utf16_encode(pair, u32(0), item.value))
+        i: u32 = 0
+        while i < width {
+          unit: u32 = u32(pair[i])
+          big_endian ? {
+            dst[out] = u8_trunc_u32(unit >> u32(8))
+            dst[out + u32(1)] = u8_trunc_u32(unit & u32(255))
+          } | {
+            dst[out] = u8_trunc_u32(unit & u32(255))
+            dst[out + u32(1)] = u8_trunc_u32(unit >> u32(8))
+          }
+          out = out + u32(2)
+          i = i + u32(1)
+        }
+        at = item.next
+      }
+      .Ok(out)
+    }
+  }
+}
+
+// Latin-1 (ISO-8859-1): every byte is the scalar of the same value.
+pub latin1_to_utf8_size: (src: []u8): Result[u32, TextError] {
+  total: u32 = 0
+  i: u32 = 0
+  while i < len(src) {
+    total = total + (src[i] < u8(128) ? u32(1) | u32(2))
+    i = i + u32(1)
+  }
+  total < len(src) ? { .Err(.SizeOverflow) } | { .Ok(total) }
+}
+
+pub latin1_to_utf8: (dst: [*]u8, src: []u8): Result[u32, TextError] {
+  measured: Result[u32, TextError] = latin1_to_utf8_size(src)
+  !text_result_ok(measured) ? { measured } | {
+    needed: u32 = text_result_value(measured)
+    needed > len(dst) ? { .Err(.DestinationTooSmall) } | {
+      out: u32 = 0
+      i: u32 = 0
+      while i < len(src) {
+        written: Result[u32, TextError] = utf8_encode(dst, out, u32(src[i]))
+        assert(text_result_ok(written))
+        out = out + text_result_value(written)
+        i = i + u32(1)
+      }
+      .Ok(out)
+    }
+  }
+}
+
+// utf8_to_latin1_size counts scalars and rejects any above U+00FF.
+pub utf8_to_latin1_size: (src: []u8): Result[u32, TextError] {
+  at: u32 = 0
+  count: u32 = 0
+  valid: Bool = true
+  in_range: Bool = true
+  while at < len(src) && valid && in_range {
+    decoded: Result[TextScalar, TextError] = utf8_decode(src, at)
+    valid = text_decode_ok(decoded)
+    valid ? {
+      item: TextScalar = text_decoded(decoded)
+      in_range = item.value <= u32(255)
+      at = item.next
+      count = count + u32(1)
+    }
+  }
+  !valid ? { .Err(.InvalidEncoding) } | !in_range ? { .Err(.InvalidScalar) } | { .Ok(count) }
+}
+
+pub utf8_to_latin1: (dst: [*]u8, src: []u8): Result[u32, TextError] {
+  measured: Result[u32, TextError] = utf8_to_latin1_size(src)
+  !text_result_ok(measured) ? { measured } | {
+    needed: u32 = text_result_value(measured)
+    needed > len(dst) ? { .Err(.DestinationTooSmall) } | {
+      at: u32 = 0
+      out: u32 = 0
+      while at < len(src) {
+        item: TextScalar = text_decoded(utf8_decode(src, at))
+        dst[out] = u8_trunc_u32(item.value)
+        out = out + u32(1)
+        at = item.next
+      }
+      .Ok(out)
+    }
+  }
+}
+
+// text_parse_i64 accepts an optional leading '-' or '+' before the digits of
+// text_parse_u64; the magnitude must fit the sign (-2^63 .. 2^63-1).
+pub text_parse_i64: (src: []u8, radix: u32): Result[i64, TextParseError] {
+  len(src) == u32(0) ? { .Err(.EmptyNumber) } | {
+    negative: Bool = src[0] == u8(45)
+    signed: Bool = negative || src[0] == u8(43)
+    digits: []u8 = signed ? src[u32(1):len(src)] | src[u32(0):len(src)]
+    magnitude: Result[u64, TextParseError] = text_parse_u64(digits, radix)
+    magnitude ?
+      | .Err(reason) => .Err(reason)
+      | .Ok(value) => {
+        limit: u64 = negative ? u64(9223372036854775808) | u64(9223372036854775807)
+        value > limit ? { .Err(.NumberOverflow) } | negative ? { .Ok(i64_bits_u64(u64(0) - value)) } | { .Ok(i64_bits_u64(value)) }
+      }
+  }
+}
+
+// append_u64_radix writes value in radix 2..36, digits above 9 as letters
+// (upper selects the case); an invalid radix records InvalidScalar.
+pub append_u64_radix: (builder: TextBuilder, dst: [*]u8, value: u64, radix: u32, upper: Bool): TextBuilder {
+  assert(builder.length <= len(dst))
+  builder.status != u32(0) ? { builder } | radix < u32(2) || radix > u32(36) ? { text_builder_error(builder, .InvalidScalar) } | {
+    digits: [64]u8
+    count: u32 = 0
+    remaining: u64 = value
+    more: Bool = true
+    while more {
+      digit: u8 = u8_trunc_u64(remaining % u64(radix))
+      letter_base: u8 = upper ? u8(55) | u8(87)
+      digits[count] = digit < u8(10) ? { u8(48) + digit } | { letter_base + digit }
+      count = count + u32(1)
+      remaining = remaining / u64(radix)
+      more = remaining != u64(0)
+    }
+    count > len(dst) - builder.length ? { text_builder_error(builder, .DestinationTooSmall) } | {
+      next: TextBuilder = builder
+      i: u32 = 0
+      while i < count {
+        dst[builder.length + i] = digits[count - i - u32(1)]
+        i = i + u32(1)
+      }
+      next.length = next.length + count
+      next
+    }
+  }
+}
+
+// append_i64 writes a decimal integer with a leading '-' when negative.
+pub append_i64: (builder: TextBuilder, dst: [*]u8, value: i64): TextBuilder {
+  assert(builder.length <= len(dst))
+  builder.status != u32(0) ? { builder } | value >= i64(0) ? { append_u64(builder, dst, u64_bits_i64(value)) } | {
+    builder.length >= len(dst) ? { text_builder_error(builder, .DestinationTooSmall) } | {
+      dst[builder.length] = u8(45)
+      signed: TextBuilder = builder
+      signed.length = signed.length + u32(1)
+      append_u64(signed, dst, u64(0) - u64_bits_i64(value))
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Text-encoding additions to the strings package, the pieces a program meets at an input boundary (`stdlib/STRINGS.md`, new section "Byte order, UTF-16 as bytes, Latin-1, and numbers"):

- **Byte order marks**: `text_bom` classifies the five marks (UTF-8, UTF-16 LE/BE, UTF-32 LE/BE; UTF-32 LE checked before the UTF-16 LE mark it extends), `text_bom_width`, `text_strip_bom`.
- **UTF-16 as bytes**: `utf16_bytes_decode` and the transcoders `utf16_bytes_to_utf8` / `utf8_to_utf16_bytes` with `_size`, in either byte order; odd tails and lone surrogates reject; no mark is written.
- **Latin-1**: `latin1_to_utf8` / `utf8_to_latin1` with `_size`; a scalar above U+00FF is `InvalidScalar`.
- **Numbers**: `text_parse_i64` (optional sign, magnitude bounded by the sign, -2^63 accepted, 2^63 rejected), `append_i64`, `append_u64_radix` for radices 2..36 in either letter case.

Same contract as the rest of the file: caller-owned storage, every input and destination validated before a byte is written, `u32` counts.

## Verification

- `TestE2EStdlibTextByteOrderAndLatin1`, `TestE2EStdlibTextSignedAndRadixNumbers`: every function, the rejections, and the untouched-destination rule; the existing `TestE2EStdlibText*` suite still passes.
- `examples/testing/text_encoding_test.oak`: round-trip properties for Latin-1, UTF-16 bytes (with the byte order flipped as the negative case), and signed decimal / radix numbers, 500 cases each.
- `go test ./compiler ./parser ./serialize` pass.

Found on the way: slicing an unnamed view (`view(&x)[lo:hi]`) breaks the C emission inside the `core_slice` macro — filed as #149; the tests name the view first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
