### PR TITLE
chore(experiments): gofmt the verification proof of concept

### DIFF
--- a/experiments/verification-poc/backend.go
+++ b/experiments/verification-poc/backend.go
@@ -1,119 +1,388 @@
 package main
 
 import (
-    "bytes"
-    "context"
-    _ "embed"
-    "encoding/json"
-    "fmt"
-    "os"
-    "os/exec"
-    "path/filepath"
-    "regexp"
-    "runtime"
-    "strings"
-    "time"
+	"bytes"
+	"context"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"time"
 
-    "github.com/SCKelemen/oak/experiments/verification-poc/internal/lrat"
+	"github.com/SCKelemen/oak/experiments/verification-poc/internal/lrat"
 )
+
 //go:embed tools.lock.json
 var lockData []byte
-type ToolPin struct{Version string `json:"version"`;SHA string `json:"sha256"`}
-var pins=func()map[string]ToolPin{p:=map[string]ToolPin{};if e:=json.Unmarshal(lockData,&p);e!=nil{panic(e)};return p}()
-type Execution struct{
-    Command []string `json:"command"`
-    ExitCode *int `json:"exit_code"`
-    Stdout string `json:"stdout"`
-    Stderr string `json:"stderr"`
-    Error string `json:"error,omitempty"`
+
+type ToolPin struct {
+	Version string `json:"version"`
+	SHA     string `json:"sha256"`
 }
-type limitedBuffer struct{bytes.Buffer}
-func (b *limitedBuffer)Write(p []byte)(int,error){if b.Len()+len(p)>20_000_000{return 0,fmt.Errorf("tool output limit")};return b.Buffer.Write(p)}
-func execute(command []string,folder string,timeout time.Duration)Execution{
-    r:=Execution{Command:command};ctx,cancel:=context.WithTimeout(context.Background(),timeout);defer cancel()
-    cmd:=exec.CommandContext(ctx,command[0],command[1:]...);cmd.Dir=folder;cmd.WaitDelay=time.Second
-    stdout,stderr:=&limitedBuffer{},&limitedBuffer{};cmd.Stdout=stdout;cmd.Stderr=stderr;err:=cmd.Run();r.Stdout=stdout.String();r.Stderr=stderr.String()
-    if ctx.Err()!=nil{r.Error=ctx.Err().Error();return r}
-    if err==nil{code:=0;r.ExitCode=&code;return r}
-    if exit,ok:=err.(*exec.ExitError);ok{code:=exit.ExitCode();r.ExitCode=&code}else{r.Error=err.Error()};return r
+
+var pins = func() map[string]ToolPin {
+	p := map[string]ToolPin{}
+	if e := json.Unmarshal(lockData, &p); e != nil {
+		panic(e)
+	}
+	return p
+}()
+
+type Execution struct {
+	Command  []string `json:"command"`
+	ExitCode *int     `json:"exit_code"`
+	Stdout   string   `json:"stdout"`
+	Stderr   string   `json:"stderr"`
+	Error    string   `json:"error,omitempty"`
 }
-type ToolStatus struct{Available bool `json:"available"`;Reason string `json:"reason,omitempty"`;Probe *Execution `json:"probe,omitempty"`;SHA string `json:"sha256,omitempty"`}
-func versionMatches(name,banner string)bool{pattern:=`(^|[^0-9.])`+regexp.QuoteMeta(pins[name].Version)+`([^0-9.]|$)`;return regexp.MustCompile(pattern).MatchString(banner)}
-func probe(name,folder,jar string,timeout time.Duration)ToolStatus{
-    fail:=func(s string)ToolStatus{return ToolStatus{Reason:s}}
-    if name=="go"{if !versionMatches(name,runtime.Version()){return fail("binary built with unpinned Go: "+runtime.Version())};code:=0;r:=Execution{Command:[]string{"runtime.Version"},ExitCode:&code,Stdout:runtime.Version()};return ToolStatus{Available:true,Probe:&r}}
-    if name=="tlc"{
-        if jar==""{return fail("TLC jar unavailable; pass --tla-jar")};b,e:=os.ReadFile(jar);if e!=nil{return fail(e.Error())};sha:=digest(string(b));if sha!=pins[name].SHA{return fail("TLC jar digest mismatch")}
-        r:=execute([]string{"java","-version"},folder,timeout);if r.ExitCode==nil||*r.ExitCode!=0{return fail("Java unavailable")}
-        match:=regexp.MustCompile(`version "([0-9]+)`).FindStringSubmatch(r.Stdout+r.Stderr);major:=0;if len(match)==2{fmt.Sscan(match[1],&major)};if major<17{return fail("Java 17+ required")};return ToolStatus{Available:true,Probe:&r,SHA:sha}
-    }
-    exe,e:=exec.LookPath(name);if e!=nil{return fail(name+" unavailable")};arg:="--version";if name=="z3"{arg="-version"};r:=execute([]string{exe,arg},folder,timeout)
-    if r.ExitCode==nil||*r.ExitCode!=0{return fail("version probe failed")};if !versionMatches(name,r.Stdout+"\n"+r.Stderr){return ToolStatus{Reason:"version mismatch",Probe:&r}};return ToolStatus{Available:true,Probe:&r}
+type limitedBuffer struct{ bytes.Buffer }
+
+func (b *limitedBuffer) Write(p []byte) (int, error) {
+	if b.Len()+len(p) > 20_000_000 {
+		return 0, fmt.Errorf("tool output limit")
+	}
+	return b.Buffer.Write(p)
 }
-type BackendResult struct{Passed bool `json:"passed"`;ExpectedSafety bool `json:"expected_safety"`;Reason string `json:"reason,omitempty"`;Claim *Claim `json:"claim,omitempty"`;Established string `json:"established,omitempty"`;Assumptions []string `json:"assumptions,omitempty"`;TrustPath []string `json:"trust_path,omitempty"`;Verdict *Verdict `json:"verdict,omitempty"`;Logs []Execution `json:"logs,omitempty"`}
-func runBackend(m *Model,name,out string,safe bool,bound int,timeout time.Duration,jar string,run func([]string,string,time.Duration)Execution)(result BackendResult){
-    result.ExpectedSafety=safe
-    defer func(){if e:=recover();e!=nil{result.Passed=false;result.Reason=fmt.Sprint(e)}}()
-    call:=func(args ...string)Execution{r:=run(args,out,timeout);result.Logs=append(result.Logs,r);demand(r.ExitCode!=nil,"execution failed: "+r.Error);return r}
-    write:=func(name,text string){demand(os.WriteFile(filepath.Join(out,name),[]byte(text),0644)==nil,"cannot write generated file")}
-    read:=func(name string)string{b,e:=os.ReadFile(filepath.Join(out,name));demand(e==nil,"cannot read generated file: "+name);return string(b)}
-    saveTrace:=func(backend,query,raw string,k *int){r:=receipt(m,backend,query,raw,k);c,e:=importTrace(m,backend,query,raw,r,k);demand(e==nil,fmt.Sprintf("trace rejected: %v",e));write(backend+"-output.txt",raw);write(backend+"-receipt.json",jsonText(r));write(backend+"-evidence.json",jsonText(c))}
-    switch name{
-    case "z3":
-        step:="unsat";if !safe{step="sat"};for _,pair:=range [][2]string{{"initial","sat"},{"base","unsat"},{"step",step}}{r:=call("z3","-smt2",filepath.Join(out,pair[0]+".smt2"));demand(*r.ExitCode==0&&strings.TrimSpace(r.Stdout)==pair[1],"unexpected Z3 "+pair[0]+" result")}
-        query,e:=bmc(m,bound,false);demand(e==nil,"invalid BMC bound");write("bmc.smt2",query);r:=call("z3","-smt2",filepath.Join(out,"bmc.smt2"));expected:="unsat";if !safe{expected="sat"};demand(*r.ExitCode==0&&strings.TrimSpace(r.Stdout)==expected,"unexpected BMC result")
-        if !safe{query,_=bmc(m,bound,true);write("bmc-values.smt2",query);r=call("z3","-smt2",filepath.Join(out,"bmc-values.smt2"));demand(*r.ExitCode==0,"get-value failed");saveTrace("z3",query,r.Stdout,&bound)}
-    case "tlc":
-        tracePath:=filepath.Join(out,"tlc-trace.json");r:=call("java","-cp",jar,"tlc2.TLC","-workers","1","-dumpTrace","json",tracePath,"-metadir",filepath.Join(out,"states"),"-config","Model.cfg","Model.tla");log:=r.Stdout+r.Stderr
-        if safe{demand(*r.ExitCode==0&&strings.Contains(log,"Model checking completed. No error has been found."),"TLC did not report completed safety") }else{demand(*r.ExitCode!=0&&strings.Contains(log,"Invariant Safe is violated"),"TLC did not report expected invariant violation");saveTrace("tlc",read("Model.tla")+"\n"+read("Model.cfg"),read("tlc-trace.json"),nil)}
-    case "lean":
-        code:=read("Model.lean");defs:=strings.SplitN(code,"theorem base (",2)[0]+"end OakFinite\n";write("Definitions.lean",defs)
-        r:=call("lean",filepath.Join(out,"Definitions.lean"));demand(*r.ExitCode==0,"Lean definition projection failed");r=call("lean",filepath.Join(out,"Model.lean"));demand((*r.ExitCode==0)==safe,"unexpected Lean theorem outcome")
-    case "cadical":
-        proofs:=map[string]Proof{};step:=20;if !safe{step=10}
-        for _,pair:=range []struct{role string;code int}{{"initial",10},{"base",20},{"step",step}}{r:=call("cadical","--lrat","--no-binary",filepath.Join(out,pair.role+".cnf"),filepath.Join(out,pair.role+".cadical.lrat"));demand(*r.ExitCode==pair.code,"unexpected CaDiCaL "+pair.role+" outcome");if pair.code==20{cnf,proof:=read(pair.role+".cnf"),read(pair.role+".cadical.lrat");_,e:=lrat.Check(cnf,proof);demand(e==nil,fmt.Sprintf("LRAT rejected: %v",e));proofs[pair.role]=Proof{digest(cnf),proof}}}
-        if safe{states,e:=m.states();demand(e==nil,"initial witness enumeration limit");var initial State;for _,s:=range states{if truth(m.Terms["initial"],s,nil){initial=s;break}};c:=&Certificate{Format:evidenceFormat,Digest:m.Digest,Kind:"lrat",Initial:initial,Proofs:proofs};verdict,e:=verify(m,c);result.Verdict=verdict;demand(e==nil,fmt.Sprintf("evidence rejected: %v",e));write("cadical-evidence.json",jsonText(c))}
-    default:panic("unsupported backend")
-    };result.Passed=true;result.contract(m,name,safe,bound);return result
+func execute(command []string, folder string, timeout time.Duration) Execution {
+	r := Execution{Command: command}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
+	cmd.Dir = folder
+	cmd.WaitDelay = time.Second
+	stdout, stderr := &limitedBuffer{}, &limitedBuffer{}
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	err := cmd.Run()
+	r.Stdout = stdout.String()
+	r.Stderr = stderr.String()
+	if ctx.Err() != nil {
+		r.Error = ctx.Err().Error()
+		return r
+	}
+	if err == nil {
+		code := 0
+		r.ExitCode = &code
+		return r
+	}
+	if exit, ok := err.(*exec.ExitError); ok {
+		code := exit.ExitCode()
+		r.ExitCode = &code
+	} else {
+		r.Error = err.Error()
+	}
+	return r
+}
+
+type ToolStatus struct {
+	Available bool       `json:"available"`
+	Reason    string     `json:"reason,omitempty"`
+	Probe     *Execution `json:"probe,omitempty"`
+	SHA       string     `json:"sha256,omitempty"`
+}
+
+func versionMatches(name, banner string) bool {
+	pattern := `(^|[^0-9.])` + regexp.QuoteMeta(pins[name].Version) + `([^0-9.]|$)`
+	return regexp.MustCompile(pattern).MatchString(banner)
+}
+func probe(name, folder, jar string, timeout time.Duration) ToolStatus {
+	fail := func(s string) ToolStatus { return ToolStatus{Reason: s} }
+	if name == "go" {
+		if !versionMatches(name, runtime.Version()) {
+			return fail("binary built with unpinned Go: " + runtime.Version())
+		}
+		code := 0
+		r := Execution{Command: []string{"runtime.Version"}, ExitCode: &code, Stdout: runtime.Version()}
+		return ToolStatus{Available: true, Probe: &r}
+	}
+	if name == "tlc" {
+		if jar == "" {
+			return fail("TLC jar unavailable; pass --tla-jar")
+		}
+		b, e := os.ReadFile(jar)
+		if e != nil {
+			return fail(e.Error())
+		}
+		sha := digest(string(b))
+		if sha != pins[name].SHA {
+			return fail("TLC jar digest mismatch")
+		}
+		r := execute([]string{"java", "-version"}, folder, timeout)
+		if r.ExitCode == nil || *r.ExitCode != 0 {
+			return fail("Java unavailable")
+		}
+		match := regexp.MustCompile(`version "([0-9]+)`).FindStringSubmatch(r.Stdout + r.Stderr)
+		major := 0
+		if len(match) == 2 {
+			fmt.Sscan(match[1], &major)
+		}
+		if major < 17 {
+			return fail("Java 17+ required")
+		}
+		return ToolStatus{Available: true, Probe: &r, SHA: sha}
+	}
+	exe, e := exec.LookPath(name)
+	if e != nil {
+		return fail(name + " unavailable")
+	}
+	arg := "--version"
+	if name == "z3" {
+		arg = "-version"
+	}
+	r := execute([]string{exe, arg}, folder, timeout)
+	if r.ExitCode == nil || *r.ExitCode != 0 {
+		return fail("version probe failed")
+	}
+	if !versionMatches(name, r.Stdout+"\n"+r.Stderr) {
+		return ToolStatus{Reason: "version mismatch", Probe: &r}
+	}
+	return ToolStatus{Available: true, Probe: &r}
+}
+
+type BackendResult struct {
+	Passed         bool        `json:"passed"`
+	ExpectedSafety bool        `json:"expected_safety"`
+	Reason         string      `json:"reason,omitempty"`
+	Claim          *Claim      `json:"claim,omitempty"`
+	Established    string      `json:"established,omitempty"`
+	Assumptions    []string    `json:"assumptions,omitempty"`
+	TrustPath      []string    `json:"trust_path,omitempty"`
+	Verdict        *Verdict    `json:"verdict,omitempty"`
+	Logs           []Execution `json:"logs,omitempty"`
+}
+
+func runBackend(m *Model, name, out string, safe bool, bound int, timeout time.Duration, jar string, run func([]string, string, time.Duration) Execution) (result BackendResult) {
+	result.ExpectedSafety = safe
+	defer func() {
+		if e := recover(); e != nil {
+			result.Passed = false
+			result.Reason = fmt.Sprint(e)
+		}
+	}()
+	call := func(args ...string) Execution {
+		r := run(args, out, timeout)
+		result.Logs = append(result.Logs, r)
+		demand(r.ExitCode != nil, "execution failed: "+r.Error)
+		return r
+	}
+	write := func(name, text string) {
+		demand(os.WriteFile(filepath.Join(out, name), []byte(text), 0644) == nil, "cannot write generated file")
+	}
+	read := func(name string) string {
+		b, e := os.ReadFile(filepath.Join(out, name))
+		demand(e == nil, "cannot read generated file: "+name)
+		return string(b)
+	}
+	saveTrace := func(backend, query, raw string, k *int) {
+		r := receipt(m, backend, query, raw, k)
+		c, e := importTrace(m, backend, query, raw, r, k)
+		demand(e == nil, fmt.Sprintf("trace rejected: %v", e))
+		write(backend+"-output.txt", raw)
+		write(backend+"-receipt.json", jsonText(r))
+		write(backend+"-evidence.json", jsonText(c))
+	}
+	switch name {
+	case "z3":
+		step := "unsat"
+		if !safe {
+			step = "sat"
+		}
+		for _, pair := range [][2]string{{"initial", "sat"}, {"base", "unsat"}, {"step", step}} {
+			r := call("z3", "-smt2", filepath.Join(out, pair[0]+".smt2"))
+			demand(*r.ExitCode == 0 && strings.TrimSpace(r.Stdout) == pair[1], "unexpected Z3 "+pair[0]+" result")
+		}
+		query, e := bmc(m, bound, false)
+		demand(e == nil, "invalid BMC bound")
+		write("bmc.smt2", query)
+		r := call("z3", "-smt2", filepath.Join(out, "bmc.smt2"))
+		expected := "unsat"
+		if !safe {
+			expected = "sat"
+		}
+		demand(*r.ExitCode == 0 && strings.TrimSpace(r.Stdout) == expected, "unexpected BMC result")
+		if !safe {
+			query, _ = bmc(m, bound, true)
+			write("bmc-values.smt2", query)
+			r = call("z3", "-smt2", filepath.Join(out, "bmc-values.smt2"))
+			demand(*r.ExitCode == 0, "get-value failed")
+			saveTrace("z3", query, r.Stdout, &bound)
+		}
+	case "tlc":
+		tracePath := filepath.Join(out, "tlc-trace.json")
+		r := call("java", "-cp", jar, "tlc2.TLC", "-workers", "1", "-dumpTrace", "json", tracePath, "-metadir", filepath.Join(out, "states"), "-config", "Model.cfg", "Model.tla")
+		log := r.Stdout + r.Stderr
+		if safe {
+			demand(*r.ExitCode == 0 && strings.Contains(log, "Model checking completed. No error has been found."), "TLC did not report completed safety")
+		} else {
+			demand(*r.ExitCode != 0 && strings.Contains(log, "Invariant Safe is violated"), "TLC did not report expected invariant violation")
+			saveTrace("tlc", read("Model.tla")+"\n"+read("Model.cfg"), read("tlc-trace.json"), nil)
+		}
+	case "lean":
+		code := read("Model.lean")
+		defs := strings.SplitN(code, "theorem base (", 2)[0] + "end OakFinite\n"
+		write("Definitions.lean", defs)
+		r := call("lean", filepath.Join(out, "Definitions.lean"))
+		demand(*r.ExitCode == 0, "Lean definition projection failed")
+		r = call("lean", filepath.Join(out, "Model.lean"))
+		demand((*r.ExitCode == 0) == safe, "unexpected Lean theorem outcome")
+	case "cadical":
+		proofs := map[string]Proof{}
+		step := 20
+		if !safe {
+			step = 10
+		}
+		for _, pair := range []struct {
+			role string
+			code int
+		}{{"initial", 10}, {"base", 20}, {"step", step}} {
+			r := call("cadical", "--lrat", "--no-binary", filepath.Join(out, pair.role+".cnf"), filepath.Join(out, pair.role+".cadical.lrat"))
+			demand(*r.ExitCode == pair.code, "unexpected CaDiCaL "+pair.role+" outcome")
+			if pair.code == 20 {
+				cnf, proof := read(pair.role+".cnf"), read(pair.role+".cadical.lrat")
+				_, e := lrat.Check(cnf, proof)
+				demand(e == nil, fmt.Sprintf("LRAT rejected: %v", e))
+				proofs[pair.role] = Proof{digest(cnf), proof}
+			}
+		}
+		if safe {
+			states, e := m.states()
+			demand(e == nil, "initial witness enumeration limit")
+			var initial State
+			for _, s := range states {
+				if truth(m.Terms["initial"], s, nil) {
+					initial = s
+					break
+				}
+			}
+			c := &Certificate{Format: evidenceFormat, Digest: m.Digest, Kind: "lrat", Initial: initial, Proofs: proofs}
+			verdict, e := verify(m, c)
+			result.Verdict = verdict
+			demand(e == nil, fmt.Sprintf("evidence rejected: %v", e))
+			write("cadical-evidence.json", jsonText(c))
+		}
+	default:
+		panic("unsupported backend")
+	}
+	result.Passed = true
+	result.contract(m, name, safe, bound)
+	return result
 }
 
 // contract states, for a passed backend row, what the tool established, what
 // the row trusts, and the path the result took (roadmap step 4). External
 // answers are the tools' claims: only CaDiCaL's LRAT refutations are checked
 // independently, and that row carries the checker's verdict.
-func (result *BackendResult) contract(m *Model,name string,safe bool,bound int){
-    property:="nonvacuous inductive safety";if !safe{property="reachable safety counterexample"}
-    claim:=claimFor(m,property);result.Claim=&claim
-    path:=append([]string{},sharedTrustPath...)
-    switch name{
-    case "z3":
-        if safe{result.Established=fmt.Sprintf("Z3 answered sat for the initial query, unsat for the base and step obligations, and unsat for the bounded model check to bound %d",bound)}else{result.Established=fmt.Sprintf("Z3 answered sat for the initial query and unsat for the base obligation, sat for the step obligation and for the bounded model check to bound %d, and its violating values replayed as a legal trace",bound)}
-        result.Assumptions=append(append([]string{},sharedAssumptions...),"Z3's answers are solver claims, not independently checked proofs","the SMT projection of the model is compared, not proved","a bounded unsat covers only its bound")
-        result.TrustPath=append(path,"Go SMT projection (projections.go)","Z3","Go trace replay of counterexample values (import_trace.go)")
-    case "tlc":
-        if safe{result.Established="TLC completed exhaustive model checking of the projected TLA+ model and found no error"}else{result.Established="TLC reported the expected invariant violation and its trace replayed as a legal trace"}
-        result.Assumptions=append(append([]string{},sharedAssumptions...),"TLC's exploration is a tool claim over the projected TLA+ model","the TLA+ projection of the model is compared, not proved")
-        result.TrustPath=append(path,"Go TLA+ projection (projections.go)","TLC (pinned tla2tools.jar)","Go trace replay (import_trace.go)")
-    case "lean":
-        if safe{result.Established="the projected Lean definitions compile and the theorems base and step check"}else{result.Established="the projected Lean definitions compile and the theorems base and step fail to check, as the violation requires"}
-        result.Assumptions=append(append([]string{},sharedAssumptions...),"the Lean projection of the model and its theorem statements are compared, not proved","Lean's kernel")
-        result.TrustPath=append(path,"Go Lean projection (projections.go)","Lean")
-    case "cadical":
-        if safe{result.Established="CaDiCaL answered sat for the initial query and produced LRAT refutations of the base and step obligations, which the evidence checker accepted as LRAT evidence: the attached verdict is the claim"}else{result.Established="CaDiCaL answered sat for the initial query, produced an LRAT refutation of the base obligation, and answered sat for the step obligation"}
-        result.Assumptions=append(append([]string{},sharedAssumptions...),"CaDiCaL is untrusted search; only its LRAT refutations are checked, by internal/lrat","the Go CNF translation (encode) is compared, not proved")
-        result.TrustPath=append(path,"Go CNF encoder (circuit.go)","CaDiCaL (untrusted search)","internal/lrat checker and its corpus gates (compiled Oak, the Lean file model, check_sound, check_refines)")
-    }
+func (result *BackendResult) contract(m *Model, name string, safe bool, bound int) {
+	property := "nonvacuous inductive safety"
+	if !safe {
+		property = "reachable safety counterexample"
+	}
+	claim := claimFor(m, property)
+	result.Claim = &claim
+	path := append([]string{}, sharedTrustPath...)
+	switch name {
+	case "z3":
+		if safe {
+			result.Established = fmt.Sprintf("Z3 answered sat for the initial query, unsat for the base and step obligations, and unsat for the bounded model check to bound %d", bound)
+		} else {
+			result.Established = fmt.Sprintf("Z3 answered sat for the initial query and unsat for the base obligation, sat for the step obligation and for the bounded model check to bound %d, and its violating values replayed as a legal trace", bound)
+		}
+		result.Assumptions = append(append([]string{}, sharedAssumptions...), "Z3's answers are solver claims, not independently checked proofs", "the SMT projection of the model is compared, not proved", "a bounded unsat covers only its bound")
+		result.TrustPath = append(path, "Go SMT projection (projections.go)", "Z3", "Go trace replay of counterexample values (import_trace.go)")
+	case "tlc":
+		if safe {
+			result.Established = "TLC completed exhaustive model checking of the projected TLA+ model and found no error"
+		} else {
+			result.Established = "TLC reported the expected invariant violation and its trace replayed as a legal trace"
+		}
+		result.Assumptions = append(append([]string{}, sharedAssumptions...), "TLC's exploration is a tool claim over the projected TLA+ model", "the TLA+ projection of the model is compared, not proved")
+		result.TrustPath = append(path, "Go TLA+ projection (projections.go)", "TLC (pinned tla2tools.jar)", "Go trace replay (import_trace.go)")
+	case "lean":
+		if safe {
+			result.Established = "the projected Lean definitions compile and the theorems base and step check"
+		} else {
+			result.Established = "the projected Lean definitions compile and the theorems base and step fail to check, as the violation requires"
+		}
+		result.Assumptions = append(append([]string{}, sharedAssumptions...), "the Lean projection of the model and its theorem statements are compared, not proved", "Lean's kernel")
+		result.TrustPath = append(path, "Go Lean projection (projections.go)", "Lean")
+	case "cadical":
+		if safe {
+			result.Established = "CaDiCaL answered sat for the initial query and produced LRAT refutations of the base and step obligations, which the evidence checker accepted as LRAT evidence: the attached verdict is the claim"
+		} else {
+			result.Established = "CaDiCaL answered sat for the initial query, produced an LRAT refutation of the base obligation, and answered sat for the step obligation"
+		}
+		result.Assumptions = append(append([]string{}, sharedAssumptions...), "CaDiCaL is untrusted search; only its LRAT refutations are checked, by internal/lrat", "the Go CNF translation (encode) is compared, not proved")
+		result.TrustPath = append(path, "Go CNF encoder (circuit.go)", "CaDiCaL (untrusted search)", "internal/lrat checker and its corpus gates (compiled Oak, the Lean file model, check_sound, check_refines)")
+	}
 }
-type SuiteResult struct{Format string `json:"format"`;Passed bool `json:"passed"`;Attempt string `json:"attempt"`;Tools map[string]ToolStatus `json:"tools"`;Models map[string]map[string]BackendResult `json:"models"`}
-func runSuite(examples,out,jar string,timeout time.Duration)(*SuiteResult,error){
-    var e error;out,e=filepath.Abs(out);if e!=nil{return nil,e};if jar!=""{jar,e=filepath.Abs(jar);if e!=nil{return nil,e}}
-    if e:=os.MkdirAll(out,0755);e!=nil{return nil,e};attempt,e:=os.MkdirTemp(out,"attempt-");if e!=nil{return nil,e}
-    r:=&SuiteResult{Format:"oak-go-integration-1",Passed:true,Attempt:attempt,Tools:map[string]ToolStatus{},Models:map[string]map[string]BackendResult{}}
-    for _,name:=range []string{"go","lean","z3","cadical","tlc"}{r.Tools[name]=probe(name,attempt,jar,timeout);r.Passed=r.Passed&&r.Tools[name].Available}
-    for _,test:=range []struct{name string;safe bool;bound int}{{"enum",true,3},{"enum-broken",false,3},{"counter",true,5},{"counter-broken",false,5},{"wrap",true,3},{"publication",true,3},{"publication-relaxed",false,3}}{
-        results:=map[string]BackendResult{};r.Models[test.name]=results;m,e:=loadModel(filepath.Join(examples,test.name+".json"));if e!=nil{results["frontend"]=BackendResult{Reason:e.Error()};r.Passed=false;continue}
-        folder:=filepath.Join(attempt,test.name);if e:=emit(m,folder);e!=nil{return nil,e}
-        for _,tool:=range []string{"lean","z3","cadical","tlc"}{if !r.Tools[tool].Available{results[tool]=BackendResult{ExpectedSafety:test.safe,Reason:r.Tools[tool].Reason};r.Passed=false;continue};result:=runBackend(m,tool,folder,test.safe,test.bound,timeout,jar,execute);results[tool]=result;r.Passed=r.Passed&&result.Passed}
-    }
-    if e:=os.WriteFile(filepath.Join(out,"report.json"),[]byte(jsonText(r)),0644);e!=nil{return nil,e};return r,nil
+
+type SuiteResult struct {
+	Format  string                              `json:"format"`
+	Passed  bool                                `json:"passed"`
+	Attempt string                              `json:"attempt"`
+	Tools   map[string]ToolStatus               `json:"tools"`
+	Models  map[string]map[string]BackendResult `json:"models"`
+}
+
+func runSuite(examples, out, jar string, timeout time.Duration) (*SuiteResult, error) {
+	var e error
+	out, e = filepath.Abs(out)
+	if e != nil {
+		return nil, e
+	}
+	if jar != "" {
+		jar, e = filepath.Abs(jar)
+		if e != nil {
+			return nil, e
+		}
+	}
+	if e := os.MkdirAll(out, 0755); e != nil {
+		return nil, e
+	}
+	attempt, e := os.MkdirTemp(out, "attempt-")
+	if e != nil {
+		return nil, e
+	}
+	r := &SuiteResult{Format: "oak-go-integration-1", Passed: true, Attempt: attempt, Tools: map[string]ToolStatus{}, Models: map[string]map[string]BackendResult{}}
+	for _, name := range []string{"go", "lean", "z3", "cadical", "tlc"} {
+		r.Tools[name] = probe(name, attempt, jar, timeout)
+		r.Passed = r.Passed && r.Tools[name].Available
+	}
+	for _, test := range []struct {
+		name  string
+		safe  bool
+		bound int
+	}{{"enum", true, 3}, {"enum-broken", false, 3}, {"counter", true, 5}, {"counter-broken", false, 5}, {"wrap", true, 3}, {"publication", true, 3}, {"publication-relaxed", false, 3}} {
+		results := map[string]BackendResult{}
+		r.Models[test.name] = results
+		m, e := loadModel(filepath.Join(examples, test.name+".json"))
+		if e != nil {
+			results["frontend"] = BackendResult{Reason: e.Error()}
+			r.Passed = false
+			continue
+		}
+		folder := filepath.Join(attempt, test.name)
+		if e := emit(m, folder); e != nil {
+			return nil, e
+		}
+		for _, tool := range []string{"lean", "z3", "cadical", "tlc"} {
+			if !r.Tools[tool].Available {
+				results[tool] = BackendResult{ExpectedSafety: test.safe, Reason: r.Tools[tool].Reason}
+				r.Passed = false
+				continue
+			}
+			result := runBackend(m, tool, folder, test.safe, test.bound, timeout, jar, execute)
+			results[tool] = result
+			r.Passed = r.Passed && result.Passed
+		}
+	}
+	if e := os.WriteFile(filepath.Join(out, "report.json"), []byte(jsonText(r)), 0644); e != nil {
+		return nil, e
+	}
+	return r, nil
 }

--- a/experiments/verification-poc/boolean_export.go
+++ b/experiments/verification-poc/boolean_export.go
@@ -5,71 +5,107 @@ import "fmt"
 // BooleanProgram is a postorder DAG over the proved Lean Boolean vocabulary.
 // Initial/invariant inputs use field indices; step uses 2*i for s and 2*i+1 for t.
 type BooleanInstruction struct {
-	Op string `json:"op"`
-	Value bool `json:"value"`
-	Index int `json:"index"`
-	Left int `json:"left"`
-	Right int `json:"right"`
+	Op    string `json:"op"`
+	Value bool   `json:"value"`
+	Index int    `json:"index"`
+	Left  int    `json:"left"`
+	Right int    `json:"right"`
 }
 type BooleanBundle struct {
-	Format string `json:"format"`
-	SourceHash string `json:"source_sha256"`
-	SemanticDigest string `json:"semantic_digest"`
-	Fields []string `json:"fields"`
-	Initial []BooleanInstruction `json:"initial"`
-	Step []BooleanInstruction `json:"step"`
-	Invariant []BooleanInstruction `json:"invariant"`
+	Format         string               `json:"format"`
+	SourceHash     string               `json:"source_sha256"`
+	SemanticDigest string               `json:"semantic_digest"`
+	Fields         []string             `json:"fields"`
+	Initial        []BooleanInstruction `json:"initial"`
+	Step           []BooleanInstruction `json:"step"`
+	Invariant      []BooleanInstruction `json:"invariant"`
 }
 
 func exportBoolean(m *Model) (*BooleanBundle, error) {
 	b := &BooleanBundle{Format: "oak-boolean-model-1", SourceHash: m.Document.SourceHash, SemanticDigest: m.Digest}
 	indices := map[string]int{}
 	for i, f := range m.Fields {
-		if f.Type != "Bool" { return nil, fmt.Errorf("Boolean proof export requires Bool fields: %s is %s", f.Name, f.Type) }
+		if f.Type != "Bool" {
+			return nil, fmt.Errorf("Boolean proof export requires Bool fields: %s is %s", f.Name, f.Type)
+		}
 		indices[f.Name] = i
 		b.Fields = append(b.Fields, f.Name)
 	}
 	compile := func(root *Node, paired bool) ([]BooleanInstruction, error) {
 		program := []BooleanInstruction{}
 		appendNode := func(n BooleanInstruction) (int, error) {
-			if len(program) >= 4096 { return 0, fmt.Errorf("Boolean proof program exceeds 4096 nodes") }
+			if len(program) >= 4096 {
+				return 0, fmt.Errorf("Boolean proof program exceeds 4096 nodes")
+			}
 			program = append(program, n)
-			return len(program)-1, nil
+			return len(program) - 1, nil
 		}
 		var walk func(*Node) (int, error)
 		walk = func(n *Node) (int, error) {
-			if n == nil || n.Type != "Bool" { return 0, fmt.Errorf("Boolean proof export requires Boolean expressions") }
-			if n.Op == "bool" { return appendNode(BooleanInstruction{Op:"bool", Value:n.B}) }
+			if n == nil || n.Type != "Bool" {
+				return 0, fmt.Errorf("Boolean proof export requires Boolean expressions")
+			}
+			if n.Op == "bool" {
+				return appendNode(BooleanInstruction{Op: "bool", Value: n.B})
+			}
 			if n.Op == "var" {
 				i, ok := indices[n.Field]
-				if !ok || (n.State != "s" && n.State != "t") || (!paired && n.State != "s") { return 0, fmt.Errorf("invalid Boolean state input") }
-				if paired { i *= 2; if n.State == "t" { i++ } }
-				return appendNode(BooleanInstruction{Op:"var", Index:i})
+				if !ok || (n.State != "s" && n.State != "t") || (!paired && n.State != "s") {
+					return 0, fmt.Errorf("invalid Boolean state input")
+				}
+				if paired {
+					i *= 2
+					if n.State == "t" {
+						i++
+					}
+				}
+				return appendNode(BooleanInstruction{Op: "var", Index: i})
 			}
-			arity := map[string]int{"!":1,"&&":2,"||":2,"==":2,"!=":2,"ite":3}[n.Op]
-			if arity == 0 || len(n.Args) != arity { return 0, fmt.Errorf("unsupported Boolean proof operator %s", n.Op) }
+			arity := map[string]int{"!": 1, "&&": 2, "||": 2, "==": 2, "!=": 2, "ite": 3}[n.Op]
+			if arity == 0 || len(n.Args) != arity {
+				return 0, fmt.Errorf("unsupported Boolean proof operator %s", n.Op)
+			}
 			// Desugar typed Boolean equality and conditionals before exporting.
 			if n.Op == "==" || n.Op == "!=" {
 				a, c := n.Args[0], n.Args[1]
 				eq := expression("||", "Bool", expression("&&", "Bool", a, c), expression("&&", "Bool", expression("!", "Bool", a), expression("!", "Bool", c)))
-				if n.Op == "!=" { eq = expression("!", "Bool", eq) }
+				if n.Op == "!=" {
+					eq = expression("!", "Bool", eq)
+				}
 				return walk(eq)
 			}
 			if n.Op == "ite" {
 				a, c, d := n.Args[0], n.Args[1], n.Args[2]
 				return walk(expression("||", "Bool", expression("&&", "Bool", a, c), expression("&&", "Bool", expression("!", "Bool", a), d)))
 			}
-			left, err := walk(n.Args[0]); if err != nil { return 0, err }
+			left, err := walk(n.Args[0])
+			if err != nil {
+				return 0, err
+			}
 			right := 0
-			if arity == 2 { right, err = walk(n.Args[1]); if err != nil { return 0, err } }
-			return appendNode(BooleanInstruction{Op:n.Op, Left:left, Right:right})
+			if arity == 2 {
+				right, err = walk(n.Args[1])
+				if err != nil {
+					return 0, err
+				}
+			}
+			return appendNode(BooleanInstruction{Op: n.Op, Left: left, Right: right})
 		}
 		_, err := walk(root)
 		return program, err
 	}
 	var err error
-	b.Initial, err = compile(m.Terms["initial"], false); if err != nil { return nil, err }
-	b.Step, err = compile(m.Terms["step"], true); if err != nil { return nil, err }
-	b.Invariant, err = compile(m.Terms["invariant"], false); if err != nil { return nil, err }
+	b.Initial, err = compile(m.Terms["initial"], false)
+	if err != nil {
+		return nil, err
+	}
+	b.Step, err = compile(m.Terms["step"], true)
+	if err != nil {
+		return nil, err
+	}
+	b.Invariant, err = compile(m.Terms["invariant"], false)
+	if err != nil {
+		return nil, err
+	}
 	return b, nil
 }

--- a/experiments/verification-poc/boolean_export_test.go
+++ b/experiments/verification-poc/boolean_export_test.go
@@ -8,12 +8,18 @@ func evalBooleanProgram(p []BooleanInstruction, inputs []bool) bool {
 	values := make([]bool, len(p))
 	for i, n := range p {
 		switch n.Op {
-		case "bool": values[i] = n.Value
-		case "var": values[i] = inputs[n.Index]
-		case "!": values[i] = !values[n.Left]
-		case "&&": values[i] = values[n.Left] && values[n.Right]
-		case "||": values[i] = values[n.Left] || values[n.Right]
-		default: panic("unexpected export operator")
+		case "bool":
+			values[i] = n.Value
+		case "var":
+			values[i] = inputs[n.Index]
+		case "!":
+			values[i] = !values[n.Left]
+		case "&&":
+			values[i] = values[n.Left] && values[n.Right]
+		case "||":
+			values[i] = values[n.Left] || values[n.Right]
+		default:
+			panic("unexpected export operator")
 		}
 	}
 	return values[len(values)-1]
@@ -22,20 +28,40 @@ func evalBooleanProgram(p []BooleanInstruction, inputs []bool) bool {
 func TestBooleanModelExport(t *testing.T) {
 	for _, name := range []string{"publication", "publication-relaxed"} {
 		t.Run(name, func(t *testing.T) {
-			m, err := loadModel("examples/native/"+name+".json"); if err != nil { t.Fatal(err) }
-			b, err := exportBoolean(m); if err != nil { t.Fatal(err) }
-			if b.SourceHash != m.Document.SourceHash || b.SemanticDigest != m.Digest { t.Fatal("source identity lost") }
-			states, err := m.states(); if err != nil { t.Fatal(err) }
+			m, err := loadModel("examples/native/" + name + ".json")
+			if err != nil {
+				t.Fatal(err)
+			}
+			b, err := exportBoolean(m)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if b.SourceHash != m.Document.SourceHash || b.SemanticDigest != m.Digest {
+				t.Fatal("source identity lost")
+			}
+			states, err := m.states()
+			if err != nil {
+				t.Fatal(err)
+			}
 			for _, s := range states {
-				input := make([]bool,len(m.Fields))
-				for i,f := range m.Fields { input[i] = s[f.Name].(bool) }
-				for role,p := range map[string][]BooleanInstruction{"initial":b.Initial,"invariant":b.Invariant} {
-					if evalBooleanProgram(p,input) != truth(m.Terms[role],s,nil) { t.Fatalf("%s differs for %v",role,s) }
+				input := make([]bool, len(m.Fields))
+				for i, f := range m.Fields {
+					input[i] = s[f.Name].(bool)
+				}
+				for role, p := range map[string][]BooleanInstruction{"initial": b.Initial, "invariant": b.Invariant} {
+					if evalBooleanProgram(p, input) != truth(m.Terms[role], s, nil) {
+						t.Fatalf("%s differs for %v", role, s)
+					}
 				}
 				for _, next := range states {
-					paired := make([]bool,2*len(m.Fields))
-					for i,f := range m.Fields { paired[2*i]=s[f.Name].(bool);paired[2*i+1]=next[f.Name].(bool) }
-					if evalBooleanProgram(b.Step,paired) != truth(m.Terms["step"],s,next) { t.Fatalf("step differs for %v -> %v",s,next) }
+					paired := make([]bool, 2*len(m.Fields))
+					for i, f := range m.Fields {
+						paired[2*i] = s[f.Name].(bool)
+						paired[2*i+1] = next[f.Name].(bool)
+					}
+					if evalBooleanProgram(b.Step, paired) != truth(m.Terms["step"], s, next) {
+						t.Fatalf("step differs for %v -> %v", s, next)
+					}
 				}
 			}
 		})
@@ -43,19 +69,35 @@ func TestBooleanModelExport(t *testing.T) {
 }
 
 func TestBooleanExportRejectsNumericModel(t *testing.T) {
-	m, err := loadModel("examples/native/counter.json"); if err != nil { t.Fatal(err) }
-	if _,err := exportBoolean(m); err == nil { t.Fatal("numeric model exported as Boolean") }
+	m, err := loadModel("examples/native/counter.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := exportBoolean(m); err == nil {
+		t.Fatal("numeric model exported as Boolean")
+	}
 }
 
 func TestBooleanExportConditional(t *testing.T) {
-	m,err:=loadModel("examples/native/publication.json");if err!=nil {t.Fatal(err)}
-	a:=&Node{Op:"var",Type:"Bool",State:"s",Field:"written"}
-	b:=&Node{Op:"var",Type:"Bool",State:"s",Field:"published"}
-	m.Terms["invariant"]=expression("ite","Bool",a,expression("!=","Bool",a,b),b)
-	bundle,err:=exportBoolean(m);if err!=nil {t.Fatal(err)}
-	states,_:=m.states()
-	for _,s:=range states {
-		inputs:=make([]bool,len(m.Fields));for i,f:=range m.Fields {inputs[i]=s[f.Name].(bool)}
-		if evalBooleanProgram(bundle.Invariant,inputs)!=truth(m.Terms["invariant"],s,nil) {t.Fatal("conditional translation differs")}
+	m, err := loadModel("examples/native/publication.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := &Node{Op: "var", Type: "Bool", State: "s", Field: "written"}
+	b := &Node{Op: "var", Type: "Bool", State: "s", Field: "published"}
+	m.Terms["invariant"] = expression("ite", "Bool", a, expression("!=", "Bool", a, b), b)
+	bundle, err := exportBoolean(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	states, _ := m.states()
+	for _, s := range states {
+		inputs := make([]bool, len(m.Fields))
+		for i, f := range m.Fields {
+			inputs[i] = s[f.Name].(bool)
+		}
+		if evalBooleanProgram(bundle.Invariant, inputs) != truth(m.Terms["invariant"], s, nil) {
+			t.Fatal("conditional translation differs")
+		}
 	}
 }

--- a/experiments/verification-poc/circuit.go
+++ b/experiments/verification-poc/circuit.go
@@ -1,71 +1,281 @@
 package main
 
 import (
-    "fmt"
-    "sort"
-    "strings"
+	"fmt"
+	"sort"
+	"strings"
 )
 
-type Gate struct { ID int; Op string; Args []int }
-type Circuit struct { Count,One int; Clauses [][]int; Inputs map[string]int; Gates []Gate; cache map[string]int }
-func newCircuit()*Circuit{c:=&Circuit{Inputs:map[string]int{},cache:map[string]int{}};c.One=c.new();c.Clauses=append(c.Clauses,[]int{c.One});return c}
-func (c *Circuit)new()int{c.Count++;return c.Count}
-func (c *Circuit)input(name string)int{if c.Inputs[name]==0{c.Inputs[name]=c.new()};return c.Inputs[name]}
-func (c *Circuit)gate(op string,x,y int)int{
-    switch op{
-    case "and":if x==-c.One||y==-c.One||x==-y{return -c.One};if x==c.One||x==y{return y};if y==c.One{return x}
-    case "or":if x==c.One||y==c.One||x==-y{return c.One};if x==-c.One||x==y{return y};if y==-c.One{return x}
-    case "xor":if x==y{return -c.One};if x==-y{return c.One};if x==c.One{return -y};if y==c.One{return -x};if x==-c.One{return y};if y==-c.One{return x}
-    default:panic("unsupported gate")
-    }
-    a,b:=x,y;if a>b{a,b=b,a};key:=fmt.Sprintf("%s:%d:%d",op,a,b);if z:=c.cache[key];z!=0{return z}
-    z:=c.new();c.cache[key]=z
-    if op=="and"{c.Clauses=append(c.Clauses,[]int{-z,x},[]int{-z,y},[]int{z,-x,-y})}else if op=="or"{c.Clauses=append(c.Clauses,[]int{z,-x},[]int{z,-y},[]int{-z,x,y})}else{
-        for i:=0;i<4;i++{a,b:=x,y;out:=-z;if i&2!=0{a=-a};if i&1!=0{b=-b};if (i&2!=0)!=(i&1!=0){out=z};c.Clauses=append(c.Clauses,[]int{a,b,out})}
-    }
-    c.Gates=append(c.Gates,Gate{z,op,[]int{x,y}});return z
+type Gate struct {
+	ID   int
+	Op   string
+	Args []int
 }
-func (c *Circuit)and(args ...int)int{r:=c.One;for _,x:=range args{r=c.gate("and",r,x)};return r}
-func (c *Circuit)or(args ...int)int{r:=-c.One;for _,x:=range args{r=c.gate("or",r,x)};return r}
-func (c *Circuit)equal(a,b []int)int{xs:=[]int{};for i,x:=range a{xs=append(xs,-c.gate("xor",x,b[i]))};return c.and(xs...)}
-func (c *Circuit)add(a,b []int)[]int{
-    carry:=-c.One;out:=[]int{}
-    for i,x:=range a{y:=b[i];xy:=c.gate("xor",x,y);out=append(out,c.gate("xor",xy,carry));carry=c.or(c.and(x,y),c.and(carry,xy))};return out
+type Circuit struct {
+	Count, One int
+	Clauses    [][]int
+	Inputs     map[string]int
+	Gates      []Gate
+	cache      map[string]int
 }
-func (c *Circuit)less(a,b []int)int{r:=-c.One;for i,x:=range a{y:=b[i];r=c.or(c.and(-x,y),c.and(-c.gate("xor",x,y),r))};return r}
-func (c *Circuit)constant(n,width int)[]int{xs:=[]int{};for i:=0;i<width;i++{x:=-c.One;if n&(1<<i)!=0{x=c.One};xs=append(xs,x)};return xs}
-func (c *Circuit)dimacs(root int)string{
-    var out strings.Builder;fmt.Fprintf(&out,"p cnf %d %d\n",c.Count,len(c.Clauses)+1)
-    emit:=func(clause []int){seen:=map[int]bool{};for _,x:=range clause{if !seen[x]{fmt.Fprintf(&out,"%d ",x);seen[x]=true}};out.WriteString("0\n")}
-    for _,clause:=range c.Clauses{emit(clause)};emit([]int{root});return out.String()
+
+func newCircuit() *Circuit {
+	c := &Circuit{Inputs: map[string]int{}, cache: map[string]int{}}
+	c.One = c.new()
+	c.Clauses = append(c.Clauses, []int{c.One})
+	return c
 }
-func (c *Circuit)priority()[]int{xs:=[]int{};for _,id:=range c.Inputs{xs=append(xs,id)};sort.Ints(xs);return xs}
-func encode(m *Model,role string)(*Circuit,int){
-    c:=newCircuit()
-    var bits func(*Node)[]int
-    bits=func(n *Node)[]int{
-        switch n.Op{
-        case "bool":v:=0;if n.B{v=1};return c.constant(v,1)
-        case "byte":return c.constant(n.N,8)
-        case "enum":index:=0;for i,s:=range m.Enums[n.Type]{if s==n.Data{index=i;break}};return c.constant(index,m.width(n.Type))
-        case "var":r:=[]int{};for i:=0;i<m.width(n.Type);i++{r=append(r,c.input(fmt.Sprintf("%s.%s.%d",n.State,n.Field,i)))};return r
-        }
-        a:=bits(n.Args[0]);if n.Op=="!"{return []int{-a[0]}};b:=bits(n.Args[1])
-        switch n.Op{
-        case "ite":d:=bits(n.Args[2]);out:=[]int{};for i,x:=range b{out=append(out,c.or(c.and(a[0],x),c.and(-a[0],d[i])))};return out
-        case "&&":return []int{c.and(a[0],b[0])}
-        case "||":return []int{c.or(a[0],b[0])}
-        case "+":return c.add(a,b)
-        case "-":neg:=[]int{};for _,x:=range b{neg=append(neg,-x)};return c.add(c.add(a,neg),c.constant(1,8))
-        case "==":return []int{c.equal(a,b)}
-        case "!=":return []int{-c.equal(a,b)}
-        case "<":return []int{c.less(a,b)}
-        case ">":return []int{c.less(b,a)}
-        case "<=":return []int{-c.less(b,a)}
-        case ">=":return []int{-c.less(a,b)}
-        };panic("unknown checked operator")
-    }
-    domain:=func(p string)int{guards:=[]int{};for _,f:=range m.Fields{v:=bits(&Node{Op:"var",Type:f.Type,State:p,Field:f.Name});if cases:=m.Enums[f.Type];cases!=nil&&len(cases)<1<<len(v){guards=append(guards,c.less(v,c.constant(len(cases),len(v))))}};return c.and(guards...)}
-    var root int
-    switch role{case "initial":root=c.and(domain("s"),bits(m.Terms["initial"])[0]);case "base":root=c.and(domain("s"),bits(m.Terms["initial"])[0],-bits(m.Terms["invariant"])[0]);case "step":root=c.and(domain("s"),domain("t"),bits(m.Terms["invariant"])[0],bits(m.Terms["step"])[0],-bits(rename(m.Terms["invariant"],"t"))[0]);default:panic("unknown obligation")};return c,root
+func (c *Circuit) new() int { c.Count++; return c.Count }
+func (c *Circuit) input(name string) int {
+	if c.Inputs[name] == 0 {
+		c.Inputs[name] = c.new()
+	}
+	return c.Inputs[name]
+}
+func (c *Circuit) gate(op string, x, y int) int {
+	switch op {
+	case "and":
+		if x == -c.One || y == -c.One || x == -y {
+			return -c.One
+		}
+		if x == c.One || x == y {
+			return y
+		}
+		if y == c.One {
+			return x
+		}
+	case "or":
+		if x == c.One || y == c.One || x == -y {
+			return c.One
+		}
+		if x == -c.One || x == y {
+			return y
+		}
+		if y == -c.One {
+			return x
+		}
+	case "xor":
+		if x == y {
+			return -c.One
+		}
+		if x == -y {
+			return c.One
+		}
+		if x == c.One {
+			return -y
+		}
+		if y == c.One {
+			return -x
+		}
+		if x == -c.One {
+			return y
+		}
+		if y == -c.One {
+			return x
+		}
+	default:
+		panic("unsupported gate")
+	}
+	a, b := x, y
+	if a > b {
+		a, b = b, a
+	}
+	key := fmt.Sprintf("%s:%d:%d", op, a, b)
+	if z := c.cache[key]; z != 0 {
+		return z
+	}
+	z := c.new()
+	c.cache[key] = z
+	if op == "and" {
+		c.Clauses = append(c.Clauses, []int{-z, x}, []int{-z, y}, []int{z, -x, -y})
+	} else if op == "or" {
+		c.Clauses = append(c.Clauses, []int{z, -x}, []int{z, -y}, []int{-z, x, y})
+	} else {
+		for i := 0; i < 4; i++ {
+			a, b := x, y
+			out := -z
+			if i&2 != 0 {
+				a = -a
+			}
+			if i&1 != 0 {
+				b = -b
+			}
+			if (i&2 != 0) != (i&1 != 0) {
+				out = z
+			}
+			c.Clauses = append(c.Clauses, []int{a, b, out})
+		}
+	}
+	c.Gates = append(c.Gates, Gate{z, op, []int{x, y}})
+	return z
+}
+func (c *Circuit) and(args ...int) int {
+	r := c.One
+	for _, x := range args {
+		r = c.gate("and", r, x)
+	}
+	return r
+}
+func (c *Circuit) or(args ...int) int {
+	r := -c.One
+	for _, x := range args {
+		r = c.gate("or", r, x)
+	}
+	return r
+}
+func (c *Circuit) equal(a, b []int) int {
+	xs := []int{}
+	for i, x := range a {
+		xs = append(xs, -c.gate("xor", x, b[i]))
+	}
+	return c.and(xs...)
+}
+func (c *Circuit) add(a, b []int) []int {
+	carry := -c.One
+	out := []int{}
+	for i, x := range a {
+		y := b[i]
+		xy := c.gate("xor", x, y)
+		out = append(out, c.gate("xor", xy, carry))
+		carry = c.or(c.and(x, y), c.and(carry, xy))
+	}
+	return out
+}
+func (c *Circuit) less(a, b []int) int {
+	r := -c.One
+	for i, x := range a {
+		y := b[i]
+		r = c.or(c.and(-x, y), c.and(-c.gate("xor", x, y), r))
+	}
+	return r
+}
+func (c *Circuit) constant(n, width int) []int {
+	xs := []int{}
+	for i := 0; i < width; i++ {
+		x := -c.One
+		if n&(1<<i) != 0 {
+			x = c.One
+		}
+		xs = append(xs, x)
+	}
+	return xs
+}
+func (c *Circuit) dimacs(root int) string {
+	var out strings.Builder
+	fmt.Fprintf(&out, "p cnf %d %d\n", c.Count, len(c.Clauses)+1)
+	emit := func(clause []int) {
+		seen := map[int]bool{}
+		for _, x := range clause {
+			if !seen[x] {
+				fmt.Fprintf(&out, "%d ", x)
+				seen[x] = true
+			}
+		}
+		out.WriteString("0\n")
+	}
+	for _, clause := range c.Clauses {
+		emit(clause)
+	}
+	emit([]int{root})
+	return out.String()
+}
+func (c *Circuit) priority() []int {
+	xs := []int{}
+	for _, id := range c.Inputs {
+		xs = append(xs, id)
+	}
+	sort.Ints(xs)
+	return xs
+}
+func encode(m *Model, role string) (*Circuit, int) {
+	c := newCircuit()
+	var bits func(*Node) []int
+	bits = func(n *Node) []int {
+		switch n.Op {
+		case "bool":
+			v := 0
+			if n.B {
+				v = 1
+			}
+			return c.constant(v, 1)
+		case "byte":
+			return c.constant(n.N, 8)
+		case "enum":
+			index := 0
+			for i, s := range m.Enums[n.Type] {
+				if s == n.Data {
+					index = i
+					break
+				}
+			}
+			return c.constant(index, m.width(n.Type))
+		case "var":
+			r := []int{}
+			for i := 0; i < m.width(n.Type); i++ {
+				r = append(r, c.input(fmt.Sprintf("%s.%s.%d", n.State, n.Field, i)))
+			}
+			return r
+		}
+		a := bits(n.Args[0])
+		if n.Op == "!" {
+			return []int{-a[0]}
+		}
+		b := bits(n.Args[1])
+		switch n.Op {
+		case "ite":
+			d := bits(n.Args[2])
+			out := []int{}
+			for i, x := range b {
+				out = append(out, c.or(c.and(a[0], x), c.and(-a[0], d[i])))
+			}
+			return out
+		case "&&":
+			return []int{c.and(a[0], b[0])}
+		case "||":
+			return []int{c.or(a[0], b[0])}
+		case "+":
+			return c.add(a, b)
+		case "-":
+			neg := []int{}
+			for _, x := range b {
+				neg = append(neg, -x)
+			}
+			return c.add(c.add(a, neg), c.constant(1, 8))
+		case "==":
+			return []int{c.equal(a, b)}
+		case "!=":
+			return []int{-c.equal(a, b)}
+		case "<":
+			return []int{c.less(a, b)}
+		case ">":
+			return []int{c.less(b, a)}
+		case "<=":
+			return []int{-c.less(b, a)}
+		case ">=":
+			return []int{-c.less(a, b)}
+		}
+		panic("unknown checked operator")
+	}
+	domain := func(p string) int {
+		guards := []int{}
+		for _, f := range m.Fields {
+			v := bits(&Node{Op: "var", Type: f.Type, State: p, Field: f.Name})
+			if cases := m.Enums[f.Type]; cases != nil && len(cases) < 1<<len(v) {
+				guards = append(guards, c.less(v, c.constant(len(cases), len(v))))
+			}
+		}
+		return c.and(guards...)
+	}
+	var root int
+	switch role {
+	case "initial":
+		root = c.and(domain("s"), bits(m.Terms["initial"])[0])
+	case "base":
+		root = c.and(domain("s"), bits(m.Terms["initial"])[0], -bits(m.Terms["invariant"])[0])
+	case "step":
+		root = c.and(domain("s"), domain("t"), bits(m.Terms["invariant"])[0], bits(m.Terms["step"])[0], -bits(rename(m.Terms["invariant"], "t"))[0])
+	default:
+		panic("unknown obligation")
+	}
+	return c, root
 }

--- a/experiments/verification-poc/cnf_spec_test.go
+++ b/experiments/verification-poc/cnf_spec_test.go
@@ -1,116 +1,173 @@
 package main
 
 import (
-    "encoding/json"
-    "fmt"
-    "os"
-    "testing"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
 
-    "github.com/SCKelemen/oak/experiments/verification-poc/internal/lrat"
+	"github.com/SCKelemen/oak/experiments/verification-poc/internal/lrat"
 )
 
 type cnfInstruction struct {
-    Op string `json:"op"`
-    Value bool `json:"value"`
-    Index int `json:"index"`
-    Left int `json:"left"`
-    Right int `json:"right"`
+	Op    string `json:"op"`
+	Value bool   `json:"value"`
+	Index int    `json:"index"`
+	Left  int    `json:"left"`
+	Right int    `json:"right"`
 }
 type cnfRow struct {
-    X bool `json:"x"`
-    Y bool `json:"y"`
-    Value bool `json:"value"`
-    GoSAT bool `json:"go_sat"`
+	X     bool `json:"x"`
+	Y     bool `json:"y"`
+	Value bool `json:"value"`
+	GoSAT bool `json:"go_sat"`
 }
 type cnfCase struct {
-    Name string `json:"name"`
-    Program []cnfInstruction `json:"program"`
-    Rows []cnfRow `json:"rows"`
+	Name    string           `json:"name"`
+	Program []cnfInstruction `json:"program"`
+	Rows    []cnfRow         `json:"rows"`
 }
-func cnfLeaf(name string)*Node {return &Node{Op:"var",Type:"Bool",State:"s",Field:name}}
-func cnfExpressions(depth int)[]*Node {
-    result:=[]*Node{constantBool(false),constantBool(true),cnfLeaf("x"),cnfLeaf("y")}
-    if depth==0{return result}
-    children:=cnfExpressions(depth-1)
-    for _,x:=range children {result=append(result,expression("!","Bool",x))}
-    for _,op:=range []string{"&&","||"} {for _,x:=range children {for _,y:=range children {
-        result=append(result,expression(op,"Bool",x,y))
-    }}}
-    return result
+
+func cnfLeaf(name string) *Node { return &Node{Op: "var", Type: "Bool", State: "s", Field: name} }
+func cnfExpressions(depth int) []*Node {
+	result := []*Node{constantBool(false), constantBool(true), cnfLeaf("x"), cnfLeaf("y")}
+	if depth == 0 {
+		return result
+	}
+	children := cnfExpressions(depth - 1)
+	for _, x := range children {
+		result = append(result, expression("!", "Bool", x))
+	}
+	for _, op := range []string{"&&", "||"} {
+		for _, x := range children {
+			for _, y := range children {
+				result = append(result, expression(op, "Bool", x, y))
+			}
+		}
+	}
+	return result
 }
+
 // Independent source evaluator: no circuit nodes, CNF clauses, or solver calls.
-func cnfValue(n *Node,x,y bool)bool {
-    switch n.Op {
-    case "bool":return n.B
-    case "var":if n.Field=="x"{return x};return y
-    case "!":return !cnfValue(n.Args[0],x,y)
-    case "&&":return cnfValue(n.Args[0],x,y)&&cnfValue(n.Args[1],x,y)
-    case "||":return cnfValue(n.Args[0],x,y)||cnfValue(n.Args[1],x,y)
-    default:panic("not a Boolean corpus expression")
-    }
+func cnfValue(n *Node, x, y bool) bool {
+	switch n.Op {
+	case "bool":
+		return n.B
+	case "var":
+		if n.Field == "x" {
+			return x
+		}
+		return y
+	case "!":
+		return !cnfValue(n.Args[0], x, y)
+	case "&&":
+		return cnfValue(n.Args[0], x, y) && cnfValue(n.Args[1], x, y)
+	case "||":
+		return cnfValue(n.Args[0], x, y) || cnfValue(n.Args[1], x, y)
+	default:
+		panic("not a Boolean corpus expression")
+	}
 }
-func cnfProgram(n *Node,out *[]cnfInstruction)int {
-    instruction:=cnfInstruction{Op:n.Op,Value:n.B}
-    if n.Field=="y"{instruction.Index=1}
-    if len(n.Args)>0{instruction.Left=cnfProgram(n.Args[0],out)}
-    if len(n.Args)>1{instruction.Right=cnfProgram(n.Args[1],out)}
-    *out=append(*out,instruction);return len(*out)-1
+func cnfProgram(n *Node, out *[]cnfInstruction) int {
+	instruction := cnfInstruction{Op: n.Op, Value: n.B}
+	if n.Field == "y" {
+		instruction.Index = 1
+	}
+	if len(n.Args) > 0 {
+		instruction.Left = cnfProgram(n.Args[0], out)
+	}
+	if len(n.Args) > 1 {
+		instruction.Right = cnfProgram(n.Args[1], out)
+	}
+	*out = append(*out, instruction)
+	return len(*out) - 1
 }
-func cnfExtensionExists(f lrat.Formula,inputs map[string]int,x,y bool)bool {
-    // Enumerate arbitrary auxiliary values; checking only the circuit's own
-    // computed extension would miss clauses that allow spurious solutions.
-    for mask:=0;mask<1<<f.Variables;mask++ {
-        bit:=func(id int)bool{return mask&(1<<(id-1))!=0}
-        if bit(inputs["s.x.0"])!=x || bit(inputs["s.y.0"])!=y {continue}
-        satisfied:=true
-        for _,clause:=range f.Clauses {
-            yes:=false
-            for literal:=range clause {
-                id:=literal;if id<0{id=-id}
-                if bit(id)==(literal>0){yes=true;break}
-            }
-            if !yes{satisfied=false;break}
-        }
-        if satisfied{return true}
-    }
-    return false
+func cnfExtensionExists(f lrat.Formula, inputs map[string]int, x, y bool) bool {
+	// Enumerate arbitrary auxiliary values; checking only the circuit's own
+	// computed extension would miss clauses that allow spurious solutions.
+	for mask := 0; mask < 1<<f.Variables; mask++ {
+		bit := func(id int) bool { return mask&(1<<(id-1)) != 0 }
+		if bit(inputs["s.x.0"]) != x || bit(inputs["s.y.0"]) != y {
+			continue
+		}
+		satisfied := true
+		for _, clause := range f.Clauses {
+			yes := false
+			for literal := range clause {
+				id := literal
+				if id < 0 {
+					id = -id
+				}
+				if bit(id) == (literal > 0) {
+					yes = true
+					break
+				}
+			}
+			if !yes {
+				satisfied = false
+				break
+			}
+		}
+		if satisfied {
+			return true
+		}
+	}
+	return false
 }
 func TestBooleanCNFSpecification(t *testing.T) {
-    expressions:=cnfExpressions(2)
-    if len(expressions)!=3244{t.Fatal("unexpected exhaustive domain size")}
-    x,y:=cnfLeaf("x"),cnfLeaf("y")
-    shared:=expression("&&","Bool",x,y)
-    // Deeper examples exercise caching, commutative reuse, and complements.
-    expressions=append(expressions,
-        expression("||","Bool",shared,expression("&&","Bool",y,x)),
-        expression("&&","Bool",shared,expression("!","Bool",shared)),
-        expression("||","Bool",shared,expression("!","Bool",shared)),
-        expression("!","Bool",expression("!","Bool",expression("!","Bool",shared))),
-        expression("&&","Bool",expression("||","Bool",x,y),expression("||","Bool",expression("!","Bool",x),expression("!","Bool",y))),
-    )
-    cases:=[]cnfCase{}
-    accepted:=0
-    for i,n:=range expressions {
-        m:=&Model{Fields:[]Field{{Name:"x",Type:"Bool"},{Name:"y",Type:"Bool"}},Enums:map[string][]string{},Terms:map[string]*Node{"initial":n}}
-        circuit,root:=encode(m,"initial")
-        formula,err:=lrat.Parse(circuit.dimacs(root));if err!=nil{t.Fatal(err)}
-        if formula.Variables>12{t.Fatal("exhaustive assignment bound exceeded")}
-        if circuit.Inputs["s.x.0"]<=0 || circuit.Inputs["s.y.0"]<=0{t.Fatal("missing inputs")}
-        c:=cnfCase{Name:fmt.Sprintf("bool-%04d",i),Program:[]cnfInstruction{},Rows:[]cnfRow{}}
-        cnfProgram(n,&c.Program)
-        for assignment:=0;assignment<4;assignment++ {
-            xv,yv:=assignment&1!=0,assignment&2!=0
-            want:=cnfValue(n,xv,yv)
-            sat:=cnfExtensionExists(formula,circuit.Inputs,xv,yv)
-            if sat!=want{t.Fatalf("%s input %d: CNF=%t expression=%t",c.Name,assignment,sat,want)}
-            c.Rows=append(c.Rows,cnfRow{X:xv,Y:yv,Value:want,GoSAT:sat})
-            if sat{accepted++}
-        }
-        cases=append(cases,c)
-    }
-    t.Logf("Boolean CNF corpus: %d expressions, %d valuations (%d satisfiable, %d unsatisfiable)",len(cases),len(cases)*4,accepted,len(cases)*4-accepted)
-    if path:=os.Getenv("OAK_BOOLEAN_CNF_CORPUS_OUT");path!="" {
-        data,err:=json.Marshal(cases);if err!=nil{t.Fatal(err)}
-        if err=os.WriteFile(path,data,0600);err!=nil{t.Fatal(err)}
-    }
+	expressions := cnfExpressions(2)
+	if len(expressions) != 3244 {
+		t.Fatal("unexpected exhaustive domain size")
+	}
+	x, y := cnfLeaf("x"), cnfLeaf("y")
+	shared := expression("&&", "Bool", x, y)
+	// Deeper examples exercise caching, commutative reuse, and complements.
+	expressions = append(expressions,
+		expression("||", "Bool", shared, expression("&&", "Bool", y, x)),
+		expression("&&", "Bool", shared, expression("!", "Bool", shared)),
+		expression("||", "Bool", shared, expression("!", "Bool", shared)),
+		expression("!", "Bool", expression("!", "Bool", expression("!", "Bool", shared))),
+		expression("&&", "Bool", expression("||", "Bool", x, y), expression("||", "Bool", expression("!", "Bool", x), expression("!", "Bool", y))),
+	)
+	cases := []cnfCase{}
+	accepted := 0
+	for i, n := range expressions {
+		m := &Model{Fields: []Field{{Name: "x", Type: "Bool"}, {Name: "y", Type: "Bool"}}, Enums: map[string][]string{}, Terms: map[string]*Node{"initial": n}}
+		circuit, root := encode(m, "initial")
+		formula, err := lrat.Parse(circuit.dimacs(root))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if formula.Variables > 12 {
+			t.Fatal("exhaustive assignment bound exceeded")
+		}
+		if circuit.Inputs["s.x.0"] <= 0 || circuit.Inputs["s.y.0"] <= 0 {
+			t.Fatal("missing inputs")
+		}
+		c := cnfCase{Name: fmt.Sprintf("bool-%04d", i), Program: []cnfInstruction{}, Rows: []cnfRow{}}
+		cnfProgram(n, &c.Program)
+		for assignment := 0; assignment < 4; assignment++ {
+			xv, yv := assignment&1 != 0, assignment&2 != 0
+			want := cnfValue(n, xv, yv)
+			sat := cnfExtensionExists(formula, circuit.Inputs, xv, yv)
+			if sat != want {
+				t.Fatalf("%s input %d: CNF=%t expression=%t", c.Name, assignment, sat, want)
+			}
+			c.Rows = append(c.Rows, cnfRow{X: xv, Y: yv, Value: want, GoSAT: sat})
+			if sat {
+				accepted++
+			}
+		}
+		cases = append(cases, c)
+	}
+	t.Logf("Boolean CNF corpus: %d expressions, %d valuations (%d satisfiable, %d unsatisfiable)", len(cases), len(cases)*4, accepted, len(cases)*4-accepted)
+	if path := os.Getenv("OAK_BOOLEAN_CNF_CORPUS_OUT"); path != "" {
+		data, err := json.Marshal(cases)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err = os.WriteFile(path, data, 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
 }

--- a/experiments/verification-poc/evidence.go
+++ b/experiments/verification-poc/evidence.go
@@ -1,11 +1,12 @@
 package main
 
 import (
-    "fmt"
-    "github.com/SCKelemen/oak/experiments/verification-poc/frontend"
-    "github.com/SCKelemen/oak/experiments/verification-poc/internal/lrat"
+	"fmt"
+	"github.com/SCKelemen/oak/experiments/verification-poc/frontend"
+	"github.com/SCKelemen/oak/experiments/verification-poc/internal/lrat"
 )
-const evidenceFormat="oak-evidence-3"
+
+const evidenceFormat = "oak-evidence-3"
 
 // Verdict is the evidence contract (roadmap step 4): every accepted result
 // states exactly what was established, under which assumptions, and through
@@ -13,141 +14,225 @@ const evidenceFormat="oak-evidence-3"
 // each field is fixed by the kind of evidence checked and by the checker's own
 // recorded trust boundary (README, "Go packages and trust").
 type Verdict struct {
-    Accepted bool `json:"accepted"`
-    // Claim is the property the evidence supports, about the identified
-    // Oak declarations (roadmap step 3): the claim names the state record and
-    // the initial, step, and invariant predicates by name and position in the
-    // source the verdict binds by hash and semantic digest.
-    Claim Claim `json:"claim"`
-    // Established is the fact this checker verified about the evidence.
-    Established string `json:"established"`
-    // Assumptions are trusted, not checked, by this verdict.
-    Assumptions []string `json:"assumptions"`
-    // TrustPath lists the components the result passed through, in order.
-    TrustPath []string `json:"trust_path"`
-    // Unsupported names what the checker rejects rather than trusts.
-    Unsupported []string `json:"unsupported,omitempty"`
-    // Details carries the evidence-specific numbers and sub-results.
-    Details map[string]any `json:"details,omitempty"`
+	Accepted bool `json:"accepted"`
+	// Claim is the property the evidence supports, about the identified
+	// Oak declarations (roadmap step 3): the claim names the state record and
+	// the initial, step, and invariant predicates by name and position in the
+	// source the verdict binds by hash and semantic digest.
+	Claim Claim `json:"claim"`
+	// Established is the fact this checker verified about the evidence.
+	Established string `json:"established"`
+	// Assumptions are trusted, not checked, by this verdict.
+	Assumptions []string `json:"assumptions"`
+	// TrustPath lists the components the result passed through, in order.
+	TrustPath []string `json:"trust_path"`
+	// Unsupported names what the checker rejects rather than trusts.
+	Unsupported []string `json:"unsupported,omitempty"`
+	// Details carries the evidence-specific numbers and sub-results.
+	Details map[string]any `json:"details,omitempty"`
 }
 
 // Claim is a property about identified Oak source declarations.
 type Claim struct {
-    Property string `json:"property"`
-    Source string `json:"source"`
-    SourceHash string `json:"source_sha256"`
-    SemanticDigest string `json:"semantic_digest"`
-    State frontend.Declaration `json:"state"`
-    Initial frontend.Declaration `json:"initial"`
-    Step frontend.Declaration `json:"step"`
-    Invariant frontend.Declaration `json:"invariant"`
+	Property       string               `json:"property"`
+	Source         string               `json:"source"`
+	SourceHash     string               `json:"source_sha256"`
+	SemanticDigest string               `json:"semantic_digest"`
+	State          frontend.Declaration `json:"state"`
+	Initial        frontend.Declaration `json:"initial"`
+	Step           frontend.Declaration `json:"step"`
+	Invariant      frontend.Declaration `json:"invariant"`
 }
 
 // claimFor names the declarations a property is about. A declaration the
 // frontend did not locate keeps its name with no position.
-func claimFor(m *Model,property string) Claim {
-    locate:=func(name string) frontend.Declaration {
-        if d,ok:=m.Declarations[name];ok{return d}
-        return frontend.Declaration{Name:name}
-    }
-    return Claim{
-        Property:property,
-        Source:m.Config.Source,
-        SourceHash:m.Document.SourceHash,
-        SemanticDigest:m.Digest,
-        State:locate(m.Document.State),
-        Initial:locate(m.Config.Initial),
-        Step:locate(m.Config.Step),
-        Invariant:locate(m.Config.Invariant),
-    }
+func claimFor(m *Model, property string) Claim {
+	locate := func(name string) frontend.Declaration {
+		if d, ok := m.Declarations[name]; ok {
+			return d
+		}
+		return frontend.Declaration{Name: name}
+	}
+	return Claim{
+		Property:       property,
+		Source:         m.Config.Source,
+		SourceHash:     m.Document.SourceHash,
+		SemanticDigest: m.Digest,
+		State:          locate(m.Document.State),
+		Initial:        locate(m.Config.Initial),
+		Step:           locate(m.Config.Step),
+		Invariant:      locate(m.Config.Invariant),
+	}
 }
 
 // The recorded trust boundary shared by every verdict: the model is exported
 // by Oak's frontend and evaluated by the Go typed-model adapter; the source
 // and settings are bound by the semantic digest, not re-derived.
-var sharedAssumptions=[]string{
-    "Oak's frontend exports the narrow model faithfully from the checked program",
-    "the Go typed-model adapter (truth, states, valid) implements the model's semantics",
-    "the source bytes and project settings bound by the semantic digest are the ones reviewed",
-    "Go and the execution environment",
+var sharedAssumptions = []string{
+	"Oak's frontend exports the narrow model faithfully from the checked program",
+	"the Go typed-model adapter (truth, states, valid) implements the model's semantics",
+	"the source bytes and project settings bound by the semantic digest are the ones reviewed",
+	"Go and the execution environment",
 }
-var sharedTrustPath=[]string{
-    "semantic digest binding (" + evidenceFormat + ")",
-    "frontend/ model export",
-}
-
-func closedSetVerdict(m *Model,states int) *Verdict {
-    return &Verdict{
-        Accepted:true,
-        Claim:claimFor(m,"nonvacuous reachable safety"),
-        Established:"a finite set of states that contains every initial state (at least one), is closed under the step relation, and satisfies the invariant in every member",
-        Assumptions:sharedAssumptions,
-        TrustPath:append(append([]string{},sharedTrustPath...),"Go closed-set checker (evidence.go)"),
-        Details:map[string]any{"states":states},
-    }
+var sharedTrustPath = []string{
+	"semantic digest binding (" + evidenceFormat + ")",
+	"frontend/ model export",
 }
 
-func traceVerdict(m *Model,states int) *Verdict {
-    return &Verdict{
-        Accepted:true,
-        Claim:claimFor(m,"reachable safety counterexample"),
-        Established:"a trace that starts in an initial state, follows legal transitions or stutters, and ends in a state violating the invariant",
-        Assumptions:sharedAssumptions,
-        TrustPath:append(append([]string{},sharedTrustPath...),"Go trace replay (evidence.go)"),
-        Details:map[string]any{"states":states},
-    }
+func closedSetVerdict(m *Model, states int) *Verdict {
+	return &Verdict{
+		Accepted:    true,
+		Claim:       claimFor(m, "nonvacuous reachable safety"),
+		Established: "a finite set of states that contains every initial state (at least one), is closed under the step relation, and satisfies the invariant in every member",
+		Assumptions: sharedAssumptions,
+		TrustPath:   append(append([]string{}, sharedTrustPath...), "Go closed-set checker (evidence.go)"),
+		Details:     map[string]any{"states": states},
+	}
 }
 
-func lratVerdict(m *Model,checks map[string]lrat.Result) *Verdict {
-    return &Verdict{
-        Accepted:true,
-        Claim:claimFor(m,"nonvacuous inductive safety"),
-        Established:"an initial-state witness, and LRAT refutations of the initialization and preservation counterexample formulas reconstructed from the source (their SHA-256 matched)",
-        Assumptions:append(append([]string{},sharedAssumptions...),
-            "the Go CNF translation (encode) is faithful to the model; it is compared, not proved"),
-        TrustPath:append(append([]string{},sharedTrustPath...),
-            "Go CNF encoder (circuit.go)",
-            "internal/lrat checker: its decisions agree with compiled Oak rup_text_check and the Lean file model CertificateFile.check on every corpus case; the Lean model is proved sound (check_sound) and the transliterated Oak decoder proved to refine it (OakTextRefinement.check_refines)"),
-        Unsupported:[]string{"RAT hints","binary LRAT","extension variables","SMT proof formats"},
-        Details:map[string]any{"obligations":checks},
-    }
+func traceVerdict(m *Model, states int) *Verdict {
+	return &Verdict{
+		Accepted:    true,
+		Claim:       claimFor(m, "reachable safety counterexample"),
+		Established: "a trace that starts in an initial state, follows legal transitions or stutters, and ends in a state violating the invariant",
+		Assumptions: sharedAssumptions,
+		TrustPath:   append(append([]string{}, sharedTrustPath...), "Go trace replay (evidence.go)"),
+		Details:     map[string]any{"states": states},
+	}
 }
-type Proof struct{ SHA string `json:"cnf_sha256"`; LRAT string `json:"lrat"` }
-type Certificate struct{
-    Format string `json:"format"`
-    Digest string `json:"semantic_digest"`
-    Kind string `json:"kind"`
-    Initial State `json:"initial_witness,omitempty"`
-    Proofs map[string]Proof `json:"proofs,omitempty"`
-    States []State `json:"states,omitempty"`
+
+func lratVerdict(m *Model, checks map[string]lrat.Result) *Verdict {
+	return &Verdict{
+		Accepted:    true,
+		Claim:       claimFor(m, "nonvacuous inductive safety"),
+		Established: "an initial-state witness, and LRAT refutations of the initialization and preservation counterexample formulas reconstructed from the source (their SHA-256 matched)",
+		Assumptions: append(append([]string{}, sharedAssumptions...),
+			"the Go CNF translation (encode) is faithful to the model; it is compared, not proved"),
+		TrustPath: append(append([]string{}, sharedTrustPath...),
+			"Go CNF encoder (circuit.go)",
+			"internal/lrat checker: its decisions agree with compiled Oak rup_text_check and the Lean file model CertificateFile.check on every corpus case; the Lean model is proved sound (check_sound) and the transliterated Oak decoder proved to refine it (OakTextRefinement.check_refines)"),
+		Unsupported: []string{"RAT hints", "binary LRAT", "extension variables", "SMT proof formats"},
+		Details:     map[string]any{"obligations": checks},
+	}
 }
-func verify(m *Model,c *Certificate)(*Verdict,error){
-    if c.Format!=evidenceFormat||c.Digest!=m.Digest{return nil,fmt.Errorf("wrong evidence format or source/model identity")}
-    if c.Kind=="closed-set" {
-        if c.Initial!=nil||c.Proofs!=nil||len(c.States)==0||len(c.States)>1024{return nil,fmt.Errorf("invalid closed-set evidence")}
-        members:=map[string]bool{}
-        for _,s:=range c.States{if e:=m.valid(s);e!=nil{return nil,e};key:=stateKey(s);if members[key]{return nil,fmt.Errorf("duplicate closed-set state")};members[key]=true;if !truth(m.Terms["invariant"],s,nil){return nil,fmt.Errorf("unsafe closed-set member")}}
-        all,e:=m.states();if e!=nil{return nil,e};initials:=0
-        for _,s:=range all{if truth(m.Terms["initial"],s,nil){initials++;if !members[stateKey(s)]{return nil,fmt.Errorf("closed set omits an initial state")}}}
-        if initials==0{return nil,fmt.Errorf("empty initial set")}
-        for _,s:=range c.States{for _,target:=range all{if truth(m.Terms["step"],s,target)&&!members[stateKey(target)]{return nil,fmt.Errorf("closed set omits a successor")}}}
-        return closedSetVerdict(m,len(c.States)),nil
-    }
-    if c.Kind=="trace"{
-        if c.Initial!=nil||c.Proofs!=nil{return nil,fmt.Errorf("unexpected trace fields")}
-        if e:=replay(m,c.States);e!=nil{return nil,e}
-        if truth(m.Terms["invariant"],c.States[len(c.States)-1],nil){return nil,fmt.Errorf("trace does not end in safety violation")}
-        return traceVerdict(m,len(c.States)),nil
-    }
-    if c.Kind!="lrat"||c.States!=nil||len(c.Proofs)!=2{return nil,fmt.Errorf("invalid proof evidence")}
-    if e:=m.valid(c.Initial);e!=nil{return nil,e};if !truth(m.Terms["initial"],c.Initial,nil){return nil,fmt.Errorf("invalid initial witness")}
-    checks:=map[string]lrat.Result{}
-    for _,role:=range []string{"base","step"}{proof,ok:=c.Proofs[role];if !ok{return nil,fmt.Errorf("missing %s proof",role)};circuit,r:=encode(m,role);cnf:=circuit.dimacs(r);if proof.SHA!=digest(cnf){return nil,fmt.Errorf("proof CNF differs from reconstructed %s obligation",role)};result,e:=lrat.Check(cnf,proof.LRAT);if e!=nil{return nil,fmt.Errorf("%s: %w",role,e)};checks[role]=result}
-    return lratVerdict(m,checks),nil
+
+type Proof struct {
+	SHA  string `json:"cnf_sha256"`
+	LRAT string `json:"lrat"`
 }
-func replay(m *Model,states []State)error{
-    if len(states)==0||len(states)>4096{return fmt.Errorf("invalid trace length")}
-    for _,s:=range states{if e:=m.valid(s);e!=nil{return e}}
-    if !truth(m.Terms["initial"],states[0],nil){return fmt.Errorf("invalid initial state")}
-    for i:=1;i<len(states);i++{s,t:=states[i-1],states[i];if stateKey(s)!=stateKey(t)&&!truth(m.Terms["step"],s,t){return fmt.Errorf("illegal transition at %d",i)}};return nil
+type Certificate struct {
+	Format  string           `json:"format"`
+	Digest  string           `json:"semantic_digest"`
+	Kind    string           `json:"kind"`
+	Initial State            `json:"initial_witness,omitempty"`
+	Proofs  map[string]Proof `json:"proofs,omitempty"`
+	States  []State          `json:"states,omitempty"`
+}
+
+func verify(m *Model, c *Certificate) (*Verdict, error) {
+	if c.Format != evidenceFormat || c.Digest != m.Digest {
+		return nil, fmt.Errorf("wrong evidence format or source/model identity")
+	}
+	if c.Kind == "closed-set" {
+		if c.Initial != nil || c.Proofs != nil || len(c.States) == 0 || len(c.States) > 1024 {
+			return nil, fmt.Errorf("invalid closed-set evidence")
+		}
+		members := map[string]bool{}
+		for _, s := range c.States {
+			if e := m.valid(s); e != nil {
+				return nil, e
+			}
+			key := stateKey(s)
+			if members[key] {
+				return nil, fmt.Errorf("duplicate closed-set state")
+			}
+			members[key] = true
+			if !truth(m.Terms["invariant"], s, nil) {
+				return nil, fmt.Errorf("unsafe closed-set member")
+			}
+		}
+		all, e := m.states()
+		if e != nil {
+			return nil, e
+		}
+		initials := 0
+		for _, s := range all {
+			if truth(m.Terms["initial"], s, nil) {
+				initials++
+				if !members[stateKey(s)] {
+					return nil, fmt.Errorf("closed set omits an initial state")
+				}
+			}
+		}
+		if initials == 0 {
+			return nil, fmt.Errorf("empty initial set")
+		}
+		for _, s := range c.States {
+			for _, target := range all {
+				if truth(m.Terms["step"], s, target) && !members[stateKey(target)] {
+					return nil, fmt.Errorf("closed set omits a successor")
+				}
+			}
+		}
+		return closedSetVerdict(m, len(c.States)), nil
+	}
+	if c.Kind == "trace" {
+		if c.Initial != nil || c.Proofs != nil {
+			return nil, fmt.Errorf("unexpected trace fields")
+		}
+		if e := replay(m, c.States); e != nil {
+			return nil, e
+		}
+		if truth(m.Terms["invariant"], c.States[len(c.States)-1], nil) {
+			return nil, fmt.Errorf("trace does not end in safety violation")
+		}
+		return traceVerdict(m, len(c.States)), nil
+	}
+	if c.Kind != "lrat" || c.States != nil || len(c.Proofs) != 2 {
+		return nil, fmt.Errorf("invalid proof evidence")
+	}
+	if e := m.valid(c.Initial); e != nil {
+		return nil, e
+	}
+	if !truth(m.Terms["initial"], c.Initial, nil) {
+		return nil, fmt.Errorf("invalid initial witness")
+	}
+	checks := map[string]lrat.Result{}
+	for _, role := range []string{"base", "step"} {
+		proof, ok := c.Proofs[role]
+		if !ok {
+			return nil, fmt.Errorf("missing %s proof", role)
+		}
+		circuit, r := encode(m, role)
+		cnf := circuit.dimacs(r)
+		if proof.SHA != digest(cnf) {
+			return nil, fmt.Errorf("proof CNF differs from reconstructed %s obligation", role)
+		}
+		result, e := lrat.Check(cnf, proof.LRAT)
+		if e != nil {
+			return nil, fmt.Errorf("%s: %w", role, e)
+		}
+		checks[role] = result
+	}
+	return lratVerdict(m, checks), nil
+}
+func replay(m *Model, states []State) error {
+	if len(states) == 0 || len(states) > 4096 {
+		return fmt.Errorf("invalid trace length")
+	}
+	for _, s := range states {
+		if e := m.valid(s); e != nil {
+			return e
+		}
+	}
+	if !truth(m.Terms["initial"], states[0], nil) {
+		return fmt.Errorf("invalid initial state")
+	}
+	for i := 1; i < len(states); i++ {
+		s, t := states[i-1], states[i]
+		if stateKey(s) != stateKey(t) && !truth(m.Terms["step"], s, t) {
+			return fmt.Errorf("illegal transition at %d", i)
+		}
+	}
+	return nil
 }

--- a/experiments/verification-poc/frontend/main.go
+++ b/experiments/verification-poc/frontend/main.go
@@ -2,98 +2,148 @@
 package frontend
 
 import (
-    "crypto/sha256"
-    "encoding/hex"
-    
-    "fmt"
-    
+	"crypto/sha256"
+	"encoding/hex"
 
-    "github.com/SCKelemen/oak/ast"
-    "github.com/SCKelemen/oak/compiler"
-    "github.com/SCKelemen/oak/typechecker"
+	"fmt"
+
+	"github.com/SCKelemen/oak/ast"
+	"github.com/SCKelemen/oak/compiler"
+	"github.com/SCKelemen/oak/typechecker"
 )
 
 type Function struct {
-    Params []string `json:"params"`
-    Body any `json:"body"`
+	Params []string `json:"params"`
+	Body   any      `json:"body"`
 }
 type Document struct {
-    Format string `json:"format"`
-    SourceHash string `json:"source_sha256"`
-    State string `json:"state"`
-    Fields [][2]string `json:"fields"`
-    Enums map[string][]string `json:"enums"`
-    Functions map[string]Function `json:"functions"`
+	Format     string              `json:"format"`
+	SourceHash string              `json:"source_sha256"`
+	State      string              `json:"state"`
+	Fields     [][2]string         `json:"fields"`
+	Enums      map[string][]string `json:"enums"`
+	Functions  map[string]Function `json:"functions"`
 }
 
 func identifier(e ast.Expression) (string, error) {
-    if i, ok := e.(*ast.Identifier); ok { return i.Value, nil }
-    return "", fmt.Errorf("expected atomic type/name, got %T", e)
+	if i, ok := e.(*ast.Identifier); ok {
+		return i.Value, nil
+	}
+	return "", fmt.Errorf("expected atomic type/name, got %T", e)
 }
 
 func expression(e ast.Expression) (any, error) {
-    switch x := e.(type) {
-    case *ast.Boolean:
-        return []any{"bool", x.Value}, nil
-    case *ast.IntegerLiteral:
-        return []any{"integer", x.Value}, nil
-    case *ast.Identifier:
-        return []any{"ref", x.Value}, nil
-    case *ast.IndexExpression:
-        // Only dot access, never array indexing or type application.
-        if x.Token.Literal != "." { return nil, fmt.Errorf("only dot member access is supported") }
-        left, err := identifier(x.Left); if err != nil { return nil, err }
-        right, err := identifier(x.Index); if err != nil { return nil, err }
-        return []any{"member", left, right}, nil
-    case *ast.VariantExpression:
-        if x.TypeName == nil || x.Payload != nil { return nil, fmt.Errorf("only qualified nullary variants supported") }
-        return []any{"member", x.TypeName.Value, x.Variant.Value}, nil
-    case *ast.PrefixExpression:
-        if x.Operator != "!" { return nil, fmt.Errorf("unsupported prefix %s", x.Operator) }
-        right, err := expression(x.Right); if err != nil { return nil, err }
-        return []any{"!", right}, nil
-    case *ast.InfixExpression:
-        switch x.Operator { case "&&", "||", "+", "-", "==", "!=", "<", ">", "<=", ">=":
-        default: return nil, fmt.Errorf("unsupported infix %s", x.Operator) }
-        left, err := expression(x.Left); if err != nil { return nil, err }
-        right, err := expression(x.Right); if err != nil { return nil, err }
-        return []any{x.Operator, left, right}, nil
-    case *ast.InvocationExpression:
-        name, err := identifier(x.Function); if err != nil { return nil, err }
-        args := make([]any, 0, len(x.Arguments))
-        for _, a := range x.Arguments { v, err := expression(a); if err != nil { return nil, err }; args = append(args, v) }
-        return []any{"call", name, args}, nil
-    case *ast.MatchExpression:
-        scrutinee, err := expression(x.Scrutinee); if err != nil { return nil, err }
-        arms := make([]any, 0, len(x.Arms))
-        for _, arm := range x.Arms {
-            var pattern any
-            switch p := arm.Pattern.(type) {
-            case *ast.LiteralPattern:
-                pattern, err = expression(p.Value)
-            case *ast.VariantPattern:
-                if p.TypeName == nil || p.Payload != nil { return nil, fmt.Errorf("qualified nullary pattern required") }
-                pattern = []any{"member", p.TypeName.Value, p.Variant.Value}
-            case *ast.WildcardPattern:
-                pattern = []any{"wildcard"}
-            case *ast.BindingPattern:
-                if p.Name.Value != "_" { return nil, fmt.Errorf("pattern bindings unsupported") }
-                pattern = []any{"wildcard"}
-            default:
-                return nil, fmt.Errorf("unsupported pattern %T", arm.Pattern)
-            }
-            if err != nil { return nil, err }
-            body, err := expression(arm.Body); if err != nil { return nil, err }
-            arms = append(arms, []any{pattern, body})
-        }
-        return []any{"match", scrutinee, arms}, nil
-    case *ast.BlockExpression:
-        if x.Block == nil || len(x.Block.Statements) != 1 { return nil, fmt.Errorf("only a single pure result expression is supported in a block") }
-        if x.Result() == nil { return nil, fmt.Errorf("block must have a result") }
-        return expression(x.Result())
-    default:
-        return nil, fmt.Errorf("unsupported expression %T", e)
-    }
+	switch x := e.(type) {
+	case *ast.Boolean:
+		return []any{"bool", x.Value}, nil
+	case *ast.IntegerLiteral:
+		return []any{"integer", x.Value}, nil
+	case *ast.Identifier:
+		return []any{"ref", x.Value}, nil
+	case *ast.IndexExpression:
+		// Only dot access, never array indexing or type application.
+		if x.Token.Literal != "." {
+			return nil, fmt.Errorf("only dot member access is supported")
+		}
+		left, err := identifier(x.Left)
+		if err != nil {
+			return nil, err
+		}
+		right, err := identifier(x.Index)
+		if err != nil {
+			return nil, err
+		}
+		return []any{"member", left, right}, nil
+	case *ast.VariantExpression:
+		if x.TypeName == nil || x.Payload != nil {
+			return nil, fmt.Errorf("only qualified nullary variants supported")
+		}
+		return []any{"member", x.TypeName.Value, x.Variant.Value}, nil
+	case *ast.PrefixExpression:
+		if x.Operator != "!" {
+			return nil, fmt.Errorf("unsupported prefix %s", x.Operator)
+		}
+		right, err := expression(x.Right)
+		if err != nil {
+			return nil, err
+		}
+		return []any{"!", right}, nil
+	case *ast.InfixExpression:
+		switch x.Operator {
+		case "&&", "||", "+", "-", "==", "!=", "<", ">", "<=", ">=":
+		default:
+			return nil, fmt.Errorf("unsupported infix %s", x.Operator)
+		}
+		left, err := expression(x.Left)
+		if err != nil {
+			return nil, err
+		}
+		right, err := expression(x.Right)
+		if err != nil {
+			return nil, err
+		}
+		return []any{x.Operator, left, right}, nil
+	case *ast.InvocationExpression:
+		name, err := identifier(x.Function)
+		if err != nil {
+			return nil, err
+		}
+		args := make([]any, 0, len(x.Arguments))
+		for _, a := range x.Arguments {
+			v, err := expression(a)
+			if err != nil {
+				return nil, err
+			}
+			args = append(args, v)
+		}
+		return []any{"call", name, args}, nil
+	case *ast.MatchExpression:
+		scrutinee, err := expression(x.Scrutinee)
+		if err != nil {
+			return nil, err
+		}
+		arms := make([]any, 0, len(x.Arms))
+		for _, arm := range x.Arms {
+			var pattern any
+			switch p := arm.Pattern.(type) {
+			case *ast.LiteralPattern:
+				pattern, err = expression(p.Value)
+			case *ast.VariantPattern:
+				if p.TypeName == nil || p.Payload != nil {
+					return nil, fmt.Errorf("qualified nullary pattern required")
+				}
+				pattern = []any{"member", p.TypeName.Value, p.Variant.Value}
+			case *ast.WildcardPattern:
+				pattern = []any{"wildcard"}
+			case *ast.BindingPattern:
+				if p.Name.Value != "_" {
+					return nil, fmt.Errorf("pattern bindings unsupported")
+				}
+				pattern = []any{"wildcard"}
+			default:
+				return nil, fmt.Errorf("unsupported pattern %T", arm.Pattern)
+			}
+			if err != nil {
+				return nil, err
+			}
+			body, err := expression(arm.Body)
+			if err != nil {
+				return nil, err
+			}
+			arms = append(arms, []any{pattern, body})
+		}
+		return []any{"match", scrutinee, arms}, nil
+	case *ast.BlockExpression:
+		if x.Block == nil || len(x.Block.Statements) != 1 {
+			return nil, fmt.Errorf("only a single pure result expression is supported in a block")
+		}
+		if x.Result() == nil {
+			return nil, fmt.Errorf("block must have a result")
+		}
+		return expression(x.Result())
+	default:
+		return nil, fmt.Errorf("unsupported expression %T", e)
+	}
 }
 
 // Declaration identifies a top-level Oak declaration by name and source
@@ -101,89 +151,129 @@ func expression(e ast.Expression) (any, error) {
 // (roadmap step 3). Positions are outside the exported document and the
 // semantic digest: they locate a claim, they do not change its identity.
 type Declaration struct {
-    Name string `json:"name"`
-    Line int `json:"line"`
-    Column int `json:"column"`
+	Name   string `json:"name"`
+	Line   int    `json:"line"`
+	Column int    `json:"column"`
 }
 
 // Declarations lists the top-level declarations of an Oak source by name.
 func Declarations(path string, source []byte) (map[string]Declaration, error) {
-    parsed, err := compiler.New().WithSource(path, string(source)).Parse().Get()
-    if err != nil { return nil, err }
-    out := map[string]Declaration{}
-    for _, statement := range parsed.Root.Statements {
-        switch s := statement.(type) {
-        case *ast.ADTType:
-            out[s.Name.Value] = Declaration{s.Name.Value, s.Name.Token.Line, s.Name.Token.Column}
-        case *ast.VariableDeclaration:
-            out[s.Name.Value] = Declaration{s.Name.Value, s.Name.Token.Line, s.Name.Token.Column}
-        case *ast.FunctionStatement:
-            if s.Name != nil { out[s.Name.Value] = Declaration{s.Name.Value, s.Name.Token.Line, s.Name.Token.Column} }
-        }
-    }
-    return out, nil
+	parsed, err := compiler.New().WithSource(path, string(source)).Parse().Get()
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]Declaration{}
+	for _, statement := range parsed.Root.Statements {
+		switch s := statement.(type) {
+		case *ast.ADTType:
+			out[s.Name.Value] = Declaration{s.Name.Value, s.Name.Token.Line, s.Name.Token.Column}
+		case *ast.VariableDeclaration:
+			out[s.Name.Value] = Declaration{s.Name.Value, s.Name.Token.Line, s.Name.Token.Column}
+		case *ast.FunctionStatement:
+			if s.Name != nil {
+				out[s.Name.Value] = Declaration{s.Name.Value, s.Name.Token.Line, s.Name.Token.Column}
+			}
+		}
+	}
+	return out, nil
 }
 
 func Export(path string, source []byte) (*Document, error) {
-    checked, err := compiler.New().WithSource(path, string(source)).Check().Get()
-    if err != nil { return nil, err }
-    hash := sha256.Sum256(source)
-    d := &Document{Format:"oak-finite-1", SourceHash:hex.EncodeToString(hash[:]), Fields:[][2]string{}, Enums:map[string][]string{}, Functions:map[string]Function{}}
-    names := map[string]bool{}
-    for _, statement := range checked.Tree.Root.Statements {
-        switch s := statement.(type) {
-        case *ast.ADTType:
-            if names[s.Name.Value] || len(s.TypeParams) != 0 { return nil, fmt.Errorf("duplicate or generic ADT") }
-            names[s.Name.Value] = true
-            // Oak represents record declarations as a single ADT variant
-            // whose Literal is the ordered RecordLiteral (compiler convention).
-            if len(s.Variants) == 1 {
-                if record, ok := s.Variants[0].Literal.(*ast.RecordLiteral); ok {
-                    if d.State != "" { return nil, fmt.Errorf("exactly one state record required") }
-                    d.State = s.Name.Value
-                    for _, field := range record.FieldOrder {
-                        typ, err := identifier(field.Value); if err != nil { return nil, err }
-                        if checked.TypeChecker.ParseTypeExpression(field.Value) == nil { return nil, fmt.Errorf("unresolved field type") }
-                        d.Fields = append(d.Fields, [2]string{field.Name, typ})
-                    }
-                    continue
-                }
-            }
-            cases := []string{}
-            for _, v := range s.Variants {
-                if v.Payload != nil || v.Literal != nil || v.Result != nil { return nil, fmt.Errorf("only nullary non-indexed ADTs supported") }
-                cases = append(cases, v.Name.Value)
-            }
-            d.Enums[s.Name.Value] = cases
-        case *ast.VariableDeclaration:
-            typ, err := identifier(s.Type); if err != nil || typ != "type" { return nil, fmt.Errorf("only type declarations allowed at top level") }
-            record, ok := s.Value.(*ast.RecordLiteral); if !ok || d.State != "" || names[s.Name.Value] { return nil, fmt.Errorf("exactly one record type required") }
-            names[s.Name.Value] = true; d.State = s.Name.Value
-            for _, field := range record.FieldOrder {
-                typ, err := identifier(field.Value); if err != nil { return nil, err }
-                resolved := checked.TypeChecker.ParseTypeExpression(field.Value)
-                if resolved == nil { return nil, fmt.Errorf("unresolved field type") }
-                // Keep the nominal source name; Oak's check has already resolved it.
-                d.Fields = append(d.Fields, [2]string{field.Name, typ})
-            }
-        case *ast.FunctionStatement:
-            if s.Receiver != nil || len(s.TypeParams) != 0 || s.ExternSymbol != "" || names[s.Name.Value] { return nil, fmt.Errorf("unsupported function declaration") }
-            names[s.Name.Value] = true
-            typ, ok := checked.TypeChecker.Env().GetType(s.Name.Value)
-            ft, okFn := typ.(*typechecker.FunctionType)
-            if !ok || !okFn || !ft.ReturnType.Equals(&typechecker.BoolType{}) { return nil, fmt.Errorf("predicate must have checked Bool result") }
-            params := []string{}
-            for _, p := range s.Parameters {
-                t, err := identifier(p.Type); if err != nil || t != d.State || p.Variadic { return nil, fmt.Errorf("predicate parameters must be the state record") }
-                params = append(params, p.Name.Value)
-            }
-            body, err := expression(s.Body); if err != nil { return nil, err }
-            d.Functions[s.Name.Value] = Function{params, body}
-        default:
-            return nil, fmt.Errorf("unsupported top-level statement %T", statement)
-        }
-    }
-    if d.State == "" || len(d.Fields) == 0 { return nil, fmt.Errorf("missing state record") }
-    return d, nil
+	checked, err := compiler.New().WithSource(path, string(source)).Check().Get()
+	if err != nil {
+		return nil, err
+	}
+	hash := sha256.Sum256(source)
+	d := &Document{Format: "oak-finite-1", SourceHash: hex.EncodeToString(hash[:]), Fields: [][2]string{}, Enums: map[string][]string{}, Functions: map[string]Function{}}
+	names := map[string]bool{}
+	for _, statement := range checked.Tree.Root.Statements {
+		switch s := statement.(type) {
+		case *ast.ADTType:
+			if names[s.Name.Value] || len(s.TypeParams) != 0 {
+				return nil, fmt.Errorf("duplicate or generic ADT")
+			}
+			names[s.Name.Value] = true
+			// Oak represents record declarations as a single ADT variant
+			// whose Literal is the ordered RecordLiteral (compiler convention).
+			if len(s.Variants) == 1 {
+				if record, ok := s.Variants[0].Literal.(*ast.RecordLiteral); ok {
+					if d.State != "" {
+						return nil, fmt.Errorf("exactly one state record required")
+					}
+					d.State = s.Name.Value
+					for _, field := range record.FieldOrder {
+						typ, err := identifier(field.Value)
+						if err != nil {
+							return nil, err
+						}
+						if checked.TypeChecker.ParseTypeExpression(field.Value) == nil {
+							return nil, fmt.Errorf("unresolved field type")
+						}
+						d.Fields = append(d.Fields, [2]string{field.Name, typ})
+					}
+					continue
+				}
+			}
+			cases := []string{}
+			for _, v := range s.Variants {
+				if v.Payload != nil || v.Literal != nil || v.Result != nil {
+					return nil, fmt.Errorf("only nullary non-indexed ADTs supported")
+				}
+				cases = append(cases, v.Name.Value)
+			}
+			d.Enums[s.Name.Value] = cases
+		case *ast.VariableDeclaration:
+			typ, err := identifier(s.Type)
+			if err != nil || typ != "type" {
+				return nil, fmt.Errorf("only type declarations allowed at top level")
+			}
+			record, ok := s.Value.(*ast.RecordLiteral)
+			if !ok || d.State != "" || names[s.Name.Value] {
+				return nil, fmt.Errorf("exactly one record type required")
+			}
+			names[s.Name.Value] = true
+			d.State = s.Name.Value
+			for _, field := range record.FieldOrder {
+				typ, err := identifier(field.Value)
+				if err != nil {
+					return nil, err
+				}
+				resolved := checked.TypeChecker.ParseTypeExpression(field.Value)
+				if resolved == nil {
+					return nil, fmt.Errorf("unresolved field type")
+				}
+				// Keep the nominal source name; Oak's check has already resolved it.
+				d.Fields = append(d.Fields, [2]string{field.Name, typ})
+			}
+		case *ast.FunctionStatement:
+			if s.Receiver != nil || len(s.TypeParams) != 0 || s.ExternSymbol != "" || names[s.Name.Value] {
+				return nil, fmt.Errorf("unsupported function declaration")
+			}
+			names[s.Name.Value] = true
+			typ, ok := checked.TypeChecker.Env().GetType(s.Name.Value)
+			ft, okFn := typ.(*typechecker.FunctionType)
+			if !ok || !okFn || !ft.ReturnType.Equals(&typechecker.BoolType{}) {
+				return nil, fmt.Errorf("predicate must have checked Bool result")
+			}
+			params := []string{}
+			for _, p := range s.Parameters {
+				t, err := identifier(p.Type)
+				if err != nil || t != d.State || p.Variadic {
+					return nil, fmt.Errorf("predicate parameters must be the state record")
+				}
+				params = append(params, p.Name.Value)
+			}
+			body, err := expression(s.Body)
+			if err != nil {
+				return nil, err
+			}
+			d.Functions[s.Name.Value] = Function{params, body}
+		default:
+			return nil, fmt.Errorf("unsupported top-level statement %T", statement)
+		}
+	}
+	if d.State == "" || len(d.Fields) == 0 {
+		return nil, fmt.Errorf("missing state record")
+	}
+	return d, nil
 }
-

--- a/experiments/verification-poc/frontend/main_test.go
+++ b/experiments/verification-poc/frontend/main_test.go
@@ -1,44 +1,48 @@
 package frontend
 
 import (
-    "os"
-    "path/filepath"
-    "strings"
-    "testing"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
 )
 
 func TestNativeFiniteExamples(t *testing.T) {
-    for _, name := range []string{"enum", "enum-broken", "counter", "counter-broken", "wrap"} {
-        t.Run(name, func(t *testing.T) {
-            path := filepath.Join("..", "examples", "native", name+".oak")
-            source, err := os.ReadFile(path)
-            if err != nil { t.Fatal(err) }
-            doc, err := Export(path, source)
-            if err != nil { t.Fatal(err) }
-            if doc.State != "State" || len(doc.Fields) != 1 || len(doc.Functions) != 3 {
-                t.Fatalf("unexpected frontend document: %+v", doc)
-            }
-            if len(doc.SourceHash) != 64 || len(doc.Functions["step"].Params) != 2 {
-                t.Fatalf("missing source identity or role parameters: %+v", doc)
-            }
-        })
-    }
+	for _, name := range []string{"enum", "enum-broken", "counter", "counter-broken", "wrap"} {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join("..", "examples", "native", name+".oak")
+			source, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			doc, err := Export(path, source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if doc.State != "State" || len(doc.Fields) != 1 || len(doc.Functions) != 3 {
+				t.Fatalf("unexpected frontend document: %+v", doc)
+			}
+			if len(doc.SourceHash) != 64 || len(doc.Functions["step"].Params) != 2 {
+				t.Fatalf("missing source identity or role parameters: %+v", doc)
+			}
+		})
+	}
 }
 
 func TestIllTypedSourceRejected(t *testing.T) {
-    source := `State: type = { count: u8 }
+	source := `State: type = { count: u8 }
 initial: (s: State): Bool = s.count
 `
-    if _, err := Export("ill-typed.oak", []byte(source)); err == nil {
-        t.Fatal("accepted a numeric predicate as Bool")
-    }
+	if _, err := Export("ill-typed.oak", []byte(source)); err == nil {
+		t.Fatal("accepted a numeric predicate as Bool")
+	}
 }
 
 func TestUnsupportedMultiplicationRejected(t *testing.T) {
-    source := `State: type = { count: u8 }
+	source := `State: type = { count: u8 }
 initial: (s: State): Bool = s.count * u8(2) == u8(0)
 `
-    if _, err := Export("unsupported.oak", []byte(source)); err == nil || !strings.Contains(err.Error(), "unsupported infix") {
-        t.Fatalf("expected fragment rejection, got %v", err)
-    }
+	if _, err := Export("unsupported.oak", []byte(source)); err == nil || !strings.Contains(err.Error(), "unsupported infix") {
+		t.Fatalf("expected fragment rejection, got %v", err)
+	}
 }

--- a/experiments/verification-poc/helper_inlining_test.go
+++ b/experiments/verification-poc/helper_inlining_test.go
@@ -1,11 +1,11 @@
 package main
 
 import (
- "os"
- "os/exec"
- "path/filepath"
- "regexp"
- "testing"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"testing"
 )
 
 // The decoder names its small operations (rup_space, rup_word, rup_encoded)
@@ -13,17 +13,31 @@ import (
 // helpers forced-inline, so at the CI optimization level no call to them
 // survives in the machine code of the actual checker sources.
 func TestCheckerHelpersInline(t *testing.T) {
- cc,err:=exec.LookPath("cc");if err!=nil {t.Skip("C compiler required")}
- generated:=emitChecker(t,"checker_inline.oak",checkerSources(t))
- dir:=t.TempDir();cpath:=filepath.Join(dir,"checker.c");spath:=filepath.Join(dir,"checker.s")
- if err:=os.WriteFile(cpath,[]byte(generated),0644);err!=nil {t.Fatal(err)}
- for _,opt:=range []string{"-O0","-O1"} {
-  if output,err:=exec.Command(cc,"-std=c99","-w",opt,"-S","-o",spath,cpath).CombinedOutput();err!=nil {t.Fatalf("cc %s: %v\n%s",opt,err,output)}
-  asm,err:=os.ReadFile(spath);if err!=nil {t.Fatal(err)}
-  for _,helper:=range []string{"oak_rup_space","oak_rup_word","oak_rup_encoded"} {
-   calls:=regexp.MustCompile(`(?m)^\s*(call|callq|bl)\s+_?`+helper+`\b`).FindAllIndex(asm,-1)
-   if len(calls)!=0 {t.Fatalf("%s: %d call(s) to %s remain",opt,len(calls),helper)}
-  }
- }
- t.Log("checker helpers rup_space, rup_word, rup_encoded: no calls remain at -O0 and -O1")
+	cc, err := exec.LookPath("cc")
+	if err != nil {
+		t.Skip("C compiler required")
+	}
+	generated := emitChecker(t, "checker_inline.oak", checkerSources(t))
+	dir := t.TempDir()
+	cpath := filepath.Join(dir, "checker.c")
+	spath := filepath.Join(dir, "checker.s")
+	if err := os.WriteFile(cpath, []byte(generated), 0644); err != nil {
+		t.Fatal(err)
+	}
+	for _, opt := range []string{"-O0", "-O1"} {
+		if output, err := exec.Command(cc, "-std=c99", "-w", opt, "-S", "-o", spath, cpath).CombinedOutput(); err != nil {
+			t.Fatalf("cc %s: %v\n%s", opt, err, output)
+		}
+		asm, err := os.ReadFile(spath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, helper := range []string{"oak_rup_space", "oak_rup_word", "oak_rup_encoded"} {
+			calls := regexp.MustCompile(`(?m)^\s*(call|callq|bl)\s+_?`+helper+`\b`).FindAllIndex(asm, -1)
+			if len(calls) != 0 {
+				t.Fatalf("%s: %d call(s) to %s remain", opt, len(calls), helper)
+			}
+		}
+	}
+	t.Log("checker helpers rup_space, rup_word, rup_encoded: no calls remain at -O0 and -O1")
 }

--- a/experiments/verification-poc/import_trace.go
+++ b/experiments/verification-poc/import_trace.go
@@ -1,69 +1,212 @@
 package main
 
 import (
-    "fmt"
-    "reflect"
-    "strconv"
-    "strings"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
 )
 
-type Receipt struct{
-    Format string `json:"format"`
-    Digest string `json:"semantic_digest"`
-    Backend string `json:"backend"`
-    QuerySHA string `json:"query_sha256"`
-    OutputSHA string `json:"output_sha256"`
-    Bound *int `json:"bound"`
+type Receipt struct {
+	Format    string `json:"format"`
+	Digest    string `json:"semantic_digest"`
+	Backend   string `json:"backend"`
+	QuerySHA  string `json:"query_sha256"`
+	OutputSHA string `json:"output_sha256"`
+	Bound     *int   `json:"bound"`
 }
-func receipt(m *Model,backend,query,raw string,bound *int)Receipt{return Receipt{"oak-go-trace-receipt-1",m.Digest,backend,digest(query),digest(raw),bound}}
-func sexprs(text string)(out []any,err error){
-    if len(text)>20_000_000{return nil,fmt.Errorf("solver output limit")}
-    tokens:=strings.Fields(strings.NewReplacer("("," ( ",")"," ) ").Replace(text));pos:=0
-    var read func(int)(any,error)
-    read=func(depth int)(any,error){
-        if pos>=len(tokens)||depth>128{return nil,fmt.Errorf("invalid S-expression")};token:=tokens[pos];pos++
-        if token==")"{return nil,fmt.Errorf("unexpected closing parenthesis")};if token!="("{return token,nil}
-        a:=[]any{};for pos<len(tokens)&&tokens[pos]!=")"{v,e:=read(depth+1);if e!=nil{return nil,e};a=append(a,v)};if pos>=len(tokens){return nil,fmt.Errorf("unterminated S-expression")};pos++;return a,nil
-    }
-    for pos<len(tokens){v,e:=read(0);if e!=nil{return nil,e};out=append(out,v)};return out,nil
+
+func receipt(m *Model, backend, query, raw string, bound *int) Receipt {
+	return Receipt{"oak-go-trace-receipt-1", m.Digest, backend, digest(query), digest(raw), bound}
 }
-func smtValue(m *Model,t string,raw any)any{
-    if t=="Bool"{s,ok:=raw.(string);demand(ok&&(s=="true"||s=="false"),"expected SMT Boolean");return s=="true"}
-    width:=m.width(t);var n int64;var e error
-    if s,ok:=raw.(string);ok&&strings.HasPrefix(s,"#b"){demand(len(s)-2==width,"bit-vector width mismatch");n,e=strconv.ParseInt(s[2:],2,32)}else if ok&&strings.HasPrefix(s,"#x"){demand((len(s)-2)*4==width,"bit-vector width mismatch");n,e=strconv.ParseInt(s[2:],16,32)}else{
-        a:=array(raw);demand(len(a)==3&&str(a[0])=="_"&&strings.HasPrefix(str(a[1]),"bv")&&str(a[2])==strconv.Itoa(width),"invalid bit-vector");n,e=strconv.ParseInt(str(a[1])[2:],10,32)
-    }
-    demand(e==nil&&n>=0&&n<int64(1<<width),"invalid bit-vector value");if t=="u8"{return int(n)};demand(int(n)<len(m.Enums[t]),"unused enum encoding");return m.Enums[t][n]
+func sexprs(text string) (out []any, err error) {
+	if len(text) > 20_000_000 {
+		return nil, fmt.Errorf("solver output limit")
+	}
+	tokens := strings.Fields(strings.NewReplacer("(", " ( ", ")", " ) ").Replace(text))
+	pos := 0
+	var read func(int) (any, error)
+	read = func(depth int) (any, error) {
+		if pos >= len(tokens) || depth > 128 {
+			return nil, fmt.Errorf("invalid S-expression")
+		}
+		token := tokens[pos]
+		pos++
+		if token == ")" {
+			return nil, fmt.Errorf("unexpected closing parenthesis")
+		}
+		if token != "(" {
+			return token, nil
+		}
+		a := []any{}
+		for pos < len(tokens) && tokens[pos] != ")" {
+			v, e := read(depth + 1)
+			if e != nil {
+				return nil, e
+			}
+			a = append(a, v)
+		}
+		if pos >= len(tokens) {
+			return nil, fmt.Errorf("unterminated S-expression")
+		}
+		pos++
+		return a, nil
+	}
+	for pos < len(tokens) {
+		v, e := read(0)
+		if e != nil {
+			return nil, e
+		}
+		out = append(out, v)
+	}
+	return out, nil
 }
-func fromZ3(m *Model,text string,bound int)(states []State,err error){
-    defer func(){if e:=recover();e!=nil{states=nil;err=fmt.Errorf("invalid Z3 trace: %v",e)}}()
-    demand(bound>=0&&bound<=64,"invalid bound");a,e:=sexprs(text);if e!=nil{return nil,e};demand(len(a)==2&&str(a[0])=="sat","expected SAT plus get-value result")
-    values:=map[string]any{};for _,v:=range array(a[1]){pair:=array(v);demand(len(pair)==2,"invalid value pair");key:=str(pair[0]);_,present:=values[key];demand(!present,"duplicate SMT variable");values[key]=pair[1]}
-    demand(len(values)==(bound+1)*len(m.Fields),"SMT variable set mismatch")
-    for i:=0;i<=bound;i++{s:=State{};for _,f:=range m.Fields{key:=fmt.Sprintf("s%d_f_%s",i,f.Name);v,ok:=values[key];demand(ok,"missing SMT variable");s[f.Name]=smtValue(m,f.Type,v)};states=append(states,s)};return states,nil
+func smtValue(m *Model, t string, raw any) any {
+	if t == "Bool" {
+		s, ok := raw.(string)
+		demand(ok && (s == "true" || s == "false"), "expected SMT Boolean")
+		return s == "true"
+	}
+	width := m.width(t)
+	var n int64
+	var e error
+	if s, ok := raw.(string); ok && strings.HasPrefix(s, "#b") {
+		demand(len(s)-2 == width, "bit-vector width mismatch")
+		n, e = strconv.ParseInt(s[2:], 2, 32)
+	} else if ok && strings.HasPrefix(s, "#x") {
+		demand((len(s)-2)*4 == width, "bit-vector width mismatch")
+		n, e = strconv.ParseInt(s[2:], 16, 32)
+	} else {
+		a := array(raw)
+		demand(len(a) == 3 && str(a[0]) == "_" && strings.HasPrefix(str(a[1]), "bv") && str(a[2]) == strconv.Itoa(width), "invalid bit-vector")
+		n, e = strconv.ParseInt(str(a[1])[2:], 10, 32)
+	}
+	demand(e == nil && n >= 0 && n < int64(1<<width), "invalid bit-vector value")
+	if t == "u8" {
+		return int(n)
+	}
+	demand(int(n) < len(m.Enums[t]), "unused enum encoding")
+	return m.Enums[t][n]
 }
-func fromTLC(m *Model,text string)(states []State,err error){
-    defer func(){if e:=recover();e!=nil{states=nil;err=fmt.Errorf("invalid TLC trace: %v",e)}}()
-    var raw map[string]any;if e:=decode([]byte(text),&raw);e!=nil{return nil,e}
-    vars:=array(raw["vars"]);demand(len(vars)==1&&str(vars[0])=="state","unexpected TLC variable set")
-    graph,ok:=raw["counterexample"].(map[string]any);demand(ok,"missing TLC counterexample");entries:=array(graph["state"]);demand(len(entries)>0&&len(entries)<=4096,"invalid TLC trace size")
-    levels:=map[int]State{}
-    for _,v:=range entries{
-        entry:=array(v);demand(len(entry)==2,"invalid TLC state entry");level,e:=number(entry[0]);demand(e==nil&&level>0&&levels[level]==nil,"invalid/duplicate TLC level")
-        record,ok:=entry[1].(map[string]any);demand(ok&&len(record)==1,"unexpected TLC state variables");fields,ok:=record["state"].(map[string]any);demand(ok&&len(fields)==len(m.Fields),"TLC fields mismatch")
-        s:=State{};for _,f:=range m.Fields{v,ok:=fields["f_"+f.Name];demand(ok,"missing TLC field");if m.Enums[f.Type]!=nil{txt:=str(v);demand(strings.HasPrefix(txt,f.Type+"."),"nominal enum mismatch");v=strings.TrimPrefix(txt,f.Type+".")};s[f.Name]=v};demand(m.valid(s)==nil,"invalid typed TLC state");levels[level]=s
-    }
-    for i:=1;i<=len(levels);i++{demand(levels[i]!=nil,"noncontiguous TLC levels");states=append(states,levels[i])};return states,nil
+func fromZ3(m *Model, text string, bound int) (states []State, err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			states = nil
+			err = fmt.Errorf("invalid Z3 trace: %v", e)
+		}
+	}()
+	demand(bound >= 0 && bound <= 64, "invalid bound")
+	a, e := sexprs(text)
+	if e != nil {
+		return nil, e
+	}
+	demand(len(a) == 2 && str(a[0]) == "sat", "expected SAT plus get-value result")
+	values := map[string]any{}
+	for _, v := range array(a[1]) {
+		pair := array(v)
+		demand(len(pair) == 2, "invalid value pair")
+		key := str(pair[0])
+		_, present := values[key]
+		demand(!present, "duplicate SMT variable")
+		values[key] = pair[1]
+	}
+	demand(len(values) == (bound+1)*len(m.Fields), "SMT variable set mismatch")
+	for i := 0; i <= bound; i++ {
+		s := State{}
+		for _, f := range m.Fields {
+			key := fmt.Sprintf("s%d_f_%s", i, f.Name)
+			v, ok := values[key]
+			demand(ok, "missing SMT variable")
+			s[f.Name] = smtValue(m, f.Type, v)
+		}
+		states = append(states, s)
+	}
+	return states, nil
 }
-func importTrace(m *Model,backend,query,raw string,r Receipt,bound *int)(*Certificate,error){
-    if !reflect.DeepEqual(r,receipt(m,backend,query,raw,bound)){return nil,fmt.Errorf("stale or mismatched trace receipt")}
-    var states []State;var e error
-    switch backend{
-    case "z3":if bound==nil{return nil,fmt.Errorf("missing BMC bound")};expected,err:=bmc(m,*bound,true);if err!=nil||query!=expected{return nil,fmt.Errorf("wrong BMC query")};states,e=fromZ3(m,raw,*bound)
-    case "tlc":files:=project(m);if bound!=nil||query!=files["Model.tla"]+"\n"+files["Model.cfg"]{return nil,fmt.Errorf("wrong TLC specification/configuration")};states,e=fromTLC(m,raw)
-    default:return nil,fmt.Errorf("unsupported trace backend")
-    }
-    if e!=nil{return nil,e};if e:=replay(m,states);e!=nil{return nil,e}
-    for i,s:=range states{if !truth(m.Terms["invariant"],s,nil){c:=&Certificate{Format:evidenceFormat,Digest:m.Digest,Kind:"trace",States:states[:i+1]};_,e:=verify(m,c);return c,e}}
-    return nil,fmt.Errorf("trace has no safety violation")
+func fromTLC(m *Model, text string) (states []State, err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			states = nil
+			err = fmt.Errorf("invalid TLC trace: %v", e)
+		}
+	}()
+	var raw map[string]any
+	if e := decode([]byte(text), &raw); e != nil {
+		return nil, e
+	}
+	vars := array(raw["vars"])
+	demand(len(vars) == 1 && str(vars[0]) == "state", "unexpected TLC variable set")
+	graph, ok := raw["counterexample"].(map[string]any)
+	demand(ok, "missing TLC counterexample")
+	entries := array(graph["state"])
+	demand(len(entries) > 0 && len(entries) <= 4096, "invalid TLC trace size")
+	levels := map[int]State{}
+	for _, v := range entries {
+		entry := array(v)
+		demand(len(entry) == 2, "invalid TLC state entry")
+		level, e := number(entry[0])
+		demand(e == nil && level > 0 && levels[level] == nil, "invalid/duplicate TLC level")
+		record, ok := entry[1].(map[string]any)
+		demand(ok && len(record) == 1, "unexpected TLC state variables")
+		fields, ok := record["state"].(map[string]any)
+		demand(ok && len(fields) == len(m.Fields), "TLC fields mismatch")
+		s := State{}
+		for _, f := range m.Fields {
+			v, ok := fields["f_"+f.Name]
+			demand(ok, "missing TLC field")
+			if m.Enums[f.Type] != nil {
+				txt := str(v)
+				demand(strings.HasPrefix(txt, f.Type+"."), "nominal enum mismatch")
+				v = strings.TrimPrefix(txt, f.Type+".")
+			}
+			s[f.Name] = v
+		}
+		demand(m.valid(s) == nil, "invalid typed TLC state")
+		levels[level] = s
+	}
+	for i := 1; i <= len(levels); i++ {
+		demand(levels[i] != nil, "noncontiguous TLC levels")
+		states = append(states, levels[i])
+	}
+	return states, nil
+}
+func importTrace(m *Model, backend, query, raw string, r Receipt, bound *int) (*Certificate, error) {
+	if !reflect.DeepEqual(r, receipt(m, backend, query, raw, bound)) {
+		return nil, fmt.Errorf("stale or mismatched trace receipt")
+	}
+	var states []State
+	var e error
+	switch backend {
+	case "z3":
+		if bound == nil {
+			return nil, fmt.Errorf("missing BMC bound")
+		}
+		expected, err := bmc(m, *bound, true)
+		if err != nil || query != expected {
+			return nil, fmt.Errorf("wrong BMC query")
+		}
+		states, e = fromZ3(m, raw, *bound)
+	case "tlc":
+		files := project(m)
+		if bound != nil || query != files["Model.tla"]+"\n"+files["Model.cfg"] {
+			return nil, fmt.Errorf("wrong TLC specification/configuration")
+		}
+		states, e = fromTLC(m, raw)
+	default:
+		return nil, fmt.Errorf("unsupported trace backend")
+	}
+	if e != nil {
+		return nil, e
+	}
+	if e := replay(m, states); e != nil {
+		return nil, e
+	}
+	for i, s := range states {
+		if !truth(m.Terms["invariant"], s, nil) {
+			c := &Certificate{Format: evidenceFormat, Digest: m.Digest, Kind: "trace", States: states[:i+1]}
+			_, e := verify(m, c)
+			return c, e
+		}
+	}
+	return nil, fmt.Errorf("trace has no safety violation")
 }

--- a/experiments/verification-poc/internal/lrat/differential_test.go
+++ b/experiments/verification-poc/internal/lrat/differential_test.go
@@ -1,173 +1,256 @@
 package lrat
 
 import (
-    "encoding/json"
-    "fmt"
-    "math/rand"
-    "os"
-    "strings"
-    "testing"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"os"
+	"strings"
+	"testing"
 )
 
 // This corpus checks decisions, not error wording. JSON is a test transport;
 // it is not a replacement for the production DIMACS/LRAT parsers.
 type commandCase struct {
-    Kind string `json:"kind"`
-    ID int `json:"id"`
-    Clause []int `json:"clause"`
-    Hints []int `json:"hints"`
-    IDs []int `json:"ids"`
+	Kind   string `json:"kind"`
+	ID     int    `json:"id"`
+	Clause []int  `json:"clause"`
+	Hints  []int  `json:"hints"`
+	IDs    []int  `json:"ids"`
 }
 type differentialCase struct {
-    Name string `json:"name"`
-    Kind string `json:"kind"`
-    Variables int `json:"variables"`
-    Database [][]int `json:"database"`
-    Clause []int `json:"clause"`
-    Hints []int `json:"hints"`
-    Commands []commandCase `json:"commands"`
-    Expected bool `json:"expected"`
+	Name      string        `json:"name"`
+	Kind      string        `json:"kind"`
+	Variables int           `json:"variables"`
+	Database  [][]int       `json:"database"`
+	Clause    []int         `json:"clause"`
+	Hints     []int         `json:"hints"`
+	Commands  []commandCase `json:"commands"`
+	Expected  bool          `json:"expected"`
 }
+
 func literalSet(xs []int) Clause {
-    c := Clause{}
-    for _,x := range xs { c[x] = true }
-    return c
+	c := Clause{}
+	for _, x := range xs {
+		c[x] = true
+	}
+	return c
 }
 func clauseMask(variables, mask int) []int {
-    out := []int{}
-    for v:=1; v<=variables; v++ {
-        if mask & (1 << (2*(v-1))) != 0 { out=append(out,v) }
-        if mask & (1 << (2*(v-1)+1)) != 0 { out=append(out,-v) }
-    }
-    return out
+	out := []int{}
+	for v := 1; v <= variables; v++ {
+		if mask&(1<<(2*(v-1))) != 0 {
+			out = append(out, v)
+		}
+		if mask&(1<<(2*(v-1)+1)) != 0 {
+			out = append(out, -v)
+		}
+	}
+	return out
 }
 func clauseTrue(c []int, assignment int) bool {
-    for _,x:=range c { if (assignment & (1 << (abs(x)-1)) != 0) == (x>0) { return true } }
-    return false
+	for _, x := range c {
+		if (assignment&(1<<(abs(x)-1)) != 0) == (x > 0) {
+			return true
+		}
+	}
+	return false
 }
 func entails(db [][]int, target []int, variables int) bool {
-    for assignment:=0; assignment < 1<<variables; assignment++ {
-        model:=true
-        for _,c:=range db { if !clauseTrue(c,assignment) { model=false; break } }
-        if model && !clauseTrue(target,assignment) { return false }
-    }
-    return true
+	for assignment := 0; assignment < 1<<variables; assignment++ {
+		model := true
+		for _, c := range db {
+			if !clauseTrue(c, assignment) {
+				model = false
+				break
+			}
+		}
+		if model && !clauseTrue(target, assignment) {
+			return false
+		}
+	}
+	return true
 }
 func emitNumbers(b *strings.Builder, xs []int) {
-    for _,x:=range xs { fmt.Fprintf(b,"%d ",x) }
-    b.WriteString("0")
+	for _, x := range xs {
+		fmt.Fprintf(b, "%d ", x)
+	}
+	b.WriteString("0")
 }
-func proofTexts(c differentialCase) (string,string) {
-    var cnf, proof strings.Builder
-    fmt.Fprintf(&cnf,"p cnf %d %d\n",c.Variables,len(c.Database))
-    for _,clause:=range c.Database { emitNumbers(&cnf,clause); cnf.WriteByte('\n') }
-    for _,command:=range c.Commands {
-        fmt.Fprintf(&proof,"%d ",command.ID)
-        if command.Kind=="delete" { proof.WriteString("d "); emitNumbers(&proof,command.IDs) } else {
-            emitNumbers(&proof,command.Clause); proof.WriteByte(' '); emitNumbers(&proof,command.Hints)
-        }
-        proof.WriteByte('\n')
-    }
-    return cnf.String(),proof.String()
+func proofTexts(c differentialCase) (string, string) {
+	var cnf, proof strings.Builder
+	fmt.Fprintf(&cnf, "p cnf %d %d\n", c.Variables, len(c.Database))
+	for _, clause := range c.Database {
+		emitNumbers(&cnf, clause)
+		cnf.WriteByte('\n')
+	}
+	for _, command := range c.Commands {
+		fmt.Fprintf(&proof, "%d ", command.ID)
+		if command.Kind == "delete" {
+			proof.WriteString("d ")
+			emitNumbers(&proof, command.IDs)
+		} else {
+			emitNumbers(&proof, command.Clause)
+			proof.WriteByte(' ')
+			emitNumbers(&proof, command.Hints)
+		}
+		proof.WriteByte('\n')
+	}
+	return cnf.String(), proof.String()
 }
 func proofDecision(c differentialCase) bool {
-    cnf,proof:=proofTexts(c)
-    result,err:=Check(cnf,proof)
-    return err==nil && result.Accepted
+	cnf, proof := proofTexts(c)
+	result, err := Check(cnf, proof)
+	return err == nil && result.Accepted
 }
 func TestLeanDifferentialCorpus(t *testing.T) {
-    cases:=[]differentialCase{}
-    add:=func(c differentialCase) {
-        c.Name=fmt.Sprintf("%s-%05d",c.Kind,len(cases))
-        if c.Clause==nil { c.Clause=[]int{} }; if c.Hints==nil { c.Hints=[]int{} }
-        if c.Commands==nil { c.Commands=[]commandCase{} }; if c.Database==nil { c.Database=[][]int{} }
-        for i:=range c.Commands {
-            if c.Commands[i].Clause==nil { c.Commands[i].Clause=[]int{} }
-            if c.Commands[i].Hints==nil { c.Commands[i].Hints=[]int{} }
-            if c.Commands[i].IDs==nil { c.Commands[i].IDs=[]int{} }
-        }
-        if c.Kind=="rup" {
-            db:=map[int]Clause{}
-            for i,clause:=range c.Database { db[i+1]=literalSet(clause) }
-            c.Expected=rup(db,literalSet(c.Clause),c.Hints)==nil
-            if c.Expected && !entails(c.Database,c.Clause,c.Variables) { t.Fatalf("unsound RUP: %+v",c) }
-        } else {
-            c.Expected=proofDecision(c)
-            if c.Expected && !entails(c.Database,nil,c.Variables) { t.Fatalf("unsound proof: %+v",c) }
-        }
-        cases=append(cases,c)
-    }
-    // Exhaust all one-variable clauses, two-entry databases, target clauses,
-    // and hint chains of length 0..3 over RAT, zero, live, and absent IDs.
-    hints:=[][]int{{}}
-    frontier:=[][]int{{}}
-    for depth:=0;depth<3;depth++ {
-        next:=[][]int{}
-        for _,prefix:=range frontier { for _,id:=range []int{-1,0,1,2,3} {
-            h:=append(append([]int{},prefix...),id); next=append(next,h); hints=append(hints,h)
-        } }; frontier=next
-    }
-    for a:=0;a<4;a++ { for b:=0;b<4;b++ { for target:=0;target<4;target++ { for _,h:=range hints {
-        add(differentialCase{Kind:"rup",Variables:1,Database:[][]int{clauseMask(1,a),clauseMask(1,b)},Clause:clauseMask(1,target),Hints:h})
-    } } } }
-    // Seeded larger clauses exercise multi-unit chains and duplicate literals.
-    rng:=rand.New(rand.NewSource(20260907))
-    for i:=0;i<512;i++ {
-        db:=[][]int{}
-        for j:=0;j<4;j++ { db=append(db,clauseMask(3,rng.Intn(64))) }
-        target:=clauseMask(3,rng.Intn(64))
-        if len(target)>0 && i%2==0 { target=append(target,target[0]) }
-        h:=[]int{}
-        for j, length:=0,rng.Intn(6);j<length;j++ { h=append(h,1+rng.Intn(5)) }
-        add(differentialCase{Kind:"rup",Variables:3,Database:db,Clause:target,Hints:h})
-    }
-    for _,h:=range [][]int{{1,2,3},{2,1,3},{1,1,2,3},{1,2},{1,2,3,1}} {
-        add(differentialCase{Kind:"rup",Variables:2,Database:[][]int{{1},{-1,2},{-2}},Hints:h})
-    }
-    add(differentialCase{Kind:"rup",Variables:2,Database:[][]int{{1},{-1,2}},Clause:[]int{2},Hints:[]int{1,2}})
-    add(differentialCase{Kind:"proof",Variables:2,Database:[][]int{{1},{-1,2},{-2}},Commands:[]commandCase{
-        {Kind:"add",ID:4,Hints:[]int{1,2,3}},
-    }})
-    add(differentialCase{Kind:"proof",Variables:0})
-    add(differentialCase{Kind:"proof",Variables:0,Database:[][]int{{}},Commands:[]commandCase{
-        {Kind:"delete",ID:1,IDs:[]int{1}},
-    }})
-    // Decoded stream tests cover ordering, deletion, reuse, and validation
-    // after an empty clause has already been established.
-    operations:=[]commandCase{
-        {Kind:"add",ID:3,Hints:[]int{1,2}},
-        {Kind:"add",ID:4,Hints:[]int{1,2}},
-        {Kind:"add",ID:3,Clause:[]int{1},Hints:[]int{1}},
-        {Kind:"add",ID:3,Clause:[]int{1,-1}},
-        {Kind:"add",ID:3,Clause:[]int{1,-1},Hints:[]int{9}},
-        {Kind:"add",ID:2,Hints:[]int{1,2}},
-        {Kind:"add",ID:4,Clause:[]int{2},Hints:[]int{1,2}},
-        {Kind:"delete",ID:2,IDs:[]int{1}},
-        {Kind:"delete",ID:3,IDs:[]int{1,1}},
-        {Kind:"delete",ID:4,IDs:[]int{3}},
-        {Kind:"delete",ID:9},
-        {Kind:"delete",ID:3,IDs:[]int{0}},
-    }
-    for a:=0;a<4;a++ { for b:=0;b<4;b++ {
-        db:=[][]int{clauseMask(1,a),clauseMask(1,b)}
-        add(differentialCase{Kind:"proof",Variables:1,Database:db})
-        for _,first:=range operations {
-            add(differentialCase{Kind:"proof",Variables:1,Database:db,Commands:[]commandCase{first}})
-            for _,second:=range operations { add(differentialCase{Kind:"proof",Variables:1,Database:db,Commands:[]commandCase{first,second}}) }
-        }
-    } }
-    add(differentialCase{Kind:"proof",Variables:1,Database:[][]int{{1},{-1}},Commands:[]commandCase{
-        {Kind:"add",ID:3,Hints:[]int{1,2}}, {Kind:"delete",ID:3,IDs:[]int{3}},
-    }})
-    add(differentialCase{Kind:"proof",Variables:1,Database:[][]int{{1,1},{-1,-1}},Commands:[]commandCase{
-        {Kind:"add",ID:3,Clause:[]int{1,1},Hints:[]int{1}}, {Kind:"add",ID:4,Hints:[]int{3,2}},
-    }})
-    checkTextCorpus(t,cases)
-    accepted:=0;for _,c:=range cases { if c.Expected {accepted++} }
-    if accepted==0 || accepted==len(cases) { t.Fatal("corpus must cover both outcomes") }
-    t.Logf("%d cases: %d accepted, %d rejected; all accepted decisions pass exhaustive truth tables",len(cases),accepted,len(cases)-accepted)
-    if path:=os.Getenv("OAK_LEAN_DIFFERENTIAL_OUT");path!="" {
-        data,err:=json.Marshal(cases);if err!=nil {t.Fatal(err)}
-        if err=os.WriteFile(path,data,0600);err!=nil {t.Fatal(err)}
-    }
+	cases := []differentialCase{}
+	add := func(c differentialCase) {
+		c.Name = fmt.Sprintf("%s-%05d", c.Kind, len(cases))
+		if c.Clause == nil {
+			c.Clause = []int{}
+		}
+		if c.Hints == nil {
+			c.Hints = []int{}
+		}
+		if c.Commands == nil {
+			c.Commands = []commandCase{}
+		}
+		if c.Database == nil {
+			c.Database = [][]int{}
+		}
+		for i := range c.Commands {
+			if c.Commands[i].Clause == nil {
+				c.Commands[i].Clause = []int{}
+			}
+			if c.Commands[i].Hints == nil {
+				c.Commands[i].Hints = []int{}
+			}
+			if c.Commands[i].IDs == nil {
+				c.Commands[i].IDs = []int{}
+			}
+		}
+		if c.Kind == "rup" {
+			db := map[int]Clause{}
+			for i, clause := range c.Database {
+				db[i+1] = literalSet(clause)
+			}
+			c.Expected = rup(db, literalSet(c.Clause), c.Hints) == nil
+			if c.Expected && !entails(c.Database, c.Clause, c.Variables) {
+				t.Fatalf("unsound RUP: %+v", c)
+			}
+		} else {
+			c.Expected = proofDecision(c)
+			if c.Expected && !entails(c.Database, nil, c.Variables) {
+				t.Fatalf("unsound proof: %+v", c)
+			}
+		}
+		cases = append(cases, c)
+	}
+	// Exhaust all one-variable clauses, two-entry databases, target clauses,
+	// and hint chains of length 0..3 over RAT, zero, live, and absent IDs.
+	hints := [][]int{{}}
+	frontier := [][]int{{}}
+	for depth := 0; depth < 3; depth++ {
+		next := [][]int{}
+		for _, prefix := range frontier {
+			for _, id := range []int{-1, 0, 1, 2, 3} {
+				h := append(append([]int{}, prefix...), id)
+				next = append(next, h)
+				hints = append(hints, h)
+			}
+		}
+		frontier = next
+	}
+	for a := 0; a < 4; a++ {
+		for b := 0; b < 4; b++ {
+			for target := 0; target < 4; target++ {
+				for _, h := range hints {
+					add(differentialCase{Kind: "rup", Variables: 1, Database: [][]int{clauseMask(1, a), clauseMask(1, b)}, Clause: clauseMask(1, target), Hints: h})
+				}
+			}
+		}
+	}
+	// Seeded larger clauses exercise multi-unit chains and duplicate literals.
+	rng := rand.New(rand.NewSource(20260907))
+	for i := 0; i < 512; i++ {
+		db := [][]int{}
+		for j := 0; j < 4; j++ {
+			db = append(db, clauseMask(3, rng.Intn(64)))
+		}
+		target := clauseMask(3, rng.Intn(64))
+		if len(target) > 0 && i%2 == 0 {
+			target = append(target, target[0])
+		}
+		h := []int{}
+		for j, length := 0, rng.Intn(6); j < length; j++ {
+			h = append(h, 1+rng.Intn(5))
+		}
+		add(differentialCase{Kind: "rup", Variables: 3, Database: db, Clause: target, Hints: h})
+	}
+	for _, h := range [][]int{{1, 2, 3}, {2, 1, 3}, {1, 1, 2, 3}, {1, 2}, {1, 2, 3, 1}} {
+		add(differentialCase{Kind: "rup", Variables: 2, Database: [][]int{{1}, {-1, 2}, {-2}}, Hints: h})
+	}
+	add(differentialCase{Kind: "rup", Variables: 2, Database: [][]int{{1}, {-1, 2}}, Clause: []int{2}, Hints: []int{1, 2}})
+	add(differentialCase{Kind: "proof", Variables: 2, Database: [][]int{{1}, {-1, 2}, {-2}}, Commands: []commandCase{
+		{Kind: "add", ID: 4, Hints: []int{1, 2, 3}},
+	}})
+	add(differentialCase{Kind: "proof", Variables: 0})
+	add(differentialCase{Kind: "proof", Variables: 0, Database: [][]int{{}}, Commands: []commandCase{
+		{Kind: "delete", ID: 1, IDs: []int{1}},
+	}})
+	// Decoded stream tests cover ordering, deletion, reuse, and validation
+	// after an empty clause has already been established.
+	operations := []commandCase{
+		{Kind: "add", ID: 3, Hints: []int{1, 2}},
+		{Kind: "add", ID: 4, Hints: []int{1, 2}},
+		{Kind: "add", ID: 3, Clause: []int{1}, Hints: []int{1}},
+		{Kind: "add", ID: 3, Clause: []int{1, -1}},
+		{Kind: "add", ID: 3, Clause: []int{1, -1}, Hints: []int{9}},
+		{Kind: "add", ID: 2, Hints: []int{1, 2}},
+		{Kind: "add", ID: 4, Clause: []int{2}, Hints: []int{1, 2}},
+		{Kind: "delete", ID: 2, IDs: []int{1}},
+		{Kind: "delete", ID: 3, IDs: []int{1, 1}},
+		{Kind: "delete", ID: 4, IDs: []int{3}},
+		{Kind: "delete", ID: 9},
+		{Kind: "delete", ID: 3, IDs: []int{0}},
+	}
+	for a := 0; a < 4; a++ {
+		for b := 0; b < 4; b++ {
+			db := [][]int{clauseMask(1, a), clauseMask(1, b)}
+			add(differentialCase{Kind: "proof", Variables: 1, Database: db})
+			for _, first := range operations {
+				add(differentialCase{Kind: "proof", Variables: 1, Database: db, Commands: []commandCase{first}})
+				for _, second := range operations {
+					add(differentialCase{Kind: "proof", Variables: 1, Database: db, Commands: []commandCase{first, second}})
+				}
+			}
+		}
+	}
+	add(differentialCase{Kind: "proof", Variables: 1, Database: [][]int{{1}, {-1}}, Commands: []commandCase{
+		{Kind: "add", ID: 3, Hints: []int{1, 2}}, {Kind: "delete", ID: 3, IDs: []int{3}},
+	}})
+	add(differentialCase{Kind: "proof", Variables: 1, Database: [][]int{{1, 1}, {-1, -1}}, Commands: []commandCase{
+		{Kind: "add", ID: 3, Clause: []int{1, 1}, Hints: []int{1}}, {Kind: "add", ID: 4, Hints: []int{3, 2}},
+	}})
+	checkTextCorpus(t, cases)
+	accepted := 0
+	for _, c := range cases {
+		if c.Expected {
+			accepted++
+		}
+	}
+	if accepted == 0 || accepted == len(cases) {
+		t.Fatal("corpus must cover both outcomes")
+	}
+	t.Logf("%d cases: %d accepted, %d rejected; all accepted decisions pass exhaustive truth tables", len(cases), accepted, len(cases)-accepted)
+	if path := os.Getenv("OAK_LEAN_DIFFERENTIAL_OUT"); path != "" {
+		data, err := json.Marshal(cases)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err = os.WriteFile(path, data, 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
 }

--- a/experiments/verification-poc/internal/lrat/lrat.go
+++ b/experiments/verification-poc/internal/lrat/lrat.go
@@ -3,109 +3,245 @@
 package lrat
 
 import (
-    "fmt"
-    "strconv"
-    "strings"
+	"fmt"
+	"strconv"
+	"strings"
 )
 
 type Clause map[int]bool
-type Formula struct { Variables int; Clauses []Clause }
+type Formula struct {
+	Variables int
+	Clauses   []Clause
+}
 type Result struct {
-    Accepted bool `json:"accepted"`
-    Additions int `json:"additions"`
-    Deletions int `json:"deletions"`
+	Accepted  bool `json:"accepted"`
+	Additions int  `json:"additions"`
+	Deletions int  `json:"deletions"`
 }
-func abs(x int) int { if x<0 { return -x }; return x }
-func integer(s string) (int,error) {
-    n,err:=strconv.Atoi(s)
-    if err!=nil || n < -2147483647 || n > 2147483647 { return 0,fmt.Errorf("invalid bounded integer %q",s) }
-    return n,nil
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
 }
-func Parse(text string) (Formula,error) {
-    var f Formula
-    if len(text)>20_000_000 { return f,fmt.Errorf("CNF input limit") }
-    header:=false; expected:=0; clause:=Clause{}
-    for _,line:=range strings.Split(text,"\n") {
-        words:=strings.Fields(line)
-        if len(words)==0 || words[0]=="c" {continue}
-        if words[0]=="p" {
-            if header || len(words)!=4 || words[1]!="cnf" {return f,fmt.Errorf("invalid DIMACS header")}
-            n,e:=integer(words[2]);if e!=nil || n<0{return f,fmt.Errorf("invalid variable count")}
-            m,e:=integer(words[3]);if e!=nil || m<0{return f,fmt.Errorf("invalid clause count")}
-            f.Variables=n;expected=m;header=true;continue
-        }
-        if !header{return f,fmt.Errorf("missing DIMACS header")}
-        for _,word:=range words {
-            n,e:=integer(word);if e!=nil{return f,e}
-            if n==0 {f.Clauses=append(f.Clauses,clause);clause=Clause{}} else {
-                if abs(n)>f.Variables{return f,fmt.Errorf("literal outside variable domain")};clause[n]=true
-            }
-        }
-    }
-    if !header || len(clause)!=0 || len(f.Clauses)!=expected{return f,fmt.Errorf("unterminated clause or count mismatch")}
-    return f,nil
+func integer(s string) (int, error) {
+	n, err := strconv.Atoi(s)
+	if err != nil || n < -2147483647 || n > 2147483647 {
+		return 0, fmt.Errorf("invalid bounded integer %q", s)
+	}
+	return n, nil
 }
-func rup(db map[int]Clause,c Clause,hints []int) error {
-    assigned:=Clause{}
-    for x:=range c{assigned[-x]=true}
-    for _,id:=range hints{if id<=0 || db[id]==nil{return fmt.Errorf("unsupported RAT or absent/deleted/future hint")}}
-    for x:=range assigned{if assigned[-x]{return nil}}
-    for i,id:=range hints {
-        remaining:=0;unit:=0
-        for x:=range db[id] {
-            if assigned[x]{return fmt.Errorf("hint is already satisfied")}
-            if !assigned[-x]{remaining++;unit=x}
-        }
-        if remaining==0 {if i!=len(hints)-1{return fmt.Errorf("unused hints after conflict")};return nil}
-        if remaining!=1{return fmt.Errorf("hint is not unit or conflicting")}
-        assigned[unit]=true
-    }
-    return fmt.Errorf("RUP chain has no conflict")
+func Parse(text string) (Formula, error) {
+	var f Formula
+	if len(text) > 20_000_000 {
+		return f, fmt.Errorf("CNF input limit")
+	}
+	header := false
+	expected := 0
+	clause := Clause{}
+	for _, line := range strings.Split(text, "\n") {
+		words := strings.Fields(line)
+		if len(words) == 0 || words[0] == "c" {
+			continue
+		}
+		if words[0] == "p" {
+			if header || len(words) != 4 || words[1] != "cnf" {
+				return f, fmt.Errorf("invalid DIMACS header")
+			}
+			n, e := integer(words[2])
+			if e != nil || n < 0 {
+				return f, fmt.Errorf("invalid variable count")
+			}
+			m, e := integer(words[3])
+			if e != nil || m < 0 {
+				return f, fmt.Errorf("invalid clause count")
+			}
+			f.Variables = n
+			expected = m
+			header = true
+			continue
+		}
+		if !header {
+			return f, fmt.Errorf("missing DIMACS header")
+		}
+		for _, word := range words {
+			n, e := integer(word)
+			if e != nil {
+				return f, e
+			}
+			if n == 0 {
+				f.Clauses = append(f.Clauses, clause)
+				clause = Clause{}
+			} else {
+				if abs(n) > f.Variables {
+					return f, fmt.Errorf("literal outside variable domain")
+				}
+				clause[n] = true
+			}
+		}
+	}
+	if !header || len(clause) != 0 || len(f.Clauses) != expected {
+		return f, fmt.Errorf("unterminated clause or count mismatch")
+	}
+	return f, nil
 }
-func Check(cnf,proof string) (Result,error) {
-    result:=Result{}
-    if len(proof)>50_000_000{return result,fmt.Errorf("proof input limit")}
-    f,err:=Parse(cnf);if err!=nil{return result,err}
-    db:=map[int]Clause{};empty:=false
-    for i,c:=range f.Clauses{db[i+1]=c;if len(c)==0{empty=true}}
-    last:=len(db)
-    for index,line:=range strings.Split(proof,"\n") {
-        w:=strings.Fields(line);if len(w)==0||w[0]=="c"{continue}
-        fail:=func(s string)(Result,error){return result,fmt.Errorf("LRAT line %d: %s",index+1,s)}
-        if len(w)<3{return fail("short line")}
-        id,e:=integer(w[0]);if e!=nil{return fail(e.Error())}
-        if w[1]=="d" {
-            if id<last || w[len(w)-1]!="0"{return fail("invalid deletion")}
-            seen:=map[int]bool{}
-            for _,word:=range w[2:len(w)-1] {
-                n,e:=integer(word);if e!=nil||n<=0||db[n]==nil||seen[n]{return fail("invalid deletion reference")}
-                seen[n]=true;delete(db,n);result.Deletions++
-            };continue
-        }
-        if id<=last{return fail("addition IDs must increase")}
-        nums:=[]int{};zeros:=[]int{}
-        for _,word:=range w[1:]{n,e:=integer(word);if e!=nil{return fail(e.Error())};if n==0{zeros=append(zeros,len(nums))};nums=append(nums,n)}
-        if len(zeros)!=2 || zeros[1]!=len(nums)-1{return fail("expected two zero terminators")}
-        c:=Clause{}
-        for _,x:=range nums[:zeros[0]]{if abs(x)>f.Variables{return fail("undeclared variable")};c[x]=true}
-        if e:=rup(db,c,nums[zeros[0]+1:len(nums)-1]);e!=nil{return fail(e.Error())}
-        db[id]=c;last=id;result.Additions++;if len(c)==0{empty=true}
-    }
-    if !empty{return result,fmt.Errorf("proof never establishes the empty clause")}
-    result.Accepted=true;return result,nil
+func rup(db map[int]Clause, c Clause, hints []int) error {
+	assigned := Clause{}
+	for x := range c {
+		assigned[-x] = true
+	}
+	for _, id := range hints {
+		if id <= 0 || db[id] == nil {
+			return fmt.Errorf("unsupported RAT or absent/deleted/future hint")
+		}
+	}
+	for x := range assigned {
+		if assigned[-x] {
+			return nil
+		}
+	}
+	for i, id := range hints {
+		remaining := 0
+		unit := 0
+		for x := range db[id] {
+			if assigned[x] {
+				return fmt.Errorf("hint is already satisfied")
+			}
+			if !assigned[-x] {
+				remaining++
+				unit = x
+			}
+		}
+		if remaining == 0 {
+			if i != len(hints)-1 {
+				return fmt.Errorf("unused hints after conflict")
+			}
+			return nil
+		}
+		if remaining != 1 {
+			return fmt.Errorf("hint is not unit or conflicting")
+		}
+		assigned[unit] = true
+	}
+	return fmt.Errorf("RUP chain has no conflict")
+}
+func Check(cnf, proof string) (Result, error) {
+	result := Result{}
+	if len(proof) > 50_000_000 {
+		return result, fmt.Errorf("proof input limit")
+	}
+	f, err := Parse(cnf)
+	if err != nil {
+		return result, err
+	}
+	db := map[int]Clause{}
+	empty := false
+	for i, c := range f.Clauses {
+		db[i+1] = c
+		if len(c) == 0 {
+			empty = true
+		}
+	}
+	last := len(db)
+	for index, line := range strings.Split(proof, "\n") {
+		w := strings.Fields(line)
+		if len(w) == 0 || w[0] == "c" {
+			continue
+		}
+		fail := func(s string) (Result, error) { return result, fmt.Errorf("LRAT line %d: %s", index+1, s) }
+		if len(w) < 3 {
+			return fail("short line")
+		}
+		id, e := integer(w[0])
+		if e != nil {
+			return fail(e.Error())
+		}
+		if w[1] == "d" {
+			if id < last || w[len(w)-1] != "0" {
+				return fail("invalid deletion")
+			}
+			seen := map[int]bool{}
+			for _, word := range w[2 : len(w)-1] {
+				n, e := integer(word)
+				if e != nil || n <= 0 || db[n] == nil || seen[n] {
+					return fail("invalid deletion reference")
+				}
+				seen[n] = true
+				delete(db, n)
+				result.Deletions++
+			}
+			continue
+		}
+		if id <= last {
+			return fail("addition IDs must increase")
+		}
+		nums := []int{}
+		zeros := []int{}
+		for _, word := range w[1:] {
+			n, e := integer(word)
+			if e != nil {
+				return fail(e.Error())
+			}
+			if n == 0 {
+				zeros = append(zeros, len(nums))
+			}
+			nums = append(nums, n)
+		}
+		if len(zeros) != 2 || zeros[1] != len(nums)-1 {
+			return fail("expected two zero terminators")
+		}
+		c := Clause{}
+		for _, x := range nums[:zeros[0]] {
+			if abs(x) > f.Variables {
+				return fail("undeclared variable")
+			}
+			c[x] = true
+		}
+		if e := rup(db, c, nums[zeros[0]+1:len(nums)-1]); e != nil {
+			return fail(e.Error())
+		}
+		db[id] = c
+		last = id
+		result.Additions++
+		if len(c) == 0 {
+			empty = true
+		}
+	}
+	if !empty {
+		return result, fmt.Errorf("proof never establishes the empty clause")
+	}
+	result.Accepted = true
+	return result, nil
 }
 
 // CheckRUPDecoded exposes one decoded RUP step for differential testing of
 // bounded self-hosted kernels. Clauses and literals use DIMACS conventions.
 func CheckRUPDecoded(variables int, clauses [][]int, target []int, hints []int) error {
-    if variables <= 0 { return fmt.Errorf("invalid variable count") }
-    db := map[int]Clause{}
-    convert := func(xs []int) (Clause,error) {
-        c:=Clause{}
-        for _,x:=range xs { if x==0 || abs(x)>variables{return nil,fmt.Errorf("literal outside variable domain")};c[x]=true }
-        return c,nil
-    }
-    for i,xs:=range clauses {c,e:=convert(xs);if e!=nil{return e};db[i+1]=c}
-    c,e:=convert(target);if e!=nil{return e}
-    return rup(db,c,hints)
+	if variables <= 0 {
+		return fmt.Errorf("invalid variable count")
+	}
+	db := map[int]Clause{}
+	convert := func(xs []int) (Clause, error) {
+		c := Clause{}
+		for _, x := range xs {
+			if x == 0 || abs(x) > variables {
+				return nil, fmt.Errorf("literal outside variable domain")
+			}
+			c[x] = true
+		}
+		return c, nil
+	}
+	for i, xs := range clauses {
+		c, e := convert(xs)
+		if e != nil {
+			return e
+		}
+		db[i+1] = c
+	}
+	c, e := convert(target)
+	if e != nil {
+		return e
+	}
+	return rup(db, c, hints)
 }

--- a/experiments/verification-poc/internal/lrat/lrat_test.go
+++ b/experiments/verification-poc/internal/lrat/lrat_test.go
@@ -1,14 +1,35 @@
 package lrat
 
 import "testing"
-func TestRejectMalformedProofs(t *testing.T){
-    cnf:="p cnf 1 2\n1 0\n-1 0\n"
-    for _,proof:=range []string{"3 0 1 2 0\n","3 1 0 1 0\n3 d 1 0\n4 0 3 2 0\n"}{if _,e:=Check(cnf,proof);e!=nil{t.Fatal(e)}}
-    for _,proof:=range []string{"","3 0 0","3 0 1 0","3 0 1 9 0","3 0 -1 2 0","2 0 1 2 0","3 2 0 1 2 0","2 d 1 0\n3 0 1 2 0","3 0 1 2 2 0","3 0 1 2 0\n4 1 0 -1 0"}{if _,e:=Check(cnf,proof);e==nil{t.Fatalf("accepted corrupt proof %q",proof)}}
+
+func TestRejectMalformedProofs(t *testing.T) {
+	cnf := "p cnf 1 2\n1 0\n-1 0\n"
+	for _, proof := range []string{"3 0 1 2 0\n", "3 1 0 1 0\n3 d 1 0\n4 0 3 2 0\n"} {
+		if _, e := Check(cnf, proof); e != nil {
+			t.Fatal(e)
+		}
+	}
+	for _, proof := range []string{"", "3 0 0", "3 0 1 0", "3 0 1 9 0", "3 0 -1 2 0", "2 0 1 2 0", "3 2 0 1 2 0", "2 d 1 0\n3 0 1 2 0", "3 0 1 2 2 0", "3 0 1 2 0\n4 1 0 -1 0"} {
+		if _, e := Check(cnf, proof); e == nil {
+			t.Fatalf("accepted corrupt proof %q", proof)
+		}
+	}
 }
-func TestDIMACSRejectsMalformedInputs(t *testing.T){for _,text:=range []string{"","1 0","p cnf 1 1\n1","p cnf 1 1\n2 0","p cnf 1 0\n1 0","p cnf 1 0\np cnf 1 0","p cnf -1 0","p cnf 1 1\n99999999999999999999999999999 0"}{if _,e:=Parse(text);e==nil{t.Fatalf("accepted invalid DIMACS %q",text)}}}
-func TestEmptyClauseAndTautology(t *testing.T){
-    if _,e:=Check("p cnf 0 1\n0\n","");e!=nil{t.Fatal(e)}
-    if _,e:=Check("p cnf 1 1\n1 -1 0\n","2 0 1 0");e==nil{t.Fatal("tautology cannot prove contradiction")}
-    if _,e:=Check("p cnf 1 0\n","1 1 -1 0 0\n");e==nil{t.Fatal("tautological addition is not empty clause")}
+func TestDIMACSRejectsMalformedInputs(t *testing.T) {
+	for _, text := range []string{"", "1 0", "p cnf 1 1\n1", "p cnf 1 1\n2 0", "p cnf 1 0\n1 0", "p cnf 1 0\np cnf 1 0", "p cnf -1 0", "p cnf 1 1\n99999999999999999999999999999 0"} {
+		if _, e := Parse(text); e == nil {
+			t.Fatalf("accepted invalid DIMACS %q", text)
+		}
+	}
+}
+func TestEmptyClauseAndTautology(t *testing.T) {
+	if _, e := Check("p cnf 0 1\n0\n", ""); e != nil {
+		t.Fatal(e)
+	}
+	if _, e := Check("p cnf 1 1\n1 -1 0\n", "2 0 1 0"); e == nil {
+		t.Fatal("tautology cannot prove contradiction")
+	}
+	if _, e := Check("p cnf 1 0\n", "1 1 -1 0 0\n"); e == nil {
+		t.Fatal("tautological addition is not empty clause")
+	}
 }

--- a/experiments/verification-poc/internal/lrat/text_corpus_test.go
+++ b/experiments/verification-poc/internal/lrat/text_corpus_test.go
@@ -1,64 +1,79 @@
 package lrat
 
 import (
-    "encoding/json"
-    "fmt"
-    "os"
-    "testing"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
 )
 
 type textCase struct {
-    Name string `json:"name"`
-    CNF string `json:"cnf"`
-    Proof string `json:"proof"`
-    Expected bool `json:"expected"`
+	Name     string `json:"name"`
+	CNF      string `json:"cnf"`
+	Proof    string `json:"proof"`
+	Expected bool   `json:"expected"`
 }
 
 func checkTextCorpus(t *testing.T, decoded []differentialCase) {
-    t.Helper()
-    cases:=[]textCase{}
-    for _,c:=range decoded {
-        if c.Kind!="proof" {continue}
-        cnf,proof:=proofTexts(c)
-        cases=append(cases,textCase{Name:c.Name,CNF:cnf,Proof:proof,Expected:c.Expected})
-    }
-    cnf:="p cnf 1 2\n1 0\n-1 0\n"
-    proof:="3 0 1 2 0\n"
-    add:=func(name,formula,certificate string,expected bool) {
-        cases=append(cases,textCase{Name:name,CNF:formula,Proof:certificate,Expected:expected})
-    }
-    add("comments-and-ascii-whitespace","c formula\r\np\tcnf 1 2\r\n1\t0\r\n-1\v\f0\r\n","c proof\r\n3\t0\t1\t2\t0\r\n",true)
-    add("multiline-clause","p cnf 2 3\n1\n0 -1\n2 0\n-2 0","4 0 1 2 3 0",true)
-    add("signed-and-leading-zero-integers","p cnf +01 02\n+1 -0\n-1 +00\n","03 +0 +1 +2 -0",true)
-    add("initial-empty-proof","p cnf 0 1\n0", "",true)
-    add("initial-empty-invalid-suffix","p cnf 0 1\n0", "garbage",false)
-    add("empty-derived-then-deleted",cnf,proof+"3 d 3 0",true)
-    add("high-deletion-stamp-does-not-advance-last",cnf,"99 d 0\n"+proof,true)
-    for i,bad:=range []string{
-        "", "1 0", "p cnf 1", "p other 1 2\n1 0 -1 0", "p cnf -1 2\n1 0 -1 0",
-        "p cnf 1 -2", "p cnf 1 2\n1 0 -1", "p cnf 1 1\n1 0 -1 0", "p cnf 1 3\n1 0 -1 0",
-        "p cnf 1 2\n2 0 -2 0", "p cnf 1 2\n1 0 -1 0\np cnf 1 2", "p cnf 1 2\n1 0 -1 0\nx",
-        "p cnf 2147483648 0", "p cnf 1 1\n-2147483648 0", "p cnf + 0", "p cnf 1 1\n1_0 0",
-        "p cnf 1 1\n0x1 0", "p cnf 1 1\n1.0 0", "p cnf 1 1\n1e0 0",
-    } { add(fmt.Sprintf("malformed-cnf-%d",i),bad,proof,false) }
-    for i,bad:=range []string{
-        "", "3", "3 0", "3 0 0", "3 0 1 0", "3 0 1 2", "3 0 1 2 0 0", "3 0 1 2 0 garbage",
-        "3 0 -1 2 0", "3 0 1 9 0", "3 0 1 2 2 0", "2 0 1 2 0", "-3 0 1 2 0", "2147483648 0 1 2 0",
-        "3 2 0 1 2 0", "2 d 1 0\n3 0 1 2 0", "2 d 1 1 0\n"+proof, "2 d 0 0\n"+proof,
-        "2 d 9 0\n"+proof, "2 d -1 0\n"+proof, "2 d 0x0\n"+proof,
-        "2 d +0\n"+proof, "2 d -0\n"+proof, "2 d 00\n"+proof,
-        proof+"4 0 -1 0", proof+"4 d 9 0", proof+"4 0 0", proof+"4 0 1 2 0 trailing",
-    } { add(fmt.Sprintf("malformed-lrat-%d",i),cnf,bad,false) }
-    accepted:=0
-    for _,c:=range cases {
-        result,err:=Check(c.CNF,c.Proof)
-        actual:=err==nil && result.Accepted
-        if actual!=c.Expected { t.Fatalf("%s: Go=%t expected=%t: %v",c.Name,actual,c.Expected,err) }
-        if actual {accepted++}
-    }
-    t.Logf("text corpus: %d cases (%d accepted, %d rejected)",len(cases),accepted,len(cases)-accepted)
-    if path:=os.Getenv("OAK_LEAN_TEXT_CORPUS_OUT");path!="" {
-        data,err:=json.Marshal(cases);if err!=nil {t.Fatal(err)}
-        if err=os.WriteFile(path,data,0600);err!=nil {t.Fatal(err)}
-    }
+	t.Helper()
+	cases := []textCase{}
+	for _, c := range decoded {
+		if c.Kind != "proof" {
+			continue
+		}
+		cnf, proof := proofTexts(c)
+		cases = append(cases, textCase{Name: c.Name, CNF: cnf, Proof: proof, Expected: c.Expected})
+	}
+	cnf := "p cnf 1 2\n1 0\n-1 0\n"
+	proof := "3 0 1 2 0\n"
+	add := func(name, formula, certificate string, expected bool) {
+		cases = append(cases, textCase{Name: name, CNF: formula, Proof: certificate, Expected: expected})
+	}
+	add("comments-and-ascii-whitespace", "c formula\r\np\tcnf 1 2\r\n1\t0\r\n-1\v\f0\r\n", "c proof\r\n3\t0\t1\t2\t0\r\n", true)
+	add("multiline-clause", "p cnf 2 3\n1\n0 -1\n2 0\n-2 0", "4 0 1 2 3 0", true)
+	add("signed-and-leading-zero-integers", "p cnf +01 02\n+1 -0\n-1 +00\n", "03 +0 +1 +2 -0", true)
+	add("initial-empty-proof", "p cnf 0 1\n0", "", true)
+	add("initial-empty-invalid-suffix", "p cnf 0 1\n0", "garbage", false)
+	add("empty-derived-then-deleted", cnf, proof+"3 d 3 0", true)
+	add("high-deletion-stamp-does-not-advance-last", cnf, "99 d 0\n"+proof, true)
+	for i, bad := range []string{
+		"", "1 0", "p cnf 1", "p other 1 2\n1 0 -1 0", "p cnf -1 2\n1 0 -1 0",
+		"p cnf 1 -2", "p cnf 1 2\n1 0 -1", "p cnf 1 1\n1 0 -1 0", "p cnf 1 3\n1 0 -1 0",
+		"p cnf 1 2\n2 0 -2 0", "p cnf 1 2\n1 0 -1 0\np cnf 1 2", "p cnf 1 2\n1 0 -1 0\nx",
+		"p cnf 2147483648 0", "p cnf 1 1\n-2147483648 0", "p cnf + 0", "p cnf 1 1\n1_0 0",
+		"p cnf 1 1\n0x1 0", "p cnf 1 1\n1.0 0", "p cnf 1 1\n1e0 0",
+	} {
+		add(fmt.Sprintf("malformed-cnf-%d", i), bad, proof, false)
+	}
+	for i, bad := range []string{
+		"", "3", "3 0", "3 0 0", "3 0 1 0", "3 0 1 2", "3 0 1 2 0 0", "3 0 1 2 0 garbage",
+		"3 0 -1 2 0", "3 0 1 9 0", "3 0 1 2 2 0", "2 0 1 2 0", "-3 0 1 2 0", "2147483648 0 1 2 0",
+		"3 2 0 1 2 0", "2 d 1 0\n3 0 1 2 0", "2 d 1 1 0\n" + proof, "2 d 0 0\n" + proof,
+		"2 d 9 0\n" + proof, "2 d -1 0\n" + proof, "2 d 0x0\n" + proof,
+		"2 d +0\n" + proof, "2 d -0\n" + proof, "2 d 00\n" + proof,
+		proof + "4 0 -1 0", proof + "4 d 9 0", proof + "4 0 0", proof + "4 0 1 2 0 trailing",
+	} {
+		add(fmt.Sprintf("malformed-lrat-%d", i), cnf, bad, false)
+	}
+	accepted := 0
+	for _, c := range cases {
+		result, err := Check(c.CNF, c.Proof)
+		actual := err == nil && result.Accepted
+		if actual != c.Expected {
+			t.Fatalf("%s: Go=%t expected=%t: %v", c.Name, actual, c.Expected, err)
+		}
+		if actual {
+			accepted++
+		}
+	}
+	t.Logf("text corpus: %d cases (%d accepted, %d rejected)", len(cases), accepted, len(cases)-accepted)
+	if path := os.Getenv("OAK_LEAN_TEXT_CORPUS_OUT"); path != "" {
+		data, err := json.Marshal(cases)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err = os.WriteFile(path, data, 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
 }

--- a/experiments/verification-poc/json.go
+++ b/experiments/verification-poc/json.go
@@ -1,41 +1,106 @@
 package main
 
 import (
-    "bytes"
-    "crypto/sha256"
-    "encoding/hex"
-    "encoding/json"
-    "fmt"
-    "io"
-    "os"
-    "strconv"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
 )
 
-func digest(data string) string { h:=sha256.Sum256([]byte(data));return hex.EncodeToString(h[:]) }
+func digest(data string) string { h := sha256.Sum256([]byte(data)); return hex.EncodeToString(h[:]) }
+
 // decode rejects duplicate keys before typed decoding can silently overwrite them.
-func decode(data []byte,target any) error {
-    if len(data)>55_000_000{return fmt.Errorf("JSON input limit")}
-    d:=json.NewDecoder(bytes.NewReader(data));d.UseNumber()
-    var scan func(int) error
-    scan=func(depth int) error {
-        if depth>128{return fmt.Errorf("JSON nesting limit")}
-        token,e:=d.Token();if e!=nil{return e}
-        delimiter,ok:=token.(json.Delim);if !ok{return nil}
-        if delimiter=='{' {
-            keys:=map[string]bool{}
-            for d.More(){t,e:=d.Token();if e!=nil{return e};key,ok:=t.(string);if !ok||keys[key]{return fmt.Errorf("invalid/duplicate JSON key")};keys[key]=true;if e:=scan(depth+1);e!=nil{return e}}
-        } else if delimiter=='[' {for d.More(){if e:=scan(depth+1);e!=nil{return e}}} else{return fmt.Errorf("unexpected JSON delimiter")}
-        _,e=d.Token();return e
-    }
-    if e:=scan(0);e!=nil{return e};if _,e:=d.Token();e!=io.EOF{return fmt.Errorf("trailing JSON")}
-    d=json.NewDecoder(bytes.NewReader(data));d.UseNumber();d.DisallowUnknownFields();return d.Decode(target)
+func decode(data []byte, target any) error {
+	if len(data) > 55_000_000 {
+		return fmt.Errorf("JSON input limit")
+	}
+	d := json.NewDecoder(bytes.NewReader(data))
+	d.UseNumber()
+	var scan func(int) error
+	scan = func(depth int) error {
+		if depth > 128 {
+			return fmt.Errorf("JSON nesting limit")
+		}
+		token, e := d.Token()
+		if e != nil {
+			return e
+		}
+		delimiter, ok := token.(json.Delim)
+		if !ok {
+			return nil
+		}
+		if delimiter == '{' {
+			keys := map[string]bool{}
+			for d.More() {
+				t, e := d.Token()
+				if e != nil {
+					return e
+				}
+				key, ok := t.(string)
+				if !ok || keys[key] {
+					return fmt.Errorf("invalid/duplicate JSON key")
+				}
+				keys[key] = true
+				if e := scan(depth + 1); e != nil {
+					return e
+				}
+			}
+		} else if delimiter == '[' {
+			for d.More() {
+				if e := scan(depth + 1); e != nil {
+					return e
+				}
+			}
+		} else {
+			return fmt.Errorf("unexpected JSON delimiter")
+		}
+		_, e = d.Token()
+		return e
+	}
+	if e := scan(0); e != nil {
+		return e
+	}
+	if _, e := d.Token(); e != io.EOF {
+		return fmt.Errorf("trailing JSON")
+	}
+	d = json.NewDecoder(bytes.NewReader(data))
+	d.UseNumber()
+	d.DisallowUnknownFields()
+	return d.Decode(target)
 }
-func readJSON(path string,target any) error {
-    f,e:=os.Open(path);if e!=nil{return e};defer f.Close()
-    b,e:=io.ReadAll(io.LimitReader(f,55_000_001));if e!=nil{return e};return decode(b,target)
+func readJSON(path string, target any) error {
+	f, e := os.Open(path)
+	if e != nil {
+		return e
+	}
+	defer f.Close()
+	b, e := io.ReadAll(io.LimitReader(f, 55_000_001))
+	if e != nil {
+		return e
+	}
+	return decode(b, target)
 }
-func jsonText(v any) string {b,e:=json.MarshalIndent(v,"","  ");if e!=nil{panic(e)};return string(b)+"\n"}
-func number(v any)(int,error){
-    switch n:=v.(type){case int:return n,nil;case int64:if n>=-2147483647&&n<=2147483647{return int(n),nil};case json.Number:return strconv.Atoi(string(n))}
-    return 0,fmt.Errorf("integer required, got %T",v)
+func jsonText(v any) string {
+	b, e := json.MarshalIndent(v, "", "  ")
+	if e != nil {
+		panic(e)
+	}
+	return string(b) + "\n"
+}
+func number(v any) (int, error) {
+	switch n := v.(type) {
+	case int:
+		return n, nil
+	case int64:
+		if n >= -2147483647 && n <= 2147483647 {
+			return int(n), nil
+		}
+	case json.Number:
+		return strconv.Atoi(string(n))
+	}
+	return 0, fmt.Errorf("integer required, got %T", v)
 }

--- a/experiments/verification-poc/literal_casts_test.go
+++ b/experiments/verification-poc/literal_casts_test.go
@@ -1,12 +1,12 @@
 package main
 
 import (
- "os"
- "regexp"
- "strings"
- "testing"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
 
- "github.com/SCKelemen/oak/compiler"
+	"github.com/SCKelemen/oak/compiler"
 )
 
 // Literal casts such as u32(1) in the checker sources exist only to name the
@@ -19,31 +19,51 @@ var literalCast = regexp.MustCompile(`\b(u8|u16|u32|u64|i8|i16|i32|i64)\(([0-9]+
 var emittedCast = regexp.MustCompile(`\(\((u8|u16|u32|u64|i8|i16|i32|i64)\)\( ([0-9]+) \)\)`)
 
 func checkerSources(t *testing.T) string {
- t.Helper()
- var source strings.Builder
- for _,path:=range []string{"self_hosted_rup.oak","self_hosted_stream.oak","self_hosted_text.oak"} {data,err:=os.ReadFile(path);if err!=nil {t.Fatal(err)};source.Write(data);source.WriteByte('\n')}
- source.WriteString("main: (): i32 {\n cnf: [1]u8\n proof: [1]u8\n cv: []u8 = cnf[0:0]\n pv: []u8 = proof[0:0]\n rup_text_check(cv, pv) ? { 1 } | { 0 }\n}\n")
- return source.String()
+	t.Helper()
+	var source strings.Builder
+	for _, path := range []string{"self_hosted_rup.oak", "self_hosted_stream.oak", "self_hosted_text.oak"} {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		source.Write(data)
+		source.WriteByte('\n')
+	}
+	source.WriteString("main: (): i32 {\n cnf: [1]u8\n proof: [1]u8\n cv: []u8 = cnf[0:0]\n pv: []u8 = proof[0:0]\n rup_text_check(cv, pv) ? { 1 } | { 0 }\n}\n")
+	return source.String()
 }
-func emitChecker(t *testing.T,name,source string) string {
- t.Helper();generated,err:=compiler.New().WithSource(name,source).EmitC().Get();if err!=nil {t.Fatalf("%s: %v",name,err)};return generated
+func emitChecker(t *testing.T, name, source string) string {
+	t.Helper()
+	generated, err := compiler.New().WithSource(name, source).EmitC().Get()
+	if err != nil {
+		t.Fatalf("%s: %v", name, err)
+	}
+	return generated
 }
 func TestLiteralCastsAreRedundantInChecker(t *testing.T) {
- original:=checkerSources(t)
- stripped:=literalCast.ReplaceAllString(original,"$2")
- removed:=len(literalCast.FindAllStringIndex(original,-1))
- if removed<150 {t.Fatalf("expected the checker sources to carry many literal casts, found %d",removed)}
- if literalCast.MatchString(stripped) {t.Fatal("literal casts survived stripping")}
- withCasts:=emittedCast.ReplaceAllString(emitChecker(t,"checker_casts.oak",original),"$2")
- withoutCasts:=emitChecker(t,"checker_literals.oak",stripped)
- // Source annotation comments carry the file name and column spans, which the
- // shorter source changes; compare the code only.
- sourceNote:=regexp.MustCompile(`(?m)^// @source: .*$`)
- normalize:=func(c string) string {return sourceNote.ReplaceAllString(c,"// @source")}
- if normalize(withCasts)!=normalize(withoutCasts) {
-  a,b:=strings.Split(normalize(withCasts),"\n"),strings.Split(normalize(withoutCasts),"\n")
-  for i:=0;i<len(a)&&i<len(b);i++ {if a[i]!=b[i] {t.Fatalf("generated C differs at line %d:\n casts:    %s\n literals: %s",i+1,a[i],b[i])}}
-  t.Fatalf("generated C differs in length: %d vs %d lines",len(a),len(b))
- }
- t.Logf("checker sources: %d literal casts removed, generated C identical after normalizing the cast wrapper",removed)
+	original := checkerSources(t)
+	stripped := literalCast.ReplaceAllString(original, "$2")
+	removed := len(literalCast.FindAllStringIndex(original, -1))
+	if removed < 150 {
+		t.Fatalf("expected the checker sources to carry many literal casts, found %d", removed)
+	}
+	if literalCast.MatchString(stripped) {
+		t.Fatal("literal casts survived stripping")
+	}
+	withCasts := emittedCast.ReplaceAllString(emitChecker(t, "checker_casts.oak", original), "$2")
+	withoutCasts := emitChecker(t, "checker_literals.oak", stripped)
+	// Source annotation comments carry the file name and column spans, which the
+	// shorter source changes; compare the code only.
+	sourceNote := regexp.MustCompile(`(?m)^// @source: .*$`)
+	normalize := func(c string) string { return sourceNote.ReplaceAllString(c, "// @source") }
+	if normalize(withCasts) != normalize(withoutCasts) {
+		a, b := strings.Split(normalize(withCasts), "\n"), strings.Split(normalize(withoutCasts), "\n")
+		for i := 0; i < len(a) && i < len(b); i++ {
+			if a[i] != b[i] {
+				t.Fatalf("generated C differs at line %d:\n casts:    %s\n literals: %s", i+1, a[i], b[i])
+			}
+		}
+		t.Fatalf("generated C differs in length: %d vs %d lines", len(a), len(b))
+	}
+	t.Logf("checker sources: %d literal casts removed, generated C identical after normalizing the cast wrapper", removed)
 }

--- a/experiments/verification-poc/main.go
+++ b/experiments/verification-poc/main.go
@@ -2,14 +2,16 @@
 package main
 
 import (
-    "flag"
-    "fmt"
-    "os"
-    "path/filepath"
-    "time"
-    "github.com/SCKelemen/oak/experiments/verification-poc/internal/lrat"
+	"flag"
+	"fmt"
+	"github.com/SCKelemen/oak/experiments/verification-poc/internal/lrat"
+	"os"
+	"path/filepath"
+	"time"
 )
-func usage()string{return `usage:
+
+func usage() string {
+	return `usage:
   go run . export-boolean --out MODEL.json PROJECT.json
   go run . emit --out DIR PROJECT.json
   go run . prove-local --out CERT.json PROJECT.json
@@ -20,29 +22,146 @@ func usage()string{return `usage:
   go run . suite [--tla-jar FILE] [--out DIR] [--timeout SECONDS]
   go run . import-trace --backend z3|tlc --query FILE --receipt FILE --out CERT.json [--bound N] PROJECT.json RAW_OUTPUT
 Options precede positional arguments. All model commands use Oak's native frontend.
-`}
-func writeArtifact(path,text string)error{if path==""{return fmt.Errorf("--out is required")};if e:=os.MkdirAll(filepath.Dir(path),0755);e!=nil{return e};return os.WriteFile(path,[]byte(text),0644)}
-func command(args []string)(any,error){
-    if len(args)==0{return nil,fmt.Errorf("%s",usage())};action:=args[0];fs:=flag.NewFlagSet(action,flag.ContinueOnError)
-    out:=fs.String("out","","output file or directory");jar:=fs.String("tla-jar","","pinned TLC jar");timeout:=fs.Float64("timeout",60,"external tool timeout in seconds");examples:=fs.String("examples","examples/native","suite projects directory")
-    backend:=fs.String("backend","","trace backend");queryFile:=fs.String("query","","original query file (TLC: Model.tla newline Model.cfg)");receiptFile:=fs.String("receipt","","trace receipt");bound:=fs.Int("bound",-1,"BMC bound")
-    if e:=fs.Parse(args[1:]);e!=nil{return nil,e};pos:=fs.Args()
-    if action=="suite"{if len(pos)!=0||*timeout<=0{return nil,fmt.Errorf("invalid suite arguments")};if *out==""{*out="build/integration"};return runSuite(*examples,*out,*jar,time.Duration(*timeout*float64(time.Second)))}
-    if action=="lrat"{if len(pos)!=2{return nil,fmt.Errorf("lrat requires CNF and proof")};a,e:=os.ReadFile(pos[0]);if e!=nil{return nil,e};b,e:=os.ReadFile(pos[1]);if e!=nil{return nil,e};return lrat.Check(string(a),string(b))}
-    need:=1;if action=="verify"||action=="import-trace"{need=2};if len(pos)!=need{return nil,fmt.Errorf("%s",usage())}
-    if action!="export-boolean"&&action!="emit"&&action!="prove-local"&&action!="trace"&&action!="closed-set"&&action!="verify"&&action!="import-trace"{return nil,fmt.Errorf("unknown action: %s",action)}
-    m,e:=loadModel(pos[0]);if e!=nil{return nil,e}
-    if action=="export-boolean"{b,e:=exportBoolean(m);if e!=nil{return nil,e};if e:=writeArtifact(*out,jsonText(b));e!=nil{return nil,e};return map[string]any{"generated":true,"format":b.Format,"semantic_digest":m.Digest,"verification_claim":false},nil}
-    if action=="emit"{if *out==""{return nil,fmt.Errorf("--out required")};if e:=emit(m,*out);e!=nil{return nil,e};return map[string]any{"generated":true,"semantic_digest":m.Digest,"verification_claim":false},nil}
-    var c *Certificate
-    switch action{
-    case "verify":c=&Certificate{};e=readJSON(pos[1],c)
-    case "prove-local":c,e=localProof(m)
-    case "trace":c,e=findTrace(m)
-    case "closed-set":c,e=closedSet(m)
-    case "import-trace":
-        var r Receipt;if e:=readJSON(*receiptFile,&r);e!=nil{return nil,e};q,e:=os.ReadFile(*queryFile);if e!=nil{return nil,e};raw,e:=os.ReadFile(pos[1]);if e!=nil{return nil,e};var k *int;if *bound>=0{k=bound};c,e=importTrace(m,*backend,string(q),string(raw),r,k);if e!=nil{return nil,e}
-    }
-    if e!=nil{return nil,e};result,e:=verify(m,c);if e!=nil{return nil,e};if action!="verify"{if e:=writeArtifact(*out,jsonText(c));e!=nil{return nil,e}};return result,nil
+`
 }
-func main(){r,e:=command(os.Args[1:]);if e!=nil{fmt.Print(jsonText(map[string]any{"accepted":false,"reason":e.Error()}));os.Exit(1)};fmt.Print(jsonText(r));if suite,ok:=r.(*SuiteResult);ok&&!suite.Passed{os.Exit(2)}}
+func writeArtifact(path, text string) error {
+	if path == "" {
+		return fmt.Errorf("--out is required")
+	}
+	if e := os.MkdirAll(filepath.Dir(path), 0755); e != nil {
+		return e
+	}
+	return os.WriteFile(path, []byte(text), 0644)
+}
+func command(args []string) (any, error) {
+	if len(args) == 0 {
+		return nil, fmt.Errorf("%s", usage())
+	}
+	action := args[0]
+	fs := flag.NewFlagSet(action, flag.ContinueOnError)
+	out := fs.String("out", "", "output file or directory")
+	jar := fs.String("tla-jar", "", "pinned TLC jar")
+	timeout := fs.Float64("timeout", 60, "external tool timeout in seconds")
+	examples := fs.String("examples", "examples/native", "suite projects directory")
+	backend := fs.String("backend", "", "trace backend")
+	queryFile := fs.String("query", "", "original query file (TLC: Model.tla newline Model.cfg)")
+	receiptFile := fs.String("receipt", "", "trace receipt")
+	bound := fs.Int("bound", -1, "BMC bound")
+	if e := fs.Parse(args[1:]); e != nil {
+		return nil, e
+	}
+	pos := fs.Args()
+	if action == "suite" {
+		if len(pos) != 0 || *timeout <= 0 {
+			return nil, fmt.Errorf("invalid suite arguments")
+		}
+		if *out == "" {
+			*out = "build/integration"
+		}
+		return runSuite(*examples, *out, *jar, time.Duration(*timeout*float64(time.Second)))
+	}
+	if action == "lrat" {
+		if len(pos) != 2 {
+			return nil, fmt.Errorf("lrat requires CNF and proof")
+		}
+		a, e := os.ReadFile(pos[0])
+		if e != nil {
+			return nil, e
+		}
+		b, e := os.ReadFile(pos[1])
+		if e != nil {
+			return nil, e
+		}
+		return lrat.Check(string(a), string(b))
+	}
+	need := 1
+	if action == "verify" || action == "import-trace" {
+		need = 2
+	}
+	if len(pos) != need {
+		return nil, fmt.Errorf("%s", usage())
+	}
+	if action != "export-boolean" && action != "emit" && action != "prove-local" && action != "trace" && action != "closed-set" && action != "verify" && action != "import-trace" {
+		return nil, fmt.Errorf("unknown action: %s", action)
+	}
+	m, e := loadModel(pos[0])
+	if e != nil {
+		return nil, e
+	}
+	if action == "export-boolean" {
+		b, e := exportBoolean(m)
+		if e != nil {
+			return nil, e
+		}
+		if e := writeArtifact(*out, jsonText(b)); e != nil {
+			return nil, e
+		}
+		return map[string]any{"generated": true, "format": b.Format, "semantic_digest": m.Digest, "verification_claim": false}, nil
+	}
+	if action == "emit" {
+		if *out == "" {
+			return nil, fmt.Errorf("--out required")
+		}
+		if e := emit(m, *out); e != nil {
+			return nil, e
+		}
+		return map[string]any{"generated": true, "semantic_digest": m.Digest, "verification_claim": false}, nil
+	}
+	var c *Certificate
+	switch action {
+	case "verify":
+		c = &Certificate{}
+		e = readJSON(pos[1], c)
+	case "prove-local":
+		c, e = localProof(m)
+	case "trace":
+		c, e = findTrace(m)
+	case "closed-set":
+		c, e = closedSet(m)
+	case "import-trace":
+		var r Receipt
+		if e := readJSON(*receiptFile, &r); e != nil {
+			return nil, e
+		}
+		q, e := os.ReadFile(*queryFile)
+		if e != nil {
+			return nil, e
+		}
+		raw, e := os.ReadFile(pos[1])
+		if e != nil {
+			return nil, e
+		}
+		var k *int
+		if *bound >= 0 {
+			k = bound
+		}
+		c, e = importTrace(m, *backend, string(q), string(raw), r, k)
+		if e != nil {
+			return nil, e
+		}
+	}
+	if e != nil {
+		return nil, e
+	}
+	result, e := verify(m, c)
+	if e != nil {
+		return nil, e
+	}
+	if action != "verify" {
+		if e := writeArtifact(*out, jsonText(c)); e != nil {
+			return nil, e
+		}
+	}
+	return result, nil
+}
+func main() {
+	r, e := command(os.Args[1:])
+	if e != nil {
+		fmt.Print(jsonText(map[string]any{"accepted": false, "reason": e.Error()}))
+		os.Exit(1)
+	}
+	fmt.Print(jsonText(r))
+	if suite, ok := r.(*SuiteResult); ok && !suite.Passed {
+		os.Exit(2)
+	}
+}

--- a/experiments/verification-poc/model.go
+++ b/experiments/verification-poc/model.go
@@ -1,153 +1,470 @@
 package main
 
 import (
-    "encoding/json"
-    "fmt"
-    "os"
-    "path/filepath"
-    "sort"
-    "strings"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
 
-    "github.com/SCKelemen/oak/experiments/verification-poc/frontend"
+	"github.com/SCKelemen/oak/experiments/verification-poc/frontend"
 )
 
 type Config struct {
-    Source string `json:"source"`
-    Initial string `json:"initial"`
-    Step string `json:"step"`
-    Invariant string `json:"invariant"`
-    Arithmetic string `json:"arithmetic,omitempty"`
+	Source     string `json:"source"`
+	Initial    string `json:"initial"`
+	Step       string `json:"step"`
+	Invariant  string `json:"invariant"`
+	Arithmetic string `json:"arithmetic,omitempty"`
 }
-type Field struct { Name,Type string }
-type Node struct { Op,Type,State,Field,Data string; B bool; N int; Args []*Node }
+type Field struct{ Name, Type string }
+type Node struct {
+	Op, Type, State, Field, Data string
+	B                            bool
+	N                            int
+	Args                         []*Node
+}
 type State map[string]any
 type Model struct {
-    Document *frontend.Document
-    Config Config
-    Fields []Field
-    Enums map[string][]string
-    Terms map[string]*Node
-    Digest string
-    // Declarations locate the source declarations by name (frontend.Declarations);
-    // they are not part of the semantic identity.
-    Declarations map[string]frontend.Declaration
+	Document *frontend.Document
+	Config   Config
+	Fields   []Field
+	Enums    map[string][]string
+	Terms    map[string]*Node
+	Digest   string
+	// Declarations locate the source declarations by name (frontend.Declarations);
+	// they are not part of the semantic identity.
+	Declarations map[string]frontend.Declaration
 }
-func demand(ok bool,why string){if !ok{panic(fmt.Errorf("%s",why))}}
-func array(v any) []any {a,ok:=v.([]any);demand(ok,"expected expression array");return a}
-func str(v any) string {s,ok:=v.(string);demand(ok,"expected name");return s}
-func contains(xs []string,s string)bool{for _,x:=range xs{if x==s{return true}};return false}
-func sortedKeys[V any](m map[string]V) []string {keys:=[]string{};for k:=range m{keys=append(keys,k)};sort.Strings(keys);return keys}
-func (m *Model) width(t string) int {if t=="Bool"{return 1};if t=="u8"{return 8};w:=1;for 1<<w<len(m.Enums[t]){w++};return w}
+
+func demand(ok bool, why string) {
+	if !ok {
+		panic(fmt.Errorf("%s", why))
+	}
+}
+func array(v any) []any { a, ok := v.([]any); demand(ok, "expected expression array"); return a }
+func str(v any) string  { s, ok := v.(string); demand(ok, "expected name"); return s }
+func contains(xs []string, s string) bool {
+	for _, x := range xs {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}
+func sortedKeys[V any](m map[string]V) []string {
+	keys := []string{}
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+func (m *Model) width(t string) int {
+	if t == "Bool" {
+		return 1
+	}
+	if t == "u8" {
+		return 8
+	}
+	w := 1
+	for 1<<w < len(m.Enums[t]) {
+		w++
+	}
+	return w
+}
 func (m *Model) domain(t string) []any {
-    if t=="Bool"{return []any{false,true}}
-    out:=[]any{};if t=="u8"{for i:=0;i<256;i++{out=append(out,i)}}else{for _,v:=range m.Enums[t]{out=append(out,v)}};return out
+	if t == "Bool" {
+		return []any{false, true}
+	}
+	out := []any{}
+	if t == "u8" {
+		for i := 0; i < 256; i++ {
+			out = append(out, i)
+		}
+	} else {
+		for _, v := range m.Enums[t] {
+			out = append(out, v)
+		}
+	}
+	return out
 }
 func (m *Model) valid(s State) error {
-    if len(s)!=len(m.Fields){return fmt.Errorf("state fields mismatch")}
-    for _,f:=range m.Fields{
-        v,ok:=s[f.Name];if !ok{return fmt.Errorf("missing field %s",f.Name)}
-        if f.Type=="Bool"{if _,ok:=v.(bool);!ok{return fmt.Errorf("expected Boolean %s",f.Name)}} else if f.Type=="u8"{
-            n,e:=number(v);if e!=nil||n<0||n>255{return fmt.Errorf("invalid u8 %s",f.Name)}
-        }else{v,ok:=v.(string);if !ok||!contains(m.Enums[f.Type],v){return fmt.Errorf("invalid nominal enum %s",f.Name)}}
-    };return nil
+	if len(s) != len(m.Fields) {
+		return fmt.Errorf("state fields mismatch")
+	}
+	for _, f := range m.Fields {
+		v, ok := s[f.Name]
+		if !ok {
+			return fmt.Errorf("missing field %s", f.Name)
+		}
+		if f.Type == "Bool" {
+			if _, ok := v.(bool); !ok {
+				return fmt.Errorf("expected Boolean %s", f.Name)
+			}
+		} else if f.Type == "u8" {
+			n, e := number(v)
+			if e != nil || n < 0 || n > 255 {
+				return fmt.Errorf("invalid u8 %s", f.Name)
+			}
+		} else {
+			v, ok := v.(string)
+			if !ok || !contains(m.Enums[f.Type], v) {
+				return fmt.Errorf("invalid nominal enum %s", f.Name)
+			}
+		}
+	}
+	return nil
 }
-func (m *Model) states() ([]State,error) {
-    count:=1;for _,f:=range m.Fields{count*=len(m.domain(f.Type))};if count>1024{return nil,fmt.Errorf("local enumeration limit: 1024 states")}
-    result:=[]State{{}}
-    for _,f:=range m.Fields{next:=[]State{};for _,s:=range result{for _,v:=range m.domain(f.Type){t:=State{};for k,x:=range s{t[k]=x};t[f.Name]=v;next=append(next,t)}};result=next};return result,nil
+func (m *Model) states() ([]State, error) {
+	count := 1
+	for _, f := range m.Fields {
+		count *= len(m.domain(f.Type))
+	}
+	if count > 1024 {
+		return nil, fmt.Errorf("local enumeration limit: 1024 states")
+	}
+	result := []State{{}}
+	for _, f := range m.Fields {
+		next := []State{}
+		for _, s := range result {
+			for _, v := range m.domain(f.Type) {
+				t := State{}
+				for k, x := range s {
+					t[k] = x
+				}
+				t[f.Name] = v
+				next = append(next, t)
+			}
+		}
+		result = next
+	}
+	return result, nil
 }
-func stateKey(s State) string{b,e:=json.Marshal(s);if e!=nil{panic(e)};return string(b)}
-func constantBool(b bool)*Node{return &Node{Op:"bool",Type:"Bool",B:b}}
-func expression(op,t string,args ...*Node)*Node{return &Node{Op:op,Type:t,Args:args}}
-func rename(n *Node,p string)*Node{
-    r:=*n;r.Args=nil;if n.Op=="var"{r.State=p};for _,a:=range n.Args{r.Args=append(r.Args,rename(a,p))};return &r
+func stateKey(s State) string {
+	b, e := json.Marshal(s)
+	if e != nil {
+		panic(e)
+	}
+	return string(b)
 }
-func newModel(doc *frontend.Document,cfg Config)(m *Model,err error){
-    defer func(){if e:=recover();e!=nil{m=nil;err=fmt.Errorf("invalid finite model: %v",e)}}()
-    demand(doc.Format=="oak-finite-1","unsupported frontend format")
-    demand(cfg.Source!=""&&cfg.Initial!=""&&cfg.Step!=""&&cfg.Invariant!="","missing project role")
-    demand(cfg.Arithmetic==""||cfg.Arithmetic=="u8-wrap","unsupported arithmetic profile")
-    // Normalize interface-valued AST arrays and integer representation.
-    data,e:=json.Marshal(doc);demand(e==nil,"invalid frontend document");var normalized frontend.Document
-    demand(decode(data,&normalized)==nil,"invalid frontend document");doc=&normalized
-    m=&Model{Document:doc,Config:cfg,Enums:doc.Enums,Terms:map[string]*Node{}}
-    demand(doc.State!=""&&doc.Enums[doc.State]==nil,"invalid state record")
-    fields:=map[string]string{};total:=0
-    for _,name:=range sortedKeys(doc.Enums){cases:=doc.Enums[name];seen:=map[string]bool{};demand(name!="Bool"&&name!="u8"&&len(cases)>0&&len(cases)<=16,"invalid enum");for _,c:=range cases{demand(!seen[c],"duplicate enum case");seen[c]=true}}
-    for _,f:=range doc.Fields{demand(fields[f[0]]=="","duplicate field");t:=f[1];demand(t=="Bool"||t=="u8"||doc.Enums[t]!=nil,"unsupported field type");fields[f[0]]=t;m.Fields=append(m.Fields,Field{f[0],t});total+=m.width(t)}
-    demand(len(fields)>0&&len(fields)<=6&&total<=16,"finite record limit: 1..6 fields and 16 state bits")
-    var expand func(string,[]string,map[string]bool)*Node
-    expand=func(name string,args []string,active map[string]bool)*Node{
-        fn,ok:=doc.Functions[name];demand(ok&&!active[name],"unknown or recursive function");demand(len(fn.Params)==len(args),"argument count mismatch")
-        nested:=map[string]bool{};for k,v:=range active{nested[k]=v};nested[name]=true
-        env:=map[string]string{}
-        for i,p:=range fn.Params{_,shadow:=doc.Functions[p];demand(env[p]==""&&!shadow&&doc.Enums[p]==nil,"duplicate/shadowed parameter");env[p]=args[i]}
-        var walk func(any)*Node
-        walk=func(raw any)*Node{
-            a:=array(raw);demand(len(a)>0,"empty expression");op:=str(a[0])
-            switch op {
-            case "bool": demand(len(a)==2,"invalid Boolean");v,ok:=a[1].(bool);demand(ok,"invalid Boolean");return constantBool(v)
-            case "member":
-                demand(len(a)==3,"invalid member");name,field:=str(a[1]),str(a[2])
-                if p:=env[name];p!=""{t:=fields[field];demand(t!="","unknown state field");return &Node{Op:"var",Type:t,State:p,Field:field}}
-                demand(contains(doc.Enums[name],field),"unknown enum constructor");return &Node{Op:"enum",Type:name,Data:field}
-            case "call":
-                demand(len(a)==3,"invalid call");name:=str(a[1]);actual:=array(a[2])
-                if name=="u8"{demand(len(actual)==1,"u8 needs one literal");lit:=array(actual[0]);demand(len(lit)==2&&str(lit[0])=="integer","u8 requires literal");n,e:=number(lit[1]);demand(e==nil&&n>=0&&n<256,"u8 literal outside 0..255");return &Node{Op:"byte",Type:"u8",N:n}}
-                ps:=[]string{};for _,arg:=range actual{v:=array(arg);demand(len(v)==2&&str(v[0])=="ref","state argument required");p:=env[str(v[1])];demand(p!="","unknown state parameter");ps=append(ps,p)};return expand(name,ps,nested)
-            case "match":
-                demand(len(a)==3,"invalid match");scrutinee:=walk(a[1]);arms:=array(a[2]);demand(len(arms)>0,"empty match")
-                seen:=map[string]bool{};var conditions,bodies []*Node;var fallback *Node;resultType:=""
-                for i,rawArm:=range arms{
-                    arm:=array(rawArm);demand(len(arm)==2,"invalid match arm");pattern:=array(arm[0]);demand(len(pattern)>0,"empty pattern");body:=walk(arm[1]);demand(resultType==""||resultType==body.Type,"match result type mismatch");resultType=body.Type
-                    if str(pattern[0])=="wildcard"{demand(len(pattern)==1&&i==len(arms)-1,"wildcard must be last");fallback=body;continue}
-                    var pat *Node;key:=""
-                    if str(pattern[0])=="integer"{demand(len(pattern)==2&&scrutinee.Type=="u8","integer pattern type mismatch");n,e:=number(pattern[1]);demand(e==nil&&n>=0&&n<256,"invalid integer pattern");pat=&Node{Op:"byte",Type:"u8",N:n};key=fmt.Sprint(n)}else{
-                        pat=walk(pattern);demand(pat.Op=="bool"||pat.Op=="enum","nonconstant pattern");key=pat.Data;if pat.Op=="bool"{key=fmt.Sprint(pat.B)}
-                    }
-                    demand(pat.Type==scrutinee.Type&&!seen[key],"mismatched or duplicate pattern");seen[key]=true
-                    conditions=append(conditions,expression("==","Bool",scrutinee,pat));bodies=append(bodies,body)
-                }
-                if fallback==nil{for _,v:=range m.domain(scrutinee.Type){demand(seen[fmt.Sprint(v)],"nonexhaustive match")};fallback=bodies[len(bodies)-1];bodies=bodies[:len(bodies)-1];conditions=conditions[:len(conditions)-1]}
-                for i:=len(bodies)-1;i>=0;i--{fallback=expression("ite",resultType,conditions[i],bodies[i],fallback)};return fallback
-            }
-            arity:=map[string]int{"!":1,"&&":2,"||":2,"==":2,"!=":2,"+":2,"-":2,"<":2,">":2,"<=":2,">=":2,"ite":3}[op]
-            demand(arity>0&&len(a)==arity+1,"unsupported expression");children:=[]*Node{};for _,v:=range a[1:]{children=append(children,walk(v))};t:="Bool"
-            if op=="!"||op=="&&"||op=="||"{for _,n:=range children{demand(n.Type=="Bool","Boolean type mismatch")}}else if op=="ite"{demand(children[0].Type=="Bool"&&children[1].Type==children[2].Type,"match type mismatch");t=children[1].Type}else if op=="=="||op=="!="{demand(children[0].Type==children[1].Type,"nominal equality mismatch")}else{
-                demand(children[0].Type=="u8"&&children[1].Type=="u8","explicit u8 operands required")
-                if op=="+"||op=="-"{demand(cfg.Arithmetic=="u8-wrap","arithmetic requires explicit experimental u8-wrap profile");t="u8"}
-            };return expression(op,t,children...)
-        }
-        n:=walk(fn.Body);demand(n.Type=="Bool","predicate must return Bool");return n
-    }
-    for _,name:=range sortedKeys(doc.Functions){args:=[]string{};for i:=range doc.Functions[name].Params{args=append(args,fmt.Sprintf("p%d",i))};expand(name,args,map[string]bool{})}
-    for _,role:=range []struct{role,name string;arity int}{{"initial",cfg.Initial,1},{"invariant",cfg.Invariant,1},{"step",cfg.Step,2}}{
-        fn,ok:=doc.Functions[role.name];demand(ok&&len(fn.Params)==role.arity,"invalid role signature");args:=[]string{"s","t"};m.Terms[role.role]=expand(role.name,args[:role.arity],map[string]bool{})
-    }
-    identity:=struct{Format string;Config Config;Document *frontend.Document}{"oak-go-finite-1",cfg,doc}
-    b,e:=json.Marshal(identity);demand(e==nil,"invalid identity");m.Digest=digest(string(b));return m,nil
+func constantBool(b bool) *Node                    { return &Node{Op: "bool", Type: "Bool", B: b} }
+func expression(op, t string, args ...*Node) *Node { return &Node{Op: op, Type: t, Args: args} }
+func rename(n *Node, p string) *Node {
+	r := *n
+	r.Args = nil
+	if n.Op == "var" {
+		r.State = p
+	}
+	for _, a := range n.Args {
+		r.Args = append(r.Args, rename(a, p))
+	}
+	return &r
 }
-func loadModel(path string)(*Model,error){
-    path,e:=filepath.Abs(path);if e!=nil{return nil,e};path,e=filepath.EvalSymlinks(path);if e!=nil{return nil,e}
-    var cfg Config;if e:=readJSON(path,&cfg);e!=nil{return nil,e}
-    sourcePath,e:=filepath.EvalSymlinks(filepath.Join(filepath.Dir(path),cfg.Source));if e!=nil{return nil,e}
-    rel,e:=filepath.Rel(filepath.Dir(path),sourcePath);if e!=nil||rel==".."||strings.HasPrefix(rel,".."+string(filepath.Separator)){return nil,fmt.Errorf("source must remain inside project directory")}
-    source,e:=os.ReadFile(sourcePath);if e!=nil{return nil,e};if len(source)>2_000_000{return nil,fmt.Errorf("source limit")}
-    doc,e:=frontend.Export(sourcePath,source);if e!=nil{return nil,e};if doc.SourceHash!=digest(string(source)){return nil,fmt.Errorf("frontend source mismatch")}
-    m,e:=newModel(doc,cfg);if e!=nil{return nil,e}
-    if declarations,e:=frontend.Declarations(sourcePath,source);e==nil{m.Declarations=declarations}
-    return m,nil
+func newModel(doc *frontend.Document, cfg Config) (m *Model, err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			m = nil
+			err = fmt.Errorf("invalid finite model: %v", e)
+		}
+	}()
+	demand(doc.Format == "oak-finite-1", "unsupported frontend format")
+	demand(cfg.Source != "" && cfg.Initial != "" && cfg.Step != "" && cfg.Invariant != "", "missing project role")
+	demand(cfg.Arithmetic == "" || cfg.Arithmetic == "u8-wrap", "unsupported arithmetic profile")
+	// Normalize interface-valued AST arrays and integer representation.
+	data, e := json.Marshal(doc)
+	demand(e == nil, "invalid frontend document")
+	var normalized frontend.Document
+	demand(decode(data, &normalized) == nil, "invalid frontend document")
+	doc = &normalized
+	m = &Model{Document: doc, Config: cfg, Enums: doc.Enums, Terms: map[string]*Node{}}
+	demand(doc.State != "" && doc.Enums[doc.State] == nil, "invalid state record")
+	fields := map[string]string{}
+	total := 0
+	for _, name := range sortedKeys(doc.Enums) {
+		cases := doc.Enums[name]
+		seen := map[string]bool{}
+		demand(name != "Bool" && name != "u8" && len(cases) > 0 && len(cases) <= 16, "invalid enum")
+		for _, c := range cases {
+			demand(!seen[c], "duplicate enum case")
+			seen[c] = true
+		}
+	}
+	for _, f := range doc.Fields {
+		demand(fields[f[0]] == "", "duplicate field")
+		t := f[1]
+		demand(t == "Bool" || t == "u8" || doc.Enums[t] != nil, "unsupported field type")
+		fields[f[0]] = t
+		m.Fields = append(m.Fields, Field{f[0], t})
+		total += m.width(t)
+	}
+	demand(len(fields) > 0 && len(fields) <= 6 && total <= 16, "finite record limit: 1..6 fields and 16 state bits")
+	var expand func(string, []string, map[string]bool) *Node
+	expand = func(name string, args []string, active map[string]bool) *Node {
+		fn, ok := doc.Functions[name]
+		demand(ok && !active[name], "unknown or recursive function")
+		demand(len(fn.Params) == len(args), "argument count mismatch")
+		nested := map[string]bool{}
+		for k, v := range active {
+			nested[k] = v
+		}
+		nested[name] = true
+		env := map[string]string{}
+		for i, p := range fn.Params {
+			_, shadow := doc.Functions[p]
+			demand(env[p] == "" && !shadow && doc.Enums[p] == nil, "duplicate/shadowed parameter")
+			env[p] = args[i]
+		}
+		var walk func(any) *Node
+		walk = func(raw any) *Node {
+			a := array(raw)
+			demand(len(a) > 0, "empty expression")
+			op := str(a[0])
+			switch op {
+			case "bool":
+				demand(len(a) == 2, "invalid Boolean")
+				v, ok := a[1].(bool)
+				demand(ok, "invalid Boolean")
+				return constantBool(v)
+			case "member":
+				demand(len(a) == 3, "invalid member")
+				name, field := str(a[1]), str(a[2])
+				if p := env[name]; p != "" {
+					t := fields[field]
+					demand(t != "", "unknown state field")
+					return &Node{Op: "var", Type: t, State: p, Field: field}
+				}
+				demand(contains(doc.Enums[name], field), "unknown enum constructor")
+				return &Node{Op: "enum", Type: name, Data: field}
+			case "call":
+				demand(len(a) == 3, "invalid call")
+				name := str(a[1])
+				actual := array(a[2])
+				if name == "u8" {
+					demand(len(actual) == 1, "u8 needs one literal")
+					lit := array(actual[0])
+					demand(len(lit) == 2 && str(lit[0]) == "integer", "u8 requires literal")
+					n, e := number(lit[1])
+					demand(e == nil && n >= 0 && n < 256, "u8 literal outside 0..255")
+					return &Node{Op: "byte", Type: "u8", N: n}
+				}
+				ps := []string{}
+				for _, arg := range actual {
+					v := array(arg)
+					demand(len(v) == 2 && str(v[0]) == "ref", "state argument required")
+					p := env[str(v[1])]
+					demand(p != "", "unknown state parameter")
+					ps = append(ps, p)
+				}
+				return expand(name, ps, nested)
+			case "match":
+				demand(len(a) == 3, "invalid match")
+				scrutinee := walk(a[1])
+				arms := array(a[2])
+				demand(len(arms) > 0, "empty match")
+				seen := map[string]bool{}
+				var conditions, bodies []*Node
+				var fallback *Node
+				resultType := ""
+				for i, rawArm := range arms {
+					arm := array(rawArm)
+					demand(len(arm) == 2, "invalid match arm")
+					pattern := array(arm[0])
+					demand(len(pattern) > 0, "empty pattern")
+					body := walk(arm[1])
+					demand(resultType == "" || resultType == body.Type, "match result type mismatch")
+					resultType = body.Type
+					if str(pattern[0]) == "wildcard" {
+						demand(len(pattern) == 1 && i == len(arms)-1, "wildcard must be last")
+						fallback = body
+						continue
+					}
+					var pat *Node
+					key := ""
+					if str(pattern[0]) == "integer" {
+						demand(len(pattern) == 2 && scrutinee.Type == "u8", "integer pattern type mismatch")
+						n, e := number(pattern[1])
+						demand(e == nil && n >= 0 && n < 256, "invalid integer pattern")
+						pat = &Node{Op: "byte", Type: "u8", N: n}
+						key = fmt.Sprint(n)
+					} else {
+						pat = walk(pattern)
+						demand(pat.Op == "bool" || pat.Op == "enum", "nonconstant pattern")
+						key = pat.Data
+						if pat.Op == "bool" {
+							key = fmt.Sprint(pat.B)
+						}
+					}
+					demand(pat.Type == scrutinee.Type && !seen[key], "mismatched or duplicate pattern")
+					seen[key] = true
+					conditions = append(conditions, expression("==", "Bool", scrutinee, pat))
+					bodies = append(bodies, body)
+				}
+				if fallback == nil {
+					for _, v := range m.domain(scrutinee.Type) {
+						demand(seen[fmt.Sprint(v)], "nonexhaustive match")
+					}
+					fallback = bodies[len(bodies)-1]
+					bodies = bodies[:len(bodies)-1]
+					conditions = conditions[:len(conditions)-1]
+				}
+				for i := len(bodies) - 1; i >= 0; i-- {
+					fallback = expression("ite", resultType, conditions[i], bodies[i], fallback)
+				}
+				return fallback
+			}
+			arity := map[string]int{"!": 1, "&&": 2, "||": 2, "==": 2, "!=": 2, "+": 2, "-": 2, "<": 2, ">": 2, "<=": 2, ">=": 2, "ite": 3}[op]
+			demand(arity > 0 && len(a) == arity+1, "unsupported expression")
+			children := []*Node{}
+			for _, v := range a[1:] {
+				children = append(children, walk(v))
+			}
+			t := "Bool"
+			if op == "!" || op == "&&" || op == "||" {
+				for _, n := range children {
+					demand(n.Type == "Bool", "Boolean type mismatch")
+				}
+			} else if op == "ite" {
+				demand(children[0].Type == "Bool" && children[1].Type == children[2].Type, "match type mismatch")
+				t = children[1].Type
+			} else if op == "==" || op == "!=" {
+				demand(children[0].Type == children[1].Type, "nominal equality mismatch")
+			} else {
+				demand(children[0].Type == "u8" && children[1].Type == "u8", "explicit u8 operands required")
+				if op == "+" || op == "-" {
+					demand(cfg.Arithmetic == "u8-wrap", "arithmetic requires explicit experimental u8-wrap profile")
+					t = "u8"
+				}
+			}
+			return expression(op, t, children...)
+		}
+		n := walk(fn.Body)
+		demand(n.Type == "Bool", "predicate must return Bool")
+		return n
+	}
+	for _, name := range sortedKeys(doc.Functions) {
+		args := []string{}
+		for i := range doc.Functions[name].Params {
+			args = append(args, fmt.Sprintf("p%d", i))
+		}
+		expand(name, args, map[string]bool{})
+	}
+	for _, role := range []struct {
+		role, name string
+		arity      int
+	}{{"initial", cfg.Initial, 1}, {"invariant", cfg.Invariant, 1}, {"step", cfg.Step, 2}} {
+		fn, ok := doc.Functions[role.name]
+		demand(ok && len(fn.Params) == role.arity, "invalid role signature")
+		args := []string{"s", "t"}
+		m.Terms[role.role] = expand(role.name, args[:role.arity], map[string]bool{})
+	}
+	identity := struct {
+		Format   string
+		Config   Config
+		Document *frontend.Document
+	}{"oak-go-finite-1", cfg, doc}
+	b, e := json.Marshal(identity)
+	demand(e == nil, "invalid identity")
+	m.Digest = digest(string(b))
+	return m, nil
 }
-func value(n *Node,env map[string]State)any{
-    switch n.Op{
-    case "bool":return n.B
-    case "byte":return n.N
-    case "enum":return n.Type+"."+n.Data
-    case "var":v:=env[n.State][n.Field];if n.Type=="u8"{x,e:=number(v);if e!=nil{panic(e)};return x};if n.Type!="Bool"{return n.Type+"."+v.(string)};return v
-    case "!":return !value(n.Args[0],env).(bool)
-    case "ite":if value(n.Args[0],env).(bool){return value(n.Args[1],env)};return value(n.Args[2],env)
-    }
-    a,b:=value(n.Args[0],env),value(n.Args[1],env)
-    switch n.Op{case "&&":return a.(bool)&&b.(bool);case "||":return a.(bool)||b.(bool);case "==":return a==b;case "!=":return a!=b;case "+":return (a.(int)+b.(int))&255;case "-":return (a.(int)-b.(int))&255;case "<":return a.(int)<b.(int);case ">":return a.(int)>b.(int);case "<=":return a.(int)<=b.(int);case ">=":return a.(int)>=b.(int)};panic("unknown checked operator")
+func loadModel(path string) (*Model, error) {
+	path, e := filepath.Abs(path)
+	if e != nil {
+		return nil, e
+	}
+	path, e = filepath.EvalSymlinks(path)
+	if e != nil {
+		return nil, e
+	}
+	var cfg Config
+	if e := readJSON(path, &cfg); e != nil {
+		return nil, e
+	}
+	sourcePath, e := filepath.EvalSymlinks(filepath.Join(filepath.Dir(path), cfg.Source))
+	if e != nil {
+		return nil, e
+	}
+	rel, e := filepath.Rel(filepath.Dir(path), sourcePath)
+	if e != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return nil, fmt.Errorf("source must remain inside project directory")
+	}
+	source, e := os.ReadFile(sourcePath)
+	if e != nil {
+		return nil, e
+	}
+	if len(source) > 2_000_000 {
+		return nil, fmt.Errorf("source limit")
+	}
+	doc, e := frontend.Export(sourcePath, source)
+	if e != nil {
+		return nil, e
+	}
+	if doc.SourceHash != digest(string(source)) {
+		return nil, fmt.Errorf("frontend source mismatch")
+	}
+	m, e := newModel(doc, cfg)
+	if e != nil {
+		return nil, e
+	}
+	if declarations, e := frontend.Declarations(sourcePath, source); e == nil {
+		m.Declarations = declarations
+	}
+	return m, nil
 }
-func truth(n *Node,s State,t State)bool{return value(n,map[string]State{"s":s,"t":t}).(bool)}
+func value(n *Node, env map[string]State) any {
+	switch n.Op {
+	case "bool":
+		return n.B
+	case "byte":
+		return n.N
+	case "enum":
+		return n.Type + "." + n.Data
+	case "var":
+		v := env[n.State][n.Field]
+		if n.Type == "u8" {
+			x, e := number(v)
+			if e != nil {
+				panic(e)
+			}
+			return x
+		}
+		if n.Type != "Bool" {
+			return n.Type + "." + v.(string)
+		}
+		return v
+	case "!":
+		return !value(n.Args[0], env).(bool)
+	case "ite":
+		if value(n.Args[0], env).(bool) {
+			return value(n.Args[1], env)
+		}
+		return value(n.Args[2], env)
+	}
+	a, b := value(n.Args[0], env), value(n.Args[1], env)
+	switch n.Op {
+	case "&&":
+		return a.(bool) && b.(bool)
+	case "||":
+		return a.(bool) || b.(bool)
+	case "==":
+		return a == b
+	case "!=":
+		return a != b
+	case "+":
+		return (a.(int) + b.(int)) & 255
+	case "-":
+		return (a.(int) - b.(int)) & 255
+	case "<":
+		return a.(int) < b.(int)
+	case ">":
+		return a.(int) > b.(int)
+	case "<=":
+		return a.(int) <= b.(int)
+	case ">=":
+		return a.(int) >= b.(int)
+	}
+	panic("unknown checked operator")
+}
+func truth(n *Node, s State, t State) bool { return value(n, map[string]State{"s": s, "t": t}).(bool) }

--- a/experiments/verification-poc/native_batches_test.go
+++ b/experiments/verification-poc/native_batches_test.go
@@ -1,67 +1,143 @@
 package main
 
 import (
- "fmt"
- "regexp"
- "strings"
- "testing"
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
 )
 
 var nativeCaseDeclaration = regexp.MustCompile(`(?m)^([A-Za-z_][A-Za-z0-9_]*_case_[0-9]+): \(\): Bool \{`)
 
 // Generated cases own their state. Keep their bodies and assertions unchanged,
 // but avoid quadratic source-position work on a single enormous translation unit.
-func batchOakCorpus(source string, size int) ([]string,error) {
- if size<=0 {return nil,fmt.Errorf("invalid native batch size")}
- matches:=nativeCaseDeclaration.FindAllStringSubmatchIndex(source,-1)
- if len(matches)==0 {return []string{source},nil}
- const mainHeader="main: (): i32 {\n"
- mainAt:=strings.LastIndex(source,mainHeader)
- if mainAt<0||mainAt<matches[len(matches)-1][0] {return nil,fmt.Errorf("generated corpus main missing")}
- var expected strings.Builder;expected.WriteString(mainHeader)
- names:=make([]string,len(matches));seen:=map[string]bool{}
- for i,m:=range matches {names[i]=source[m[2]:m[3]];if seen[names[i]] {return nil,fmt.Errorf("duplicate generated case")};seen[names[i]]=true;fmt.Fprintf(&expected,"assert(%s())\n",names[i])}
- expected.WriteString("42\n}\n")
- if strings.TrimSpace(source[mainAt:])!=strings.TrimSpace(expected.String()) {return nil,fmt.Errorf("generated main must assert every case exactly once, in order")}
- if len(matches)<=size {return []string{source},nil}
- batches:=[]string{};shared:=source[:matches[0][0]]
- for first:=0;first<len(matches);first+=size {
-  last:=first+size;if last>len(matches) {last=len(matches)}
-  end:=mainAt;if last<len(matches) {end=matches[last][0]}
-  var out strings.Builder;out.WriteString(shared);out.WriteString(source[matches[first][0]:end]);out.WriteString(mainHeader)
-  for i:=first;i<last;i++ {fmt.Fprintf(&out,"assert(%s())\n",names[i])}
-  out.WriteString("42\n}\n");batches=append(batches,out.String())
- }
- return batches,nil
+func batchOakCorpus(source string, size int) ([]string, error) {
+	if size <= 0 {
+		return nil, fmt.Errorf("invalid native batch size")
+	}
+	matches := nativeCaseDeclaration.FindAllStringSubmatchIndex(source, -1)
+	if len(matches) == 0 {
+		return []string{source}, nil
+	}
+	const mainHeader = "main: (): i32 {\n"
+	mainAt := strings.LastIndex(source, mainHeader)
+	if mainAt < 0 || mainAt < matches[len(matches)-1][0] {
+		return nil, fmt.Errorf("generated corpus main missing")
+	}
+	var expected strings.Builder
+	expected.WriteString(mainHeader)
+	names := make([]string, len(matches))
+	seen := map[string]bool{}
+	for i, m := range matches {
+		names[i] = source[m[2]:m[3]]
+		if seen[names[i]] {
+			return nil, fmt.Errorf("duplicate generated case")
+		}
+		seen[names[i]] = true
+		fmt.Fprintf(&expected, "assert(%s())\n", names[i])
+	}
+	expected.WriteString("42\n}\n")
+	if strings.TrimSpace(source[mainAt:]) != strings.TrimSpace(expected.String()) {
+		return nil, fmt.Errorf("generated main must assert every case exactly once, in order")
+	}
+	if len(matches) <= size {
+		return []string{source}, nil
+	}
+	batches := []string{}
+	shared := source[:matches[0][0]]
+	for first := 0; first < len(matches); first += size {
+		last := first + size
+		if last > len(matches) {
+			last = len(matches)
+		}
+		end := mainAt
+		if last < len(matches) {
+			end = matches[last][0]
+		}
+		var out strings.Builder
+		out.WriteString(shared)
+		out.WriteString(source[matches[first][0]:end])
+		out.WriteString(mainHeader)
+		for i := first; i < last; i++ {
+			fmt.Fprintf(&out, "assert(%s())\n", names[i])
+		}
+		out.WriteString("42\n}\n")
+		batches = append(batches, out.String())
+	}
+	return batches, nil
 }
-func runOakStream(t *testing.T,source string) {
- t.Helper();batches,err:=batchOakCorpus(source,64);if err!=nil {t.Fatal(err)}
- if len(batches)==1 {runOakStreamUnit(t,batches[0]);return}
- for i,batch:=range batches {if !t.Run(fmt.Sprintf("batch-%03d",i),func(t *testing.T){runOakStreamUnit(t,batch)}) {t.FailNow()}}
+func runOakStream(t *testing.T, source string) {
+	t.Helper()
+	batches, err := batchOakCorpus(source, 64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batches) == 1 {
+		runOakStreamUnit(t, batches[0])
+		return
+	}
+	for i, batch := range batches {
+		if !t.Run(fmt.Sprintf("batch-%03d", i), func(t *testing.T) { runOakStreamUnit(t, batch) }) {
+			t.FailNow()
+		}
+	}
 }
 func nativeBatchFixture(count int) string {
- var out,main strings.Builder;out.WriteString("shared: (): Bool { true }\n");main.WriteString("main: (): i32 {\n")
- for i:=0;i<count;i++ {fmt.Fprintf(&out,"batch_case_%d: (): Bool {\n// payload %d\nshared()\n}\n",i,i);fmt.Fprintf(&main,"assert(batch_case_%d())\n",i)}
- main.WriteString("42\n}\n");out.WriteString(main.String());return out.String()
+	var out, main strings.Builder
+	out.WriteString("shared: (): Bool { true }\n")
+	main.WriteString("main: (): i32 {\n")
+	for i := 0; i < count; i++ {
+		fmt.Fprintf(&out, "batch_case_%d: (): Bool {\n// payload %d\nshared()\n}\n", i, i)
+		fmt.Fprintf(&main, "assert(batch_case_%d())\n", i)
+	}
+	main.WriteString("42\n}\n")
+	out.WriteString(main.String())
+	return out.String()
 }
 func TestNativeCorpusBatchCoverage(t *testing.T) {
- source:=nativeBatchFixture(130);batches,err:=batchOakCorpus(source,64);if err!=nil {t.Fatal(err)};if len(batches)!=3 {t.Fatalf("got %d batches",len(batches))}
- for _,batch:=range batches {if strings.Count(batch,"shared: (): Bool")!=1 {t.Fatal("shared definitions changed")};if len(nativeCaseDeclaration.FindAllStringIndex(batch,-1))>64 {t.Fatal("oversized batch")}}
- combined:=strings.Join(batches,"\n")
- for i:=0;i<130;i++ {
-  body:=fmt.Sprintf("batch_case_%d: (): Bool {\n// payload %d\nshared()\n}\n",i,i)
-  assertion:=fmt.Sprintf("assert(batch_case_%d())",i)
-  if strings.Count(combined,body)!=1||strings.Count(combined,assertion)!=1 {t.Fatalf("case %d omitted, duplicated or modified",i)}
- }
- small:=nativeBatchFixture(1);one,err:=batchOakCorpus(small,64);if err!=nil||len(one)!=1||one[0]!=small {t.Fatal("single unit changed")}
+	source := nativeBatchFixture(130)
+	batches, err := batchOakCorpus(source, 64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batches) != 3 {
+		t.Fatalf("got %d batches", len(batches))
+	}
+	for _, batch := range batches {
+		if strings.Count(batch, "shared: (): Bool") != 1 {
+			t.Fatal("shared definitions changed")
+		}
+		if len(nativeCaseDeclaration.FindAllStringIndex(batch, -1)) > 64 {
+			t.Fatal("oversized batch")
+		}
+	}
+	combined := strings.Join(batches, "\n")
+	for i := 0; i < 130; i++ {
+		body := fmt.Sprintf("batch_case_%d: (): Bool {\n// payload %d\nshared()\n}\n", i, i)
+		assertion := fmt.Sprintf("assert(batch_case_%d())", i)
+		if strings.Count(combined, body) != 1 || strings.Count(combined, assertion) != 1 {
+			t.Fatalf("case %d omitted, duplicated or modified", i)
+		}
+	}
+	small := nativeBatchFixture(1)
+	one, err := batchOakCorpus(small, 64)
+	if err != nil || len(one) != 1 || one[0] != small {
+		t.Fatal("single unit changed")
+	}
 }
 func TestNativeCorpusBatchRejectsLostAssertions(t *testing.T) {
- good:=nativeBatchFixture(130)
- for _,bad:=range []string{
-  strings.Replace(good,"assert(batch_case_0())\n","",1),
-  strings.Replace(good,"assert(batch_case_0())","assert(batch_case_1())",1),
-  strings.Replace(good,"42\n}","assert(shared())\n42\n}",1),
-  strings.Replace(good,"batch_case_1: ()","batch_case_0: ()",1),
- } {if _,err:=batchOakCorpus(bad,64);err==nil {t.Fatal("unsafe corpus split accepted")}}
- if _,err:=batchOakCorpus(good,0);err==nil {t.Fatal("zero batch size accepted")}
+	good := nativeBatchFixture(130)
+	for _, bad := range []string{
+		strings.Replace(good, "assert(batch_case_0())\n", "", 1),
+		strings.Replace(good, "assert(batch_case_0())", "assert(batch_case_1())", 1),
+		strings.Replace(good, "42\n}", "assert(shared())\n42\n}", 1),
+		strings.Replace(good, "batch_case_1: ()", "batch_case_0: ()", 1),
+	} {
+		if _, err := batchOakCorpus(bad, 64); err == nil {
+			t.Fatal("unsafe corpus split accepted")
+		}
+	}
+	if _, err := batchOakCorpus(good, 0); err == nil {
+		t.Fatal("zero batch size accepted")
+	}
 }

--- a/experiments/verification-poc/produce.go
+++ b/experiments/verification-poc/produce.go
@@ -2,60 +2,216 @@
 package main
 
 import (
-    "fmt"
-    "sort"
-    "strings"
-    "github.com/SCKelemen/oak/experiments/verification-poc/internal/lrat"
+	"fmt"
+	"github.com/SCKelemen/oak/experiments/verification-poc/internal/lrat"
+	"sort"
+	"strings"
 )
-func absolute(x int)int{if x<0{return -x};return x}
-func localLRAT(text string,priority []int)(string,error){
-    f,e:=lrat.Parse(text);if e!=nil{return "",e};db:=map[int]lrat.Clause{};for i,c:=range f.Clauses{db[i+1]=c}
-    last:=len(db);nodes:=0;var output strings.Builder
-    propagate:=func(decisions []int)(bool,[]int,lrat.Clause){
-        assigned:=lrat.Clause{};for _,x:=range decisions{assigned[x]=true};hints:=[]int{}
-        ids:=[]int{};for id:=range db{ids=append(ids,id)};sort.Ints(ids)
-        for {changed:=false
-            for _,id:=range ids{clause:=db[id];satisfied:=false;left:=0;unit:=0
-                for x:=range clause{if assigned[x]{satisfied=true;break};if !assigned[-x]{left++;unit=x}}
-                if satisfied{continue};if left==0{return true,append(hints,id),assigned};if left==1{assigned[unit]=true;hints=append(hints,id);changed=true}
-            };if !changed{return false,hints,assigned}
-        }
-    }
-    var search func([]int)error
-    search=func(decisions []int)error{
-        nodes++;if nodes>4096{return fmt.Errorf("local proof search limit: 4096 nodes")}
-        conflict,hints,assigned:=propagate(decisions)
-        if !conflict{
-            variable:=0;order:=append([]int{},priority...);for v:=1;v<=f.Variables;v++{order=append(order,v)}
-            for _,v:=range order{if !assigned[v]&&!assigned[-v]{variable=v;break}}
-            if variable==0{return fmt.Errorf("SAT: no refutation")}
-            for _,v:=range []int{variable,-variable}{ds:=append(append([]int{},decisions...),v);if e:=search(ds);e!=nil{return e}}
-            conflict,hints,_=propagate(decisions);if !conflict{return fmt.Errorf("producer failed to derive parent")}
-        }
-        last++;clause:=lrat.Clause{};fmt.Fprintf(&output,"%d ",last)
-        for _,x:=range decisions{clause[-x]=true;fmt.Fprintf(&output,"%d ",-x)};output.WriteString("0 ");for _,id:=range hints{fmt.Fprintf(&output,"%d ",id)};output.WriteString("0\n");db[last]=clause;return nil
-    }
-    if e:=search(nil);e!=nil{return "",e};return output.String(),nil
+
+func absolute(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
 }
-func localProof(m *Model)(*Certificate,error){
-    states,e:=m.states();if e!=nil{return nil,e};var witness State;for _,s:=range states{if truth(m.Terms["initial"],s,nil){witness=s;break}};if witness==nil{return nil,fmt.Errorf("empty initial set")}
-    cert:=&Certificate{Format:evidenceFormat,Digest:m.Digest,Kind:"lrat",Initial:witness,Proofs:map[string]Proof{}}
-    for _,role:=range []string{"base","step"}{c,r:=encode(m,role);cnf:=c.dimacs(r);proof,e:=localLRAT(cnf,c.priority());if e!=nil{return nil,e};cert.Proofs[role]=Proof{digest(cnf),proof}}
-    return cert,nil
+func localLRAT(text string, priority []int) (string, error) {
+	f, e := lrat.Parse(text)
+	if e != nil {
+		return "", e
+	}
+	db := map[int]lrat.Clause{}
+	for i, c := range f.Clauses {
+		db[i+1] = c
+	}
+	last := len(db)
+	nodes := 0
+	var output strings.Builder
+	propagate := func(decisions []int) (bool, []int, lrat.Clause) {
+		assigned := lrat.Clause{}
+		for _, x := range decisions {
+			assigned[x] = true
+		}
+		hints := []int{}
+		ids := []int{}
+		for id := range db {
+			ids = append(ids, id)
+		}
+		sort.Ints(ids)
+		for {
+			changed := false
+			for _, id := range ids {
+				clause := db[id]
+				satisfied := false
+				left := 0
+				unit := 0
+				for x := range clause {
+					if assigned[x] {
+						satisfied = true
+						break
+					}
+					if !assigned[-x] {
+						left++
+						unit = x
+					}
+				}
+				if satisfied {
+					continue
+				}
+				if left == 0 {
+					return true, append(hints, id), assigned
+				}
+				if left == 1 {
+					assigned[unit] = true
+					hints = append(hints, id)
+					changed = true
+				}
+			}
+			if !changed {
+				return false, hints, assigned
+			}
+		}
+	}
+	var search func([]int) error
+	search = func(decisions []int) error {
+		nodes++
+		if nodes > 4096 {
+			return fmt.Errorf("local proof search limit: 4096 nodes")
+		}
+		conflict, hints, assigned := propagate(decisions)
+		if !conflict {
+			variable := 0
+			order := append([]int{}, priority...)
+			for v := 1; v <= f.Variables; v++ {
+				order = append(order, v)
+			}
+			for _, v := range order {
+				if !assigned[v] && !assigned[-v] {
+					variable = v
+					break
+				}
+			}
+			if variable == 0 {
+				return fmt.Errorf("SAT: no refutation")
+			}
+			for _, v := range []int{variable, -variable} {
+				ds := append(append([]int{}, decisions...), v)
+				if e := search(ds); e != nil {
+					return e
+				}
+			}
+			conflict, hints, _ = propagate(decisions)
+			if !conflict {
+				return fmt.Errorf("producer failed to derive parent")
+			}
+		}
+		last++
+		clause := lrat.Clause{}
+		fmt.Fprintf(&output, "%d ", last)
+		for _, x := range decisions {
+			clause[-x] = true
+			fmt.Fprintf(&output, "%d ", -x)
+		}
+		output.WriteString("0 ")
+		for _, id := range hints {
+			fmt.Fprintf(&output, "%d ", id)
+		}
+		output.WriteString("0\n")
+		db[last] = clause
+		return nil
+	}
+	if e := search(nil); e != nil {
+		return "", e
+	}
+	return output.String(), nil
 }
-func findTrace(m *Model)(*Certificate,error){
-    states,e:=m.states();if e!=nil{return nil,e};paths:=[][]State{};seen:=map[string]bool{}
-    for _,s:=range states{if truth(m.Terms["initial"],s,nil){paths=append(paths,[]State{s});seen[stateKey(s)]=true}}
-    if len(paths)==0{return nil,fmt.Errorf("empty initial set")}
-    for head:=0;head<len(paths);head++{path:=paths[head];s:=path[len(path)-1]
-        if !truth(m.Terms["invariant"],s,nil){return &Certificate{Format:evidenceFormat,Digest:m.Digest,Kind:"trace",States:path},nil}
-        for _,t:=range states{key:=stateKey(t);if !seen[key]&&truth(m.Terms["step"],s,t){seen[key]=true;next:=append(append([]State{},path...),t);paths=append(paths,next)}}
-    };return nil,fmt.Errorf("no counterexample in exhaustively explored finite model")
+func localProof(m *Model) (*Certificate, error) {
+	states, e := m.states()
+	if e != nil {
+		return nil, e
+	}
+	var witness State
+	for _, s := range states {
+		if truth(m.Terms["initial"], s, nil) {
+			witness = s
+			break
+		}
+	}
+	if witness == nil {
+		return nil, fmt.Errorf("empty initial set")
+	}
+	cert := &Certificate{Format: evidenceFormat, Digest: m.Digest, Kind: "lrat", Initial: witness, Proofs: map[string]Proof{}}
+	for _, role := range []string{"base", "step"} {
+		c, r := encode(m, role)
+		cnf := c.dimacs(r)
+		proof, e := localLRAT(cnf, c.priority())
+		if e != nil {
+			return nil, e
+		}
+		cert.Proofs[role] = Proof{digest(cnf), proof}
+	}
+	return cert, nil
 }
-func closedSet(m *Model)(*Certificate,error){
-    all,e:=m.states();if e!=nil{return nil,e};queue:=[]State{};seen:=map[string]bool{}
-    for _,s:=range all{if truth(m.Terms["initial"],s,nil){queue=append(queue,s);seen[stateKey(s)]=true}}
-    if len(queue)==0{return nil,fmt.Errorf("empty initial set")}
-    for head:=0;head<len(queue);head++{s:=queue[head];if !truth(m.Terms["invariant"],s,nil){return nil,fmt.Errorf("reachable safety violation; use trace")};for _,target:=range all{key:=stateKey(target);if !seen[key]&&truth(m.Terms["step"],s,target){seen[key]=true;queue=append(queue,target)}}}
-    return &Certificate{Format:evidenceFormat,Digest:m.Digest,Kind:"closed-set",States:queue},nil
+func findTrace(m *Model) (*Certificate, error) {
+	states, e := m.states()
+	if e != nil {
+		return nil, e
+	}
+	paths := [][]State{}
+	seen := map[string]bool{}
+	for _, s := range states {
+		if truth(m.Terms["initial"], s, nil) {
+			paths = append(paths, []State{s})
+			seen[stateKey(s)] = true
+		}
+	}
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("empty initial set")
+	}
+	for head := 0; head < len(paths); head++ {
+		path := paths[head]
+		s := path[len(path)-1]
+		if !truth(m.Terms["invariant"], s, nil) {
+			return &Certificate{Format: evidenceFormat, Digest: m.Digest, Kind: "trace", States: path}, nil
+		}
+		for _, t := range states {
+			key := stateKey(t)
+			if !seen[key] && truth(m.Terms["step"], s, t) {
+				seen[key] = true
+				next := append(append([]State{}, path...), t)
+				paths = append(paths, next)
+			}
+		}
+	}
+	return nil, fmt.Errorf("no counterexample in exhaustively explored finite model")
+}
+func closedSet(m *Model) (*Certificate, error) {
+	all, e := m.states()
+	if e != nil {
+		return nil, e
+	}
+	queue := []State{}
+	seen := map[string]bool{}
+	for _, s := range all {
+		if truth(m.Terms["initial"], s, nil) {
+			queue = append(queue, s)
+			seen[stateKey(s)] = true
+		}
+	}
+	if len(queue) == 0 {
+		return nil, fmt.Errorf("empty initial set")
+	}
+	for head := 0; head < len(queue); head++ {
+		s := queue[head]
+		if !truth(m.Terms["invariant"], s, nil) {
+			return nil, fmt.Errorf("reachable safety violation; use trace")
+		}
+		for _, target := range all {
+			key := stateKey(target)
+			if !seen[key] && truth(m.Terms["step"], s, target) {
+				seen[key] = true
+				queue = append(queue, target)
+			}
+		}
+	}
+	return &Certificate{Format: evidenceFormat, Digest: m.Digest, Kind: "closed-set", States: queue}, nil
 }

--- a/experiments/verification-poc/projections.go
+++ b/experiments/verification-poc/projections.go
@@ -1,63 +1,267 @@
 package main
 
 import (
-    "fmt"
-    "os"
-    "path/filepath"
-    "strconv"
-    "strings"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
 )
-func term(m *Model,n *Node,backend string)string{
-    switch n.Op{
-    case "bool":s:=strconv.FormatBool(n.B);if backend=="tla"{s=strings.ToUpper(s)};return s
-    case "byte":if backend=="tla"{return strconv.Itoa(n.N)};if backend=="lean"{return fmt.Sprintf("(BitVec.ofNat 8 %d)",n.N)};return fmt.Sprintf("(_ bv%d 8)",n.N)
-    case "enum":if backend=="tla"{return strconv.Quote(n.Type+"."+n.Data)};if backend=="lean"{return "E_"+n.Type+".c_"+n.Data};index:=0;for i,s:=range m.Enums[n.Type]{if s==n.Data{index=i;break}};return fmt.Sprintf("(_ bv%d %d)",index,m.width(n.Type))
-    case "var":if backend=="smt"{return n.State+"_f_"+n.Field};return n.State+".f_"+n.Field
-    }
-    args:=[]string{};for _,a:=range n.Args{args=append(args,term(m,a,backend))};op:=n.Op
-    if backend=="smt"{symbol:=map[string]string{"ite":"ite","!":"not","&&":"and","||":"or","==":"=","!=":"distinct","+":"bvadd","-":"bvsub","<":"bvult",">":"bvugt","<=":"bvule",">=":"bvuge"}[op];return "("+symbol+" "+strings.Join(args," ")+")"}
-    if op=="ite"{if backend=="tla"{return "(IF "+args[0]+" THEN "+args[1]+" ELSE "+args[2]+")"};return "(bif "+args[0]+" then "+args[1]+" else "+args[2]+")"}
-    if op=="!"{prefix:="!";if backend=="tla"{prefix="~"};return "("+prefix+args[0]+")"}
-    if backend=="tla"{symbol:=map[string]string{"&&":"/\\","||":"\\/","==":"=","!=":"#","+":"+","-":"-","<":"<",">":">","<=":"<=",">=":">="}[op];result:="("+args[0]+" "+symbol+" "+args[1]+")";if op=="-"{result="("+args[0]+" + 256 - "+args[1]+")"};if op=="+"||op=="-"{result="("+result+" % 256)"};return result}
-    if contains([]string{"==","!=","<",">","<=",">="},op){symbol:=op;if op=="=="{symbol="="};if op=="!="{symbol="≠"};return "(decide ("+args[0]+" "+symbol+" "+args[1]+"))"}
-    return "("+args[0]+" "+op+" "+args[1]+")"
+
+func term(m *Model, n *Node, backend string) string {
+	switch n.Op {
+	case "bool":
+		s := strconv.FormatBool(n.B)
+		if backend == "tla" {
+			s = strings.ToUpper(s)
+		}
+		return s
+	case "byte":
+		if backend == "tla" {
+			return strconv.Itoa(n.N)
+		}
+		if backend == "lean" {
+			return fmt.Sprintf("(BitVec.ofNat 8 %d)", n.N)
+		}
+		return fmt.Sprintf("(_ bv%d 8)", n.N)
+	case "enum":
+		if backend == "tla" {
+			return strconv.Quote(n.Type + "." + n.Data)
+		}
+		if backend == "lean" {
+			return "E_" + n.Type + ".c_" + n.Data
+		}
+		index := 0
+		for i, s := range m.Enums[n.Type] {
+			if s == n.Data {
+				index = i
+				break
+			}
+		}
+		return fmt.Sprintf("(_ bv%d %d)", index, m.width(n.Type))
+	case "var":
+		if backend == "smt" {
+			return n.State + "_f_" + n.Field
+		}
+		return n.State + ".f_" + n.Field
+	}
+	args := []string{}
+	for _, a := range n.Args {
+		args = append(args, term(m, a, backend))
+	}
+	op := n.Op
+	if backend == "smt" {
+		symbol := map[string]string{"ite": "ite", "!": "not", "&&": "and", "||": "or", "==": "=", "!=": "distinct", "+": "bvadd", "-": "bvsub", "<": "bvult", ">": "bvugt", "<=": "bvule", ">=": "bvuge"}[op]
+		return "(" + symbol + " " + strings.Join(args, " ") + ")"
+	}
+	if op == "ite" {
+		if backend == "tla" {
+			return "(IF " + args[0] + " THEN " + args[1] + " ELSE " + args[2] + ")"
+		}
+		return "(bif " + args[0] + " then " + args[1] + " else " + args[2] + ")"
+	}
+	if op == "!" {
+		prefix := "!"
+		if backend == "tla" {
+			prefix = "~"
+		}
+		return "(" + prefix + args[0] + ")"
+	}
+	if backend == "tla" {
+		symbol := map[string]string{"&&": "/\\", "||": "\\/", "==": "=", "!=": "#", "+": "+", "-": "-", "<": "<", ">": ">", "<=": "<=", ">=": ">="}[op]
+		result := "(" + args[0] + " " + symbol + " " + args[1] + ")"
+		if op == "-" {
+			result = "(" + args[0] + " + 256 - " + args[1] + ")"
+		}
+		if op == "+" || op == "-" {
+			result = "(" + result + " % 256)"
+		}
+		return result
+	}
+	if contains([]string{"==", "!=", "<", ">", "<=", ">="}, op) {
+		symbol := op
+		if op == "==" {
+			symbol = "="
+		}
+		if op == "!=" {
+			symbol = "≠"
+		}
+		return "(decide (" + args[0] + " " + symbol + " " + args[1] + "))"
+	}
+	return "(" + args[0] + " " + op + " " + args[1] + ")"
 }
-func smtDomain(m *Model,p string)string{guards:=[]string{};for _,f:=range m.Fields{if cases:=m.Enums[f.Type];cases!=nil&&len(cases)<1<<m.width(f.Type){guards=append(guards,fmt.Sprintf("(bvult %s_f_%s (_ bv%d %d))",p,f.Name,len(cases),m.width(f.Type)))}};return "(and true "+strings.Join(guards," ")+")"}
-func declarations(m *Model,names []string)string{lines:=[]string{};for _,p:=range names{for _,f:=range m.Fields{t:="Bool";if f.Type!="Bool"{t=fmt.Sprintf("(_ BitVec %d)",m.width(f.Type))};lines=append(lines,"(declare-const "+p+"_f_"+f.Name+" "+t+")")}};return strings.Join(lines,"\n")}
-func bmc(m *Model,bound int,values bool)(string,error){
-    if bound<0||bound>64{return "",fmt.Errorf("BMC bound must be 0..64")};ps:=[]string{};for i:=0;i<=bound;i++{ps=append(ps,fmt.Sprintf("s%d",i))}
-    lines:=[]string{"(set-logic QF_BV)",declarations(m,ps)};for _,p:=range ps{lines=append(lines,"(assert "+smtDomain(m,p)+")")};lines=append(lines,"(assert "+term(m,rename(m.Terms["initial"],"s0"),"smt")+")")
-    for i:=0;i<bound;i++{
-        var rewrite func(*Node)*Node;rewrite=func(n *Node)*Node{r:=*n;r.Args=nil;if n.Op=="var"{r.State=ps[i];if n.State=="t"{r.State=ps[i+1]}};for _,a:=range n.Args{r.Args=append(r.Args,rewrite(a))};return &r}
-        same:=[]string{};for _,f:=range m.Fields{same=append(same,fmt.Sprintf("(= %s_f_%s %s_f_%s)",ps[i],f.Name,ps[i+1],f.Name))};lines=append(lines,"(assert (or (and "+strings.Join(same," ")+") "+term(m,rewrite(m.Terms["step"]),"smt")+"))")
-    }
-    bad:=[]string{};names:=[]string{};for _,p:=range ps{bad=append(bad,"(not "+term(m,rename(m.Terms["invariant"],p),"smt")+")");for _,f:=range m.Fields{names=append(names,p+"_f_"+f.Name)}}
-    lines=append(lines,"(assert (or "+strings.Join(bad," ")+"))","(check-sat)");if values{lines=append(lines,"(get-value ("+strings.Join(names," ")+"))")};return strings.Join(lines,"\n")+"\n",nil
+func smtDomain(m *Model, p string) string {
+	guards := []string{}
+	for _, f := range m.Fields {
+		if cases := m.Enums[f.Type]; cases != nil && len(cases) < 1<<m.width(f.Type) {
+			guards = append(guards, fmt.Sprintf("(bvult %s_f_%s (_ bv%d %d))", p, f.Name, len(cases), m.width(f.Type)))
+		}
+	}
+	return "(and true " + strings.Join(guards, " ") + ")"
 }
-func project(m *Model)map[string]string{
-    files:=map[string]string{};obligations:=map[string]any{}
-    for _,role:=range []string{"initial","base","step"}{c,r:=encode(m,role);text:=c.dimacs(r);files[role+".cnf"]=text;obligations[role]=map[string]any{"sha256":digest(text),"variables":c.Count,"inputs":c.Inputs}}
-    ini,inv,nxt,invt:=term(m,m.Terms["initial"],"smt"),term(m,m.Terms["invariant"],"smt"),term(m,m.Terms["step"],"smt"),term(m,rename(m.Terms["invariant"],"t"),"smt")
-    assertions:=map[string]string{"initial":"(and "+smtDomain(m,"s")+" "+ini+")","base":"(and "+smtDomain(m,"s")+" "+ini+" (not "+inv+"))","step":"(and "+smtDomain(m,"s")+" "+smtDomain(m,"t")+" "+inv+" "+nxt+" (not "+invt+"))"}
-    for role,a:=range assertions{files[role+".smt2"]="(set-logic QF_BV)\n"+declarations(m,[]string{"s","t"})+"\n(assert "+a+")\n(check-sat)\n"}
-    lines:=[]string{"import Std.Tactic.BVDecide","namespace OakFinite"}
-    for _,name:=range sortedKeys(m.Enums){lines=append(lines,"inductive E_"+name+" where");for _,v:=range m.Enums[name]{lines=append(lines,"  | c_"+v)};lines=append(lines,"  deriving DecidableEq")}
-    lines=append(lines,"structure State where");for _,f:=range m.Fields{t:=f.Type;if t=="u8"{t="BitVec 8"}else if t!="Bool"{t="E_"+t};lines=append(lines,"  f_"+f.Name+" : "+t)};lines=append(lines,"  deriving DecidableEq")
-    for _,r:=range []struct{role,name string}{{"initial","oakInitial"},{"invariant","oakInvariant"},{"step","oakStep"}}{params:="s";if r.role=="step"{params="s t"};lines=append(lines,"def "+r.name+" ("+params+" : State) : Bool := "+term(m,m.Terms[r.role],"lean"))}
-    for _,r:=range []struct{name,claim string;params []string}{{"base","oakInitial s = true → oakInvariant s = true",[]string{"s"}},{"step","oakInvariant s = true → oakStep s t = true → oakInvariant t = true",[]string{"s","t"}}}{
-        lines=append(lines,"theorem "+r.name+" ("+strings.Join(r.params," ")+" : State) : "+r.claim+" := by")
-        split:=[]string{};for _,p:=range r.params{vars:=[]string{};for i,f:=range m.Fields{v:=fmt.Sprintf("%s%d",p,i);vars=append(vars,v);if m.Enums[f.Type]!=nil{split=append(split,"cases "+v)}};lines=append(lines,"  rcases "+p+" with ⟨"+strings.Join(vars,", ")+"⟩")}
-        split=append(split,"simp_all only [oakInitial, oakInvariant, oakStep]","bv_decide");lines=append(lines,"  "+strings.Join(split," <;> "))
-    };lines=append(lines,"end OakFinite","");files["Model.lean"]=strings.Join(lines,"\n")
-    fields:=[]string{};for _,f:=range m.Fields{domain:="BOOLEAN";if f.Type=="u8"{domain="0..255"}else if m.Enums[f.Type]!=nil{vs:=[]string{};for _,v:=range m.Enums[f.Type]{vs=append(vs,strconv.Quote(f.Type+"."+v))};domain="{"+strings.Join(vs,", ")+"}"};fields=append(fields,"f_"+f.Name+" : "+domain)}
-    lines=[]string{"---- MODULE Model ----","EXTENDS Integers, TLC","VARIABLE state","StateSpace == ["+strings.Join(fields,", ")+"]"}
-    for _,r:=range []struct{role,name string}{{"initial","OakInitial"},{"invariant","OakInvariant"},{"step","OakStep"}}{params:="s";if r.role=="step"{params="s, t"};lines=append(lines,r.name+"("+params+") == "+term(m,m.Terms[r.role],"tla"))}
-    lines=append(lines,"Init == state \\in StateSpace /\\ OakInitial(state)","Next == \\E target \\in StateSpace : state' = target /\\ OakStep(state, target)","Spec == Init /\\ [][Next]_state","TypeOK == state \\in StateSpace","Safe == OakInvariant(state)","====","")
-    files["Model.tla"]=strings.Join(lines,"\n");files["Model.cfg"]="SPECIFICATION Spec\nINVARIANT TypeOK\nINVARIANT Safe\nCHECK_DEADLOCK FALSE\n"
-    files["manifest.json"]=jsonText(map[string]any{"format":"oak-go-projection-1","semantic_digest":m.Digest,"frontend":"oak","translation_trusted":true,"obligations":obligations});return files
+func declarations(m *Model, names []string) string {
+	lines := []string{}
+	for _, p := range names {
+		for _, f := range m.Fields {
+			t := "Bool"
+			if f.Type != "Bool" {
+				t = fmt.Sprintf("(_ BitVec %d)", m.width(f.Type))
+			}
+			lines = append(lines, "(declare-const "+p+"_f_"+f.Name+" "+t+")")
+		}
+	}
+	return strings.Join(lines, "\n")
 }
-func emit(m *Model,out string)error{
-    if e:=os.MkdirAll(out,0755);e!=nil{return e}
-    if e:=os.Remove(filepath.Join(out,"report.json"));e!=nil&&!os.IsNotExist(e){return e}
-    for name,text:=range project(m){if e:=os.WriteFile(filepath.Join(out,name),[]byte(text),0644);e!=nil{return e}};return nil
+func bmc(m *Model, bound int, values bool) (string, error) {
+	if bound < 0 || bound > 64 {
+		return "", fmt.Errorf("BMC bound must be 0..64")
+	}
+	ps := []string{}
+	for i := 0; i <= bound; i++ {
+		ps = append(ps, fmt.Sprintf("s%d", i))
+	}
+	lines := []string{"(set-logic QF_BV)", declarations(m, ps)}
+	for _, p := range ps {
+		lines = append(lines, "(assert "+smtDomain(m, p)+")")
+	}
+	lines = append(lines, "(assert "+term(m, rename(m.Terms["initial"], "s0"), "smt")+")")
+	for i := 0; i < bound; i++ {
+		var rewrite func(*Node) *Node
+		rewrite = func(n *Node) *Node {
+			r := *n
+			r.Args = nil
+			if n.Op == "var" {
+				r.State = ps[i]
+				if n.State == "t" {
+					r.State = ps[i+1]
+				}
+			}
+			for _, a := range n.Args {
+				r.Args = append(r.Args, rewrite(a))
+			}
+			return &r
+		}
+		same := []string{}
+		for _, f := range m.Fields {
+			same = append(same, fmt.Sprintf("(= %s_f_%s %s_f_%s)", ps[i], f.Name, ps[i+1], f.Name))
+		}
+		lines = append(lines, "(assert (or (and "+strings.Join(same, " ")+") "+term(m, rewrite(m.Terms["step"]), "smt")+"))")
+	}
+	bad := []string{}
+	names := []string{}
+	for _, p := range ps {
+		bad = append(bad, "(not "+term(m, rename(m.Terms["invariant"], p), "smt")+")")
+		for _, f := range m.Fields {
+			names = append(names, p+"_f_"+f.Name)
+		}
+	}
+	lines = append(lines, "(assert (or "+strings.Join(bad, " ")+"))", "(check-sat)")
+	if values {
+		lines = append(lines, "(get-value ("+strings.Join(names, " ")+"))")
+	}
+	return strings.Join(lines, "\n") + "\n", nil
+}
+func project(m *Model) map[string]string {
+	files := map[string]string{}
+	obligations := map[string]any{}
+	for _, role := range []string{"initial", "base", "step"} {
+		c, r := encode(m, role)
+		text := c.dimacs(r)
+		files[role+".cnf"] = text
+		obligations[role] = map[string]any{"sha256": digest(text), "variables": c.Count, "inputs": c.Inputs}
+	}
+	ini, inv, nxt, invt := term(m, m.Terms["initial"], "smt"), term(m, m.Terms["invariant"], "smt"), term(m, m.Terms["step"], "smt"), term(m, rename(m.Terms["invariant"], "t"), "smt")
+	assertions := map[string]string{"initial": "(and " + smtDomain(m, "s") + " " + ini + ")", "base": "(and " + smtDomain(m, "s") + " " + ini + " (not " + inv + "))", "step": "(and " + smtDomain(m, "s") + " " + smtDomain(m, "t") + " " + inv + " " + nxt + " (not " + invt + "))"}
+	for role, a := range assertions {
+		files[role+".smt2"] = "(set-logic QF_BV)\n" + declarations(m, []string{"s", "t"}) + "\n(assert " + a + ")\n(check-sat)\n"
+	}
+	lines := []string{"import Std.Tactic.BVDecide", "namespace OakFinite"}
+	for _, name := range sortedKeys(m.Enums) {
+		lines = append(lines, "inductive E_"+name+" where")
+		for _, v := range m.Enums[name] {
+			lines = append(lines, "  | c_"+v)
+		}
+		lines = append(lines, "  deriving DecidableEq")
+	}
+	lines = append(lines, "structure State where")
+	for _, f := range m.Fields {
+		t := f.Type
+		if t == "u8" {
+			t = "BitVec 8"
+		} else if t != "Bool" {
+			t = "E_" + t
+		}
+		lines = append(lines, "  f_"+f.Name+" : "+t)
+	}
+	lines = append(lines, "  deriving DecidableEq")
+	for _, r := range []struct{ role, name string }{{"initial", "oakInitial"}, {"invariant", "oakInvariant"}, {"step", "oakStep"}} {
+		params := "s"
+		if r.role == "step" {
+			params = "s t"
+		}
+		lines = append(lines, "def "+r.name+" ("+params+" : State) : Bool := "+term(m, m.Terms[r.role], "lean"))
+	}
+	for _, r := range []struct {
+		name, claim string
+		params      []string
+	}{{"base", "oakInitial s = true → oakInvariant s = true", []string{"s"}}, {"step", "oakInvariant s = true → oakStep s t = true → oakInvariant t = true", []string{"s", "t"}}} {
+		lines = append(lines, "theorem "+r.name+" ("+strings.Join(r.params, " ")+" : State) : "+r.claim+" := by")
+		split := []string{}
+		for _, p := range r.params {
+			vars := []string{}
+			for i, f := range m.Fields {
+				v := fmt.Sprintf("%s%d", p, i)
+				vars = append(vars, v)
+				if m.Enums[f.Type] != nil {
+					split = append(split, "cases "+v)
+				}
+			}
+			lines = append(lines, "  rcases "+p+" with ⟨"+strings.Join(vars, ", ")+"⟩")
+		}
+		split = append(split, "simp_all only [oakInitial, oakInvariant, oakStep]", "bv_decide")
+		lines = append(lines, "  "+strings.Join(split, " <;> "))
+	}
+	lines = append(lines, "end OakFinite", "")
+	files["Model.lean"] = strings.Join(lines, "\n")
+	fields := []string{}
+	for _, f := range m.Fields {
+		domain := "BOOLEAN"
+		if f.Type == "u8" {
+			domain = "0..255"
+		} else if m.Enums[f.Type] != nil {
+			vs := []string{}
+			for _, v := range m.Enums[f.Type] {
+				vs = append(vs, strconv.Quote(f.Type+"."+v))
+			}
+			domain = "{" + strings.Join(vs, ", ") + "}"
+		}
+		fields = append(fields, "f_"+f.Name+" : "+domain)
+	}
+	lines = []string{"---- MODULE Model ----", "EXTENDS Integers, TLC", "VARIABLE state", "StateSpace == [" + strings.Join(fields, ", ") + "]"}
+	for _, r := range []struct{ role, name string }{{"initial", "OakInitial"}, {"invariant", "OakInvariant"}, {"step", "OakStep"}} {
+		params := "s"
+		if r.role == "step" {
+			params = "s, t"
+		}
+		lines = append(lines, r.name+"("+params+") == "+term(m, m.Terms[r.role], "tla"))
+	}
+	lines = append(lines, "Init == state \\in StateSpace /\\ OakInitial(state)", "Next == \\E target \\in StateSpace : state' = target /\\ OakStep(state, target)", "Spec == Init /\\ [][Next]_state", "TypeOK == state \\in StateSpace", "Safe == OakInvariant(state)", "====", "")
+	files["Model.tla"] = strings.Join(lines, "\n")
+	files["Model.cfg"] = "SPECIFICATION Spec\nINVARIANT TypeOK\nINVARIANT Safe\nCHECK_DEADLOCK FALSE\n"
+	files["manifest.json"] = jsonText(map[string]any{"format": "oak-go-projection-1", "semantic_digest": m.Digest, "frontend": "oak", "translation_trusted": true, "obligations": obligations})
+	return files
+}
+func emit(m *Model, out string) error {
+	if e := os.MkdirAll(out, 0755); e != nil {
+		return e
+	}
+	if e := os.Remove(filepath.Join(out, "report.json")); e != nil && !os.IsNotExist(e) {
+		return e
+	}
+	for name, text := range project(m) {
+		if e := os.WriteFile(filepath.Join(out, name), []byte(text), 0644); e != nil {
+			return e
+		}
+	}
+	return nil
 }

--- a/experiments/verification-poc/publication_test.go
+++ b/experiments/verification-poc/publication_test.go
@@ -1,67 +1,128 @@
 package main
 
 import (
-    "testing"
-    "github.com/SCKelemen/oak/semir"
+	"github.com/SCKelemen/oak/semir"
+	"testing"
 )
 
 // This is a bounded correspondence test, not a compiler-refinement theorem.
 // The model's observation specifically reads from event 1, not an equal value
 // from another write or the implicit initial flag value.
 func publicationExecution(s State, release, acquire bool) semir.MemoryExecution {
-    x := semir.MemoryExecution{}
-    if s["written"].(bool) {
-        x.Events = append(x.Events, semir.MemoryEvent{Thread:0, Sequence:0, Location:1, Access:semir.MemoryAccessWrite})
-    }
-    if s["published"].(bool) {
-        order := semir.MemoryOrderRelaxed
-        if release { order = semir.MemoryOrderRelease }
-        x.Events = append(x.Events, semir.MemoryEvent{Thread:0, Sequence:1, Location:2, Access:semir.MemoryAccessWrite, Atomic:true, Order:order, HasModification:true, Modification:0})
-    }
-    if s["observed"].(bool) {
-        order := semir.MemoryOrderRelaxed
-        if acquire { order = semir.MemoryOrderAcquire }
-        x.Events = append(x.Events, semir.MemoryEvent{Thread:1, Sequence:0, Location:2, Access:semir.MemoryAccessRead, Atomic:true, Order:order, HasReadsFrom:true, ReadsFrom:1})
-        if release && acquire { x.Synchronizes = []semir.MemorySyncEdge{{From:1, To:2, Kind:semir.MemorySyncReleaseAcquire}} }
-    }
-    return x
+	x := semir.MemoryExecution{}
+	if s["written"].(bool) {
+		x.Events = append(x.Events, semir.MemoryEvent{Thread: 0, Sequence: 0, Location: 1, Access: semir.MemoryAccessWrite})
+	}
+	if s["published"].(bool) {
+		order := semir.MemoryOrderRelaxed
+		if release {
+			order = semir.MemoryOrderRelease
+		}
+		x.Events = append(x.Events, semir.MemoryEvent{Thread: 0, Sequence: 1, Location: 2, Access: semir.MemoryAccessWrite, Atomic: true, Order: order, HasModification: true, Modification: 0})
+	}
+	if s["observed"].(bool) {
+		order := semir.MemoryOrderRelaxed
+		if acquire {
+			order = semir.MemoryOrderAcquire
+		}
+		x.Events = append(x.Events, semir.MemoryEvent{Thread: 1, Sequence: 0, Location: 2, Access: semir.MemoryAccessRead, Atomic: true, Order: order, HasReadsFrom: true, ReadsFrom: 1})
+		if release && acquire {
+			x.Synchronizes = []semir.MemorySyncEdge{{From: 1, To: 2, Kind: semir.MemorySyncReleaseAcquire}}
+		}
+	}
+	return x
 }
 func publicationWorkspace(n int) semir.MemoryWorkspace {
-    return semir.MemoryWorkspace{Visited:make([]bool,n), Stack:make([]semir.MemoryEventID,n)}
+	return semir.MemoryWorkspace{Visited: make([]bool, n), Stack: make([]semir.MemoryEventID, n)}
 }
 func TestPublicationMatchesMemoryExecution(t *testing.T) {
-    for _,orders := range []struct{release,acquire bool}{{true,true},{true,false},{false,true},{false,false}} {
-        synchronized := orders.release && orders.acquire
-        name := "publication-relaxed"
-        if synchronized { name = "publication" }
-        m := fixture(t,name)
-        // Enumerate reachable states without stopping at the first violation.
-        all,e := m.states(); if e != nil { t.Fatal(e) }
-        reachable := []State{}; seen := map[string]bool{}
-        for _,s := range all { if truth(m.Terms["initial"],s,nil) { reachable=append(reachable,s);seen[stateKey(s)]=true } }
-        for head:=0;head<len(reachable);head++ {
-            s:=reachable[head]
-            for _,target:=range all { if !seen[stateKey(target)] && truth(m.Terms["step"],s,target) { seen[stateKey(target)]=true;reachable=append(reachable,target) } }
-            x:=publicationExecution(s,orders.release,orders.acquire)
-            if e:=x.Validate();e!=nil { t.Fatal(e) }
-            if s["observed"].(bool) {
-                hb,e:=x.HappensBefore(0,2,publicationWorkspace(len(x.Events)));if e!=nil { t.Fatal(e) }
-                if hb!=s["ordered"].(bool)||hb!=synchronized { t.Fatal("model/API publication disagreement",orders,s) }
-                x.Events=append(x.Events,semir.MemoryEvent{Thread:1,Sequence:1,Location:1,Access:semir.MemoryAccessRead})
-                if e:=x.Validate();e!=nil { t.Fatal(e) }
-                race,e:=x.IsDataRace(0,3,publicationWorkspace(4));if e!=nil||race==synchronized { t.Fatal("payload-race corollary disagrees",race,e) }
-            } else if s["ordered"].(bool) { t.Fatal("HB recorded before observation") }
-        }
-        if len(reachable)!=4 { t.Fatal("unexpected publication state space",len(reachable)) }
-        if synchronized { cert,e:=localProof(m);if e!=nil { t.Fatal(e) };if _,e:=verify(m,cert);e!=nil { t.Fatal(e) } } else {
-            cert,e:=findTrace(m);if e!=nil { t.Fatal(e) };if len(cert.States)!=4 { t.Fatal("expected write/publish/observe trace") };if _,e:=verify(m,cert);e!=nil { t.Fatal(e) }
-        }
-    }
+	for _, orders := range []struct{ release, acquire bool }{{true, true}, {true, false}, {false, true}, {false, false}} {
+		synchronized := orders.release && orders.acquire
+		name := "publication-relaxed"
+		if synchronized {
+			name = "publication"
+		}
+		m := fixture(t, name)
+		// Enumerate reachable states without stopping at the first violation.
+		all, e := m.states()
+		if e != nil {
+			t.Fatal(e)
+		}
+		reachable := []State{}
+		seen := map[string]bool{}
+		for _, s := range all {
+			if truth(m.Terms["initial"], s, nil) {
+				reachable = append(reachable, s)
+				seen[stateKey(s)] = true
+			}
+		}
+		for head := 0; head < len(reachable); head++ {
+			s := reachable[head]
+			for _, target := range all {
+				if !seen[stateKey(target)] && truth(m.Terms["step"], s, target) {
+					seen[stateKey(target)] = true
+					reachable = append(reachable, target)
+				}
+			}
+			x := publicationExecution(s, orders.release, orders.acquire)
+			if e := x.Validate(); e != nil {
+				t.Fatal(e)
+			}
+			if s["observed"].(bool) {
+				hb, e := x.HappensBefore(0, 2, publicationWorkspace(len(x.Events)))
+				if e != nil {
+					t.Fatal(e)
+				}
+				if hb != s["ordered"].(bool) || hb != synchronized {
+					t.Fatal("model/API publication disagreement", orders, s)
+				}
+				x.Events = append(x.Events, semir.MemoryEvent{Thread: 1, Sequence: 1, Location: 1, Access: semir.MemoryAccessRead})
+				if e := x.Validate(); e != nil {
+					t.Fatal(e)
+				}
+				race, e := x.IsDataRace(0, 3, publicationWorkspace(4))
+				if e != nil || race == synchronized {
+					t.Fatal("payload-race corollary disagrees", race, e)
+				}
+			} else if s["ordered"].(bool) {
+				t.Fatal("HB recorded before observation")
+			}
+		}
+		if len(reachable) != 4 {
+			t.Fatal("unexpected publication state space", len(reachable))
+		}
+		if synchronized {
+			cert, e := localProof(m)
+			if e != nil {
+				t.Fatal(e)
+			}
+			if _, e := verify(m, cert); e != nil {
+				t.Fatal(e)
+			}
+		} else {
+			cert, e := findTrace(m)
+			if e != nil {
+				t.Fatal(e)
+			}
+			if len(cert.States) != 4 {
+				t.Fatal("expected write/publish/observe trace")
+			}
+			if _, e := verify(m, cert); e != nil {
+				t.Fatal(e)
+			}
+		}
+	}
 }
 func TestPublicationRequiresTheReadsFromWitness(t *testing.T) {
-    s:=State{"written":true,"published":true,"observed":true,"ordered":true}
-    x:=publicationExecution(s,true,true);x.Events[2].HasReadsFrom=false
-    if e:=x.Validate();e==nil { t.Fatal("SW accepted without reads-from") }
-    x=publicationExecution(s,true,false);x.Synchronizes=[]semir.MemorySyncEdge{{From:1,To:2,Kind:semir.MemorySyncReleaseAcquire}}
-    if e:=x.Validate();e==nil { t.Fatal("SW accepted for relaxed observation") }
+	s := State{"written": true, "published": true, "observed": true, "ordered": true}
+	x := publicationExecution(s, true, true)
+	x.Events[2].HasReadsFrom = false
+	if e := x.Validate(); e == nil {
+		t.Fatal("SW accepted without reads-from")
+	}
+	x = publicationExecution(s, true, false)
+	x.Synchronizes = []semir.MemorySyncEdge{{From: 1, To: 2, Kind: semir.MemorySyncReleaseAcquire}}
+	if e := x.Validate(); e == nil {
+		t.Fatal("SW accepted for relaxed observation")
+	}
 }

--- a/experiments/verification-poc/self_hosted_assembly_test.go
+++ b/experiments/verification-poc/self_hosted_assembly_test.go
@@ -1,95 +1,210 @@
 package main
 
 import (
- "encoding/json"
- "fmt"
- "math/rand"
- "os"
- "strconv"
- "strings"
- "testing"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
 )
 
 // Command assembly with explicit identifier words. Unlike the buffer corpus,
 // addition IDs and deletion stamps are arbitrary spellings taken from the text.
-type assemblyCommand struct { ID string `json:"id"`; Deletion bool `json:"deletion"`; Clause string `json:"clause"`; Hints string `json:"hints"` }
-type assemblyCase struct {
- Name string `json:"name"`
- Variables uint32 `json:"variables"`
- Initial []string `json:"initial"`
- Commands []assemblyCommand `json:"commands"`
- Accepted bool `json:"accepted"`
- Layout []uint32 `json:"layout"`
+type assemblyCommand struct {
+	ID       string `json:"id"`
+	Deletion bool   `json:"deletion"`
+	Clause   string `json:"clause"`
+	Hints    string `json:"hints"`
 }
+type assemblyCase struct {
+	Name      string            `json:"name"`
+	Variables uint32            `json:"variables"`
+	Initial   []string          `json:"initial"`
+	Commands  []assemblyCommand `json:"commands"`
+	Accepted  bool              `json:"accepted"`
+	Layout    []uint32          `json:"layout"`
+}
+
 // The decoder accepts one numeric word with a valid sign that is nonnegative or
 // a spelling of zero. Go's parser is the independent oracle for that rule.
-func assemblyIdentifier(word string) (uint32,bool) {
- fields:=strings.Fields(word);if len(fields)!=1 {return 0,false}
- n,err:=strconv.ParseInt(fields[0],10,64);if err!=nil||n<0||n>2147483647 {return 0,false}
- return uint32(n),true
+func assemblyIdentifier(word string) (uint32, bool) {
+	fields := strings.Fields(word)
+	if len(fields) != 1 {
+		return 0, false
+	}
+	n, err := strconv.ParseInt(fields[0], 10, 64)
+	if err != nil || n < 0 || n > 2147483647 {
+		return 0, false
+	}
+	return uint32(n), true
 }
-func assemblyReference(c assemblyCase) ([]uint32,bool) {
- pool,starts,sizes,refs,commands:=[]uint32{},[]uint32{},[]uint32{},[]uint32{},[]uint32{}
- if c.Variables==0||c.Variables>64||len(c.Initial)>256||len(c.Commands)>256 {return nil,false}
- for _,body:=range c.Initial {items,ok:=bufferSegment(body,0,c.Variables);if !ok||len(pool)+len(items)>4096 {return nil,false};starts=append(starts,uint32(len(pool)));sizes=append(sizes,uint32(len(items)));pool=append(pool,items...)}
- for _,cmd:=range c.Commands {
-  id,ok:=assemblyIdentifier(cmd.ID);if !ok {return nil,false}
-  // Deletions publish no literals but record the current literal offset.
-  start:=uint32(len(pool));count:=uint32(0);addition:=uint32(1);mode:=1
-  if cmd.Deletion {addition=0;mode=2} else {items,ok:=bufferSegment(cmd.Clause,0,c.Variables);if !ok||len(pool)+len(items)>4096 {return nil,false};count=uint32(len(items));pool=append(pool,items...)}
-  items,ok:=bufferSegment(cmd.Hints,mode,c.Variables);if !ok||len(refs)+len(items)>4096 {return nil,false}
-  commands=append(commands,addition,id,start,count,uint32(len(refs)),uint32(len(items)));refs=append(refs,items...)
- }
- flat:=[]uint32{c.Variables,uint32(len(pool)),uint32(len(starts)),uint32(len(refs)),uint32(len(c.Commands))}
- for _,items:=range [][]uint32{pool,starts,sizes,refs,commands} {flat=append(flat,items...)}
- return flat,true
+func assemblyReference(c assemblyCase) ([]uint32, bool) {
+	pool, starts, sizes, refs, commands := []uint32{}, []uint32{}, []uint32{}, []uint32{}, []uint32{}
+	if c.Variables == 0 || c.Variables > 64 || len(c.Initial) > 256 || len(c.Commands) > 256 {
+		return nil, false
+	}
+	for _, body := range c.Initial {
+		items, ok := bufferSegment(body, 0, c.Variables)
+		if !ok || len(pool)+len(items) > 4096 {
+			return nil, false
+		}
+		starts = append(starts, uint32(len(pool)))
+		sizes = append(sizes, uint32(len(items)))
+		pool = append(pool, items...)
+	}
+	for _, cmd := range c.Commands {
+		id, ok := assemblyIdentifier(cmd.ID)
+		if !ok {
+			return nil, false
+		}
+		// Deletions publish no literals but record the current literal offset.
+		start := uint32(len(pool))
+		count := uint32(0)
+		addition := uint32(1)
+		mode := 1
+		if cmd.Deletion {
+			addition = 0
+			mode = 2
+		} else {
+			items, ok := bufferSegment(cmd.Clause, 0, c.Variables)
+			if !ok || len(pool)+len(items) > 4096 {
+				return nil, false
+			}
+			count = uint32(len(items))
+			pool = append(pool, items...)
+		}
+		items, ok := bufferSegment(cmd.Hints, mode, c.Variables)
+		if !ok || len(refs)+len(items) > 4096 {
+			return nil, false
+		}
+		commands = append(commands, addition, id, start, count, uint32(len(refs)), uint32(len(items)))
+		refs = append(refs, items...)
+	}
+	flat := []uint32{c.Variables, uint32(len(pool)), uint32(len(starts)), uint32(len(refs)), uint32(len(c.Commands))}
+	for _, items := range [][]uint32{pool, starts, sizes, refs, commands} {
+		flat = append(flat, items...)
+	}
+	return flat, true
 }
-func assemblyTexts(c assemblyCase) (string,string) {
- var cnf,proof strings.Builder;fmt.Fprintf(&cnf,"p cnf %d %d\n",c.Variables,len(c.Initial))
- for _,s:=range c.Initial {cnf.WriteString(s);cnf.WriteByte('\n')}
- for _,cmd:=range c.Commands {proof.WriteString(cmd.ID);proof.WriteByte(' ');if cmd.Deletion {proof.WriteString("d ")} else {proof.WriteString(cmd.Clause);proof.WriteByte(' ')};proof.WriteString(cmd.Hints);proof.WriteByte('\n')}
- return cnf.String(),proof.String()
+func assemblyTexts(c assemblyCase) (string, string) {
+	var cnf, proof strings.Builder
+	fmt.Fprintf(&cnf, "p cnf %d %d\n", c.Variables, len(c.Initial))
+	for _, s := range c.Initial {
+		cnf.WriteString(s)
+		cnf.WriteByte('\n')
+	}
+	for _, cmd := range c.Commands {
+		proof.WriteString(cmd.ID)
+		proof.WriteByte(' ')
+		if cmd.Deletion {
+			proof.WriteString("d ")
+		} else {
+			proof.WriteString(cmd.Clause)
+			proof.WriteByte(' ')
+		}
+		proof.WriteString(cmd.Hints)
+		proof.WriteByte('\n')
+	}
+	return cnf.String(), proof.String()
 }
 func assemblyCorpus() []assemblyCase {
- out:=[]assemblyCase{}
- add:=func(name string,initial []string,commands ...assemblyCommand) {if initial==nil {initial=[]string{}};if commands==nil {commands=[]assemblyCommand{}};c:=assemblyCase{Name:name,Variables:64,Initial:initial,Commands:commands};c.Layout,c.Accepted=assemblyReference(c);if c.Layout==nil {c.Layout=[]uint32{}};out=append(out,c)}
- db:=[]string{"1 0","-1 0"}
- addition:=func(id string) assemblyCommand {return assemblyCommand{ID:id,Clause:"0",Hints:"1 2 0"}}
- deletion:=func(id string) assemblyCommand {return assemblyCommand{ID:id,Deletion:true,Hints:"1 0"}}
- add("sequential",db,addition("3"))
- // Identifier spellings: signs, zero, leading zeros, whitespace, and limits.
- for _,id:=range []string{"3","+3","0","-0","+0","-00","007","\t7","7\t","1","9","256","257","2147483647","-1","-3","2147483648","4294967295","4294967296","x","3x","d","+","-","1e3","3.0"} {
-  add("addition-id-"+strconv.Quote(id),db,addition(id))
-  add("deletion-stamp-"+strconv.Quote(id),db,deletion(id))
- }
- // Non-sequential and repeated identifiers are decoded; validity is checked later.
- add("repeated-ids",db,addition("3"),addition("3"),deletion("3"),addition("1"))
- add("descending-ids",db,addition("9"),addition("8"),deletion("0"))
- // Deletions after additions record the literal offset at that point.
- add("deletion-offset",db,assemblyCommand{ID:"3",Clause:"1 2 0",Hints:"0"},deletion("4"),assemblyCommand{ID:"5",Clause:"-2 0",Hints:"3 0"},deletion("6"))
- add("empty-clauses-and-hints",db,assemblyCommand{ID:"3",Clause:"0",Hints:"0"},assemblyCommand{ID:"4",Deletion:true,Hints:"0"})
- add("mixed-spellings",[]string{"1 -64 0","0"},assemblyCommand{ID:"+3",Clause:"64 -2 +0",Hints:"1 2 2147483647 -0"},assemblyCommand{ID:"-0",Deletion:true,Hints:"2 2 0"},assemblyCommand{ID:"2147483647",Clause:"-1 0",Hints:"0"})
- // Malformed segments after a valid identifier still reject the whole layout.
- add("bad-clause-after-id",db,assemblyCommand{ID:"3",Clause:"65 0",Hints:"0"})
- add("bad-hint-after-id",db,assemblyCommand{ID:"3",Clause:"0",Hints:"-1 0"})
- add("bad-deletion-zero-after-stamp",db,assemblyCommand{ID:"3",Deletion:true,Hints:"1 +0"})
- for _,n:=range []int{256,257} {cmds:=make([]assemblyCommand,n);for i:=range cmds {cmds[i]=deletion(strconv.Itoa(i))};add(fmt.Sprintf("command-count-%d",n),nil,cmds...)}
- rng:=rand.New(rand.NewSource(51907))
- body:=func(hints bool) string {var s strings.Builder;for j:=rng.Intn(6);j>0;j-- {n:=1+rng.Intn(64);if !hints&&rng.Intn(2)==0 {n=-n};fmt.Fprintf(&s,"%d ",n)};s.WriteString("0");return s.String()}
- spellings:=[]string{"%d","+%d","%03d","-0","%d\t","2147483647","-%d","%dq"}
- for i:=0;i<32;i++ {
-  initial:=[]string{};for j:=rng.Intn(4);j>0;j-- {initial=append(initial,body(false))}
-  cmds:=[]assemblyCommand{};next:=len(initial)
-  for j:=rng.Intn(6);j>0;j-- {next++;id:=fmt.Sprintf(spellings[rng.Intn(len(spellings))],next);cmds=append(cmds,assemblyCommand{ID:id,Deletion:rng.Intn(3)==0,Clause:body(false),Hints:body(true)})}
-  add(fmt.Sprintf("random-%d",i),initial,cmds...)
- }
- return out
+	out := []assemblyCase{}
+	add := func(name string, initial []string, commands ...assemblyCommand) {
+		if initial == nil {
+			initial = []string{}
+		}
+		if commands == nil {
+			commands = []assemblyCommand{}
+		}
+		c := assemblyCase{Name: name, Variables: 64, Initial: initial, Commands: commands}
+		c.Layout, c.Accepted = assemblyReference(c)
+		if c.Layout == nil {
+			c.Layout = []uint32{}
+		}
+		out = append(out, c)
+	}
+	db := []string{"1 0", "-1 0"}
+	addition := func(id string) assemblyCommand { return assemblyCommand{ID: id, Clause: "0", Hints: "1 2 0"} }
+	deletion := func(id string) assemblyCommand { return assemblyCommand{ID: id, Deletion: true, Hints: "1 0"} }
+	add("sequential", db, addition("3"))
+	// Identifier spellings: signs, zero, leading zeros, whitespace, and limits.
+	for _, id := range []string{"3", "+3", "0", "-0", "+0", "-00", "007", "\t7", "7\t", "1", "9", "256", "257", "2147483647", "-1", "-3", "2147483648", "4294967295", "4294967296", "x", "3x", "d", "+", "-", "1e3", "3.0"} {
+		add("addition-id-"+strconv.Quote(id), db, addition(id))
+		add("deletion-stamp-"+strconv.Quote(id), db, deletion(id))
+	}
+	// Non-sequential and repeated identifiers are decoded; validity is checked later.
+	add("repeated-ids", db, addition("3"), addition("3"), deletion("3"), addition("1"))
+	add("descending-ids", db, addition("9"), addition("8"), deletion("0"))
+	// Deletions after additions record the literal offset at that point.
+	add("deletion-offset", db, assemblyCommand{ID: "3", Clause: "1 2 0", Hints: "0"}, deletion("4"), assemblyCommand{ID: "5", Clause: "-2 0", Hints: "3 0"}, deletion("6"))
+	add("empty-clauses-and-hints", db, assemblyCommand{ID: "3", Clause: "0", Hints: "0"}, assemblyCommand{ID: "4", Deletion: true, Hints: "0"})
+	add("mixed-spellings", []string{"1 -64 0", "0"}, assemblyCommand{ID: "+3", Clause: "64 -2 +0", Hints: "1 2 2147483647 -0"}, assemblyCommand{ID: "-0", Deletion: true, Hints: "2 2 0"}, assemblyCommand{ID: "2147483647", Clause: "-1 0", Hints: "0"})
+	// Malformed segments after a valid identifier still reject the whole layout.
+	add("bad-clause-after-id", db, assemblyCommand{ID: "3", Clause: "65 0", Hints: "0"})
+	add("bad-hint-after-id", db, assemblyCommand{ID: "3", Clause: "0", Hints: "-1 0"})
+	add("bad-deletion-zero-after-stamp", db, assemblyCommand{ID: "3", Deletion: true, Hints: "1 +0"})
+	for _, n := range []int{256, 257} {
+		cmds := make([]assemblyCommand, n)
+		for i := range cmds {
+			cmds[i] = deletion(strconv.Itoa(i))
+		}
+		add(fmt.Sprintf("command-count-%d", n), nil, cmds...)
+	}
+	rng := rand.New(rand.NewSource(51907))
+	body := func(hints bool) string {
+		var s strings.Builder
+		for j := rng.Intn(6); j > 0; j-- {
+			n := 1 + rng.Intn(64)
+			if !hints && rng.Intn(2) == 0 {
+				n = -n
+			}
+			fmt.Fprintf(&s, "%d ", n)
+		}
+		s.WriteString("0")
+		return s.String()
+	}
+	spellings := []string{"%d", "+%d", "%03d", "-0", "%d\t", "2147483647", "-%d", "%dq"}
+	for i := 0; i < 32; i++ {
+		initial := []string{}
+		for j := rng.Intn(4); j > 0; j-- {
+			initial = append(initial, body(false))
+		}
+		cmds := []assemblyCommand{}
+		next := len(initial)
+		for j := rng.Intn(6); j > 0; j-- {
+			next++
+			id := fmt.Sprintf(spellings[rng.Intn(len(spellings))], next)
+			cmds = append(cmds, assemblyCommand{ID: id, Deletion: rng.Intn(3) == 0, Clause: body(false), Hints: body(true)})
+		}
+		add(fmt.Sprintf("random-%d", i), initial, cmds...)
+	}
+	return out
 }
 func TestSelfHostedCommandAssembly(t *testing.T) {
- cases:=assemblyCorpus();accepted:=0;observations:=[]layoutObservation{}
- for _,c:=range cases {cnf,proof:=assemblyTexts(c);observations=append(observations,layoutObservation{cnf,proof,c.Layout,c.Accepted});if c.Accepted {accepted++}}
- if accepted==0||accepted==len(cases) {t.Fatal("assembly corpus must contain decoded and rejected layouts")}
- observeDecoderLayouts(t,"assembly",observations)
- if path:=os.Getenv("OAK_ASSEMBLY_CORPUS_OUT");path!="" {data,err:=json.MarshalIndent(cases,"","  ");if err!=nil {t.Fatal(err)};if err:=os.WriteFile(path,append(data,'\n'),0644);err!=nil {t.Fatal(err)}}
- t.Logf("Oak/Go command assembly: %d cases (%d decoded, %d rejected)",len(cases),accepted,len(cases)-accepted)
+	cases := assemblyCorpus()
+	accepted := 0
+	observations := []layoutObservation{}
+	for _, c := range cases {
+		cnf, proof := assemblyTexts(c)
+		observations = append(observations, layoutObservation{cnf, proof, c.Layout, c.Accepted})
+		if c.Accepted {
+			accepted++
+		}
+	}
+	if accepted == 0 || accepted == len(cases) {
+		t.Fatal("assembly corpus must contain decoded and rejected layouts")
+	}
+	observeDecoderLayouts(t, "assembly", observations)
+	if path := os.Getenv("OAK_ASSEMBLY_CORPUS_OUT"); path != "" {
+		data, err := json.MarshalIndent(cases, "", "  ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, append(data, '\n'), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Logf("Oak/Go command assembly: %d cases (%d decoded, %d rejected)", len(cases), accepted, len(cases)-accepted)
 }

--- a/experiments/verification-poc/self_hosted_buffers_test.go
+++ b/experiments/verification-poc/self_hosted_buffers_test.go
@@ -1,111 +1,270 @@
 package main
 
 import (
- "encoding/json"
- "fmt"
- "math/rand"
- "os"
- "strconv"
- "strings"
- "testing"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
 )
 
-type bufferCommand struct { Deletion bool `json:"deletion"`; Clause string `json:"clause"`; Hints string `json:"hints"` }
+type bufferCommand struct {
+	Deletion bool   `json:"deletion"`
+	Clause   string `json:"clause"`
+	Hints    string `json:"hints"`
+}
 type bufferCase struct {
- Name string `json:"name"`
- Variables uint32 `json:"variables"`
- Initial []string `json:"initial"`
- Commands []bufferCommand `json:"commands"`
- Accepted bool `json:"accepted"`
- Layout []uint32 `json:"layout"`
+	Name      string          `json:"name"`
+	Variables uint32          `json:"variables"`
+	Initial   []string        `json:"initial"`
+	Commands  []bufferCommand `json:"commands"`
+	Accepted  bool            `json:"accepted"`
+	Layout    []uint32        `json:"layout"`
 }
-func bufferSegment(text string, mode int, variables uint32) ([]uint32,bool) {
- out:=[]uint32{};words:=strings.Fields(text)
- for i,w:=range words {
-  n,err:=strconv.ParseInt(w,10,64);if err!=nil||n < -2147483647||n>2147483647 {return nil,false}
-  if n==0 {return out,i==len(words)-1&&(mode!=2||w=="0")}
-  if mode!=0 {if n<0 {return nil,false};out=append(out,uint32(n))} else {
-   negative:=n<0;if negative {n=-n};if n>int64(variables) {return nil,false}
-   v:=uint32(n-1)*2;if !negative {v++};out=append(out,v)
-  }
- }
- return nil,false
+
+func bufferSegment(text string, mode int, variables uint32) ([]uint32, bool) {
+	out := []uint32{}
+	words := strings.Fields(text)
+	for i, w := range words {
+		n, err := strconv.ParseInt(w, 10, 64)
+		if err != nil || n < -2147483647 || n > 2147483647 {
+			return nil, false
+		}
+		if n == 0 {
+			return out, i == len(words)-1 && (mode != 2 || w == "0")
+		}
+		if mode != 0 {
+			if n < 0 {
+				return nil, false
+			}
+			out = append(out, uint32(n))
+		} else {
+			negative := n < 0
+			if negative {
+				n = -n
+			}
+			if n > int64(variables) {
+				return nil, false
+			}
+			v := uint32(n-1) * 2
+			if !negative {
+				v++
+			}
+			out = append(out, v)
+		}
+	}
+	return nil, false
 }
-func bufferReference(c bufferCase) ([]uint32,bool) {
- pool,starts,sizes,refs,commands:=[]uint32{},[]uint32{},[]uint32{},[]uint32{},[]uint32{}
- if c.Variables==0||c.Variables>64||len(c.Initial)>256||len(c.Commands)>256 {return nil,false}
- for _,body:=range c.Initial {items,ok:=bufferSegment(body,0,c.Variables);if !ok||len(pool)+len(items)>4096 {return nil,false};starts=append(starts,uint32(len(pool)));sizes=append(sizes,uint32(len(items)));pool=append(pool,items...)}
- for i,cmd:=range c.Commands {
-  start:=uint32(len(pool));count:=uint32(0);addition:=uint32(1);mode:=1
-  if cmd.Deletion {addition=0;mode=2} else {items,ok:=bufferSegment(cmd.Clause,0,c.Variables);if !ok||len(pool)+len(items)>4096 {return nil,false};count=uint32(len(items));pool=append(pool,items...)}
-  items,ok:=bufferSegment(cmd.Hints,mode,c.Variables);if !ok||len(refs)+len(items)>4096 {return nil,false}
-  commands=append(commands,addition,uint32(len(c.Initial)+i+1),start,count,uint32(len(refs)),uint32(len(items)));refs=append(refs,items...)
- }
- flat:=[]uint32{c.Variables,uint32(len(pool)),uint32(len(starts)),uint32(len(refs)),uint32(len(c.Commands))}
- for _,items:=range [][]uint32{pool,starts,sizes,refs,commands} {flat=append(flat,items...)}
- return flat,true
+func bufferReference(c bufferCase) ([]uint32, bool) {
+	pool, starts, sizes, refs, commands := []uint32{}, []uint32{}, []uint32{}, []uint32{}, []uint32{}
+	if c.Variables == 0 || c.Variables > 64 || len(c.Initial) > 256 || len(c.Commands) > 256 {
+		return nil, false
+	}
+	for _, body := range c.Initial {
+		items, ok := bufferSegment(body, 0, c.Variables)
+		if !ok || len(pool)+len(items) > 4096 {
+			return nil, false
+		}
+		starts = append(starts, uint32(len(pool)))
+		sizes = append(sizes, uint32(len(items)))
+		pool = append(pool, items...)
+	}
+	for i, cmd := range c.Commands {
+		start := uint32(len(pool))
+		count := uint32(0)
+		addition := uint32(1)
+		mode := 1
+		if cmd.Deletion {
+			addition = 0
+			mode = 2
+		} else {
+			items, ok := bufferSegment(cmd.Clause, 0, c.Variables)
+			if !ok || len(pool)+len(items) > 4096 {
+				return nil, false
+			}
+			count = uint32(len(items))
+			pool = append(pool, items...)
+		}
+		items, ok := bufferSegment(cmd.Hints, mode, c.Variables)
+		if !ok || len(refs)+len(items) > 4096 {
+			return nil, false
+		}
+		commands = append(commands, addition, uint32(len(c.Initial)+i+1), start, count, uint32(len(refs)), uint32(len(items)))
+		refs = append(refs, items...)
+	}
+	flat := []uint32{c.Variables, uint32(len(pool)), uint32(len(starts)), uint32(len(refs)), uint32(len(c.Commands))}
+	for _, items := range [][]uint32{pool, starts, sizes, refs, commands} {
+		flat = append(flat, items...)
+	}
+	return flat, true
 }
-func bufferTexts(c bufferCase) (string,string) {
- var cnf,proof strings.Builder;fmt.Fprintf(&cnf,"p cnf %d %d\n",c.Variables,len(c.Initial))
- for _,s:=range c.Initial {cnf.WriteString(s);cnf.WriteByte('\n')}
- for i,cmd:=range c.Commands {fmt.Fprintf(&proof,"%d ",len(c.Initial)+i+1);if cmd.Deletion {proof.WriteString("d ")} else {proof.WriteString(cmd.Clause);proof.WriteByte(' ')};proof.WriteString(cmd.Hints);proof.WriteByte('\n')}
- return cnf.String(),proof.String()
+func bufferTexts(c bufferCase) (string, string) {
+	var cnf, proof strings.Builder
+	fmt.Fprintf(&cnf, "p cnf %d %d\n", c.Variables, len(c.Initial))
+	for _, s := range c.Initial {
+		cnf.WriteString(s)
+		cnf.WriteByte('\n')
+	}
+	for i, cmd := range c.Commands {
+		fmt.Fprintf(&proof, "%d ", len(c.Initial)+i+1)
+		if cmd.Deletion {
+			proof.WriteString("d ")
+		} else {
+			proof.WriteString(cmd.Clause)
+			proof.WriteByte(' ')
+		}
+		proof.WriteString(cmd.Hints)
+		proof.WriteByte('\n')
+	}
+	return cnf.String(), proof.String()
 }
 func bufferCorpus() []bufferCase {
- out:=[]bufferCase{}
- add:=func(name string,initial []string,commands ...bufferCommand) {if initial==nil {initial=[]string{}};if commands==nil {commands=[]bufferCommand{}};c:=bufferCase{Name:name,Variables:64,Initial:initial,Commands:commands};c.Layout,c.Accepted=bufferReference(c);if c.Layout==nil {c.Layout=[]uint32{}};out=append(out,c)}
- add("empty",nil)
- add("empty-ranges",[]string{"0","-0","+0"},bufferCommand{Clause:"0",Hints:"0"},bufferCommand{Deletion:true,Hints:"0"})
- add("mixed",[]string{"1 -64 0","0","-1 2 -0"},bufferCommand{Clause:"64 -2 +0",Hints:"1 2 2147483647 -0"},bufferCommand{Deletion:true,Hints:"2 2 0"})
- for _,bad:=range []string{"1","1 x 0","65 0","2147483648 0","+ 0","0 1"} {add("literal-"+bad,[]string{bad})}
- for _,bad:=range []string{"-1 0","1","1 x 0","2147483648 0","0 1"} {add("hint-"+bad,[]string{"0"},bufferCommand{Clause:"0",Hints:bad})}
- for _,zero:=range []string{"0","+0","-0","00"} {add("delete-zero-"+zero,[]string{"0"},bufferCommand{Deletion:true,Hints:"1 "+zero})}
- for _,n:=range []int{4095,4096,4097} {
-  add(fmt.Sprintf("literal-capacity-%d",n),[]string{strings.Repeat("1 ",n)+"0"})
-  add(fmt.Sprintf("hint-capacity-%d",n),[]string{"0"},bufferCommand{Clause:"0",Hints:strings.Repeat("1 ",n)+"0"})
- }
- add("shared-literal-full",[]string{strings.Repeat("1 ",4095)+"0"},bufferCommand{Clause:"-64 0",Hints:"0"},bufferCommand{Clause:"0",Hints:"0"})
- add("shared-literal-overflow",[]string{strings.Repeat("1 ",4095)+"0"},bufferCommand{Clause:"-64 1 0",Hints:"0"})
- add("shared-hints-full",[]string{"0"},bufferCommand{Clause:"0",Hints:strings.Repeat("1 ",4095)+"0"},bufferCommand{Deletion:true,Hints:"2 0"})
- add("shared-hints-overflow",[]string{"0"},bufferCommand{Clause:"0",Hints:strings.Repeat("1 ",4095)+"0"},bufferCommand{Deletion:true,Hints:"2 3 0"})
- for _,n:=range []int{256,257} {initial:=make([]string,n);cmds:=make([]bufferCommand,n);for i:=range initial {initial[i]="0";cmds[i]=bufferCommand{Deletion:true,Hints:"0"}};add(fmt.Sprintf("clause-count-%d",n),initial);add(fmt.Sprintf("command-count-%d",n),nil,cmds...)}
- rng:=rand.New(rand.NewSource(88412))
- body:=func(hints bool) string {var s strings.Builder;for j:=rng.Intn(8);j>0;j-- {n:=1+rng.Intn(64);if !hints&&rng.Intn(2)==0 {n=-n};fmt.Fprintf(&s,"%d\t",n)};s.WriteString("0");return s.String()}
- for i:=0;i<40;i++ {initial:=[]string{};for j:=rng.Intn(5);j>0;j-- {initial=append(initial,body(false))};cmds:=[]bufferCommand{};for j:=rng.Intn(5);j>0;j-- {cmds=append(cmds,bufferCommand{Deletion:rng.Intn(3)==0,Clause:body(false),Hints:body(true)})};add(fmt.Sprintf("random-%d",i),initial,cmds...)}
- return out
+	out := []bufferCase{}
+	add := func(name string, initial []string, commands ...bufferCommand) {
+		if initial == nil {
+			initial = []string{}
+		}
+		if commands == nil {
+			commands = []bufferCommand{}
+		}
+		c := bufferCase{Name: name, Variables: 64, Initial: initial, Commands: commands}
+		c.Layout, c.Accepted = bufferReference(c)
+		if c.Layout == nil {
+			c.Layout = []uint32{}
+		}
+		out = append(out, c)
+	}
+	add("empty", nil)
+	add("empty-ranges", []string{"0", "-0", "+0"}, bufferCommand{Clause: "0", Hints: "0"}, bufferCommand{Deletion: true, Hints: "0"})
+	add("mixed", []string{"1 -64 0", "0", "-1 2 -0"}, bufferCommand{Clause: "64 -2 +0", Hints: "1 2 2147483647 -0"}, bufferCommand{Deletion: true, Hints: "2 2 0"})
+	for _, bad := range []string{"1", "1 x 0", "65 0", "2147483648 0", "+ 0", "0 1"} {
+		add("literal-"+bad, []string{bad})
+	}
+	for _, bad := range []string{"-1 0", "1", "1 x 0", "2147483648 0", "0 1"} {
+		add("hint-"+bad, []string{"0"}, bufferCommand{Clause: "0", Hints: bad})
+	}
+	for _, zero := range []string{"0", "+0", "-0", "00"} {
+		add("delete-zero-"+zero, []string{"0"}, bufferCommand{Deletion: true, Hints: "1 " + zero})
+	}
+	for _, n := range []int{4095, 4096, 4097} {
+		add(fmt.Sprintf("literal-capacity-%d", n), []string{strings.Repeat("1 ", n) + "0"})
+		add(fmt.Sprintf("hint-capacity-%d", n), []string{"0"}, bufferCommand{Clause: "0", Hints: strings.Repeat("1 ", n) + "0"})
+	}
+	add("shared-literal-full", []string{strings.Repeat("1 ", 4095) + "0"}, bufferCommand{Clause: "-64 0", Hints: "0"}, bufferCommand{Clause: "0", Hints: "0"})
+	add("shared-literal-overflow", []string{strings.Repeat("1 ", 4095) + "0"}, bufferCommand{Clause: "-64 1 0", Hints: "0"})
+	add("shared-hints-full", []string{"0"}, bufferCommand{Clause: "0", Hints: strings.Repeat("1 ", 4095) + "0"}, bufferCommand{Deletion: true, Hints: "2 0"})
+	add("shared-hints-overflow", []string{"0"}, bufferCommand{Clause: "0", Hints: strings.Repeat("1 ", 4095) + "0"}, bufferCommand{Deletion: true, Hints: "2 3 0"})
+	for _, n := range []int{256, 257} {
+		initial := make([]string, n)
+		cmds := make([]bufferCommand, n)
+		for i := range initial {
+			initial[i] = "0"
+			cmds[i] = bufferCommand{Deletion: true, Hints: "0"}
+		}
+		add(fmt.Sprintf("clause-count-%d", n), initial)
+		add(fmt.Sprintf("command-count-%d", n), nil, cmds...)
+	}
+	rng := rand.New(rand.NewSource(88412))
+	body := func(hints bool) string {
+		var s strings.Builder
+		for j := rng.Intn(8); j > 0; j-- {
+			n := 1 + rng.Intn(64)
+			if !hints && rng.Intn(2) == 0 {
+				n = -n
+			}
+			fmt.Fprintf(&s, "%d\t", n)
+		}
+		s.WriteString("0")
+		return s.String()
+	}
+	for i := 0; i < 40; i++ {
+		initial := []string{}
+		for j := rng.Intn(5); j > 0; j-- {
+			initial = append(initial, body(false))
+		}
+		cmds := []bufferCommand{}
+		for j := rng.Intn(5); j > 0; j-- {
+			cmds = append(cmds, bufferCommand{Deletion: rng.Intn(3) == 0, Clause: body(false), Hints: body(true)})
+		}
+		add(fmt.Sprintf("random-%d", i), initial, cmds...)
+	}
+	return out
 }
 
 // Periodic initialization keeps the capacity regressions small in generated Oak.
-func emitBufferArray(out *strings.Builder,name,typ string,values []uint32) {
- capacity:=len(values);if capacity==0 {capacity=1};fmt.Fprintf(out,"%s: [%d]%s\n",name,capacity,typ)
- for i:=0;i<len(values); {
-  bestPeriod,bestEnd:=1,i+1
-  for p:=1;p<=16&&i+p<=len(values);p++ {end:=i+p;for end<len(values)&&values[end]==values[i+(end-i)%p] {end++};end=i+(end-i)/p*p;if end-i>=p*4&&end>bestEnd {bestPeriod,bestEnd=p,end}}
-  if bestEnd-i>8 {
-   fmt.Fprintf(out,"%s_i_%d: u32 = %d\nwhile %s_i_%d < u32(%d) {\n",name,i,i,name,i,bestEnd)
-   for k:=0;k<bestPeriod;k++ {fmt.Fprintf(out,"%s[%s_i_%d + u32(%d)] = %s(%d)\n",name,name,i,k,typ,values[i+k])}
-   fmt.Fprintf(out,"%s_i_%d = %s_i_%d + u32(%d)\n}\n",name,i,name,i,bestPeriod);i=bestEnd
-  } else {fmt.Fprintf(out,"%s[%d] = %s(%d)\n",name,i,typ,values[i]);i++}
- }
- fmt.Fprintf(out,"%s_view: []%s = %s[0:%d]\n",name,typ,name,len(values))
+func emitBufferArray(out *strings.Builder, name, typ string, values []uint32) {
+	capacity := len(values)
+	if capacity == 0 {
+		capacity = 1
+	}
+	fmt.Fprintf(out, "%s: [%d]%s\n", name, capacity, typ)
+	for i := 0; i < len(values); {
+		bestPeriod, bestEnd := 1, i+1
+		for p := 1; p <= 16 && i+p <= len(values); p++ {
+			end := i + p
+			for end < len(values) && values[end] == values[i+(end-i)%p] {
+				end++
+			}
+			end = i + (end-i)/p*p
+			if end-i >= p*4 && end > bestEnd {
+				bestPeriod, bestEnd = p, end
+			}
+		}
+		if bestEnd-i > 8 {
+			fmt.Fprintf(out, "%s_i_%d: u32 = %d\nwhile %s_i_%d < u32(%d) {\n", name, i, i, name, i, bestEnd)
+			for k := 0; k < bestPeriod; k++ {
+				fmt.Fprintf(out, "%s[%s_i_%d + u32(%d)] = %s(%d)\n", name, name, i, k, typ, values[i+k])
+			}
+			fmt.Fprintf(out, "%s_i_%d = %s_i_%d + u32(%d)\n}\n", name, i, name, i, bestPeriod)
+			i = bestEnd
+		} else {
+			fmt.Fprintf(out, "%s[%d] = %s(%d)\n", name, i, typ, values[i])
+			i++
+		}
+	}
+	fmt.Fprintf(out, "%s_view: []%s = %s[0:%d]\n", name, typ, name, len(values))
 }
+
 // One decoder observation: the texts fed to the actual Oak decoder and the
 // flat layout the oracle expects it to publish, or a decoder rejection.
-type layoutObservation struct { CNF,Proof string; Layout []uint32; Accepted bool }
+type layoutObservation struct {
+	CNF, Proof string
+	Layout     []uint32
+	Accepted   bool
+}
 
 // Instrument only the decoder's entry signature and final handoff, then compare
 // every published pool item, range, and command field in compiled Oak.
-func observeDecoderLayouts(t *testing.T,prefix string,cases []layoutObservation) {
- t.Helper()
- var source,main strings.Builder
- for _,path:=range []string{"self_hosted_rup.oak","self_hosted_stream.oak"} {data,err:=os.ReadFile(path);if err!=nil {t.Fatal(err)};source.Write(data);source.WriteByte('\n')}
- data,err:=os.ReadFile("self_hosted_text.oak");if err!=nil {t.Fatal(err)};decoder:=string(data)
- replacements:=[][2]string{
-  {"rup_text_check: (cnf: []u8, proof: []u8): Bool {","rup_text_check: (cnf: []u8, proof: []u8, expected_layout: []u32): u32 {"},
-  {"  accepted: Bool = false\n  valid ? { accepted = rup_stream_check(pool_view, initial_view, sizes_view, refs_view, commands_view, variables) }\n  accepted", "  status: u32 = 0\n  valid ? {\n    status = u32(1)\n    buffer_observe(pool_view, initial_view, sizes_view, refs_view, commands_view, variables, expected_layout) ? { status = u32(2) }\n  }\n  status"},
- }
- for _,r:=range replacements {if strings.Count(decoder,r[0])!=1 {t.Fatal("decoder observation seam changed")};decoder=strings.Replace(decoder,r[0],r[1],1)}
- source.WriteString(decoder);source.WriteString(`
+func observeDecoderLayouts(t *testing.T, prefix string, cases []layoutObservation) {
+	t.Helper()
+	var source, main strings.Builder
+	for _, path := range []string{"self_hosted_rup.oak", "self_hosted_stream.oak"} {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		source.Write(data)
+		source.WriteByte('\n')
+	}
+	data, err := os.ReadFile("self_hosted_text.oak")
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoder := string(data)
+	replacements := [][2]string{
+		{"rup_text_check: (cnf: []u8, proof: []u8): Bool {", "rup_text_check: (cnf: []u8, proof: []u8, expected_layout: []u32): u32 {"},
+		{"  accepted: Bool = false\n  valid ? { accepted = rup_stream_check(pool_view, initial_view, sizes_view, refs_view, commands_view, variables) }\n  accepted", "  status: u32 = 0\n  valid ? {\n    status = u32(1)\n    buffer_observe(pool_view, initial_view, sizes_view, refs_view, commands_view, variables, expected_layout) ? { status = u32(2) }\n  }\n  status"},
+	}
+	for _, r := range replacements {
+		if strings.Count(decoder, r[0]) != 1 {
+			t.Fatal("decoder observation seam changed")
+		}
+		decoder = strings.Replace(decoder, r[0], r[1], 1)
+	}
+	source.WriteString(decoder)
+	source.WriteString(`
 buffer_observe: (pool: []u32, starts: []u32, sizes: []u32, refs: []u32, commands: []RUPCommand, variables: u32, expected: []u32): Bool {
  good: Bool = len(expected) == u32(5) + len(pool) + len(starts) + len(sizes) + len(refs) + len(commands) * u32(6)
  good ? {
@@ -130,19 +289,48 @@ buffer_observe: (pool: []u32, starts: []u32, sizes: []u32, refs: []u32, commands
  good
 }
 `)
- main.WriteString("main: (): i32 {\n")
- for i,c:=range cases {
-  fmt.Fprintf(&source,"%s_case_%d: (): Bool {\n",prefix,i)
-  for _,a:=range []struct{name,text string}{{"cnf",c.CNF},{"proof",c.Proof}} {values:=[]uint32{};for _,b:=range []byte(a.text) {values=append(values,uint32(b))};emitBufferArray(&source,a.name,"u8",values)}
-  emitBufferArray(&source,"expected","u32",c.Layout);status:=0;if c.Accepted {status=2}
-  fmt.Fprintf(&source,"rup_text_check(cnf_view, proof_view, expected_view) == u32(%d)\n}\n",status);fmt.Fprintf(&main,"assert(%s_case_%d())\n",prefix,i)
- }
- main.WriteString("42\n}\n");source.WriteString(main.String());runOakStream(t,source.String())
+	main.WriteString("main: (): i32 {\n")
+	for i, c := range cases {
+		fmt.Fprintf(&source, "%s_case_%d: (): Bool {\n", prefix, i)
+		for _, a := range []struct{ name, text string }{{"cnf", c.CNF}, {"proof", c.Proof}} {
+			values := []uint32{}
+			for _, b := range []byte(a.text) {
+				values = append(values, uint32(b))
+			}
+			emitBufferArray(&source, a.name, "u8", values)
+		}
+		emitBufferArray(&source, "expected", "u32", c.Layout)
+		status := 0
+		if c.Accepted {
+			status = 2
+		}
+		fmt.Fprintf(&source, "rup_text_check(cnf_view, proof_view, expected_view) == u32(%d)\n}\n", status)
+		fmt.Fprintf(&main, "assert(%s_case_%d())\n", prefix, i)
+	}
+	main.WriteString("42\n}\n")
+	source.WriteString(main.String())
+	runOakStream(t, source.String())
 }
 func TestSelfHostedBufferLayouts(t *testing.T) {
- cases:=bufferCorpus();accepted:=0;observations:=[]layoutObservation{}
- for _,c:=range cases {cnf,proof:=bufferTexts(c);observations=append(observations,layoutObservation{cnf,proof,c.Layout,c.Accepted});if c.Accepted {accepted++}}
- observeDecoderLayouts(t,"buffer",observations)
- if path:=os.Getenv("OAK_BUFFER_CORPUS_OUT");path!="" {data,err:=json.MarshalIndent(cases,"","  ");if err!=nil {t.Fatal(err)};if err:=os.WriteFile(path,append(data,'\n'),0644);err!=nil {t.Fatal(err)}}
- t.Logf("Oak/Go buffer layouts: %d cases (%d decoded, %d rejected)",len(cases),accepted,len(cases)-accepted)
+	cases := bufferCorpus()
+	accepted := 0
+	observations := []layoutObservation{}
+	for _, c := range cases {
+		cnf, proof := bufferTexts(c)
+		observations = append(observations, layoutObservation{cnf, proof, c.Layout, c.Accepted})
+		if c.Accepted {
+			accepted++
+		}
+	}
+	observeDecoderLayouts(t, "buffer", observations)
+	if path := os.Getenv("OAK_BUFFER_CORPUS_OUT"); path != "" {
+		data, err := json.MarshalIndent(cases, "", "  ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, append(data, '\n'), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Logf("Oak/Go buffer layouts: %d cases (%d decoded, %d rejected)", len(cases), accepted, len(cases)-accepted)
 }

--- a/experiments/verification-poc/self_hosted_certified_stream_test.go
+++ b/experiments/verification-poc/self_hosted_certified_stream_test.go
@@ -1,66 +1,141 @@
 package main
 
 import (
- "encoding/json"
- "fmt"
- "os"
- "strings"
- "testing"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
 )
 
 func certifiedStreamCorpus(t *testing.T) []rangeCase {
- t.Helper();cases:=rangeCorpus(t)
- add:=func(name string,s streamCase,want bool){c:=rangeFromStream(s);c.Name=name;decoded,meaning,ok:=rangeDecode(c);if !ok {t.Fatal("constructed stream did not decode",name)};c.Decoded=true;c.Meaning=meaning;c.Accepted=streamReference(decoded);if c.Accepted!=want {t.Fatal("constructed stream reference differs",name)};cases=append(cases,c)}
- for n:=1;n<=64;n++ {
-  db:=[][]int{{1}};for v:=1;v<n;v++ {db=append(db,[]int{-v,v+1})};db=append(db,[]int{-n})
-  commands:=[]streamCommand{};previous:=uint32(1);id:=uint32(n+2)
-  for v:=2;v<=n;v++ {commands=append(commands,streamAdd(id,[]int{v},int(previous),v),streamDelete(id,previous));previous=id;id++}
-  emptyID:=id;commands=append(commands,streamAdd(id,nil,int(previous),n+1),streamDelete(id,id));id++
-  commands=append(commands,streamAdd(id,[]int{1,-1}))
-  s:=streamCase{Variables:n,Database:db,Commands:commands}
-  add(fmt.Sprintf("certified-live-chain-%d",n),s,true)
-  s.Commands=append(append([]streamCommand{},commands...),streamAdd(id,[]int{1,-1}));add(fmt.Sprintf("reused-id-after-refutation-%d",n),s,false)
-  s.Commands=append(append([]streamCommand{},commands...),streamAdd(id+1,[]int{1,-1},int(emptyID)));add(fmt.Sprintf("deleted-empty-hint-%d",n),s,false)
-  s.Commands=append(append([]streamCommand{},commands...),streamDelete(id,uint32(n+1),uint32(n+1)));add(fmt.Sprintf("duplicate-delete-after-refutation-%d",n),s,false)
- }
- return cases
+	t.Helper()
+	cases := rangeCorpus(t)
+	add := func(name string, s streamCase, want bool) {
+		c := rangeFromStream(s)
+		c.Name = name
+		decoded, meaning, ok := rangeDecode(c)
+		if !ok {
+			t.Fatal("constructed stream did not decode", name)
+		}
+		c.Decoded = true
+		c.Meaning = meaning
+		c.Accepted = streamReference(decoded)
+		if c.Accepted != want {
+			t.Fatal("constructed stream reference differs", name)
+		}
+		cases = append(cases, c)
+	}
+	for n := 1; n <= 64; n++ {
+		db := [][]int{{1}}
+		for v := 1; v < n; v++ {
+			db = append(db, []int{-v, v + 1})
+		}
+		db = append(db, []int{-n})
+		commands := []streamCommand{}
+		previous := uint32(1)
+		id := uint32(n + 2)
+		for v := 2; v <= n; v++ {
+			commands = append(commands, streamAdd(id, []int{v}, int(previous), v), streamDelete(id, previous))
+			previous = id
+			id++
+		}
+		emptyID := id
+		commands = append(commands, streamAdd(id, nil, int(previous), n+1), streamDelete(id, id))
+		id++
+		commands = append(commands, streamAdd(id, []int{1, -1}))
+		s := streamCase{Variables: n, Database: db, Commands: commands}
+		add(fmt.Sprintf("certified-live-chain-%d", n), s, true)
+		s.Commands = append(append([]streamCommand{}, commands...), streamAdd(id, []int{1, -1}))
+		add(fmt.Sprintf("reused-id-after-refutation-%d", n), s, false)
+		s.Commands = append(append([]streamCommand{}, commands...), streamAdd(id+1, []int{1, -1}, int(emptyID)))
+		add(fmt.Sprintf("deleted-empty-hint-%d", n), s, false)
+		s.Commands = append(append([]streamCommand{}, commands...), streamDelete(id, uint32(n+1), uint32(n+1)))
+		add(fmt.Sprintf("duplicate-delete-after-refutation-%d", n), s, false)
+	}
+	return cases
 }
 func TestSelfHostedCertifiedStream(t *testing.T) {
- cases:=certifiedStreamCorpus(t)
- runCertifiedStreamCases(t,cases)
+	cases := certifiedStreamCorpus(t)
+	runCertifiedStreamCases(t, cases)
 }
-func runCertifiedStreamCases(t *testing.T,cases []rangeCase) {
- t.Helper();accepted:=0
- var source,main strings.Builder
- for _,path:=range []string{"self_hosted_rup.oak","self_hosted_stream.oak"} {data,err:=os.ReadFile(path);if err!=nil {t.Fatal(err)};source.Write(data);source.WriteByte('\n')}
- main.WriteString("main: (): i32 {\n")
- for i,c:=range cases {
-  fmt.Fprintf(&source,"certified_stream_case_%d: (): Bool {\n",i)
-  for _,a:=range []struct{name string;items []uint32}{{"pool",c.Pool},{"starts",c.Starts},{"sizes",c.Sizes},{"refs",c.Refs}} {emitBufferArray(&source,a.name,"u32",a.items)}
-  capacity:=len(c.Commands);if capacity==0 {capacity=1};fmt.Fprintf(&source,"commands: [%d]RUPCommand\n",capacity)
-  for j,r:=range c.Commands {fmt.Fprintf(&source,"commands[%d] = RUPCommand { addition: %t, id: u32(%d), start: u32(%d), count: u32(%d), refs_start: u32(%d), refs_count: u32(%d) }\n",j,r.Addition,r.ID,r.Start,r.Count,r.RefsStart,r.RefsCount)}
-  fmt.Fprintf(&source,"command_view: []RUPCommand = commands[0:%d]\nrup_stream_check(pool_view, starts_view, sizes_view, refs_view, command_view, u32(%d)) == %t\n}\n",len(c.Commands),c.Variables,c.Accepted)
-  fmt.Fprintf(&main,"assert(certified_stream_case_%d())\n",i);if c.Accepted {accepted++}
- }
- main.WriteString("42\n}\n");source.WriteString(main.String());runOakStream(t,source.String())
- if path:=os.Getenv("OAK_CERTIFIED_STREAM_CORPUS_OUT");path!="" {data,err:=json.MarshalIndent(cases,"","  ");if err!=nil {t.Fatal(err)};if err:=os.WriteFile(path,append(data,'\n'),0644);err!=nil {t.Fatal(err)}}
- t.Logf("Oak/Go certified stream: %d layouts (%d accepted, %d rejected)",len(cases),accepted,len(cases)-accepted)
+func runCertifiedStreamCases(t *testing.T, cases []rangeCase) {
+	t.Helper()
+	accepted := 0
+	var source, main strings.Builder
+	for _, path := range []string{"self_hosted_rup.oak", "self_hosted_stream.oak"} {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		source.Write(data)
+		source.WriteByte('\n')
+	}
+	main.WriteString("main: (): i32 {\n")
+	for i, c := range cases {
+		fmt.Fprintf(&source, "certified_stream_case_%d: (): Bool {\n", i)
+		for _, a := range []struct {
+			name  string
+			items []uint32
+		}{{"pool", c.Pool}, {"starts", c.Starts}, {"sizes", c.Sizes}, {"refs", c.Refs}} {
+			emitBufferArray(&source, a.name, "u32", a.items)
+		}
+		capacity := len(c.Commands)
+		if capacity == 0 {
+			capacity = 1
+		}
+		fmt.Fprintf(&source, "commands: [%d]RUPCommand\n", capacity)
+		for j, r := range c.Commands {
+			fmt.Fprintf(&source, "commands[%d] = RUPCommand { addition: %t, id: u32(%d), start: u32(%d), count: u32(%d), refs_start: u32(%d), refs_count: u32(%d) }\n", j, r.Addition, r.ID, r.Start, r.Count, r.RefsStart, r.RefsCount)
+		}
+		fmt.Fprintf(&source, "command_view: []RUPCommand = commands[0:%d]\nrup_stream_check(pool_view, starts_view, sizes_view, refs_view, command_view, u32(%d)) == %t\n}\n", len(c.Commands), c.Variables, c.Accepted)
+		fmt.Fprintf(&main, "assert(certified_stream_case_%d())\n", i)
+		if c.Accepted {
+			accepted++
+		}
+	}
+	main.WriteString("42\n}\n")
+	source.WriteString(main.String())
+	runOakStream(t, source.String())
+	if path := os.Getenv("OAK_CERTIFIED_STREAM_CORPUS_OUT"); path != "" {
+		data, err := json.MarshalIndent(cases, "", "  ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, append(data, '\n'), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Logf("Oak/Go certified stream: %d layouts (%d accepted, %d rejected)", len(cases), accepted, len(cases)-accepted)
 }
 
 // Actual solver files are selected and packed by the Lean gate. The independent
 // Go oracle and uninstrumented compiled Oak must replay every exported case.
 func TestSelfHostedCertifiedCertificates(t *testing.T) {
- path:=os.Getenv("OAK_CERTIFIED_CERTIFICATE_CASES")
- if path=="" {t.Skip("actual certificate replay runs in the opt-in solver gate")}
- data,err:=os.ReadFile(path);if err!=nil {t.Fatal(err)}
- var cases []rangeCase
- if err:=json.Unmarshal(data,&cases);err!=nil {t.Fatal(err)}
- if len(cases)==0||len(cases)%3!=0 {t.Fatal("expected certificate/corruption triples")}
- for i,c:=range cases {
-  if c.Accepted!=(i%3==0) {t.Fatal("invalid replay expectation",c.Name)}
-  s,_,ok:=rangeDecode(c)
-  if (ok&&streamReference(s))!=c.Accepted {t.Fatal("Go replay differs",c.Name)}
- }
- runCertifiedStreamCases(t,cases)
- t.Logf("Oak/Go actual certified replay: %d certificates, %d rejected corruptions",len(cases)/3,len(cases)*2/3)
+	path := os.Getenv("OAK_CERTIFIED_CERTIFICATE_CASES")
+	if path == "" {
+		t.Skip("actual certificate replay runs in the opt-in solver gate")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cases []rangeCase
+	if err := json.Unmarshal(data, &cases); err != nil {
+		t.Fatal(err)
+	}
+	if len(cases) == 0 || len(cases)%3 != 0 {
+		t.Fatal("expected certificate/corruption triples")
+	}
+	for i, c := range cases {
+		if c.Accepted != (i%3 == 0) {
+			t.Fatal("invalid replay expectation", c.Name)
+		}
+		s, _, ok := rangeDecode(c)
+		if (ok && streamReference(s)) != c.Accepted {
+			t.Fatal("Go replay differs", c.Name)
+		}
+	}
+	runCertifiedStreamCases(t, cases)
+	t.Logf("Oak/Go actual certified replay: %d certificates, %d rejected corruptions", len(cases)/3, len(cases)*2/3)
 }

--- a/experiments/verification-poc/self_hosted_chain_test.go
+++ b/experiments/verification-poc/self_hosted_chain_test.go
@@ -1,56 +1,140 @@
 package main
 
 import (
- "encoding/json"
- "fmt"
- "os"
- "strings"
- "testing"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
 
- "github.com/SCKelemen/oak/experiments/verification-poc/internal/lrat"
+	"github.com/SCKelemen/oak/experiments/verification-poc/internal/lrat"
 )
 
 type chainCase struct {
- selfHostedRUPCase
- Name string `json:"name"`
+	selfHostedRUPCase
+	Name string `json:"name"`
 }
+
 func chainCorpus(t *testing.T) []chainCase {
- t.Helper();cases:=[]chainCase{}
- add:=func(name string,c selfHostedRUPCase){
-  clauses:=[][]int{};for _,clause:=range c.Clauses {clauses=append(clauses,append([]int{},clause...))};c.Clauses=clauses;c.Target=append([]int{},c.Target...);c.Hints=append([]int{},c.Hints...)
-  c.Accepted=c.Variables>0&&c.Variables<=64&&lrat.CheckRUPDecoded(c.Variables,c.Clauses,c.Target,c.Hints)==nil
-  cases=append(cases,chainCase{c,name})
- }
- for i,c:=range propagationCorpus(t) {add(fmt.Sprintf("scratch-%d",i),c.selfHostedRUPCase)}
- for n:=1;n<=64;n++ {
-  clauses:=[][]int{{1}};for v:=1;v<n;v++ {clauses=append(clauses,[]int{-v,v+1})};clauses=append(clauses,[]int{-n})
-  hints:=[]int{};for id:=1;id<=len(clauses);id++ {hints=append(hints,id)}
-  c:=selfHostedRUPCase{Variables:n,Clauses:clauses,Hints:hints}
-  add(fmt.Sprintf("chain-%d",n),c);if !cases[len(cases)-1].Accepted {t.Fatal("ordered chain must refute",n)}
-  repeated:=[][]int{};for _,clause:=range clauses {xs:=[]int{};for _,lit:=range clause {xs=append(xs,lit,lit,lit)};repeated=append(repeated,xs)}
-  c.Clauses=repeated;add(fmt.Sprintf("duplicates-%d",n),c);if !cases[len(cases)-1].Accepted {t.Fatal("duplicate literals changed chain",n)}
-  c.Clauses=clauses;c.Hints=hints[:len(hints)-1];add(fmt.Sprintf("missing-conflict-%d",n),c);if cases[len(cases)-1].Accepted {t.Fatal("unfinished chain accepted",n)}
-  c.Hints=append(append([]int{},hints...),1);add(fmt.Sprintf("nonfinal-conflict-%d",n),c);if cases[len(cases)-1].Accepted {t.Fatal("nonfinal conflict accepted",n)}
-  c.Hints=append([]int{},hints...);c.Hints[0],c.Hints[1]=c.Hints[1],c.Hints[0];add(fmt.Sprintf("swapped-hints-%d",n),c)
-  if cases[len(cases)-1].Accepted!=(n==1) {t.Fatal("unexpected swapped chain result",n)}
- }
- return cases
+	t.Helper()
+	cases := []chainCase{}
+	add := func(name string, c selfHostedRUPCase) {
+		clauses := [][]int{}
+		for _, clause := range c.Clauses {
+			clauses = append(clauses, append([]int{}, clause...))
+		}
+		c.Clauses = clauses
+		c.Target = append([]int{}, c.Target...)
+		c.Hints = append([]int{}, c.Hints...)
+		c.Accepted = c.Variables > 0 && c.Variables <= 64 && lrat.CheckRUPDecoded(c.Variables, c.Clauses, c.Target, c.Hints) == nil
+		cases = append(cases, chainCase{c, name})
+	}
+	for i, c := range propagationCorpus(t) {
+		add(fmt.Sprintf("scratch-%d", i), c.selfHostedRUPCase)
+	}
+	for n := 1; n <= 64; n++ {
+		clauses := [][]int{{1}}
+		for v := 1; v < n; v++ {
+			clauses = append(clauses, []int{-v, v + 1})
+		}
+		clauses = append(clauses, []int{-n})
+		hints := []int{}
+		for id := 1; id <= len(clauses); id++ {
+			hints = append(hints, id)
+		}
+		c := selfHostedRUPCase{Variables: n, Clauses: clauses, Hints: hints}
+		add(fmt.Sprintf("chain-%d", n), c)
+		if !cases[len(cases)-1].Accepted {
+			t.Fatal("ordered chain must refute", n)
+		}
+		repeated := [][]int{}
+		for _, clause := range clauses {
+			xs := []int{}
+			for _, lit := range clause {
+				xs = append(xs, lit, lit, lit)
+			}
+			repeated = append(repeated, xs)
+		}
+		c.Clauses = repeated
+		add(fmt.Sprintf("duplicates-%d", n), c)
+		if !cases[len(cases)-1].Accepted {
+			t.Fatal("duplicate literals changed chain", n)
+		}
+		c.Clauses = clauses
+		c.Hints = hints[:len(hints)-1]
+		add(fmt.Sprintf("missing-conflict-%d", n), c)
+		if cases[len(cases)-1].Accepted {
+			t.Fatal("unfinished chain accepted", n)
+		}
+		c.Hints = append(append([]int{}, hints...), 1)
+		add(fmt.Sprintf("nonfinal-conflict-%d", n), c)
+		if cases[len(cases)-1].Accepted {
+			t.Fatal("nonfinal conflict accepted", n)
+		}
+		c.Hints = append([]int{}, hints...)
+		c.Hints[0], c.Hints[1] = c.Hints[1], c.Hints[0]
+		add(fmt.Sprintf("swapped-hints-%d", n), c)
+		if cases[len(cases)-1].Accepted != (n == 1) {
+			t.Fatal("unexpected swapped chain result", n)
+		}
+	}
+	return cases
 }
 func TestSelfHostedPropagationChain(t *testing.T) {
- cases:=chainCorpus(t);accepted:=0
- kernel,err:=os.ReadFile("self_hosted_rup.oak");if err!=nil {t.Fatal(err)}
- var source,main strings.Builder;source.Write(kernel);source.WriteByte('\n');main.WriteString("main: (): i32 {\n")
- for i,c:=range cases {
-  fmt.Fprintf(&source,"chain_case_%d: (): Bool {\n",i)
-  pool,starts,sizes,target,hints:=[]uint32{},[]uint32{},[]uint32{},[]uint32{},[]uint32{}
-  for _,clause:=range c.Clauses {starts=append(starts,uint32(len(pool)));sizes=append(sizes,uint32(len(clause)));for _,lit:=range clause {pool=append(pool,oakLiteral(lit))}}
-  for _,lit:=range c.Target {target=append(target,oakLiteral(lit))};for _,id:=range c.Hints {n:=uint32(4294967295);if id>0 {n=uint32(id-1)};hints=append(hints,n)}
-  for _,a:=range []struct{name string;items []uint32}{{"pool",pool},{"starts",starts},{"sizes",sizes},{"target",target},{"hints",hints}} {emitBufferArray(&source,a.name,"u32",a.items)}
-  source.WriteString("assignments: [64]u8\n")
-  fmt.Fprintf(&source,"rup_check(pool_view, starts_view, sizes_view, u32(%d), target_view, u32(%d), hints_view, u32(%d), span(&assignments), u32(%d)) == %t\n}\n",len(starts),len(target),len(hints),c.Variables,c.Accepted)
-  fmt.Fprintf(&main,"assert(chain_case_%d())\n",i);if c.Accepted {accepted++}
- }
- main.WriteString("42\n}\n");source.WriteString(main.String());runOakStream(t,source.String())
- if path:=os.Getenv("OAK_CHAIN_CORPUS_OUT");path!="" {data,err:=json.MarshalIndent(cases,"","  ");if err!=nil {t.Fatal(err)};if err:=os.WriteFile(path,append(data,'\n'),0644);err!=nil {t.Fatal(err)}}
- t.Logf("Oak/Go propagation chain: %d cases (%d accepted, %d rejected), up to 64 unit writes",len(cases),accepted,len(cases)-accepted)
+	cases := chainCorpus(t)
+	accepted := 0
+	kernel, err := os.ReadFile("self_hosted_rup.oak")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var source, main strings.Builder
+	source.Write(kernel)
+	source.WriteByte('\n')
+	main.WriteString("main: (): i32 {\n")
+	for i, c := range cases {
+		fmt.Fprintf(&source, "chain_case_%d: (): Bool {\n", i)
+		pool, starts, sizes, target, hints := []uint32{}, []uint32{}, []uint32{}, []uint32{}, []uint32{}
+		for _, clause := range c.Clauses {
+			starts = append(starts, uint32(len(pool)))
+			sizes = append(sizes, uint32(len(clause)))
+			for _, lit := range clause {
+				pool = append(pool, oakLiteral(lit))
+			}
+		}
+		for _, lit := range c.Target {
+			target = append(target, oakLiteral(lit))
+		}
+		for _, id := range c.Hints {
+			n := uint32(4294967295)
+			if id > 0 {
+				n = uint32(id - 1)
+			}
+			hints = append(hints, n)
+		}
+		for _, a := range []struct {
+			name  string
+			items []uint32
+		}{{"pool", pool}, {"starts", starts}, {"sizes", sizes}, {"target", target}, {"hints", hints}} {
+			emitBufferArray(&source, a.name, "u32", a.items)
+		}
+		source.WriteString("assignments: [64]u8\n")
+		fmt.Fprintf(&source, "rup_check(pool_view, starts_view, sizes_view, u32(%d), target_view, u32(%d), hints_view, u32(%d), span(&assignments), u32(%d)) == %t\n}\n", len(starts), len(target), len(hints), c.Variables, c.Accepted)
+		fmt.Fprintf(&main, "assert(chain_case_%d())\n", i)
+		if c.Accepted {
+			accepted++
+		}
+	}
+	main.WriteString("42\n}\n")
+	source.WriteString(main.String())
+	runOakStream(t, source.String())
+	if path := os.Getenv("OAK_CHAIN_CORPUS_OUT"); path != "" {
+		data, err := json.MarshalIndent(cases, "", "  ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, append(data, '\n'), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Logf("Oak/Go propagation chain: %d cases (%d accepted, %d rejected), up to 64 unit writes", len(cases), accepted, len(cases)-accepted)
 }

--- a/experiments/verification-poc/self_hosted_classifier_test.go
+++ b/experiments/verification-poc/self_hosted_classifier_test.go
@@ -1,52 +1,99 @@
 package main
 
 import (
- "encoding/json"
- "fmt"
- "os"
- "strings"
- "testing"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
 )
 
 type classifierCase struct {
- Clause []uint32 `json:"clause"`
- Cells []uint32 `json:"cells"`
- Expected []uint32 `json:"expected"`
+	Clause   []uint32 `json:"clause"`
+	Cells    []uint32 `json:"cells"`
+	Expected []uint32 `json:"expected"`
 }
+
 func classifierReference(c classifierCase) []uint32 {
- unknown:=map[uint32]bool{};satisfied:=false
- for _,n:=range c.Clause {value:=c.Cells[n/2];if value==0 {unknown[n]=true} else if (value==2)==(n%2==1) {satisfied=true}}
- if satisfied {return []uint32{2,0}}
- if len(unknown)==0 {return []uint32{0,0}}
- if len(unknown)==1 {for n:=range unknown {return []uint32{1,n}}}
- return []uint32{3,0}
+	unknown := map[uint32]bool{}
+	satisfied := false
+	for _, n := range c.Clause {
+		value := c.Cells[n/2]
+		if value == 0 {
+			unknown[n] = true
+		} else if (value == 2) == (n%2 == 1) {
+			satisfied = true
+		}
+	}
+	if satisfied {
+		return []uint32{2, 0}
+	}
+	if len(unknown) == 0 {
+		return []uint32{0, 0}
+	}
+	if len(unknown) == 1 {
+		for n := range unknown {
+			return []uint32{1, n}
+		}
+	}
+	return []uint32{3, 0}
 }
 func classifierCorpus() []classifierCase {
- cases:=[]classifierCase{}
- add:=func(clause,cells []uint32){c:=classifierCase{append([]uint32{},clause...),append([]uint32{},cells...),nil};c.Expected=classifierReference(c);cases=append(cases,c)}
- // All 9 assignments and 85 ordered clauses of length 0..3 on two variables.
- for a:=uint32(0);a<3;a++ {for b:=uint32(0);b<3;b++ {
-  var visit func([]uint32,int)
-  visit=func(clause []uint32,left int){add(clause,[]uint32{a,b});if left>0 {for n:=uint32(0);n<4;n++ {visit(append(append([]uint32{},clause...),n),left-1)}}}
-  visit(nil,3)
- }}
- // Both polarities, every variable boundary, all assignment states. Repeated
- // units must count once even when their encoding is zero or at the upper limit.
- for v:=0;v<64;v++ {for polarity:=uint32(0);polarity<2;polarity++ {for value:=uint32(0);value<3;value++ {cells:=make([]uint32,v+1);cells[v]=value;n:=uint32(v*2)+polarity;add([]uint32{n,n,n,n},cells)}}}
- return cases
+	cases := []classifierCase{}
+	add := func(clause, cells []uint32) {
+		c := classifierCase{append([]uint32{}, clause...), append([]uint32{}, cells...), nil}
+		c.Expected = classifierReference(c)
+		cases = append(cases, c)
+	}
+	// All 9 assignments and 85 ordered clauses of length 0..3 on two variables.
+	for a := uint32(0); a < 3; a++ {
+		for b := uint32(0); b < 3; b++ {
+			var visit func([]uint32, int)
+			visit = func(clause []uint32, left int) {
+				add(clause, []uint32{a, b})
+				if left > 0 {
+					for n := uint32(0); n < 4; n++ {
+						visit(append(append([]uint32{}, clause...), n), left-1)
+					}
+				}
+			}
+			visit(nil, 3)
+		}
+	}
+	// Both polarities, every variable boundary, all assignment states. Repeated
+	// units must count once even when their encoding is zero or at the upper limit.
+	for v := 0; v < 64; v++ {
+		for polarity := uint32(0); polarity < 2; polarity++ {
+			for value := uint32(0); value < 3; value++ {
+				cells := make([]uint32, v+1)
+				cells[v] = value
+				n := uint32(v*2) + polarity
+				add([]uint32{n, n, n, n}, cells)
+			}
+		}
+	}
+	return cases
 }
-func classifierLoop(t *testing.T,source string) string {
- t.Helper();begin:="    satisfied: Bool = false\n";end:="    valid && !satisfied ? {\n"
- if strings.Count(source,begin)!=1||strings.Count(source,end)!=1 {t.Fatal("classifier extraction seam changed")}
- start:=strings.Index(source,begin);stop:=strings.Index(source,end);if stop<=start {t.Fatal("classifier extraction order changed")}
- // Preserve the actual duplicate-aware scan byte-for-byte, including its early
- // stop. The wrapper supplies a single valid clause and a complete assignment.
- return `classifier_observed: (clause_literals: []u32, assignments: []u8, expected: []u32): Bool {
+func classifierLoop(t *testing.T, source string) string {
+	t.Helper()
+	begin := "    satisfied: Bool = false\n"
+	end := "    valid && !satisfied ? {\n"
+	if strings.Count(source, begin) != 1 || strings.Count(source, end) != 1 {
+		t.Fatal("classifier extraction seam changed")
+	}
+	start := strings.Index(source, begin)
+	stop := strings.Index(source, end)
+	if stop <= start {
+		t.Fatal("classifier extraction order changed")
+	}
+	// Preserve the actual duplicate-aware scan byte-for-byte, including its early
+	// stop. The wrapper supplies a single valid clause and a complete assignment.
+	return `classifier_observed: (clause_literals: []u32, assignments: []u8, expected: []u32): Bool {
   variables: u32 = len(assignments)
   start: u32 = 0
   count: u32 = len(clause_literals)
   valid: Bool = variables > u32(0) && variables <= u32(64)
-`+source[start:stop]+`
+` + source[start:stop] + `
   kind: u32 = 3
   unit: u32 = 0
   satisfied ? { kind = u32(2) } | {
@@ -59,14 +106,64 @@ func classifierLoop(t *testing.T,source string) string {
 `
 }
 func TestSelfHostedClauseClassifier(t *testing.T) {
- cases:=classifierCorpus();counts:=[4]int{}
- kernel,err:=os.ReadFile("self_hosted_rup.oak");if err!=nil {t.Fatal(err)}
- var source,main strings.Builder;for _,line:=range strings.Split(string(kernel),"\n") {if strings.HasPrefix(line,"literal_value:") {source.WriteString(line);source.WriteByte('\n')}};source.WriteString(classifierLoop(t,string(kernel)));main.WriteString("main: (): i32 {\n")
- emit:=func(i int,c classifierCase,want bool){fmt.Fprintf(&source,"classifier_case_%d: (): Bool {\n",i);emitBufferArray(&source,"clause","u32",c.Clause);emitBufferArray(&source,"cells","u8",c.Cells);emitBufferArray(&source,"expected","u32",c.Expected);fmt.Fprintf(&source,"classifier_observed(clause_view, cells_view, expected_view) == %t\n}\n",want);fmt.Fprintf(&main,"assert(classifier_case_%d())\n",i)}
- for i,c:=range cases {counts[c.Expected[0]]++;emit(i,c,true)}
- unitCase:=cases[0];for _,c:=range cases {if c.Expected[0]==1 {unitCase=c;break}}
- for i:=0;i<3;i++ {c:=unitCase;c.Expected=append([]uint32{},c.Expected...);switch i {case 0:c.Expected[0]=0;case 1:c.Expected[1]^=1;case 2:c.Expected=c.Expected[:1]};emit(len(cases)+i,c,false)}
- main.WriteString("42\n}\n");source.WriteString(main.String());runOakStream(t,source.String())
- if path:=os.Getenv("OAK_CLASSIFIER_CORPUS_OUT");path!="" {data,err:=json.MarshalIndent(cases,"","  ");if err!=nil {t.Fatal(err)};if err:=os.WriteFile(path,append(data,'\n'),0644);err!=nil {t.Fatal(err)}}
- t.Logf("Oak/Go clause classifier: %d cases (%d conflict, %d unit, %d satisfied, %d unresolved), 3 corruptions rejected",len(cases),counts[0],counts[1],counts[2],counts[3])
+	cases := classifierCorpus()
+	counts := [4]int{}
+	kernel, err := os.ReadFile("self_hosted_rup.oak")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var source, main strings.Builder
+	for _, line := range strings.Split(string(kernel), "\n") {
+		if strings.HasPrefix(line, "literal_value:") {
+			source.WriteString(line)
+			source.WriteByte('\n')
+		}
+	}
+	source.WriteString(classifierLoop(t, string(kernel)))
+	main.WriteString("main: (): i32 {\n")
+	emit := func(i int, c classifierCase, want bool) {
+		fmt.Fprintf(&source, "classifier_case_%d: (): Bool {\n", i)
+		emitBufferArray(&source, "clause", "u32", c.Clause)
+		emitBufferArray(&source, "cells", "u8", c.Cells)
+		emitBufferArray(&source, "expected", "u32", c.Expected)
+		fmt.Fprintf(&source, "classifier_observed(clause_view, cells_view, expected_view) == %t\n}\n", want)
+		fmt.Fprintf(&main, "assert(classifier_case_%d())\n", i)
+	}
+	for i, c := range cases {
+		counts[c.Expected[0]]++
+		emit(i, c, true)
+	}
+	unitCase := cases[0]
+	for _, c := range cases {
+		if c.Expected[0] == 1 {
+			unitCase = c
+			break
+		}
+	}
+	for i := 0; i < 3; i++ {
+		c := unitCase
+		c.Expected = append([]uint32{}, c.Expected...)
+		switch i {
+		case 0:
+			c.Expected[0] = 0
+		case 1:
+			c.Expected[1] ^= 1
+		case 2:
+			c.Expected = c.Expected[:1]
+		}
+		emit(len(cases)+i, c, false)
+	}
+	main.WriteString("42\n}\n")
+	source.WriteString(main.String())
+	runOakStream(t, source.String())
+	if path := os.Getenv("OAK_CLASSIFIER_CORPUS_OUT"); path != "" {
+		data, err := json.MarshalIndent(cases, "", "  ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, append(data, '\n'), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Logf("Oak/Go clause classifier: %d cases (%d conflict, %d unit, %d satisfied, %d unresolved), 3 corruptions rejected", len(cases), counts[0], counts[1], counts[2], counts[3])
 }

--- a/experiments/verification-poc/self_hosted_decimal_test.go
+++ b/experiments/verification-poc/self_hosted_decimal_test.go
@@ -1,65 +1,135 @@
 package main
 
 import (
- "encoding/json"
- "fmt"
- "math/rand"
- "os"
- "strconv"
- "strings"
- "testing"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
 )
 
 type decimalCase struct {
- Name string `json:"name"`
- Bytes []uint32 `json:"bytes"`
- Accepted bool `json:"accepted"`
- Negative bool `json:"negative"`
- Magnitude uint32 `json:"magnitude"`
+	Name      string   `json:"name"`
+	Bytes     []uint32 `json:"bytes"`
+	Accepted  bool     `json:"accepted"`
+	Negative  bool     `json:"negative"`
+	Magnitude uint32   `json:"magnitude"`
 }
+
 func decimalCorpus() []decimalCase {
- out:=[]decimalCase{};seen:=map[string]bool{}
- add:=func(input string) {
-  if seen[input] {return};seen[input]=true
-  c:=decimalCase{Name:fmt.Sprintf("decimal-%d",len(out)),Bytes:[]uint32{}}
-  for _,b:=range []byte(input) {c.Bytes=append(c.Bytes,uint32(b))}
-  n,err:=strconv.ParseInt(input,10,64)
-  c.Accepted=err==nil && n>=-2147483647 && n<=2147483647
-  if c.Accepted {c.Negative=strings.HasPrefix(input,"-");if n<0 {n=-n};c.Magnitude=uint32(n)}
-  out=append(out,c)
- }
- for _,input:=range []string{"","+","-","0","-0","+0","00","-00","++1","--1","+-1","-+1"," 1","1 ","1\n","1\t2","0x10","1_000","1.0",strings.Repeat("0",1024),"-"+strings.Repeat("0",1024),strings.Repeat("9",1024)} {add(input)}
- for _,prefix:=range []uint64{0,1,214748363,214748364,214748365,429496729,922337203685477580} {
-  for digit:=uint64(0);digit<10;digit++ {
-   word:=strconv.FormatUint(prefix*10+digit,10)
-   for _,sign:=range []string{"","+","-"} {add(sign+word);add(sign+"000"+word)}
-  }
- }
- for b:=0;b<256;b++ {add(string([]byte{byte(b)}));add("1"+string([]byte{byte(b)})+"2")}
- rng:=rand.New(rand.NewSource(918273))
- for i:=0;i<400;i++ {n:=rng.Uint32();sign:="";if i%3==1 {sign="-"};if i%3==2 {sign="+"};add(sign+strconv.FormatUint(uint64(n),10))}
- return out
+	out := []decimalCase{}
+	seen := map[string]bool{}
+	add := func(input string) {
+		if seen[input] {
+			return
+		}
+		seen[input] = true
+		c := decimalCase{Name: fmt.Sprintf("decimal-%d", len(out)), Bytes: []uint32{}}
+		for _, b := range []byte(input) {
+			c.Bytes = append(c.Bytes, uint32(b))
+		}
+		n, err := strconv.ParseInt(input, 10, 64)
+		c.Accepted = err == nil && n >= -2147483647 && n <= 2147483647
+		if c.Accepted {
+			c.Negative = strings.HasPrefix(input, "-")
+			if n < 0 {
+				n = -n
+			}
+			c.Magnitude = uint32(n)
+		}
+		out = append(out, c)
+	}
+	for _, input := range []string{"", "+", "-", "0", "-0", "+0", "00", "-00", "++1", "--1", "+-1", "-+1", " 1", "1 ", "1\n", "1\t2", "0x10", "1_000", "1.0", strings.Repeat("0", 1024), "-" + strings.Repeat("0", 1024), strings.Repeat("9", 1024)} {
+		add(input)
+	}
+	for _, prefix := range []uint64{0, 1, 214748363, 214748364, 214748365, 429496729, 922337203685477580} {
+		for digit := uint64(0); digit < 10; digit++ {
+			word := strconv.FormatUint(prefix*10+digit, 10)
+			for _, sign := range []string{"", "+", "-"} {
+				add(sign + word)
+				add(sign + "000" + word)
+			}
+		}
+	}
+	for b := 0; b < 256; b++ {
+		add(string([]byte{byte(b)}))
+		add("1" + string([]byte{byte(b)}) + "2")
+	}
+	rng := rand.New(rand.NewSource(918273))
+	for i := 0; i < 400; i++ {
+		n := rng.Uint32()
+		sign := ""
+		if i%3 == 1 {
+			sign = "-"
+		}
+		if i%3 == 2 {
+			sign = "+"
+		}
+		add(sign + strconv.FormatUint(uint64(n), 10))
+	}
+	return out
 }
 func TestSelfHostedDecimal(t *testing.T) {
- cases:=decimalCorpus();accepted:=0
- var source,main strings.Builder
- for _,path:=range []string{"self_hosted_rup.oak","self_hosted_stream.oak","self_hosted_text.oak"} {data,err:=os.ReadFile(path);if err!=nil {t.Fatal(err)};source.Write(data);source.WriteByte('\n')}
- main.WriteString("main: (): i32 {\n")
- for i,c:=range cases {
-  fmt.Fprintf(&source,"decimal_case_%d: (): Bool {\n",i)
-  capacity:=len(c.Bytes);if capacity==0 {capacity=1}
-  fmt.Fprintf(&source,"input: [%d]u8\n",capacity)
-  for begin:=0;begin<len(c.Bytes); {
-   end:=begin+1;for end<len(c.Bytes)&&c.Bytes[end]==c.Bytes[begin] {end++}
-   if end-begin>8 {fmt.Fprintf(&source,"i_%d: u32 = %d\nwhile i_%d < u32(%d) { input[i_%d] = u8(%d); i_%d = i_%d + u32(1) }\n",begin,begin,begin,end,begin,c.Bytes[begin],begin,begin)} else {for j:=begin;j<end;j++ {fmt.Fprintf(&source,"input[%d] = u8(%d)\n",j,c.Bytes[j])}}
-   begin=end
-  }
-  fmt.Fprintf(&source,"bytes: []u8 = input[0:%d]\nstate: [5]u32\nstate[0] = u32(0)\nkind: u32 = rup_token(bytes, span(&state))\n",len(c.Bytes))
-  source.WriteString("accepted: Bool = kind == u32(2) && state[1] == u32(0) && state[0] == len(bytes) && state[4] != u32(0)\n")
-  if c.Accepted {accepted++;tag:=1;if c.Negative {tag=2};fmt.Fprintf(&source,"accepted && state[3] == u32(%d) && state[4] == u32(%d)\n}\n",c.Magnitude,tag)} else {source.WriteString("!accepted\n}\n")}
-  fmt.Fprintf(&main,"assert(decimal_case_%d())\n",i)
- }
- main.WriteString("42\n}\n");source.WriteString(main.String());runOakStream(t,source.String())
- if path:=os.Getenv("OAK_DECIMAL_CORPUS_OUT");path!="" {data,err:=json.MarshalIndent(cases,"","  ");if err!=nil {t.Fatal(err)};if err:=os.WriteFile(path,append(data,'\n'),0644);err!=nil {t.Fatal(err)}}
- t.Logf("Oak/Go decimal agreement: %d cases (%d accepted, %d rejected)",len(cases),accepted,len(cases)-accepted)
+	cases := decimalCorpus()
+	accepted := 0
+	var source, main strings.Builder
+	for _, path := range []string{"self_hosted_rup.oak", "self_hosted_stream.oak", "self_hosted_text.oak"} {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		source.Write(data)
+		source.WriteByte('\n')
+	}
+	main.WriteString("main: (): i32 {\n")
+	for i, c := range cases {
+		fmt.Fprintf(&source, "decimal_case_%d: (): Bool {\n", i)
+		capacity := len(c.Bytes)
+		if capacity == 0 {
+			capacity = 1
+		}
+		fmt.Fprintf(&source, "input: [%d]u8\n", capacity)
+		for begin := 0; begin < len(c.Bytes); {
+			end := begin + 1
+			for end < len(c.Bytes) && c.Bytes[end] == c.Bytes[begin] {
+				end++
+			}
+			if end-begin > 8 {
+				fmt.Fprintf(&source, "i_%d: u32 = %d\nwhile i_%d < u32(%d) { input[i_%d] = u8(%d); i_%d = i_%d + u32(1) }\n", begin, begin, begin, end, begin, c.Bytes[begin], begin, begin)
+			} else {
+				for j := begin; j < end; j++ {
+					fmt.Fprintf(&source, "input[%d] = u8(%d)\n", j, c.Bytes[j])
+				}
+			}
+			begin = end
+		}
+		fmt.Fprintf(&source, "bytes: []u8 = input[0:%d]\nstate: [5]u32\nstate[0] = u32(0)\nkind: u32 = rup_token(bytes, span(&state))\n", len(c.Bytes))
+		source.WriteString("accepted: Bool = kind == u32(2) && state[1] == u32(0) && state[0] == len(bytes) && state[4] != u32(0)\n")
+		if c.Accepted {
+			accepted++
+			tag := 1
+			if c.Negative {
+				tag = 2
+			}
+			fmt.Fprintf(&source, "accepted && state[3] == u32(%d) && state[4] == u32(%d)\n}\n", c.Magnitude, tag)
+		} else {
+			source.WriteString("!accepted\n}\n")
+		}
+		fmt.Fprintf(&main, "assert(decimal_case_%d())\n", i)
+	}
+	main.WriteString("42\n}\n")
+	source.WriteString(main.String())
+	runOakStream(t, source.String())
+	if path := os.Getenv("OAK_DECIMAL_CORPUS_OUT"); path != "" {
+		data, err := json.MarshalIndent(cases, "", "  ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, append(data, '\n'), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Logf("Oak/Go decimal agreement: %d cases (%d accepted, %d rejected)", len(cases), accepted, len(cases)-accepted)
 }

--- a/experiments/verification-poc/self_hosted_propagation_test.go
+++ b/experiments/verification-poc/self_hosted_propagation_test.go
@@ -1,80 +1,180 @@
 package main
 
 import (
- "encoding/json"
- "fmt"
- "os"
- "strings"
- "testing"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
 
- "github.com/SCKelemen/oak/experiments/verification-poc/internal/lrat"
+	"github.com/SCKelemen/oak/experiments/verification-poc/internal/lrat"
 )
 
 type propagationCase struct {
- selfHostedRUPCase
- Trace []uint32 `json:"trace"`
+	selfHostedRUPCase
+	Trace []uint32 `json:"trace"`
 }
 
 // Logical assignments use signed variable names and Bool values, independently
 // of Oak's three-valued byte representation. Only snapshot serialization encodes.
 func propagationReference(c selfHostedRUPCase) []uint32 {
- values:=map[int]bool{};valid:=c.Variables>0&&c.Variables<=64
- reset:=valid;contradictory,conflict:=false,false
- for _,id:=range c.Hints {if id<=0||id>len(c.Clauses) {valid=false}}
- out:=[]uint32{};bit:=func(b bool) uint32 {if b {return 1};return 0}
- snapshot:=func(){out=append(out,bit(valid),bit(contradictory),bit(conflict));for v:=1;v<=64;v++ {n:=uint32(7);if reset&&v<=c.Variables {n=0};if b,ok:=values[v];ok {n=1+bit(b)};out=append(out,n)}}
- abs:=func(n int) int {if n<0 {return -n};return n}
- snapshot()
- for _,lit:=range c.Target {
-  if !valid||contradictory {break};v:=abs(lit);valid=v>0&&v<=c.Variables
-  if valid {wanted:=lit<0;prior,present:=values[v];contradictory=present&&prior!=wanted;if !present {values[v]=wanted}}
-  snapshot()
- }
- for h,id:=range c.Hints {
-  if !valid||contradictory||conflict {break}
-  seen:=map[int]bool{};unknown:=[]int{};satisfied:=false
-  for _,lit:=range c.Clauses[id-1] {
-   if !valid||satisfied {break};v:=abs(lit);valid=v>0&&v<=c.Variables
-   if valid&&!seen[lit] {b,present:=values[v];satisfied=present&&b==(lit>0);if !present {unknown=append(unknown,lit)}};seen[lit]=true
-  }
-  if valid&&!satisfied {
-   switch len(unknown) {case 0:conflict=h==len(c.Hints)-1;valid=conflict;case 1:lit:=unknown[0];values[abs(lit)]=lit>0;default:valid=false}
-  } else {valid=false}
-  snapshot()
- }
- return out
+	values := map[int]bool{}
+	valid := c.Variables > 0 && c.Variables <= 64
+	reset := valid
+	contradictory, conflict := false, false
+	for _, id := range c.Hints {
+		if id <= 0 || id > len(c.Clauses) {
+			valid = false
+		}
+	}
+	out := []uint32{}
+	bit := func(b bool) uint32 {
+		if b {
+			return 1
+		}
+		return 0
+	}
+	snapshot := func() {
+		out = append(out, bit(valid), bit(contradictory), bit(conflict))
+		for v := 1; v <= 64; v++ {
+			n := uint32(7)
+			if reset && v <= c.Variables {
+				n = 0
+			}
+			if b, ok := values[v]; ok {
+				n = 1 + bit(b)
+			}
+			out = append(out, n)
+		}
+	}
+	abs := func(n int) int {
+		if n < 0 {
+			return -n
+		}
+		return n
+	}
+	snapshot()
+	for _, lit := range c.Target {
+		if !valid || contradictory {
+			break
+		}
+		v := abs(lit)
+		valid = v > 0 && v <= c.Variables
+		if valid {
+			wanted := lit < 0
+			prior, present := values[v]
+			contradictory = present && prior != wanted
+			if !present {
+				values[v] = wanted
+			}
+		}
+		snapshot()
+	}
+	for h, id := range c.Hints {
+		if !valid || contradictory || conflict {
+			break
+		}
+		seen := map[int]bool{}
+		unknown := []int{}
+		satisfied := false
+		for _, lit := range c.Clauses[id-1] {
+			if !valid || satisfied {
+				break
+			}
+			v := abs(lit)
+			valid = v > 0 && v <= c.Variables
+			if valid && !seen[lit] {
+				b, present := values[v]
+				satisfied = present && b == (lit > 0)
+				if !present {
+					unknown = append(unknown, lit)
+				}
+			}
+			seen[lit] = true
+		}
+		if valid && !satisfied {
+			switch len(unknown) {
+			case 0:
+				conflict = h == len(c.Hints)-1
+				valid = conflict
+			case 1:
+				lit := unknown[0]
+				values[abs(lit)] = lit > 0
+			default:
+				valid = false
+			}
+		} else {
+			valid = false
+		}
+		snapshot()
+	}
+	return out
 }
 func propagationCorpus(t *testing.T) []propagationCase {
- t.Helper();base:=selfHostedCases()
- for v:=1;v<=64;v++ {for _,sign:=range []int{-1,1} {lit:=v*sign;base=append(base,selfHostedRUPCase{Variables:v,Target:[]int{lit,lit,-lit},Clauses:[][]int{},Hints:[]int{}})}}
- literals:=[]int{-2,-1,1,2}
- var targets func([]int,int)
- targets=func(xs []int,left int){if len(xs)>0 {base=append(base,selfHostedRUPCase{Variables:2,Target:append([]int{},xs...),Clauses:[][]int{{1,1},{-1,-1}},Hints:[]int{1,2}})};if left>0 {for _,lit:=range literals {targets(append(append([]int{},xs...),lit),left-1)}}}
- targets(nil,3)
- base=append(base,
-  selfHostedRUPCase{Variables:0},selfHostedRUPCase{Variables:65},
-  selfHostedRUPCase{Variables:1,Target:[]int{2}},
-  selfHostedRUPCase{Variables:1,Clauses:[][]int{{2}},Hints:[]int{1}},
-  selfHostedRUPCase{Variables:1,Clauses:[][]int{{},{}},Hints:[]int{1,2}})
- out:=[]propagationCase{}
- for i,c:=range base {
-  if c.Clauses==nil {c.Clauses=[][]int{}};if c.Target==nil {c.Target=[]int{}};if c.Hints==nil {c.Hints=[]int{}}
-  c.Accepted=c.Variables<=64&&lrat.CheckRUPDecoded(c.Variables,c.Clauses,c.Target,c.Hints)==nil
-  trace:=propagationReference(c);last:=trace[len(trace)-67:]
-  if (last[0]==1&&(last[1]==1||last[2]==1))!=c.Accepted {t.Fatalf("propagation oracle acceptance differs at case %d",i)}
-  out=append(out,propagationCase{c,trace})
- }
- return out
+	t.Helper()
+	base := selfHostedCases()
+	for v := 1; v <= 64; v++ {
+		for _, sign := range []int{-1, 1} {
+			lit := v * sign
+			base = append(base, selfHostedRUPCase{Variables: v, Target: []int{lit, lit, -lit}, Clauses: [][]int{}, Hints: []int{}})
+		}
+	}
+	literals := []int{-2, -1, 1, 2}
+	var targets func([]int, int)
+	targets = func(xs []int, left int) {
+		if len(xs) > 0 {
+			base = append(base, selfHostedRUPCase{Variables: 2, Target: append([]int{}, xs...), Clauses: [][]int{{1, 1}, {-1, -1}}, Hints: []int{1, 2}})
+		}
+		if left > 0 {
+			for _, lit := range literals {
+				targets(append(append([]int{}, xs...), lit), left-1)
+			}
+		}
+	}
+	targets(nil, 3)
+	base = append(base,
+		selfHostedRUPCase{Variables: 0}, selfHostedRUPCase{Variables: 65},
+		selfHostedRUPCase{Variables: 1, Target: []int{2}},
+		selfHostedRUPCase{Variables: 1, Clauses: [][]int{{2}}, Hints: []int{1}},
+		selfHostedRUPCase{Variables: 1, Clauses: [][]int{{}, {}}, Hints: []int{1, 2}})
+	out := []propagationCase{}
+	for i, c := range base {
+		if c.Clauses == nil {
+			c.Clauses = [][]int{}
+		}
+		if c.Target == nil {
+			c.Target = []int{}
+		}
+		if c.Hints == nil {
+			c.Hints = []int{}
+		}
+		c.Accepted = c.Variables <= 64 && lrat.CheckRUPDecoded(c.Variables, c.Clauses, c.Target, c.Hints) == nil
+		trace := propagationReference(c)
+		last := trace[len(trace)-67:]
+		if (last[0] == 1 && (last[1] == 1 || last[2] == 1)) != c.Accepted {
+			t.Fatalf("propagation oracle acceptance differs at case %d", i)
+		}
+		out = append(out, propagationCase{c, trace})
+	}
+	return out
 }
-func propagationInstrument(t *testing.T,source string) string {
- t.Helper();replace:=func(old,next string){if strings.Count(source,old)!=1 {t.Fatalf("propagation observation seam changed: %q",old)};source=strings.Replace(source,old,next,1)}
- replace("  variables: u32\n): Bool {","  variables: u32,\n  expected: []u32,\n  expected_accepted: Bool\n): Bool {")
- observe:=func(conflict string) string {return "  trace_ok = propagation_observe(assignments, valid, contradictory, "+conflict+", expected, trace_cursor) && trace_ok\n  trace_cursor = trace_cursor + u32(67)\n"}
- replace("  contradictory: Bool = false\n","  contradictory: Bool = false\n  trace_ok: Bool = true\n  trace_cursor: u32 = 0\n"+observe("false"))
- replace("    i = i + u32(1)\n  }\n\n  conflict: Bool = false", "    i = i + u32(1)\n"+observe("false")+"  }\n\n  conflict: Bool = false")
- replace("    h = h + u32(1)\n","    h = h + u32(1)\n"+observe("conflict"))
- replace("  valid && (contradictory || conflict)\n}","  trace_ok && trace_cursor == len(expected) && (valid && (contradictory || conflict)) == expected_accepted\n}")
- return source+`
+func propagationInstrument(t *testing.T, source string) string {
+	t.Helper()
+	replace := func(old, next string) {
+		if strings.Count(source, old) != 1 {
+			t.Fatalf("propagation observation seam changed: %q", old)
+		}
+		source = strings.Replace(source, old, next, 1)
+	}
+	replace("  variables: u32\n): Bool {", "  variables: u32,\n  expected: []u32,\n  expected_accepted: Bool\n): Bool {")
+	observe := func(conflict string) string {
+		return "  trace_ok = propagation_observe(assignments, valid, contradictory, " + conflict + ", expected, trace_cursor) && trace_ok\n  trace_cursor = trace_cursor + u32(67)\n"
+	}
+	replace("  contradictory: Bool = false\n", "  contradictory: Bool = false\n  trace_ok: Bool = true\n  trace_cursor: u32 = 0\n"+observe("false"))
+	replace("    i = i + u32(1)\n  }\n\n  conflict: Bool = false", "    i = i + u32(1)\n"+observe("false")+"  }\n\n  conflict: Bool = false")
+	replace("    h = h + u32(1)\n", "    h = h + u32(1)\n"+observe("conflict"))
+	replace("  valid && (contradictory || conflict)\n}", "  trace_ok && trace_cursor == len(expected) && (valid && (contradictory || conflict)) == expected_accepted\n}")
+	return source + `
 propagation_observe: (cells: [*]u8, valid: Bool, contradictory: Bool, conflict: Bool,
   expected: []u32, offset: u32): Bool {
   ok: Bool = offset <= len(expected) && u32(67) <= len(expected) - offset
@@ -91,22 +191,74 @@ propagation_observe: (cells: [*]u8, valid: Bool, contradictory: Bool, conflict: 
 `
 }
 func TestSelfHostedPropagationState(t *testing.T) {
- cases:=propagationCorpus(t);snapshots:=0;accepted:=0
- kernel,err:=os.ReadFile("self_hosted_rup.oak");if err!=nil {t.Fatal(err)}
- var source,main strings.Builder;source.WriteString(propagationInstrument(t,string(kernel)));main.WriteString("main: (): i32 {\n")
- emit:=func(i int,c propagationCase,want bool){
-  fmt.Fprintf(&source,"propagation_case_%d: (): Bool {\n",i)
-  pool,starts,sizes,target,hints:=[]uint32{},[]uint32{},[]uint32{},[]uint32{},[]uint32{}
-  for _,clause:=range c.Clauses {starts=append(starts,uint32(len(pool)));sizes=append(sizes,uint32(len(clause)));for _,lit:=range clause {pool=append(pool,oakLiteral(lit))}}
-  for _,lit:=range c.Target {target=append(target,oakLiteral(lit))};for _,id:=range c.Hints {n:=uint32(4294967295);if id>0 {n=uint32(id-1)};hints=append(hints,n)}
-  for _,a:=range []struct{name string;items []uint32}{{"pool",pool},{"starts",starts},{"sizes",sizes},{"target",target},{"hints",hints},{"expected",c.Trace}} {emitBufferArray(&source,a.name,"u32",a.items)}
-  source.WriteString("assignments: [64]u8\nslot: u32 = 0\nwhile slot < u32(64) { assignments[slot] = u8(7); slot = slot + u32(1) }\n")
-  fmt.Fprintf(&source,"rup_check(pool_view, starts_view, sizes_view, u32(%d), target_view, u32(%d), hints_view, u32(%d), span(&assignments), u32(%d), expected_view, %t) == %t\n}\n",len(starts),len(target),len(hints),c.Variables,c.Accepted,want)
-  fmt.Fprintf(&main,"assert(propagation_case_%d())\n",i)
- }
- for i,c:=range cases {emit(i,c,true);snapshots+=len(c.Trace)/67;if c.Accepted {accepted++}}
- for i,field:=range []int{0,1,2,3,66,-1} {c:=cases[0];c.Trace=append([]uint32{},c.Trace...);if field<0 {c.Trace=c.Trace[:len(c.Trace)-67]} else {c.Trace[field]^=1};emit(len(cases)+i,c,false)}
- main.WriteString("42\n}\n");source.WriteString(main.String());runOakStream(t,source.String())
- if path:=os.Getenv("OAK_PROPAGATION_CORPUS_OUT");path!="" {data,err:=json.MarshalIndent(cases,"","  ");if err!=nil {t.Fatal(err)};if err:=os.WriteFile(path,append(data,'\n'),0644);err!=nil {t.Fatal(err)}}
- t.Logf("Oak/Go propagation state: %d cases, %d complete 64-cell snapshots, %d accepted, 6 observer corruptions rejected",len(cases),snapshots,accepted)
+	cases := propagationCorpus(t)
+	snapshots := 0
+	accepted := 0
+	kernel, err := os.ReadFile("self_hosted_rup.oak")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var source, main strings.Builder
+	source.WriteString(propagationInstrument(t, string(kernel)))
+	main.WriteString("main: (): i32 {\n")
+	emit := func(i int, c propagationCase, want bool) {
+		fmt.Fprintf(&source, "propagation_case_%d: (): Bool {\n", i)
+		pool, starts, sizes, target, hints := []uint32{}, []uint32{}, []uint32{}, []uint32{}, []uint32{}
+		for _, clause := range c.Clauses {
+			starts = append(starts, uint32(len(pool)))
+			sizes = append(sizes, uint32(len(clause)))
+			for _, lit := range clause {
+				pool = append(pool, oakLiteral(lit))
+			}
+		}
+		for _, lit := range c.Target {
+			target = append(target, oakLiteral(lit))
+		}
+		for _, id := range c.Hints {
+			n := uint32(4294967295)
+			if id > 0 {
+				n = uint32(id - 1)
+			}
+			hints = append(hints, n)
+		}
+		for _, a := range []struct {
+			name  string
+			items []uint32
+		}{{"pool", pool}, {"starts", starts}, {"sizes", sizes}, {"target", target}, {"hints", hints}, {"expected", c.Trace}} {
+			emitBufferArray(&source, a.name, "u32", a.items)
+		}
+		source.WriteString("assignments: [64]u8\nslot: u32 = 0\nwhile slot < u32(64) { assignments[slot] = u8(7); slot = slot + u32(1) }\n")
+		fmt.Fprintf(&source, "rup_check(pool_view, starts_view, sizes_view, u32(%d), target_view, u32(%d), hints_view, u32(%d), span(&assignments), u32(%d), expected_view, %t) == %t\n}\n", len(starts), len(target), len(hints), c.Variables, c.Accepted, want)
+		fmt.Fprintf(&main, "assert(propagation_case_%d())\n", i)
+	}
+	for i, c := range cases {
+		emit(i, c, true)
+		snapshots += len(c.Trace) / 67
+		if c.Accepted {
+			accepted++
+		}
+	}
+	for i, field := range []int{0, 1, 2, 3, 66, -1} {
+		c := cases[0]
+		c.Trace = append([]uint32{}, c.Trace...)
+		if field < 0 {
+			c.Trace = c.Trace[:len(c.Trace)-67]
+		} else {
+			c.Trace[field] ^= 1
+		}
+		emit(len(cases)+i, c, false)
+	}
+	main.WriteString("42\n}\n")
+	source.WriteString(main.String())
+	runOakStream(t, source.String())
+	if path := os.Getenv("OAK_PROPAGATION_CORPUS_OUT"); path != "" {
+		data, err := json.MarshalIndent(cases, "", "  ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, append(data, '\n'), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Logf("Oak/Go propagation state: %d cases, %d complete 64-cell snapshots, %d accepted, 6 observer corruptions rejected", len(cases), snapshots, accepted)
 }

--- a/experiments/verification-poc/self_hosted_ranges_test.go
+++ b/experiments/verification-poc/self_hosted_ranges_test.go
@@ -1,137 +1,344 @@
 package main
 
 import (
- "encoding/json"
- "fmt"
- "os"
- "strings"
- "testing"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
 )
 
 type rangeCommand struct {
- Addition bool `json:"addition"`
- ID uint32 `json:"id"`
- Start uint32 `json:"start"`
- Count uint32 `json:"count"`
- RefsStart uint32 `json:"refsStart"`
- RefsCount uint32 `json:"refsCount"`
+	Addition  bool   `json:"addition"`
+	ID        uint32 `json:"id"`
+	Start     uint32 `json:"start"`
+	Count     uint32 `json:"count"`
+	RefsStart uint32 `json:"refsStart"`
+	RefsCount uint32 `json:"refsCount"`
 }
 type rangeCase struct {
- Name string `json:"name"`
- Variables uint32 `json:"variables"`
- Pool []uint32 `json:"pool"`
- Starts []uint32 `json:"starts"`
- Sizes []uint32 `json:"sizes"`
- Refs []uint32 `json:"refs"`
- Commands []rangeCommand `json:"commands"`
- Decoded bool `json:"decoded"`
- Meaning []int64 `json:"meaning"`
- Accepted bool `json:"accepted"`
+	Name      string         `json:"name"`
+	Variables uint32         `json:"variables"`
+	Pool      []uint32       `json:"pool"`
+	Starts    []uint32       `json:"starts"`
+	Sizes     []uint32       `json:"sizes"`
+	Refs      []uint32       `json:"refs"`
+	Commands  []rangeCommand `json:"commands"`
+	Decoded   bool           `json:"decoded"`
+	Meaning   []int64        `json:"meaning"`
+	Accepted  bool           `json:"accepted"`
 }
-func rangeSlice(pool []uint32,start,count uint32) ([]uint32,bool) {
- // Wide sum is independent of Oak's subtraction-based guard.
- end:=uint64(start)+uint64(count);if end>uint64(len(pool)) {return nil,false};return pool[start:int(end)],true
+
+func rangeSlice(pool []uint32, start, count uint32) ([]uint32, bool) {
+	// Wide sum is independent of Oak's subtraction-based guard.
+	end := uint64(start) + uint64(count)
+	if end > uint64(len(pool)) {
+		return nil, false
+	}
+	return pool[start:int(end)], true
 }
-func rangeLiteral(n uint32) int {v:=int(n/2)+1;if n%2==0 {v=-v};return v}
-func rangeDecode(c rangeCase) (streamCase,[]int64,bool) {
- s:=streamCase{Kind:"proof",Variables:int(c.Variables),Database:[][]int{},Commands:[]streamCommand{}}
- if c.Variables==0||c.Variables>64||len(c.Pool)>4096||len(c.Refs)>4096||len(c.Starts)!=len(c.Sizes)||len(c.Starts)>256||len(c.Commands)>256 {return s,nil,false}
- for _,n:=range c.Pool {if n/2>=c.Variables {return s,nil,false}}
- meaning:=[]int64{int64(c.Variables),int64(len(c.Starts))}
- for i,start:=range c.Starts {items,ok:=rangeSlice(c.Pool,start,c.Sizes[i]);if !ok {return s,nil,false};clause:=[]int{};meaning=append(meaning,int64(len(items)));for _,v:=range items {lit:=rangeLiteral(v);clause=append(clause,lit);meaning=append(meaning,int64(lit))};s.Database=append(s.Database,clause)}
- meaning=append(meaning,int64(len(c.Commands)))
- for _,cmd:=range c.Commands {
-  if cmd.ID>2147483647 {return s,nil,false}
-  refs,ok:=rangeSlice(c.Refs,cmd.RefsStart,cmd.RefsCount);if !ok {return s,nil,false}
-  for _,id:=range refs {if id==0||id>256 {return s,nil,false}}
-  if cmd.Addition {
-   if cmd.ID>256||cmd.RefsCount>256 {return s,nil,false}
-   items,ok:=rangeSlice(c.Pool,cmd.Start,cmd.Count);if !ok {return s,nil,false};clause:=[]int{};hints:=[]int{}
-   meaning=append(meaning,1,int64(cmd.ID),int64(len(items)))
-   for _,v:=range items {lit:=rangeLiteral(v);clause=append(clause,lit);meaning=append(meaning,int64(lit))}
-   meaning=append(meaning,int64(len(refs)));for _,id:=range refs {hints=append(hints,int(id));meaning=append(meaning,int64(id))}
-   s.Commands=append(s.Commands,streamAdd(cmd.ID,clause,hints...))
-  } else {
-   meaning=append(meaning,0,int64(cmd.ID),int64(len(refs)));for _,id:=range refs {meaning=append(meaning,int64(id))};s.Commands=append(s.Commands,streamDelete(cmd.ID,refs...))
-  }
- }
- return s,meaning,true
+func rangeLiteral(n uint32) int {
+	v := int(n/2) + 1
+	if n%2 == 0 {
+		v = -v
+	}
+	return v
+}
+func rangeDecode(c rangeCase) (streamCase, []int64, bool) {
+	s := streamCase{Kind: "proof", Variables: int(c.Variables), Database: [][]int{}, Commands: []streamCommand{}}
+	if c.Variables == 0 || c.Variables > 64 || len(c.Pool) > 4096 || len(c.Refs) > 4096 || len(c.Starts) != len(c.Sizes) || len(c.Starts) > 256 || len(c.Commands) > 256 {
+		return s, nil, false
+	}
+	for _, n := range c.Pool {
+		if n/2 >= c.Variables {
+			return s, nil, false
+		}
+	}
+	meaning := []int64{int64(c.Variables), int64(len(c.Starts))}
+	for i, start := range c.Starts {
+		items, ok := rangeSlice(c.Pool, start, c.Sizes[i])
+		if !ok {
+			return s, nil, false
+		}
+		clause := []int{}
+		meaning = append(meaning, int64(len(items)))
+		for _, v := range items {
+			lit := rangeLiteral(v)
+			clause = append(clause, lit)
+			meaning = append(meaning, int64(lit))
+		}
+		s.Database = append(s.Database, clause)
+	}
+	meaning = append(meaning, int64(len(c.Commands)))
+	for _, cmd := range c.Commands {
+		if cmd.ID > 2147483647 {
+			return s, nil, false
+		}
+		refs, ok := rangeSlice(c.Refs, cmd.RefsStart, cmd.RefsCount)
+		if !ok {
+			return s, nil, false
+		}
+		for _, id := range refs {
+			if id == 0 || id > 256 {
+				return s, nil, false
+			}
+		}
+		if cmd.Addition {
+			if cmd.ID > 256 || cmd.RefsCount > 256 {
+				return s, nil, false
+			}
+			items, ok := rangeSlice(c.Pool, cmd.Start, cmd.Count)
+			if !ok {
+				return s, nil, false
+			}
+			clause := []int{}
+			hints := []int{}
+			meaning = append(meaning, 1, int64(cmd.ID), int64(len(items)))
+			for _, v := range items {
+				lit := rangeLiteral(v)
+				clause = append(clause, lit)
+				meaning = append(meaning, int64(lit))
+			}
+			meaning = append(meaning, int64(len(refs)))
+			for _, id := range refs {
+				hints = append(hints, int(id))
+				meaning = append(meaning, int64(id))
+			}
+			s.Commands = append(s.Commands, streamAdd(cmd.ID, clause, hints...))
+		} else {
+			meaning = append(meaning, 0, int64(cmd.ID), int64(len(refs)))
+			for _, id := range refs {
+				meaning = append(meaning, int64(id))
+			}
+			s.Commands = append(s.Commands, streamDelete(cmd.ID, refs...))
+		}
+	}
+	return s, meaning, true
 }
 func rangeFromStream(s streamCase) rangeCase {
- c:=rangeCase{Variables:uint32(s.Variables),Pool:[]uint32{},Starts:[]uint32{},Sizes:[]uint32{},Refs:[]uint32{},Commands:[]rangeCommand{}}
- for _,clause:=range s.Database {c.Starts=append(c.Starts,uint32(len(c.Pool)));c.Sizes=append(c.Sizes,uint32(len(clause)));for _,lit:=range clause {c.Pool=append(c.Pool,oakLiteral(lit))}}
- for _,cmd:=range s.Commands {
-  r:=rangeCommand{Addition:cmd.Kind!="delete",ID:cmd.ID,Start:uint32(len(c.Pool)),RefsStart:uint32(len(c.Refs))}
-  if r.Addition {r.Count=uint32(len(cmd.Clause));for _,lit:=range cmd.Clause {c.Pool=append(c.Pool,oakLiteral(lit))};for _,id:=range cmd.Hints {n:=uint32(0);if id>0 {n=uint32(id)};c.Refs=append(c.Refs,n)}} else {c.Refs=append(c.Refs,cmd.IDs...)}
-  r.RefsCount=uint32(len(c.Refs))-r.RefsStart;c.Commands=append(c.Commands,r)
- }
- return c
+	c := rangeCase{Variables: uint32(s.Variables), Pool: []uint32{}, Starts: []uint32{}, Sizes: []uint32{}, Refs: []uint32{}, Commands: []rangeCommand{}}
+	for _, clause := range s.Database {
+		c.Starts = append(c.Starts, uint32(len(c.Pool)))
+		c.Sizes = append(c.Sizes, uint32(len(clause)))
+		for _, lit := range clause {
+			c.Pool = append(c.Pool, oakLiteral(lit))
+		}
+	}
+	for _, cmd := range s.Commands {
+		r := rangeCommand{Addition: cmd.Kind != "delete", ID: cmd.ID, Start: uint32(len(c.Pool)), RefsStart: uint32(len(c.Refs))}
+		if r.Addition {
+			r.Count = uint32(len(cmd.Clause))
+			for _, lit := range cmd.Clause {
+				c.Pool = append(c.Pool, oakLiteral(lit))
+			}
+			for _, id := range cmd.Hints {
+				n := uint32(0)
+				if id > 0 {
+					n = uint32(id)
+				}
+				c.Refs = append(c.Refs, n)
+			}
+		} else {
+			c.Refs = append(c.Refs, cmd.IDs...)
+		}
+		r.RefsCount = uint32(len(c.Refs)) - r.RefsStart
+		c.Commands = append(c.Commands, r)
+	}
+	return c
 }
-func rangeTruthCheck(t *testing.T,s streamCase) {
- t.Helper();vars:=[]int{};seen:=map[int]bool{}
- for _,clause:=range s.Database {if len(clause)==0 {return};for _,lit:=range clause {if lit<0 {lit=-lit};if !seen[lit] {seen[lit]=true;vars=append(vars,lit)}}}
- if len(vars)>12 {t.Fatal("accepted corpus case exceeds truth-table budget")}
- for mask:=0;mask<1<<len(vars);mask++ {
-  values:=map[int]bool{};for i,v:=range vars {values[v]=mask&(1<<i)!=0};sat:=true
-  for _,clause:=range s.Database {holds:=false;for _,lit:=range clause {v:=lit;if v<0 {v=-v};holds=holds||values[v]==(lit>0)};sat=sat&&holds}
-  if sat {t.Fatal("reference accepted a satisfiable initial database")}
- }
+func rangeTruthCheck(t *testing.T, s streamCase) {
+	t.Helper()
+	vars := []int{}
+	seen := map[int]bool{}
+	for _, clause := range s.Database {
+		if len(clause) == 0 {
+			return
+		}
+		for _, lit := range clause {
+			if lit < 0 {
+				lit = -lit
+			}
+			if !seen[lit] {
+				seen[lit] = true
+				vars = append(vars, lit)
+			}
+		}
+	}
+	if len(vars) > 12 {
+		t.Fatal("accepted corpus case exceeds truth-table budget")
+	}
+	for mask := 0; mask < 1<<len(vars); mask++ {
+		values := map[int]bool{}
+		for i, v := range vars {
+			values[v] = mask&(1<<i) != 0
+		}
+		sat := true
+		for _, clause := range s.Database {
+			holds := false
+			for _, lit := range clause {
+				v := lit
+				if v < 0 {
+					v = -v
+				}
+				holds = holds || values[v] == (lit > 0)
+			}
+			sat = sat && holds
+		}
+		if sat {
+			t.Fatal("reference accepted a satisfiable initial database")
+		}
+	}
 }
 func rangeCorpus(t *testing.T) []rangeCase {
- out:=[]rangeCase{}
- add:=func(name string,c rangeCase) {
-  c.Name=name;c.Pool=append([]uint32{},c.Pool...);c.Starts=append([]uint32{},c.Starts...);c.Sizes=append([]uint32{},c.Sizes...);c.Refs=append([]uint32{},c.Refs...);c.Commands=append([]rangeCommand{},c.Commands...)
-  s,meaning,ok:=rangeDecode(c);c.Decoded=ok;c.Meaning=meaning;if c.Meaning==nil {c.Meaning=[]int64{}};c.Accepted=ok&&streamReference(s);if c.Accepted {rangeTruthCheck(t,s)};out=append(out,c)
- }
- for _,s:=range streamCorpus(t) {c:=rangeFromStream(s);add("stream-"+s.Name,c);if out[len(out)-1].Accepted!=s.Expected {t.Fatal("layout changed existing stream semantics",s.Name)}}
- // Reuse actual decoder-layout cases from the preceding milestone.
- for _,b:=range bufferCorpus() {if !b.Accepted {continue};f:=b.Layout;c:=rangeCase{Variables:f[0]};at:=5
-  c.Pool=f[at:at+int(f[1])];at+=int(f[1]);c.Starts=f[at:at+int(f[2])];at+=int(f[2]);c.Sizes=f[at:at+int(f[2])];at+=int(f[2]);c.Refs=f[at:at+int(f[3])];at+=int(f[3])
-  for i:=uint32(0);i<f[4];i++ {c.Commands=append(c.Commands,rangeCommand{f[at]==1,f[at+1],f[at+2],f[at+3],f[at+4],f[at+5]});at+=6};add("buffer-"+b.Name,c)
- }
- for n:=uint32(0);n<128;n++ {add(fmt.Sprintf("literal-%d",n),rangeCase{Variables:64,Pool:[]uint32{n},Starts:[]uint32{0,1},Sizes:[]uint32{1,0}})}
- base:=func() rangeCase {return rangeFromStream(streamCase{Variables:3,Database:[][]int{{1},{-1}},Commands:[]streamCommand{streamAdd(3,nil,1,2)}})}
- mutations:=[]struct{name string;change func(*rangeCase)}{
-  {"reordered",func(c *rangeCase){c.Starts=[]uint32{1,0}}},
-  {"overlap",func(c *rangeCase){c.Starts=[]uint32{0,0};c.Sizes=[]uint32{2,2}}},
-  {"bad-start",func(c *rangeCase){c.Starts[0]=4294967295}},
-  {"bad-count",func(c *rangeCase){c.Sizes[0]=4294967295}},
-  {"missing-size",func(c *rangeCase){c.Sizes=c.Sizes[:1]}},
-  {"bad-command-start",func(c *rangeCase){c.Commands[0].Start=3}},
-  {"bad-command-count",func(c *rangeCase){c.Commands[0].Count=4294967295}},
-  {"bad-ref-start",func(c *rangeCase){c.Commands[0].RefsStart=4294967295}},
-  {"bad-ref-count",func(c *rangeCase){c.Commands[0].RefsCount=4294967295}},
-  {"zero-reference",func(c *rangeCase){c.Refs[0]=0}},
-  {"large-reference",func(c *rangeCase){c.Refs[0]=257}},
-  {"unused-reference",func(c *rangeCase){c.Refs=append(c.Refs,4294967295)}},
-  {"unused-invalid-literal",func(c *rangeCase){c.Pool=append(c.Pool,6)}},
-  {"unused-valid-literal",func(c *rangeCase){c.Pool=append(c.Pool,5)}},
-  {"zero-variables",func(c *rangeCase){c.Variables=0}},
-  {"large-variables",func(c *rangeCase){c.Variables=65}},
-  {"large-addition-id",func(c *rangeCase){c.Commands[0].ID=257}},
-  {"ignored-deletion-literal-range",func(c *rangeCase){c.Commands=append(c.Commands,rangeCommand{false,3,4294967295,4294967295,2,0})}},
-  {"max-deletion-stamp",func(c *rangeCase){c.Commands=append(c.Commands,rangeCommand{false,2147483647,0,0,2,0})}},
-  {"overflow-deletion-stamp",func(c *rangeCase){c.Commands=append(c.Commands,rangeCommand{false,2147483648,0,0,2,0})}},
- }
- for _,m:=range mutations {c:=base();m.change(&c);add(m.name,c)}
- for _,n:=range []int{4096,4097} {add(fmt.Sprintf("pool-%d",n),rangeCase{Variables:1,Pool:make([]uint32,n),Starts:[]uint32{0},Sizes:[]uint32{0}});add(fmt.Sprintf("refs-%d",n),rangeCase{Variables:1,Refs:make([]uint32,n),Starts:[]uint32{0},Sizes:[]uint32{0}})}
- for _,n:=range []int{256,257} {refs:=make([]uint32,n);for i:=range refs {refs[i]=1};add(fmt.Sprintf("hint-count-%d",n),rangeCase{Variables:1,Pool:[]uint32{1,0},Starts:[]uint32{0,2},Sizes:[]uint32{1,0},Refs:refs,Commands:[]rangeCommand{{true,3,0,2,0,uint32(n)}}})}
- return out
+	out := []rangeCase{}
+	add := func(name string, c rangeCase) {
+		c.Name = name
+		c.Pool = append([]uint32{}, c.Pool...)
+		c.Starts = append([]uint32{}, c.Starts...)
+		c.Sizes = append([]uint32{}, c.Sizes...)
+		c.Refs = append([]uint32{}, c.Refs...)
+		c.Commands = append([]rangeCommand{}, c.Commands...)
+		s, meaning, ok := rangeDecode(c)
+		c.Decoded = ok
+		c.Meaning = meaning
+		if c.Meaning == nil {
+			c.Meaning = []int64{}
+		}
+		c.Accepted = ok && streamReference(s)
+		if c.Accepted {
+			rangeTruthCheck(t, s)
+		}
+		out = append(out, c)
+	}
+	for _, s := range streamCorpus(t) {
+		c := rangeFromStream(s)
+		add("stream-"+s.Name, c)
+		if out[len(out)-1].Accepted != s.Expected {
+			t.Fatal("layout changed existing stream semantics", s.Name)
+		}
+	}
+	// Reuse actual decoder-layout cases from the preceding milestone.
+	for _, b := range bufferCorpus() {
+		if !b.Accepted {
+			continue
+		}
+		f := b.Layout
+		c := rangeCase{Variables: f[0]}
+		at := 5
+		c.Pool = f[at : at+int(f[1])]
+		at += int(f[1])
+		c.Starts = f[at : at+int(f[2])]
+		at += int(f[2])
+		c.Sizes = f[at : at+int(f[2])]
+		at += int(f[2])
+		c.Refs = f[at : at+int(f[3])]
+		at += int(f[3])
+		for i := uint32(0); i < f[4]; i++ {
+			c.Commands = append(c.Commands, rangeCommand{f[at] == 1, f[at+1], f[at+2], f[at+3], f[at+4], f[at+5]})
+			at += 6
+		}
+		add("buffer-"+b.Name, c)
+	}
+	for n := uint32(0); n < 128; n++ {
+		add(fmt.Sprintf("literal-%d", n), rangeCase{Variables: 64, Pool: []uint32{n}, Starts: []uint32{0, 1}, Sizes: []uint32{1, 0}})
+	}
+	base := func() rangeCase {
+		return rangeFromStream(streamCase{Variables: 3, Database: [][]int{{1}, {-1}}, Commands: []streamCommand{streamAdd(3, nil, 1, 2)}})
+	}
+	mutations := []struct {
+		name   string
+		change func(*rangeCase)
+	}{
+		{"reordered", func(c *rangeCase) { c.Starts = []uint32{1, 0} }},
+		{"overlap", func(c *rangeCase) { c.Starts = []uint32{0, 0}; c.Sizes = []uint32{2, 2} }},
+		{"bad-start", func(c *rangeCase) { c.Starts[0] = 4294967295 }},
+		{"bad-count", func(c *rangeCase) { c.Sizes[0] = 4294967295 }},
+		{"missing-size", func(c *rangeCase) { c.Sizes = c.Sizes[:1] }},
+		{"bad-command-start", func(c *rangeCase) { c.Commands[0].Start = 3 }},
+		{"bad-command-count", func(c *rangeCase) { c.Commands[0].Count = 4294967295 }},
+		{"bad-ref-start", func(c *rangeCase) { c.Commands[0].RefsStart = 4294967295 }},
+		{"bad-ref-count", func(c *rangeCase) { c.Commands[0].RefsCount = 4294967295 }},
+		{"zero-reference", func(c *rangeCase) { c.Refs[0] = 0 }},
+		{"large-reference", func(c *rangeCase) { c.Refs[0] = 257 }},
+		{"unused-reference", func(c *rangeCase) { c.Refs = append(c.Refs, 4294967295) }},
+		{"unused-invalid-literal", func(c *rangeCase) { c.Pool = append(c.Pool, 6) }},
+		{"unused-valid-literal", func(c *rangeCase) { c.Pool = append(c.Pool, 5) }},
+		{"zero-variables", func(c *rangeCase) { c.Variables = 0 }},
+		{"large-variables", func(c *rangeCase) { c.Variables = 65 }},
+		{"large-addition-id", func(c *rangeCase) { c.Commands[0].ID = 257 }},
+		{"ignored-deletion-literal-range", func(c *rangeCase) {
+			c.Commands = append(c.Commands, rangeCommand{false, 3, 4294967295, 4294967295, 2, 0})
+		}},
+		{"max-deletion-stamp", func(c *rangeCase) { c.Commands = append(c.Commands, rangeCommand{false, 2147483647, 0, 0, 2, 0}) }},
+		{"overflow-deletion-stamp", func(c *rangeCase) { c.Commands = append(c.Commands, rangeCommand{false, 2147483648, 0, 0, 2, 0}) }},
+	}
+	for _, m := range mutations {
+		c := base()
+		m.change(&c)
+		add(m.name, c)
+	}
+	for _, n := range []int{4096, 4097} {
+		add(fmt.Sprintf("pool-%d", n), rangeCase{Variables: 1, Pool: make([]uint32, n), Starts: []uint32{0}, Sizes: []uint32{0}})
+		add(fmt.Sprintf("refs-%d", n), rangeCase{Variables: 1, Refs: make([]uint32, n), Starts: []uint32{0}, Sizes: []uint32{0}})
+	}
+	for _, n := range []int{256, 257} {
+		refs := make([]uint32, n)
+		for i := range refs {
+			refs[i] = 1
+		}
+		add(fmt.Sprintf("hint-count-%d", n), rangeCase{Variables: 1, Pool: []uint32{1, 0}, Starts: []uint32{0, 2}, Sizes: []uint32{1, 0}, Refs: refs, Commands: []rangeCommand{{true, 3, 0, 2, 0, uint32(n)}}})
+	}
+	return out
 }
 func TestSelfHostedRangeBridge(t *testing.T) {
- cases:=rangeCorpus(t);accepted,decoded:=0,0
- var source,main strings.Builder
- for _,path:=range []string{"self_hosted_rup.oak","self_hosted_stream.oak"} {data,err:=os.ReadFile(path);if err!=nil {t.Fatal(err)};source.Write(data);source.WriteByte('\n')}
- main.WriteString("main: (): i32 {\n")
- for i,c:=range cases {
-  fmt.Fprintf(&source,"range_case_%d: (): Bool {\n",i)
-  for _,a:=range []struct{name string;items []uint32}{{"pool",c.Pool},{"starts",c.Starts},{"sizes",c.Sizes},{"refs",c.Refs}} {emitBufferArray(&source,a.name,"u32",a.items)}
-  capacity:=len(c.Commands);if capacity==0 {capacity=1};fmt.Fprintf(&source,"commands: [%d]RUPCommand\n",capacity)
-  for j,r:=range c.Commands {fmt.Fprintf(&source,"commands[%d] = RUPCommand { addition: %t, id: u32(%d), start: u32(%d), count: u32(%d), refs_start: u32(%d), refs_count: u32(%d) }\n",j,r.Addition,r.ID,r.Start,r.Count,r.RefsStart,r.RefsCount)}
-  fmt.Fprintf(&source,"command_view: []RUPCommand = commands[0:%d]\nrup_stream_check(pool_view, starts_view, sizes_view, refs_view, command_view, u32(%d)) == %t\n}\n",len(c.Commands),c.Variables,c.Accepted)
-  fmt.Fprintf(&main,"assert(range_case_%d())\n",i);if c.Accepted {accepted++};if c.Decoded {decoded++}
- }
- main.WriteString("42\n}\n");source.WriteString(main.String());runOakStream(t,source.String())
- if path:=os.Getenv("OAK_RANGE_CORPUS_OUT");path!="" {data,err:=json.MarshalIndent(cases,"","  ");if err!=nil {t.Fatal(err)};if err:=os.WriteFile(path,append(data,'\n'),0644);err!=nil {t.Fatal(err)}}
- t.Logf("Oak/Go range bridge: %d layouts (%d decoded, %d accepted, %d rejected)",len(cases),decoded,accepted,len(cases)-accepted)
+	cases := rangeCorpus(t)
+	accepted, decoded := 0, 0
+	var source, main strings.Builder
+	for _, path := range []string{"self_hosted_rup.oak", "self_hosted_stream.oak"} {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		source.Write(data)
+		source.WriteByte('\n')
+	}
+	main.WriteString("main: (): i32 {\n")
+	for i, c := range cases {
+		fmt.Fprintf(&source, "range_case_%d: (): Bool {\n", i)
+		for _, a := range []struct {
+			name  string
+			items []uint32
+		}{{"pool", c.Pool}, {"starts", c.Starts}, {"sizes", c.Sizes}, {"refs", c.Refs}} {
+			emitBufferArray(&source, a.name, "u32", a.items)
+		}
+		capacity := len(c.Commands)
+		if capacity == 0 {
+			capacity = 1
+		}
+		fmt.Fprintf(&source, "commands: [%d]RUPCommand\n", capacity)
+		for j, r := range c.Commands {
+			fmt.Fprintf(&source, "commands[%d] = RUPCommand { addition: %t, id: u32(%d), start: u32(%d), count: u32(%d), refs_start: u32(%d), refs_count: u32(%d) }\n", j, r.Addition, r.ID, r.Start, r.Count, r.RefsStart, r.RefsCount)
+		}
+		fmt.Fprintf(&source, "command_view: []RUPCommand = commands[0:%d]\nrup_stream_check(pool_view, starts_view, sizes_view, refs_view, command_view, u32(%d)) == %t\n}\n", len(c.Commands), c.Variables, c.Accepted)
+		fmt.Fprintf(&main, "assert(range_case_%d())\n", i)
+		if c.Accepted {
+			accepted++
+		}
+		if c.Decoded {
+			decoded++
+		}
+	}
+	main.WriteString("42\n}\n")
+	source.WriteString(main.String())
+	runOakStream(t, source.String())
+	if path := os.Getenv("OAK_RANGE_CORPUS_OUT"); path != "" {
+		data, err := json.MarshalIndent(cases, "", "  ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, append(data, '\n'), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Logf("Oak/Go range bridge: %d layouts (%d decoded, %d accepted, %d rejected)", len(cases), decoded, accepted, len(cases)-accepted)
 }

--- a/experiments/verification-poc/self_hosted_rup_test.go
+++ b/experiments/verification-poc/self_hosted_rup_test.go
@@ -15,90 +15,156 @@ import (
 )
 
 type selfHostedRUPCase struct {
-	Variables int `json:"variables"`
-	Clauses [][]int `json:"clauses"`
-	Target []int `json:"target"`
-	Hints []int `json:"hints"`
-	Accepted bool `json:"accepted"`
+	Variables int     `json:"variables"`
+	Clauses   [][]int `json:"clauses"`
+	Target    []int   `json:"target"`
+	Hints     []int   `json:"hints"`
+	Accepted  bool    `json:"accepted"`
 }
 
 func selfHostedCases() []selfHostedRUPCase {
 	cases := []selfHostedRUPCase{
-		{2,[][]int{{1},{-1}},nil,[]int{1,2},false},
-		{2,[][]int{{1}},[]int{1,-1},[]int{1},false},
-		{2,[][]int{{}},nil,[]int{1},false},
-		{2,[][]int{{1}},[]int{-1},[]int{1},false},
-		{2,[][]int{{1}},nil,nil,false},
-		{2,[][]int{{1}},[]int{1,-1},nil,false},
+		{2, [][]int{{1}, {-1}}, nil, []int{1, 2}, false},
+		{2, [][]int{{1}}, []int{1, -1}, []int{1}, false},
+		{2, [][]int{{}}, nil, []int{1}, false},
+		{2, [][]int{{1}}, []int{-1}, []int{1}, false},
+		{2, [][]int{{1}}, nil, nil, false},
+		{2, [][]int{{1}}, []int{1, -1}, nil, false},
 	}
 	rng := rand.New(rand.NewSource(741921))
-	literals := []int{-3,-2,-1,1,2,3}
+	literals := []int{-3, -2, -1, 1, 2, 3}
 	for len(cases) < 400 {
 		variables := 3
 		clauses := make([][]int, rng.Intn(3)+1)
 		for i := range clauses {
 			clauses[i] = make([]int, rng.Intn(5))
-			for j := range clauses[i] { clauses[i][j] = literals[rng.Intn(len(literals))] }
+			for j := range clauses[i] {
+				clauses[i][j] = literals[rng.Intn(len(literals))]
+			}
 		}
 		target := make([]int, rng.Intn(5))
-		for i := range target { target[i] = literals[rng.Intn(len(literals))] }
+		for i := range target {
+			target[i] = literals[rng.Intn(len(literals))]
+		}
 		hints := make([]int, rng.Intn(4))
-		for i := range hints { hints[i] = rng.Intn(len(clauses)+2) }
-		cases = append(cases, selfHostedRUPCase{Variables:variables,Clauses:clauses,Target:target,Hints:hints})
+		for i := range hints {
+			hints[i] = rng.Intn(len(clauses) + 2)
+		}
+		cases = append(cases, selfHostedRUPCase{Variables: variables, Clauses: clauses, Target: target, Hints: hints})
 	}
 	for i := range cases {
-		if cases[i].Target==nil {cases[i].Target=[]int{}}
-		if cases[i].Hints==nil {cases[i].Hints=[]int{}}
-		for j:=range cases[i].Clauses {if cases[i].Clauses[j]==nil {cases[i].Clauses[j]=[]int{}}}
-		cases[i].Accepted = lrat.CheckRUPDecoded(cases[i].Variables,cases[i].Clauses,cases[i].Target,cases[i].Hints) == nil
+		if cases[i].Target == nil {
+			cases[i].Target = []int{}
+		}
+		if cases[i].Hints == nil {
+			cases[i].Hints = []int{}
+		}
+		for j := range cases[i].Clauses {
+			if cases[i].Clauses[j] == nil {
+				cases[i].Clauses[j] = []int{}
+			}
+		}
+		cases[i].Accepted = lrat.CheckRUPDecoded(cases[i].Variables, cases[i].Clauses, cases[i].Target, cases[i].Hints) == nil
 	}
 	return cases
 }
 
 func oakLiteral(x int) uint32 {
-	v:=x;if v<0 {v=-v}
-	code:=uint32(2*(v-1));if x>0 {code++};return code
+	v := x
+	if v < 0 {
+		v = -v
+	}
+	code := uint32(2 * (v - 1))
+	if x > 0 {
+		code++
+	}
+	return code
 }
 
 func emitOakRUPCase(out *strings.Builder, c selfHostedRUPCase) {
-	fmt.Fprintln(out,"true ? {")
-	fmt.Fprintln(out,"clause_literals: [12]u32")
-	fmt.Fprintln(out,"clause_starts: [3]u32")
-	fmt.Fprintln(out,"clause_lengths: [3]u32")
-	fmt.Fprintln(out,"target: [4]u32")
-	fmt.Fprintln(out,"hints: [3]u32")
-	fmt.Fprintln(out,"assignments: [4]u8")
-	at:=0
-	for i,clause:=range c.Clauses {
-		fmt.Fprintf(out,"clause_starts[%d] = u32(%d)\nclause_lengths[%d] = u32(%d)\n",i,at,i,len(clause))
-		for _,lit:=range clause {fmt.Fprintf(out,"clause_literals[%d] = u32(%d)\n",at,oakLiteral(lit));at++}
+	fmt.Fprintln(out, "true ? {")
+	fmt.Fprintln(out, "clause_literals: [12]u32")
+	fmt.Fprintln(out, "clause_starts: [3]u32")
+	fmt.Fprintln(out, "clause_lengths: [3]u32")
+	fmt.Fprintln(out, "target: [4]u32")
+	fmt.Fprintln(out, "hints: [3]u32")
+	fmt.Fprintln(out, "assignments: [4]u8")
+	at := 0
+	for i, clause := range c.Clauses {
+		fmt.Fprintf(out, "clause_starts[%d] = u32(%d)\nclause_lengths[%d] = u32(%d)\n", i, at, i, len(clause))
+		for _, lit := range clause {
+			fmt.Fprintf(out, "clause_literals[%d] = u32(%d)\n", at, oakLiteral(lit))
+			at++
+		}
 	}
-	for i,lit:=range c.Target {fmt.Fprintf(out,"target[%d] = u32(%d)\n",i,oakLiteral(lit))}
-	for i,h:=range c.Hints {encoded:=uint32(4294967295);if h>0 {encoded=uint32(h-1)};fmt.Fprintf(out,"hints[%d] = u32(%d)\n",i,encoded)}
-	fmt.Fprintf(out,"accepted: Bool = rup_check(view(&clause_literals), view(&clause_starts), view(&clause_lengths), u32(%d), view(&target), u32(%d), view(&hints), u32(%d), span(&assignments), u32(%d))\n",len(c.Clauses),len(c.Target),len(c.Hints),c.Variables)
-	fmt.Fprintf(out,"assert(accepted == %t)\n",c.Accepted)
-	fmt.Fprintln(out,"}")
+	for i, lit := range c.Target {
+		fmt.Fprintf(out, "target[%d] = u32(%d)\n", i, oakLiteral(lit))
+	}
+	for i, h := range c.Hints {
+		encoded := uint32(4294967295)
+		if h > 0 {
+			encoded = uint32(h - 1)
+		}
+		fmt.Fprintf(out, "hints[%d] = u32(%d)\n", i, encoded)
+	}
+	fmt.Fprintf(out, "accepted: Bool = rup_check(view(&clause_literals), view(&clause_starts), view(&clause_lengths), u32(%d), view(&target), u32(%d), view(&hints), u32(%d), span(&assignments), u32(%d))\n", len(c.Clauses), len(c.Target), len(c.Hints), c.Variables)
+	fmt.Fprintf(out, "assert(accepted == %t)\n", c.Accepted)
+	fmt.Fprintln(out, "}")
 }
 
 func TestSelfHostedRUPKernel(t *testing.T) {
-	cc,err:=exec.LookPath("cc");if err!=nil {t.Skip("no C compiler")}
-	core,err:=os.ReadFile("self_hosted_rup.oak");if err!=nil {t.Fatal(err)}
-	cases:=selfHostedCases()
+	cc, err := exec.LookPath("cc")
+	if err != nil {
+		t.Skip("no C compiler")
+	}
+	core, err := os.ReadFile("self_hosted_rup.oak")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := selfHostedCases()
 	var source strings.Builder
 	source.Write(core)
 	source.WriteString("\nmain: (): i32 {\n")
-	for _,c:=range cases {emitOakRUPCase(&source,c)}
+	for _, c := range cases {
+		emitOakRUPCase(&source, c)
+	}
 	source.WriteString("42\n}\n")
-	generated,err:=compiler.New().WithSource("self_hosted_rup_test.oak",source.String()).EmitC().Get();if err!=nil {t.Fatalf("Oak compile: %v",err)}
-	for _,bad:=range []string{"malloc(","calloc(","realloc(","OAK_UNSUPPORTED"} {if strings.Contains(generated,bad){t.Fatalf("generated C contains %s",bad)}}
-	dir:=t.TempDir();cpath:=filepath.Join(dir,"checker.c");bin:=filepath.Join(dir,"checker")
-	if err:=os.WriteFile(cpath,[]byte(generated),0644);err!=nil {t.Fatal(err)}
-	if output,err:=exec.Command(cc,"-std=c99","-O1","-o",bin,cpath).CombinedOutput();err!=nil {t.Fatalf("cc: %v\n%s",err,output)}
-	run:=exec.Command(bin)
-	output,err:=run.CombinedOutput()
-	exitCode:=0
-	if err!=nil {if e,ok:=err.(*exec.ExitError);ok {exitCode=e.ExitCode()} else {t.Fatalf("Oak checker: %v\n%s",err,output)}}
-	if exitCode!=42 {t.Fatalf("Oak checker exit=%d, want 42\n%s",exitCode,output)}
-	if path:=os.Getenv("OAK_SELF_HOSTED_RUP_CORPUS_OUT");path!="" {data,_:=json.MarshalIndent(cases,"","  ");if err:=os.WriteFile(path,append(data,'\n'),0644);err!=nil {t.Fatal(err)}}
-	t.Logf("Oak RUP kernel agreed with Go on %d cases",len(cases))
+	generated, err := compiler.New().WithSource("self_hosted_rup_test.oak", source.String()).EmitC().Get()
+	if err != nil {
+		t.Fatalf("Oak compile: %v", err)
+	}
+	for _, bad := range []string{"malloc(", "calloc(", "realloc(", "OAK_UNSUPPORTED"} {
+		if strings.Contains(generated, bad) {
+			t.Fatalf("generated C contains %s", bad)
+		}
+	}
+	dir := t.TempDir()
+	cpath := filepath.Join(dir, "checker.c")
+	bin := filepath.Join(dir, "checker")
+	if err := os.WriteFile(cpath, []byte(generated), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if output, err := exec.Command(cc, "-std=c99", "-O1", "-o", bin, cpath).CombinedOutput(); err != nil {
+		t.Fatalf("cc: %v\n%s", err, output)
+	}
+	run := exec.Command(bin)
+	output, err := run.CombinedOutput()
+	exitCode := 0
+	if err != nil {
+		if e, ok := err.(*exec.ExitError); ok {
+			exitCode = e.ExitCode()
+		} else {
+			t.Fatalf("Oak checker: %v\n%s", err, output)
+		}
+	}
+	if exitCode != 42 {
+		t.Fatalf("Oak checker exit=%d, want 42\n%s", exitCode, output)
+	}
+	if path := os.Getenv("OAK_SELF_HOSTED_RUP_CORPUS_OUT"); path != "" {
+		data, _ := json.MarshalIndent(cases, "", "  ")
+		if err := os.WriteFile(path, append(data, '\n'), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Logf("Oak RUP kernel agreed with Go on %d cases", len(cases))
 }

--- a/experiments/verification-poc/self_hosted_scanner_test.go
+++ b/experiments/verification-poc/self_hosted_scanner_test.go
@@ -1,111 +1,207 @@
 package main
 
 import (
- "encoding/json"
- "fmt"
- "math/rand"
- "os"
- "strings"
- "testing"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"os"
+	"strings"
+	"testing"
 )
 
 type scannerToken struct {
- Kind uint32 `json:"kind"`
- Next uint32 `json:"next"`
- Start uint32 `json:"start"`
- Stop uint32 `json:"stop"`
- Magnitude uint32 `json:"magnitude"`
- Sign uint32 `json:"sign"`
+	Kind      uint32 `json:"kind"`
+	Next      uint32 `json:"next"`
+	Start     uint32 `json:"start"`
+	Stop      uint32 `json:"stop"`
+	Magnitude uint32 `json:"magnitude"`
+	Sign      uint32 `json:"sign"`
 }
 type scannerCase struct {
- Name string `json:"name"`
- Bytes []uint32 `json:"bytes"`
- Cursor uint32 `json:"cursor"`
- Tokens []scannerToken `json:"tokens"`
+	Name   string         `json:"name"`
+	Bytes  []uint32       `json:"bytes"`
+	Cursor uint32         `json:"cursor"`
+	Tokens []scannerToken `json:"tokens"`
 }
-func scannerSpace(b byte) bool {return b==' '||b=='\t'||b=='\r'||b=='\v'||b=='\f'}
+
+func scannerSpace(b byte) bool { return b == ' ' || b == '\t' || b == '\r' || b == '\v' || b == '\f' }
+
 // Mathematical uint64 arithmetic, followed by a bound check. This deliberately
 // does not copy Oak's pre-multiplication threshold guard.
 func scannerOracle(input []byte, cursor uint32) scannerToken {
- pos:=int(cursor)
- for pos<len(input)&&scannerSpace(input[pos]) {pos++}
- r:=scannerToken{Next:uint32(pos),Start:uint32(pos),Stop:uint32(pos),Sign:1}
- if pos==len(input) {return r}
- if input[pos]=='\n' {r.Kind=1;r.Next++;r.Stop++;return r}
- r.Kind=2
- for pos<len(input)&&input[pos]!='\n'&&!scannerSpace(input[pos]) {pos++}
- r.Next=uint32(pos);r.Stop=uint32(pos)
- word:=input[r.Start:r.Stop]
- if word[0]=='+'||word[0]=='-' {if word[0]=='-' {r.Sign=2};word=word[1:]}
- if len(word)==0 {r.Sign=0;return r}
- for _,b:=range word {
-  if b<'0'||b>'9' {r.Sign=0;break}
-  next:=uint64(r.Magnitude)*10+uint64(b-'0')
-  if next>2147483647 {r.Sign=0;break}
-  r.Magnitude=uint32(next)
- }
- return r
+	pos := int(cursor)
+	for pos < len(input) && scannerSpace(input[pos]) {
+		pos++
+	}
+	r := scannerToken{Next: uint32(pos), Start: uint32(pos), Stop: uint32(pos), Sign: 1}
+	if pos == len(input) {
+		return r
+	}
+	if input[pos] == '\n' {
+		r.Kind = 1
+		r.Next++
+		r.Stop++
+		return r
+	}
+	r.Kind = 2
+	for pos < len(input) && input[pos] != '\n' && !scannerSpace(input[pos]) {
+		pos++
+	}
+	r.Next = uint32(pos)
+	r.Stop = uint32(pos)
+	word := input[r.Start:r.Stop]
+	if word[0] == '+' || word[0] == '-' {
+		if word[0] == '-' {
+			r.Sign = 2
+		}
+		word = word[1:]
+	}
+	if len(word) == 0 {
+		r.Sign = 0
+		return r
+	}
+	for _, b := range word {
+		if b < '0' || b > '9' {
+			r.Sign = 0
+			break
+		}
+		next := uint64(r.Magnitude)*10 + uint64(b-'0')
+		if next > 2147483647 {
+			r.Sign = 0
+			break
+		}
+		r.Magnitude = uint32(next)
+	}
+	return r
 }
 func TestScannerOracle(t *testing.T) {
- cases:=[]struct{input string;cursor uint32;want scannerToken}{
-  {" \t",0,scannerToken{0,2,2,2,0,1}},
-  {" \n9",0,scannerToken{1,2,1,2,0,1}},
-  {"x -0!9 tail",2,scannerToken{2,6,2,6,0,0}},
-  {"2147483648suffix",0,scannerToken{2,16,0,16,214748364,0}},
-  {"skip -0",5,scannerToken{2,7,5,7,0,2}},
-  {"+ -",0,scannerToken{2,1,0,1,0,0}},
- }
- for _,c:=range cases {if got:=scannerOracle([]byte(c.input),c.cursor);got!=c.want {t.Fatalf("%q @ %d: got %+v want %+v",c.input,c.cursor,got,c.want)}}
+	cases := []struct {
+		input  string
+		cursor uint32
+		want   scannerToken
+	}{
+		{" \t", 0, scannerToken{0, 2, 2, 2, 0, 1}},
+		{" \n9", 0, scannerToken{1, 2, 1, 2, 0, 1}},
+		{"x -0!9 tail", 2, scannerToken{2, 6, 2, 6, 0, 0}},
+		{"2147483648suffix", 0, scannerToken{2, 16, 0, 16, 214748364, 0}},
+		{"skip -0", 5, scannerToken{2, 7, 5, 7, 0, 2}},
+		{"+ -", 0, scannerToken{2, 1, 0, 1, 0, 0}},
+	}
+	for _, c := range cases {
+		if got := scannerOracle([]byte(c.input), c.cursor); got != c.want {
+			t.Fatalf("%q @ %d: got %+v want %+v", c.input, c.cursor, got, c.want)
+		}
+	}
 }
 func scannerCorpus() []scannerCase {
- out:=[]scannerCase{}
- add:=func(input string,cursor uint32,steps int) {
-  c:=scannerCase{Name:fmt.Sprintf("scanner-%d",len(out)),Bytes:[]uint32{},Cursor:cursor,Tokens:[]scannerToken{}}
-  for _,b:=range []byte(input) {c.Bytes=append(c.Bytes,uint32(b))}
-  for i:=0;i<steps;i++ {r:=scannerOracle([]byte(input),cursor);c.Tokens=append(c.Tokens,r);cursor=r.Next}
-  out=append(out,c)
- }
- for _,input:=range []string{""," \t\r\v\f","\n\n","  + - -0 +0 00\n","12x999 2147483648suffix -2147483647\n9","c comment\np cnf 2 1\n1 -2 0\n"} {
-  for cursor:=0;cursor<=len(input);cursor++ {add(input,uint32(cursor),8)}
- }
- for b:=0;b<256;b++ {add(string([]byte{byte(b)}),0,3);add(" \t12"+string([]byte{byte(b)})+"34\n-0",1,5)}
- for i,c:=range decimalCorpus() {if i%4!=0 {continue};var s strings.Builder;s.WriteString("\t ");for _,b:=range c.Bytes {s.WriteByte(byte(b))};s.WriteString(" tail\n");add(s.String(),0,4)}
- rng:=rand.New(rand.NewSource(20260908));alphabet:=[]byte("0123456789+-xyz \t\n\r\v\f")
- for i:=0;i<300;i++ {input:=make([]byte,rng.Intn(65));for j:=range input {input[j]=alphabet[rng.Intn(len(alphabet))]};add(string(input),uint32(rng.Intn(len(input)+1)),8)}
- add(strings.Repeat(" ",65535)+"0",0,3)
- add(strings.Repeat("0",65536),0,3)
- add(strings.Repeat("9",65536),65535,3)
- return out
+	out := []scannerCase{}
+	add := func(input string, cursor uint32, steps int) {
+		c := scannerCase{Name: fmt.Sprintf("scanner-%d", len(out)), Bytes: []uint32{}, Cursor: cursor, Tokens: []scannerToken{}}
+		for _, b := range []byte(input) {
+			c.Bytes = append(c.Bytes, uint32(b))
+		}
+		for i := 0; i < steps; i++ {
+			r := scannerOracle([]byte(input), cursor)
+			c.Tokens = append(c.Tokens, r)
+			cursor = r.Next
+		}
+		out = append(out, c)
+	}
+	for _, input := range []string{"", " \t\r\v\f", "\n\n", "  + - -0 +0 00\n", "12x999 2147483648suffix -2147483647\n9", "c comment\np cnf 2 1\n1 -2 0\n"} {
+		for cursor := 0; cursor <= len(input); cursor++ {
+			add(input, uint32(cursor), 8)
+		}
+	}
+	for b := 0; b < 256; b++ {
+		add(string([]byte{byte(b)}), 0, 3)
+		add(" \t12"+string([]byte{byte(b)})+"34\n-0", 1, 5)
+	}
+	for i, c := range decimalCorpus() {
+		if i%4 != 0 {
+			continue
+		}
+		var s strings.Builder
+		s.WriteString("\t ")
+		for _, b := range c.Bytes {
+			s.WriteByte(byte(b))
+		}
+		s.WriteString(" tail\n")
+		add(s.String(), 0, 4)
+	}
+	rng := rand.New(rand.NewSource(20260908))
+	alphabet := []byte("0123456789+-xyz \t\n\r\v\f")
+	for i := 0; i < 300; i++ {
+		input := make([]byte, rng.Intn(65))
+		for j := range input {
+			input[j] = alphabet[rng.Intn(len(alphabet))]
+		}
+		add(string(input), uint32(rng.Intn(len(input)+1)), 8)
+	}
+	add(strings.Repeat(" ", 65535)+"0", 0, 3)
+	add(strings.Repeat("0", 65536), 0, 3)
+	add(strings.Repeat("9", 65536), 65535, 3)
+	return out
 }
 func TestSelfHostedScanner(t *testing.T) {
- cases:=scannerCorpus();transitions:=0
- var source,main strings.Builder
- for _,path:=range []string{"self_hosted_rup.oak","self_hosted_stream.oak","self_hosted_text.oak"} {data,err:=os.ReadFile(path);if err!=nil {t.Fatal(err)};source.Write(data);source.WriteByte('\n')}
- source.WriteString(`scanner_expect: (bytes: []u8, state: [*]u32, want_kind: u32, want_next: u32, want_start: u32, want_stop: u32, want_magnitude: u32, want_sign: u32): Bool {
+	cases := scannerCorpus()
+	transitions := 0
+	var source, main strings.Builder
+	for _, path := range []string{"self_hosted_rup.oak", "self_hosted_stream.oak", "self_hosted_text.oak"} {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		source.Write(data)
+		source.WriteByte('\n')
+	}
+	source.WriteString(`scanner_expect: (bytes: []u8, state: [*]u32, want_kind: u32, want_next: u32, want_start: u32, want_stop: u32, want_magnitude: u32, want_sign: u32): Bool {
  kind: u32 = rup_token(bytes, state)
  kind == want_kind && state[0] == want_next && state[1] == want_start && state[2] == want_stop && state[3] == want_magnitude && state[4] == want_sign
 }
 `)
- main.WriteString("main: (): i32 {\n")
- for i,c:=range cases {
-  fmt.Fprintf(&source,"scanner_case_%d: (): Bool {\n",i)
-  capacity:=len(c.Bytes);if capacity==0 {capacity=1}
-  fmt.Fprintf(&source,"input: [%d]u8\n",capacity)
-  for begin:=0;begin<len(c.Bytes); {
-   end:=begin+1;for end<len(c.Bytes)&&c.Bytes[end]==c.Bytes[begin] {end++}
-   if end-begin>8 {fmt.Fprintf(&source,"i_%d: u32 = %d\nwhile i_%d < u32(%d) { input[i_%d] = u8(%d); i_%d = i_%d + u32(1) }\n",begin,begin,begin,end,begin,c.Bytes[begin],begin,begin)} else {for j:=begin;j<end;j++ {fmt.Fprintf(&source,"input[%d] = u8(%d)\n",j,c.Bytes[j])}}
-   begin=end
-  }
-  fmt.Fprintf(&source,"bytes: []u8 = input[0:%d]\nstate: [5]u32\nstate[0] = u32(%d)\n",len(c.Bytes),c.Cursor)
-  // Poison fields the scanner must overwrite, then preserve state across calls.
-  source.WriteString("state[1] = u32(999)\nstate[2] = u32(998)\nstate[3] = u32(997)\nstate[4] = u32(996)\nok: Bool = true\n")
-  for _,r:=range c.Tokens {
-   transitions++
-   fmt.Fprintf(&source,"ok = scanner_expect(bytes, span(&state), u32(%d), u32(%d), u32(%d), u32(%d), u32(%d), u32(%d)) && ok\n",r.Kind,r.Next,r.Start,r.Stop,r.Magnitude,r.Sign)
-  }
-  source.WriteString("ok\n}\n");fmt.Fprintf(&main,"assert(scanner_case_%d())\n",i)
- }
- main.WriteString("42\n}\n");source.WriteString(main.String());runOakStream(t,source.String())
- if path:=os.Getenv("OAK_SCANNER_CORPUS_OUT");path!="" {data,err:=json.MarshalIndent(cases,"","  ");if err!=nil {t.Fatal(err)};if err:=os.WriteFile(path,append(data,'\n'),0644);err!=nil {t.Fatal(err)}}
- t.Logf("Oak/Go scanner agreement: %d cases, %d transitions",len(cases),transitions)
+	main.WriteString("main: (): i32 {\n")
+	for i, c := range cases {
+		fmt.Fprintf(&source, "scanner_case_%d: (): Bool {\n", i)
+		capacity := len(c.Bytes)
+		if capacity == 0 {
+			capacity = 1
+		}
+		fmt.Fprintf(&source, "input: [%d]u8\n", capacity)
+		for begin := 0; begin < len(c.Bytes); {
+			end := begin + 1
+			for end < len(c.Bytes) && c.Bytes[end] == c.Bytes[begin] {
+				end++
+			}
+			if end-begin > 8 {
+				fmt.Fprintf(&source, "i_%d: u32 = %d\nwhile i_%d < u32(%d) { input[i_%d] = u8(%d); i_%d = i_%d + u32(1) }\n", begin, begin, begin, end, begin, c.Bytes[begin], begin, begin)
+			} else {
+				for j := begin; j < end; j++ {
+					fmt.Fprintf(&source, "input[%d] = u8(%d)\n", j, c.Bytes[j])
+				}
+			}
+			begin = end
+		}
+		fmt.Fprintf(&source, "bytes: []u8 = input[0:%d]\nstate: [5]u32\nstate[0] = u32(%d)\n", len(c.Bytes), c.Cursor)
+		// Poison fields the scanner must overwrite, then preserve state across calls.
+		source.WriteString("state[1] = u32(999)\nstate[2] = u32(998)\nstate[3] = u32(997)\nstate[4] = u32(996)\nok: Bool = true\n")
+		for _, r := range c.Tokens {
+			transitions++
+			fmt.Fprintf(&source, "ok = scanner_expect(bytes, span(&state), u32(%d), u32(%d), u32(%d), u32(%d), u32(%d), u32(%d)) && ok\n", r.Kind, r.Next, r.Start, r.Stop, r.Magnitude, r.Sign)
+		}
+		source.WriteString("ok\n}\n")
+		fmt.Fprintf(&main, "assert(scanner_case_%d())\n", i)
+	}
+	main.WriteString("42\n}\n")
+	source.WriteString(main.String())
+	runOakStream(t, source.String())
+	if path := os.Getenv("OAK_SCANNER_CORPUS_OUT"); path != "" {
+		data, err := json.MarshalIndent(cases, "", "  ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, append(data, '\n'), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Logf("Oak/Go scanner agreement: %d cases, %d transitions", len(cases), transitions)
 }

--- a/experiments/verification-poc/self_hosted_stream_test.go
+++ b/experiments/verification-poc/self_hosted_stream_test.go
@@ -1,189 +1,388 @@
 package main
 
 import (
- "context"
- "encoding/json"
- "fmt"
- "math/rand"
- "os"
- "os/exec"
- "path/filepath"
- "strings"
- "testing"
- "time"
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
 
- "github.com/SCKelemen/oak/compiler"
- "github.com/SCKelemen/oak/experiments/verification-poc/internal/lrat"
+	"github.com/SCKelemen/oak/compiler"
+	"github.com/SCKelemen/oak/experiments/verification-poc/internal/lrat"
 )
 
 type streamCommand struct {
- Kind string `json:"kind"`
- ID uint32 `json:"id"`
- Clause []int `json:"clause"`
- Hints []int `json:"hints"`
- IDs []uint32 `json:"ids"`
+	Kind   string   `json:"kind"`
+	ID     uint32   `json:"id"`
+	Clause []int    `json:"clause"`
+	Hints  []int    `json:"hints"`
+	IDs    []uint32 `json:"ids"`
 }
 type streamCase struct {
- Name string `json:"name"`
- Kind string `json:"kind"`
- Variables int `json:"variables"`
- Database [][]int `json:"database"`
- Clause []int `json:"clause"`
- Hints []int `json:"hints"`
- Commands []streamCommand `json:"commands"`
- Expected bool `json:"expected"`
-}
-func streamAdd(id uint32, clause []int, hints ...int) streamCommand {return streamCommand{Kind:"add",ID:id,Clause:clause,Hints:hints}}
-func streamDelete(stamp uint32, ids ...uint32) streamCommand {return streamCommand{Kind:"delete",ID:stamp,IDs:ids}}
-func streamReference(c streamCase) bool {
- var cnf,proof strings.Builder
- fmt.Fprintf(&cnf,"p cnf %d %d\n",c.Variables,len(c.Database))
- for _,clause:=range c.Database {for _,lit:=range clause {fmt.Fprintf(&cnf,"%d ",lit)};cnf.WriteString("0\n")}
- for _,cmd:=range c.Commands {
-  fmt.Fprintf(&proof,"%d ",cmd.ID)
-  if cmd.Kind=="delete" {proof.WriteString("d ");for _,id:=range cmd.IDs {fmt.Fprintf(&proof,"%d ",id)}} else {
-   for _,lit:=range cmd.Clause {fmt.Fprintf(&proof,"%d ",lit)};proof.WriteString("0 ")
-   for _,id:=range cmd.Hints {fmt.Fprintf(&proof,"%d ",id)}
-  };proof.WriteString("0\n")
- }
- _,err:=lrat.Check(cnf.String(),proof.String());return err==nil
-}
-func streamCorpus(t *testing.T) []streamCase {
- t.Helper()
- out:=[]streamCase{}
- add:=func(name string, db [][]int, expected bool, commands ...streamCommand) {
-  c:=streamCase{Name:name,Variables:3,Database:db,Commands:commands}
-  got:=streamReference(c);if got!=expected {t.Fatalf("reference disagrees with labelled %s: %v",name,got)}
-  out=append(out,c)
- }
- db:=[][]int{{1},{-1}}
- add("derive-empty",db,true,streamAdd(3,nil,1,2))
- add("empty-initial",[][]int{{}},true)
- add("no-refutation",db,false)
- add("delete-derived-empty",db,true,streamAdd(3,nil,1,2),streamDelete(3,3))
- add("delete-initial-empty",[][]int{{}},true,streamDelete(1,1))
- add("invalid-suffix",db,false,streamAdd(3,nil,1,2),streamAdd(4,nil))
- add("valid-suffix",db,true,streamAdd(3,nil,1,2),streamAdd(4,[]int{1,-1}))
- add("reuse-deleted-id",db,false,streamAdd(3,[]int{1},1),streamDelete(3,3),streamAdd(3,nil,1,2))
- add("deleted-hint",db,false,streamDelete(2,1),streamAdd(3,nil,1,2))
- add("deleted-hint-tautology",db,false,streamDelete(2,1),streamAdd(3,[]int{1,-1},1))
- add("duplicate-deletion",db,false,streamAdd(3,nil,1,2),streamDelete(3,1,1))
- add("missing-deletion",db,false,streamAdd(3,nil,1,2),streamDelete(3,4))
- add("zero-deletion",db,false,streamAdd(3,nil,1,2),streamDelete(3,0))
- add("low-stamp",db,false,streamAdd(3,nil,1,2),streamDelete(2,1))
- add("stamp-does-not-advance",db,true,streamDelete(100),streamAdd(3,nil,1,2))
- add("sparse-addition",db,true,streamAdd(100,[]int{1},1),streamAdd(256,nil,100,2))
- add("zero-addition",db,false,streamAdd(0,nil,1,2))
- add("initial-id-reuse",db,false,streamAdd(2,nil,1,2))
- add("future-hint",db,false,streamAdd(3,nil,3))
- add("zero-hint",db,false,streamAdd(3,nil,0))
- add("RAT-hint",db,false,streamAdd(3,nil,-1))
- add("conflict-suffix",db,false,streamAdd(3,nil,1,2,1))
- add("satisfied-hint",db,false,streamAdd(3,nil,1,1,2))
- add("duplicates",[][]int{{1,1},{-1,-1}},true,streamAdd(3,nil,1,2))
- add("derived-chain",[][]int{{1},{-1,2},{-2,3},{-3}},true,streamAdd(5,[]int{2},1,2),streamAdd(6,[]int{3},5,3),streamDelete(6,1,2,3,5),streamAdd(7,nil,6,4),streamDelete(7,7,6,4))
- // Seeded mutation of previously valid streams exercises later instructions.
- rng:=rand.New(rand.NewSource(81043))
- for i:=0;i<200;i++ {
-  id:=uint32(3+rng.Intn(100))
-  commands:=[]streamCommand{streamAdd(id,[]int{1},1),streamAdd(id+1,nil,int(id),2),streamDelete(id+1,id+1)}
-  switch i%8 {
-  case 0: commands=append(commands,streamAdd(id+2,[]int{1,-1}))
-  case 1: commands=append(commands,streamAdd(id+2,nil))
-  case 2: commands[1].Hints=[]int{int(id+1)}
-  case 3: commands[2]=streamDelete(id+1,id+1,id+1)
-  case 4: commands[1].ID=id
-  case 5: commands=append([]streamCommand{streamDelete(200)},commands...)
-  case 6: commands[2]=streamDelete(id,1)
-  }
-  out=append(out,streamCase{Name:fmt.Sprintf("mutation-%d",i),Variables:3,Database:db,Commands:commands})
- }
- for i:=0;i<200;i++ {
-  database:=make([][]int,1+rng.Intn(4))
-  for j:=range database {database[j]=[]int{};for k:=rng.Intn(4);k>0;k-- {lit:=1+rng.Intn(3);if rng.Intn(2)==0 {lit=-lit};database[j]=append(database[j],lit)}}
-  commands:=[]streamCommand{}
-  for j:=0;j<rng.Intn(6);j++ {
-   id:=uint32(rng.Intn(9))
-   if rng.Intn(3)==0 {ids:=[]uint32{};for k:=rng.Intn(4);k>0;k-- {ids=append(ids,uint32(rng.Intn(9)))};commands=append(commands,streamDelete(id,ids...))} else {
-    clause:=[]int{};for k:=rng.Intn(4);k>0;k-- {lit:=1+rng.Intn(3);if rng.Intn(2)==0 {lit=-lit};clause=append(clause,lit)}
-    hints:=[]int{};for k:=rng.Intn(5);k>0;k-- {hints=append(hints,rng.Intn(10)-1)};commands=append(commands,streamAdd(id,clause,hints...))
-   }
-  }
-  out=append(out,streamCase{Name:fmt.Sprintf("random-%d",i),Variables:3,Database:database,Commands:commands})
- }
- for i:=range out {
-  c:=&out[i];c.Kind="proof";c.Clause=[]int{};c.Hints=[]int{};if c.Commands==nil {c.Commands=[]streamCommand{}}
-  for j:=range c.Database {if c.Database[j]==nil {c.Database[j]=[]int{}}}
-  for j:=range c.Commands {cmd:=&c.Commands[j];if cmd.Clause==nil {cmd.Clause=[]int{}};if cmd.Hints==nil {cmd.Hints=[]int{}};if cmd.IDs==nil {cmd.IDs=[]uint32{}}}
-  c.Expected=streamReference(*c)
-  // An independent truth table guards the reference's accepted decisions.
-  if c.Expected {
-   for mask:=0;mask<1<<c.Variables;mask++ {
-    sat:=true;for _,clause:=range c.Database {holds:=false;for _,lit:=range clause {n:=lit;if n<0 {n=-n};value:=mask&(1<<(n-1))!=0;holds=holds || value==(lit>0)};sat=sat&&holds}
-    if sat {t.Fatalf("reference accepted satisfiable %s",c.Name)}
-   }
-  }
- }
- return out
+	Name      string          `json:"name"`
+	Kind      string          `json:"kind"`
+	Variables int             `json:"variables"`
+	Database  [][]int         `json:"database"`
+	Clause    []int           `json:"clause"`
+	Hints     []int           `json:"hints"`
+	Commands  []streamCommand `json:"commands"`
+	Expected  bool            `json:"expected"`
 }
 
-type streamLayout struct {lits,starts,lengths,refs []uint32; commands []string}
+func streamAdd(id uint32, clause []int, hints ...int) streamCommand {
+	return streamCommand{Kind: "add", ID: id, Clause: clause, Hints: hints}
+}
+func streamDelete(stamp uint32, ids ...uint32) streamCommand {
+	return streamCommand{Kind: "delete", ID: stamp, IDs: ids}
+}
+func streamReference(c streamCase) bool {
+	var cnf, proof strings.Builder
+	fmt.Fprintf(&cnf, "p cnf %d %d\n", c.Variables, len(c.Database))
+	for _, clause := range c.Database {
+		for _, lit := range clause {
+			fmt.Fprintf(&cnf, "%d ", lit)
+		}
+		cnf.WriteString("0\n")
+	}
+	for _, cmd := range c.Commands {
+		fmt.Fprintf(&proof, "%d ", cmd.ID)
+		if cmd.Kind == "delete" {
+			proof.WriteString("d ")
+			for _, id := range cmd.IDs {
+				fmt.Fprintf(&proof, "%d ", id)
+			}
+		} else {
+			for _, lit := range cmd.Clause {
+				fmt.Fprintf(&proof, "%d ", lit)
+			}
+			proof.WriteString("0 ")
+			for _, id := range cmd.Hints {
+				fmt.Fprintf(&proof, "%d ", id)
+			}
+		}
+		proof.WriteString("0\n")
+	}
+	_, err := lrat.Check(cnf.String(), proof.String())
+	return err == nil
+}
+func streamCorpus(t *testing.T) []streamCase {
+	t.Helper()
+	out := []streamCase{}
+	add := func(name string, db [][]int, expected bool, commands ...streamCommand) {
+		c := streamCase{Name: name, Variables: 3, Database: db, Commands: commands}
+		got := streamReference(c)
+		if got != expected {
+			t.Fatalf("reference disagrees with labelled %s: %v", name, got)
+		}
+		out = append(out, c)
+	}
+	db := [][]int{{1}, {-1}}
+	add("derive-empty", db, true, streamAdd(3, nil, 1, 2))
+	add("empty-initial", [][]int{{}}, true)
+	add("no-refutation", db, false)
+	add("delete-derived-empty", db, true, streamAdd(3, nil, 1, 2), streamDelete(3, 3))
+	add("delete-initial-empty", [][]int{{}}, true, streamDelete(1, 1))
+	add("invalid-suffix", db, false, streamAdd(3, nil, 1, 2), streamAdd(4, nil))
+	add("valid-suffix", db, true, streamAdd(3, nil, 1, 2), streamAdd(4, []int{1, -1}))
+	add("reuse-deleted-id", db, false, streamAdd(3, []int{1}, 1), streamDelete(3, 3), streamAdd(3, nil, 1, 2))
+	add("deleted-hint", db, false, streamDelete(2, 1), streamAdd(3, nil, 1, 2))
+	add("deleted-hint-tautology", db, false, streamDelete(2, 1), streamAdd(3, []int{1, -1}, 1))
+	add("duplicate-deletion", db, false, streamAdd(3, nil, 1, 2), streamDelete(3, 1, 1))
+	add("missing-deletion", db, false, streamAdd(3, nil, 1, 2), streamDelete(3, 4))
+	add("zero-deletion", db, false, streamAdd(3, nil, 1, 2), streamDelete(3, 0))
+	add("low-stamp", db, false, streamAdd(3, nil, 1, 2), streamDelete(2, 1))
+	add("stamp-does-not-advance", db, true, streamDelete(100), streamAdd(3, nil, 1, 2))
+	add("sparse-addition", db, true, streamAdd(100, []int{1}, 1), streamAdd(256, nil, 100, 2))
+	add("zero-addition", db, false, streamAdd(0, nil, 1, 2))
+	add("initial-id-reuse", db, false, streamAdd(2, nil, 1, 2))
+	add("future-hint", db, false, streamAdd(3, nil, 3))
+	add("zero-hint", db, false, streamAdd(3, nil, 0))
+	add("RAT-hint", db, false, streamAdd(3, nil, -1))
+	add("conflict-suffix", db, false, streamAdd(3, nil, 1, 2, 1))
+	add("satisfied-hint", db, false, streamAdd(3, nil, 1, 1, 2))
+	add("duplicates", [][]int{{1, 1}, {-1, -1}}, true, streamAdd(3, nil, 1, 2))
+	add("derived-chain", [][]int{{1}, {-1, 2}, {-2, 3}, {-3}}, true, streamAdd(5, []int{2}, 1, 2), streamAdd(6, []int{3}, 5, 3), streamDelete(6, 1, 2, 3, 5), streamAdd(7, nil, 6, 4), streamDelete(7, 7, 6, 4))
+	// Seeded mutation of previously valid streams exercises later instructions.
+	rng := rand.New(rand.NewSource(81043))
+	for i := 0; i < 200; i++ {
+		id := uint32(3 + rng.Intn(100))
+		commands := []streamCommand{streamAdd(id, []int{1}, 1), streamAdd(id+1, nil, int(id), 2), streamDelete(id+1, id+1)}
+		switch i % 8 {
+		case 0:
+			commands = append(commands, streamAdd(id+2, []int{1, -1}))
+		case 1:
+			commands = append(commands, streamAdd(id+2, nil))
+		case 2:
+			commands[1].Hints = []int{int(id + 1)}
+		case 3:
+			commands[2] = streamDelete(id+1, id+1, id+1)
+		case 4:
+			commands[1].ID = id
+		case 5:
+			commands = append([]streamCommand{streamDelete(200)}, commands...)
+		case 6:
+			commands[2] = streamDelete(id, 1)
+		}
+		out = append(out, streamCase{Name: fmt.Sprintf("mutation-%d", i), Variables: 3, Database: db, Commands: commands})
+	}
+	for i := 0; i < 200; i++ {
+		database := make([][]int, 1+rng.Intn(4))
+		for j := range database {
+			database[j] = []int{}
+			for k := rng.Intn(4); k > 0; k-- {
+				lit := 1 + rng.Intn(3)
+				if rng.Intn(2) == 0 {
+					lit = -lit
+				}
+				database[j] = append(database[j], lit)
+			}
+		}
+		commands := []streamCommand{}
+		for j := 0; j < rng.Intn(6); j++ {
+			id := uint32(rng.Intn(9))
+			if rng.Intn(3) == 0 {
+				ids := []uint32{}
+				for k := rng.Intn(4); k > 0; k-- {
+					ids = append(ids, uint32(rng.Intn(9)))
+				}
+				commands = append(commands, streamDelete(id, ids...))
+			} else {
+				clause := []int{}
+				for k := rng.Intn(4); k > 0; k-- {
+					lit := 1 + rng.Intn(3)
+					if rng.Intn(2) == 0 {
+						lit = -lit
+					}
+					clause = append(clause, lit)
+				}
+				hints := []int{}
+				for k := rng.Intn(5); k > 0; k-- {
+					hints = append(hints, rng.Intn(10)-1)
+				}
+				commands = append(commands, streamAdd(id, clause, hints...))
+			}
+		}
+		out = append(out, streamCase{Name: fmt.Sprintf("random-%d", i), Variables: 3, Database: database, Commands: commands})
+	}
+	for i := range out {
+		c := &out[i]
+		c.Kind = "proof"
+		c.Clause = []int{}
+		c.Hints = []int{}
+		if c.Commands == nil {
+			c.Commands = []streamCommand{}
+		}
+		for j := range c.Database {
+			if c.Database[j] == nil {
+				c.Database[j] = []int{}
+			}
+		}
+		for j := range c.Commands {
+			cmd := &c.Commands[j]
+			if cmd.Clause == nil {
+				cmd.Clause = []int{}
+			}
+			if cmd.Hints == nil {
+				cmd.Hints = []int{}
+			}
+			if cmd.IDs == nil {
+				cmd.IDs = []uint32{}
+			}
+		}
+		c.Expected = streamReference(*c)
+		// An independent truth table guards the reference's accepted decisions.
+		if c.Expected {
+			for mask := 0; mask < 1<<c.Variables; mask++ {
+				sat := true
+				for _, clause := range c.Database {
+					holds := false
+					for _, lit := range clause {
+						n := lit
+						if n < 0 {
+							n = -n
+						}
+						value := mask&(1<<(n-1)) != 0
+						holds = holds || value == (lit > 0)
+					}
+					sat = sat && holds
+				}
+				if sat {
+					t.Fatalf("reference accepted satisfiable %s", c.Name)
+				}
+			}
+		}
+	}
+	return out
+}
+
+type streamLayout struct {
+	lits, starts, lengths, refs []uint32
+	commands                    []string
+}
+
 func layoutStream(c streamCase) streamLayout {
- r:=streamLayout{}
- for _,clause:=range c.Database {r.starts=append(r.starts,uint32(len(r.lits)));r.lengths=append(r.lengths,uint32(len(clause)));for _,lit:=range clause {r.lits=append(r.lits,oakLiteral(lit))}}
- for _,cmd:=range c.Commands {
-  start,refstart:=len(r.lits),len(r.refs);count:=0;action:="true"
-  if cmd.Kind=="delete" {action="false";r.refs=append(r.refs,cmd.IDs...)} else {
-   count=len(cmd.Clause);for _,lit:=range cmd.Clause {r.lits=append(r.lits,oakLiteral(lit))}
-   for _,hint:=range cmd.Hints {encoded:=uint32(0);if hint>0 {encoded=uint32(hint)};r.refs=append(r.refs,encoded)}
-  }
-  r.commands=append(r.commands,fmt.Sprintf("RUPCommand { addition: %s, id: u32(%d), start: u32(%d), count: u32(%d), refs_start: u32(%d), refs_count: u32(%d) }",action,cmd.ID,start,count,refstart,len(r.refs)-refstart))
- }
- return r
+	r := streamLayout{}
+	for _, clause := range c.Database {
+		r.starts = append(r.starts, uint32(len(r.lits)))
+		r.lengths = append(r.lengths, uint32(len(clause)))
+		for _, lit := range clause {
+			r.lits = append(r.lits, oakLiteral(lit))
+		}
+	}
+	for _, cmd := range c.Commands {
+		start, refstart := len(r.lits), len(r.refs)
+		count := 0
+		action := "true"
+		if cmd.Kind == "delete" {
+			action = "false"
+			r.refs = append(r.refs, cmd.IDs...)
+		} else {
+			count = len(cmd.Clause)
+			for _, lit := range cmd.Clause {
+				r.lits = append(r.lits, oakLiteral(lit))
+			}
+			for _, hint := range cmd.Hints {
+				encoded := uint32(0)
+				if hint > 0 {
+					encoded = uint32(hint)
+				}
+				r.refs = append(r.refs, encoded)
+			}
+		}
+		r.commands = append(r.commands, fmt.Sprintf("RUPCommand { addition: %s, id: u32(%d), start: u32(%d), count: u32(%d), refs_start: u32(%d), refs_count: u32(%d) }", action, cmd.ID, start, count, refstart, len(r.refs)-refstart))
+	}
+	return r
 }
-func emitStreamCase(b *strings.Builder,c streamCase,mutation string,expected bool) {
- r:=layoutStream(c)
- 
- for _,a:=range []struct{name string; values []uint32}{{"pool",r.lits},{"initial",r.starts},{"sizes",r.lengths},{"refs",r.refs}} {
-  capacity:=len(a.values);if capacity==0 {capacity=1}
-  fmt.Fprintf(b,"%s: [%d]u32\n",a.name,capacity)
-  for i,v:=range a.values {fmt.Fprintf(b,"%s[%d] = u32(%d)\n",a.name,i,v)}
- }
- capacity:=len(r.commands);if capacity==0 {capacity=1}
- fmt.Fprintf(b,"commands: [%d]RUPCommand\n",capacity)
- for i,cmd:=range r.commands {fmt.Fprintf(b,"commands[%d] = %s\n",i,cmd)}
- fmt.Fprintf(b,"nvars: u32 = %d\n",c.Variables)
- b.WriteString(mutation)
- fmt.Fprintf(b,"pool_view: []u32 = pool[0:%d]\ninitial_view: []u32 = initial[0:%d]\nsizes_view: []u32 = sizes[0:%d]\nrefs_view: []u32 = refs[0:%d]\ncommands_view: []RUPCommand = commands[0:%d]\n",len(r.lits),len(r.starts),len(r.lengths),len(r.refs),len(r.commands))
- fmt.Fprintln(b,"result: Bool = rup_stream_check(pool_view, initial_view, sizes_view, refs_view, commands_view, nvars)")
- fmt.Fprintf(b,"assert(result == %t)\n",expected)
+func emitStreamCase(b *strings.Builder, c streamCase, mutation string, expected bool) {
+	r := layoutStream(c)
+
+	for _, a := range []struct {
+		name   string
+		values []uint32
+	}{{"pool", r.lits}, {"initial", r.starts}, {"sizes", r.lengths}, {"refs", r.refs}} {
+		capacity := len(a.values)
+		if capacity == 0 {
+			capacity = 1
+		}
+		fmt.Fprintf(b, "%s: [%d]u32\n", a.name, capacity)
+		for i, v := range a.values {
+			fmt.Fprintf(b, "%s[%d] = u32(%d)\n", a.name, i, v)
+		}
+	}
+	capacity := len(r.commands)
+	if capacity == 0 {
+		capacity = 1
+	}
+	fmt.Fprintf(b, "commands: [%d]RUPCommand\n", capacity)
+	for i, cmd := range r.commands {
+		fmt.Fprintf(b, "commands[%d] = %s\n", i, cmd)
+	}
+	fmt.Fprintf(b, "nvars: u32 = %d\n", c.Variables)
+	b.WriteString(mutation)
+	fmt.Fprintf(b, "pool_view: []u32 = pool[0:%d]\ninitial_view: []u32 = initial[0:%d]\nsizes_view: []u32 = sizes[0:%d]\nrefs_view: []u32 = refs[0:%d]\ncommands_view: []RUPCommand = commands[0:%d]\n", len(r.lits), len(r.starts), len(r.lengths), len(r.refs), len(r.commands))
+	fmt.Fprintln(b, "result: Bool = rup_stream_check(pool_view, initial_view, sizes_view, refs_view, commands_view, nvars)")
+	fmt.Fprintf(b, "assert(result == %t)\n", expected)
 }
-func runOakStreamUnit(t *testing.T,source string) {
- t.Helper();cc,err:=exec.LookPath("cc");if err!=nil {t.Fatal("C compiler required for Oak stream checks")}
- generated,err:=compiler.New().WithSource("self_hosted_stream_test.oak",source).EmitC().Get();if err!=nil {t.Fatalf("Oak stream compile: %v",err)}
- for _,bad:=range []string{"malloc(","calloc(","realloc(","OAK_UNSUPPORTED"} {if at:=strings.Index(generated,bad);at>=0 {start:=at-180;if start<0 {start=0};end:=at+400;if end>len(generated) {end=len(generated)};t.Fatalf("unexpected %s in generated checker: %s",bad,generated[start:end])}}
- dir:=t.TempDir();cpath:=filepath.Join(dir,"stream.c");bin:=filepath.Join(dir,"stream")
- if err:=os.WriteFile(cpath,[]byte(generated),0644);err!=nil {t.Fatal(err)}
- ctx,cancel:=context.WithTimeout(context.Background(),90*time.Second);defer cancel()
- if output,err:=exec.CommandContext(ctx,cc,"-std=c99","-O1",cpath,"-o",bin).CombinedOutput();err!=nil {t.Fatalf("C compile: %v\n%s",err,output)}
- runctx,stop:=context.WithTimeout(context.Background(),15*time.Second);defer stop()
- output,err:=exec.CommandContext(runctx,bin).CombinedOutput()
- code:=0;if err!=nil {if e,ok:=err.(*exec.ExitError);ok {code=e.ExitCode()} else {t.Fatal(err)}}
- if runctx.Err()!=nil || code!=42 {t.Fatalf("Oak stream exit %d, want 42: %v\n%s",code,runctx.Err(),output)}
+func runOakStreamUnit(t *testing.T, source string) {
+	t.Helper()
+	cc, err := exec.LookPath("cc")
+	if err != nil {
+		t.Fatal("C compiler required for Oak stream checks")
+	}
+	generated, err := compiler.New().WithSource("self_hosted_stream_test.oak", source).EmitC().Get()
+	if err != nil {
+		t.Fatalf("Oak stream compile: %v", err)
+	}
+	for _, bad := range []string{"malloc(", "calloc(", "realloc(", "OAK_UNSUPPORTED"} {
+		if at := strings.Index(generated, bad); at >= 0 {
+			start := at - 180
+			if start < 0 {
+				start = 0
+			}
+			end := at + 400
+			if end > len(generated) {
+				end = len(generated)
+			}
+			t.Fatalf("unexpected %s in generated checker: %s", bad, generated[start:end])
+		}
+	}
+	dir := t.TempDir()
+	cpath := filepath.Join(dir, "stream.c")
+	bin := filepath.Join(dir, "stream")
+	if err := os.WriteFile(cpath, []byte(generated), 0644); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	if output, err := exec.CommandContext(ctx, cc, "-std=c99", "-O1", cpath, "-o", bin).CombinedOutput(); err != nil {
+		t.Fatalf("C compile: %v\n%s", err, output)
+	}
+	runctx, stop := context.WithTimeout(context.Background(), 15*time.Second)
+	defer stop()
+	output, err := exec.CommandContext(runctx, bin).CombinedOutput()
+	code := 0
+	if err != nil {
+		if e, ok := err.(*exec.ExitError); ok {
+			code = e.ExitCode()
+		} else {
+			t.Fatal(err)
+		}
+	}
+	if runctx.Err() != nil || code != 42 {
+		t.Fatalf("Oak stream exit %d, want 42: %v\n%s", code, runctx.Err(), output)
+	}
 }
 func TestSelfHostedProofStreams(t *testing.T) {
- rup,err:=os.ReadFile("self_hosted_rup.oak");if err!=nil {t.Fatal(err)}
- stream,err:=os.ReadFile("self_hosted_stream.oak");if err!=nil {t.Fatal(err)}
- corpus:=streamCorpus(t);accepted:=0
- var source, main strings.Builder;source.Write(rup);source.Write(stream);main.WriteString("\nmain: (): i32 {\n")
- caseIndex:=0
- emit:=func(c streamCase,mutation string,expected bool) {fmt.Fprintf(&source,"\nstream_case_%d: (): Bool {\n",caseIndex);emitStreamCase(&source,c,mutation,expected);source.WriteString("true\n}\n");fmt.Fprintf(&main,"assert(stream_case_%d())\n",caseIndex);caseIndex++}
- for _,c:=range corpus {emit(c,"",c.Expected);if c.Expected {accepted++}}
- // Raw representation and resource failures are separate from semantic parity.
- base:=corpus[0]
- mutations:=[]string{"nvars = u32(0)\n","nvars = u32(65)\n","initial[0] = u32(4294967295)\n","sizes[0] = u32(4294967295)\n","commands[0].start = u32(4294967295)\n","commands[0].count = u32(4294967295)\n","commands[0].refs_start = u32(4294967295)\n","commands[0].refs_count = u32(4294967295)\n","commands[0].id = u32(257)\n","pool[0] = u32(4294967295)\n","refs[0] = u32(257)\n"}
- for _,mutation:=range mutations {emit(base,mutation,false)}
- main.WriteString("42\n}\n");source.WriteString(main.String());runOakStream(t,source.String())
- if path:=os.Getenv("OAK_SELF_HOSTED_STREAM_CORPUS_OUT");path!="" {data,err:=json.MarshalIndent(corpus,"","  ");if err!=nil {t.Fatal(err)};if err:=os.WriteFile(path,append(data,'\n'),0644);err!=nil {t.Fatal(err)}}
- t.Logf("Oak/Go proof-stream agreement: %d cases (%d accepted, %d rejected); %d malformed/resource cases rejected",len(corpus),accepted,len(corpus)-accepted,len(mutations))
+	rup, err := os.ReadFile("self_hosted_rup.oak")
+	if err != nil {
+		t.Fatal(err)
+	}
+	stream, err := os.ReadFile("self_hosted_stream.oak")
+	if err != nil {
+		t.Fatal(err)
+	}
+	corpus := streamCorpus(t)
+	accepted := 0
+	var source, main strings.Builder
+	source.Write(rup)
+	source.Write(stream)
+	main.WriteString("\nmain: (): i32 {\n")
+	caseIndex := 0
+	emit := func(c streamCase, mutation string, expected bool) {
+		fmt.Fprintf(&source, "\nstream_case_%d: (): Bool {\n", caseIndex)
+		emitStreamCase(&source, c, mutation, expected)
+		source.WriteString("true\n}\n")
+		fmt.Fprintf(&main, "assert(stream_case_%d())\n", caseIndex)
+		caseIndex++
+	}
+	for _, c := range corpus {
+		emit(c, "", c.Expected)
+		if c.Expected {
+			accepted++
+		}
+	}
+	// Raw representation and resource failures are separate from semantic parity.
+	base := corpus[0]
+	mutations := []string{"nvars = u32(0)\n", "nvars = u32(65)\n", "initial[0] = u32(4294967295)\n", "sizes[0] = u32(4294967295)\n", "commands[0].start = u32(4294967295)\n", "commands[0].count = u32(4294967295)\n", "commands[0].refs_start = u32(4294967295)\n", "commands[0].refs_count = u32(4294967295)\n", "commands[0].id = u32(257)\n", "pool[0] = u32(4294967295)\n", "refs[0] = u32(257)\n"}
+	for _, mutation := range mutations {
+		emit(base, mutation, false)
+	}
+	main.WriteString("42\n}\n")
+	source.WriteString(main.String())
+	runOakStream(t, source.String())
+	if path := os.Getenv("OAK_SELF_HOSTED_STREAM_CORPUS_OUT"); path != "" {
+		data, err := json.MarshalIndent(corpus, "", "  ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, append(data, '\n'), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Logf("Oak/Go proof-stream agreement: %d cases (%d accepted, %d rejected); %d malformed/resource cases rejected", len(corpus), accepted, len(corpus)-accepted, len(mutations))
 }

--- a/experiments/verification-poc/self_hosted_table_test.go
+++ b/experiments/verification-poc/self_hosted_table_test.go
@@ -1,70 +1,137 @@
 package main
 
 import (
- "encoding/json"
- "fmt"
- "os"
- "strings"
- "testing"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
 
- "github.com/SCKelemen/oak/experiments/verification-poc/internal/lrat"
+	"github.com/SCKelemen/oak/experiments/verification-poc/internal/lrat"
 )
 
 type tableCase struct {
- rangeCase
- Trace []uint32 `json:"trace"`
+	rangeCase
+	Trace []uint32 `json:"trace"`
 }
-type tableEntry struct { start,count uint32; live bool }
+type tableEntry struct {
+	start, count uint32
+	live         bool
+}
 
 // A map of logical clauses is independent of the observed Oak metadata arrays.
 // RUP uses the existing Go checker after compacting live IDs and translating hints.
 func tableReference(c rangeCase) []uint32 {
- entries:=make([]tableEntry,256);db:=map[uint32][]int{}
- last:=uint32(len(c.Starts));refuted:=false
- valid:=c.Variables>0&&c.Variables<=64&&len(c.Pool)<=4096&&len(c.Refs)<=4096&&len(c.Starts)==len(c.Sizes)&&len(c.Starts)<=256&&len(c.Commands)<=256
- for _,n:=range c.Pool {if n/2>=c.Variables {valid=false}}
- decode:=func(items []uint32) []int {out:=[]int{};for _,n:=range items {out=append(out,rangeLiteral(n))};return out}
- for i,start:=range c.Starts {
-  if !valid {break};items,ok:=rangeSlice(c.Pool,start,c.Sizes[i]);valid=ok
-  if ok {entries[i]=tableEntry{start,c.Sizes[i],true};db[uint32(i+1)]=decode(items);refuted=refuted||len(items)==0}
- }
- out:=[]uint32{}
- bit:=func(b bool) uint32 {if b {return 1};return 0}
- snapshot:=func(){out=append(out,last,bit(refuted),bit(valid));for _,e:=range entries {out=append(out,e.start,e.count,bit(e.live))}}
- snapshot()
- for _,cmd:=range c.Commands {
-  if !valid {break}
-  refs,ok:=rangeSlice(c.Refs,cmd.RefsStart,cmd.RefsCount);valid=cmd.ID<=2147483647&&ok
-  if valid&&cmd.Addition {
-   items,rangeOK:=rangeSlice(c.Pool,cmd.Start,cmd.Count)
-   valid=cmd.ID>last&&cmd.ID<=256&&rangeOK&&cmd.RefsCount<=256
-   clauses:=[][]int{};mapping:=map[uint32]int{}
-   for id:=uint32(1);id<=256;id++ {if clause,present:=db[id];present {clauses=append(clauses,clause);mapping[id]=len(clauses)}}
-   hints:=[]int{}
-   for _,id:=range refs {mapped,present:=mapping[id];if !present {valid=false};hints=append(hints,mapped)}
-   if valid {valid=lrat.CheckRUPDecoded(int(c.Variables),clauses,decode(items),hints)==nil}
-   if valid {entries[cmd.ID-1]=tableEntry{cmd.Start,cmd.Count,true};db[cmd.ID]=decode(items);last=cmd.ID;refuted=refuted||len(items)==0}
-  } else if valid {
-   valid=cmd.ID>=last
-   for _,id:=range refs {
-    if !valid {break};_,present:=db[id];valid=present
-    if id>0&&id<=256 {entries[id-1].live=false};delete(db,id)
-   }
-  }
-  snapshot()
- }
- return out
+	entries := make([]tableEntry, 256)
+	db := map[uint32][]int{}
+	last := uint32(len(c.Starts))
+	refuted := false
+	valid := c.Variables > 0 && c.Variables <= 64 && len(c.Pool) <= 4096 && len(c.Refs) <= 4096 && len(c.Starts) == len(c.Sizes) && len(c.Starts) <= 256 && len(c.Commands) <= 256
+	for _, n := range c.Pool {
+		if n/2 >= c.Variables {
+			valid = false
+		}
+	}
+	decode := func(items []uint32) []int {
+		out := []int{}
+		for _, n := range items {
+			out = append(out, rangeLiteral(n))
+		}
+		return out
+	}
+	for i, start := range c.Starts {
+		if !valid {
+			break
+		}
+		items, ok := rangeSlice(c.Pool, start, c.Sizes[i])
+		valid = ok
+		if ok {
+			entries[i] = tableEntry{start, c.Sizes[i], true}
+			db[uint32(i+1)] = decode(items)
+			refuted = refuted || len(items) == 0
+		}
+	}
+	out := []uint32{}
+	bit := func(b bool) uint32 {
+		if b {
+			return 1
+		}
+		return 0
+	}
+	snapshot := func() {
+		out = append(out, last, bit(refuted), bit(valid))
+		for _, e := range entries {
+			out = append(out, e.start, e.count, bit(e.live))
+		}
+	}
+	snapshot()
+	for _, cmd := range c.Commands {
+		if !valid {
+			break
+		}
+		refs, ok := rangeSlice(c.Refs, cmd.RefsStart, cmd.RefsCount)
+		valid = cmd.ID <= 2147483647 && ok
+		if valid && cmd.Addition {
+			items, rangeOK := rangeSlice(c.Pool, cmd.Start, cmd.Count)
+			valid = cmd.ID > last && cmd.ID <= 256 && rangeOK && cmd.RefsCount <= 256
+			clauses := [][]int{}
+			mapping := map[uint32]int{}
+			for id := uint32(1); id <= 256; id++ {
+				if clause, present := db[id]; present {
+					clauses = append(clauses, clause)
+					mapping[id] = len(clauses)
+				}
+			}
+			hints := []int{}
+			for _, id := range refs {
+				mapped, present := mapping[id]
+				if !present {
+					valid = false
+				}
+				hints = append(hints, mapped)
+			}
+			if valid {
+				valid = lrat.CheckRUPDecoded(int(c.Variables), clauses, decode(items), hints) == nil
+			}
+			if valid {
+				entries[cmd.ID-1] = tableEntry{cmd.Start, cmd.Count, true}
+				db[cmd.ID] = decode(items)
+				last = cmd.ID
+				refuted = refuted || len(items) == 0
+			}
+		} else if valid {
+			valid = cmd.ID >= last
+			for _, id := range refs {
+				if !valid {
+					break
+				}
+				_, present := db[id]
+				valid = present
+				if id > 0 && id <= 256 {
+					entries[id-1].live = false
+				}
+				delete(db, id)
+			}
+		}
+		snapshot()
+	}
+	return out
 }
 
-func tableInstrument(t *testing.T,source string) string {
- t.Helper()
- replace:=func(old,next string){if strings.Count(source,old)!=1 {t.Fatalf("live-table observation seam changed: %q",old)};source=strings.Replace(source,old,next,1)}
- replace("  variables: u32\n): Bool {","  variables: u32,\n  expected: []u32,\n  expected_accepted: Bool\n): Bool {")
- observation:="  trace_ok = table_observe(view(&starts), view(&lengths), view(&live), last, refuted, valid, expected, trace_cursor) && trace_ok\n  trace_cursor = trace_cursor + u32(771)\n"
- replace("  c: u32 = 0\n","  c: u32 = 0\n  trace_ok: Bool = true\n  trace_cursor: u32 = 0\n"+observation)
- replace("    c = c + u32(1)\n","    c = c + u32(1)\n"+observation)
- replace("  valid && refuted\n}","  trace_ok && trace_cursor == len(expected) && (valid && refuted) == expected_accepted\n}")
- return source+`
+func tableInstrument(t *testing.T, source string) string {
+	t.Helper()
+	replace := func(old, next string) {
+		if strings.Count(source, old) != 1 {
+			t.Fatalf("live-table observation seam changed: %q", old)
+		}
+		source = strings.Replace(source, old, next, 1)
+	}
+	replace("  variables: u32\n): Bool {", "  variables: u32,\n  expected: []u32,\n  expected_accepted: Bool\n): Bool {")
+	observation := "  trace_ok = table_observe(view(&starts), view(&lengths), view(&live), last, refuted, valid, expected, trace_cursor) && trace_ok\n  trace_cursor = trace_cursor + u32(771)\n"
+	replace("  c: u32 = 0\n", "  c: u32 = 0\n  trace_ok: Bool = true\n  trace_cursor: u32 = 0\n"+observation)
+	replace("    c = c + u32(1)\n", "    c = c + u32(1)\n"+observation)
+	replace("  valid && refuted\n}", "  trace_ok && trace_cursor == len(expected) && (valid && refuted) == expected_accepted\n}")
+	return source + `
 // Test-only observer. It cannot change the checker's table or control flags.
 table_observe: (starts: []u32, sizes: []u32, live: []Bool,
   last: u32, refuted: Bool, valid: Bool, expected: []u32, offset: u32): Bool {
@@ -84,32 +151,74 @@ table_observe: (starts: []u32, sizes: []u32, live: []Bool,
 }
 
 func TestSelfHostedLiveTable(t *testing.T) {
- cases:=[]tableCase{};snapshots:=0
- for _,c:=range rangeCorpus(t) {
-  trace:=tableReference(c);last:=trace[len(trace)-771:]
-  if (last[1]==1&&last[2]==1)!=c.Accepted {t.Fatalf("%s: table oracle changed acceptance",c.Name)}
-  cases=append(cases,tableCase{c,trace});snapshots+=len(trace)/771
- }
- var source,main strings.Builder
- kernel,err:=os.ReadFile("self_hosted_rup.oak");if err!=nil {t.Fatal(err)};source.Write(kernel);source.WriteByte('\n')
- stream,err:=os.ReadFile("self_hosted_stream.oak");if err!=nil {t.Fatal(err)};source.WriteString(tableInstrument(t,string(stream)))
- main.WriteString("main: (): i32 {\n")
- emit:=func(i int,c tableCase,want bool){
-  fmt.Fprintf(&source,"table_case_%d: (): Bool {\n",i)
-  for _,a:=range []struct{name string;items []uint32}{{"pool",c.Pool},{"starts",c.Starts},{"sizes",c.Sizes},{"refs",c.Refs},{"expected",c.Trace}} {emitBufferArray(&source,a.name,"u32",a.items)}
-  capacity:=len(c.Commands);if capacity==0 {capacity=1};fmt.Fprintf(&source,"commands: [%d]RUPCommand\n",capacity)
-  for j,r:=range c.Commands {fmt.Fprintf(&source,"commands[%d] = RUPCommand { addition: %t, id: u32(%d), start: u32(%d), count: u32(%d), refs_start: u32(%d), refs_count: u32(%d) }\n",j,r.Addition,r.ID,r.Start,r.Count,r.RefsStart,r.RefsCount)}
-  fmt.Fprintf(&source,"command_view: []RUPCommand = commands[0:%d]\nrup_stream_check(pool_view, starts_view, sizes_view, refs_view, command_view, u32(%d), expected_view, %t) == %t\n}\n",len(c.Commands),c.Variables,c.Accepted,want)
-  fmt.Fprintf(&main,"assert(table_case_%d())\n",i)
- }
- for i,c:=range cases {emit(i,c,true)}
- // Make sure missing snapshots and corrupt metadata/control bits cannot pass the observer.
- for i,field:=range []int{0,1,2,3,4,5,-1} {
-  c:=cases[0];c.Trace=append([]uint32{},c.Trace...)
-  if field<0 {c.Trace=c.Trace[:len(c.Trace)-771]} else {c.Trace[field]^=1}
-  emit(len(cases)+i,c,false)
- }
- main.WriteString("42\n}\n");source.WriteString(main.String());runOakStream(t,source.String())
- if path:=os.Getenv("OAK_TABLE_CORPUS_OUT");path!="" {data,err:=json.MarshalIndent(cases,"","  ");if err!=nil {t.Fatal(err)};if err:=os.WriteFile(path,append(data,'\n'),0644);err!=nil {t.Fatal(err)}}
- t.Logf("Oak/Go live table: %d layouts, %d complete 256-slot snapshots, 7 observer corruptions rejected",len(cases),snapshots)
+	cases := []tableCase{}
+	snapshots := 0
+	for _, c := range rangeCorpus(t) {
+		trace := tableReference(c)
+		last := trace[len(trace)-771:]
+		if (last[1] == 1 && last[2] == 1) != c.Accepted {
+			t.Fatalf("%s: table oracle changed acceptance", c.Name)
+		}
+		cases = append(cases, tableCase{c, trace})
+		snapshots += len(trace) / 771
+	}
+	var source, main strings.Builder
+	kernel, err := os.ReadFile("self_hosted_rup.oak")
+	if err != nil {
+		t.Fatal(err)
+	}
+	source.Write(kernel)
+	source.WriteByte('\n')
+	stream, err := os.ReadFile("self_hosted_stream.oak")
+	if err != nil {
+		t.Fatal(err)
+	}
+	source.WriteString(tableInstrument(t, string(stream)))
+	main.WriteString("main: (): i32 {\n")
+	emit := func(i int, c tableCase, want bool) {
+		fmt.Fprintf(&source, "table_case_%d: (): Bool {\n", i)
+		for _, a := range []struct {
+			name  string
+			items []uint32
+		}{{"pool", c.Pool}, {"starts", c.Starts}, {"sizes", c.Sizes}, {"refs", c.Refs}, {"expected", c.Trace}} {
+			emitBufferArray(&source, a.name, "u32", a.items)
+		}
+		capacity := len(c.Commands)
+		if capacity == 0 {
+			capacity = 1
+		}
+		fmt.Fprintf(&source, "commands: [%d]RUPCommand\n", capacity)
+		for j, r := range c.Commands {
+			fmt.Fprintf(&source, "commands[%d] = RUPCommand { addition: %t, id: u32(%d), start: u32(%d), count: u32(%d), refs_start: u32(%d), refs_count: u32(%d) }\n", j, r.Addition, r.ID, r.Start, r.Count, r.RefsStart, r.RefsCount)
+		}
+		fmt.Fprintf(&source, "command_view: []RUPCommand = commands[0:%d]\nrup_stream_check(pool_view, starts_view, sizes_view, refs_view, command_view, u32(%d), expected_view, %t) == %t\n}\n", len(c.Commands), c.Variables, c.Accepted, want)
+		fmt.Fprintf(&main, "assert(table_case_%d())\n", i)
+	}
+	for i, c := range cases {
+		emit(i, c, true)
+	}
+	// Make sure missing snapshots and corrupt metadata/control bits cannot pass the observer.
+	for i, field := range []int{0, 1, 2, 3, 4, 5, -1} {
+		c := cases[0]
+		c.Trace = append([]uint32{}, c.Trace...)
+		if field < 0 {
+			c.Trace = c.Trace[:len(c.Trace)-771]
+		} else {
+			c.Trace[field] ^= 1
+		}
+		emit(len(cases)+i, c, false)
+	}
+	main.WriteString("42\n}\n")
+	source.WriteString(main.String())
+	runOakStream(t, source.String())
+	if path := os.Getenv("OAK_TABLE_CORPUS_OUT"); path != "" {
+		data, err := json.MarshalIndent(cases, "", "  ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, append(data, '\n'), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Logf("Oak/Go live table: %d layouts, %d complete 256-slot snapshots, 7 observer corruptions rejected", len(cases), snapshots)
 }

--- a/experiments/verification-poc/self_hosted_text_test.go
+++ b/experiments/verification-poc/self_hosted_text_test.go
@@ -1,123 +1,211 @@
 package main
 
 import (
- "encoding/json"
- "fmt"
- "os"
- "strings"
- "testing"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
 
- "github.com/SCKelemen/oak/experiments/verification-poc/internal/lrat"
+	"github.com/SCKelemen/oak/experiments/verification-poc/internal/lrat"
 )
 
 type oakTextCase struct {
- Name string `json:"name"`
- CNF string `json:"cnf"`
- Proof string `json:"proof"`
- Expected bool `json:"expected"`
+	Name     string `json:"name"`
+	CNF      string `json:"cnf"`
+	Proof    string `json:"proof"`
+	Expected bool   `json:"expected"`
 }
-func streamText(c streamCase) (string,string) {
- var cnf,proof strings.Builder
- fmt.Fprintf(&cnf,"p cnf %d %d\n",c.Variables,len(c.Database))
- for _,clause:=range c.Database {for _,lit:=range clause {fmt.Fprintf(&cnf,"%d ",lit)};cnf.WriteString("0\n")}
- for _,cmd:=range c.Commands {
-  fmt.Fprintf(&proof,"%d ",cmd.ID)
-  if cmd.Kind=="delete" {proof.WriteString("d ");for _,id:=range cmd.IDs {fmt.Fprintf(&proof,"%d ",id)}} else {
-   for _,lit:=range cmd.Clause {fmt.Fprintf(&proof,"%d ",lit)};proof.WriteString("0 ")
-   for _,id:=range cmd.Hints {fmt.Fprintf(&proof,"%d ",id)}
-  };proof.WriteString("0\n")
- }
- return cnf.String(),proof.String()
+
+func streamText(c streamCase) (string, string) {
+	var cnf, proof strings.Builder
+	fmt.Fprintf(&cnf, "p cnf %d %d\n", c.Variables, len(c.Database))
+	for _, clause := range c.Database {
+		for _, lit := range clause {
+			fmt.Fprintf(&cnf, "%d ", lit)
+		}
+		cnf.WriteString("0\n")
+	}
+	for _, cmd := range c.Commands {
+		fmt.Fprintf(&proof, "%d ", cmd.ID)
+		if cmd.Kind == "delete" {
+			proof.WriteString("d ")
+			for _, id := range cmd.IDs {
+				fmt.Fprintf(&proof, "%d ", id)
+			}
+		} else {
+			for _, lit := range cmd.Clause {
+				fmt.Fprintf(&proof, "%d ", lit)
+			}
+			proof.WriteString("0 ")
+			for _, id := range cmd.Hints {
+				fmt.Fprintf(&proof, "%d ", id)
+			}
+		}
+		proof.WriteString("0\n")
+	}
+	return cnf.String(), proof.String()
 }
 func oakTextCorpus(t *testing.T) []oakTextCase {
- t.Helper();out:=[]oakTextCase{}
- add:=func(name,cnf,proof string) {_,err:=lrat.Check(cnf,proof);out=append(out,oakTextCase{name,cnf,proof,err==nil})}
- for _,c:=range streamCorpus(t) {cnf,proof:=streamText(c);add("stream-"+c.Name,cnf,proof)}
- cnf,proof:="p cnf 1 2\n1 0\n-1 0\n","3 0 1 2 0\n"
- for i,input:=range []string{
-  "", "1 0\n", "p cnf 1 2", "p cnf 1 1\n1 0 -1 0", "p cnf 1 2\n1 0 -1", "p cnf 1 2\n1 0 -2 0",
-  "p cnf 1 2 extra\n1 0 -1 0", "p cnf\n1 2\n1 0 -1 0", cnf+"p cnf 1 2\n", cnf+"garbage",
-  "p cnf -1 2\n1 0 -1 0", "p cnf 2147483648 2\n1 0 -1 0", "p cnf 1 -2\n1 0 -1 0",
-  "p cnf +1 +2\n+1 -0\n-1 +0", " c comment\r\np\tcnf\v1\f2\r\n1\n c between clause tokens\n0 -1 0",
-  "p cnf 1 2\n1 c inline\n0 -1 0", "p cnf 1 2\n1 0 -1 0\x00", "p cnf 1 2\n1 0 -1 0\ncomment",
-  "p cnf 1 2\n1 0 -1 0\nc final", "p cnf 1 2\n0001 00 -01 000", "p cnf 1 2\n+ 0 -1 0",
- } {add(fmt.Sprintf("cnf-%d",i),input,proof)}
- for i,input:=range []string{
-  "", "3", "3 0", "3 0 1 2", "3 0 1 2 0 extra", "3 0 1 2 0 0", "3 0 1\n2 0", "3 0 1 2 0\n4 0 0",
-  "3 0 -1 2 0", "3 0 2147483648 2 0", "2147483648 0 1 2 0", "-3 0 1 2 0", "3 0 1 2 0\x00",
-  "+3 -0 +1 02 +0", "\tc ignored\r\n3\t0\v1\f2\t0\r\nc final", "3 0 1 2 0\n3 d 3 0",
-  "3 0 1 2 0\n3 d 3 +0", "3 0 1 2 0\n3 d 3 -0", "3 0 1 2 0\n3 d 3 00", "3 0 1 2 0\n3 d 3 0 0",
-  "3 0 1 2 0\n3 d 0", "3 0 1 2 0\n3 d 3 3 0", "3 0 1 2 0\n3 d -1 0", "3 0 1 2 0\n3 d",
-  "3 0 1 2 0\n3 d 0 1 0", "3 0 1 2 0\n2147483647 d 0", "3 0 1 2 0\n4 1 -1 2147483648 0 0",
- } {add(fmt.Sprintf("proof-%d",i),cnf,input)}
- // Every byte class appears in a numeric token and as a token separator.
- for b:=0;b<128;b++ {
-  add(fmt.Sprintf("byte-token-%d",b),cnf,"3 0 1 "+string(byte(b))+" 0")
-  add(fmt.Sprintf("byte-space-%d",b),cnf,"3"+string(byte(b))+"0 1 2 0")
- }
- return out
+	t.Helper()
+	out := []oakTextCase{}
+	add := func(name, cnf, proof string) {
+		_, err := lrat.Check(cnf, proof)
+		out = append(out, oakTextCase{name, cnf, proof, err == nil})
+	}
+	for _, c := range streamCorpus(t) {
+		cnf, proof := streamText(c)
+		add("stream-"+c.Name, cnf, proof)
+	}
+	cnf, proof := "p cnf 1 2\n1 0\n-1 0\n", "3 0 1 2 0\n"
+	for i, input := range []string{
+		"", "1 0\n", "p cnf 1 2", "p cnf 1 1\n1 0 -1 0", "p cnf 1 2\n1 0 -1", "p cnf 1 2\n1 0 -2 0",
+		"p cnf 1 2 extra\n1 0 -1 0", "p cnf\n1 2\n1 0 -1 0", cnf + "p cnf 1 2\n", cnf + "garbage",
+		"p cnf -1 2\n1 0 -1 0", "p cnf 2147483648 2\n1 0 -1 0", "p cnf 1 -2\n1 0 -1 0",
+		"p cnf +1 +2\n+1 -0\n-1 +0", " c comment\r\np\tcnf\v1\f2\r\n1\n c between clause tokens\n0 -1 0",
+		"p cnf 1 2\n1 c inline\n0 -1 0", "p cnf 1 2\n1 0 -1 0\x00", "p cnf 1 2\n1 0 -1 0\ncomment",
+		"p cnf 1 2\n1 0 -1 0\nc final", "p cnf 1 2\n0001 00 -01 000", "p cnf 1 2\n+ 0 -1 0",
+	} {
+		add(fmt.Sprintf("cnf-%d", i), input, proof)
+	}
+	for i, input := range []string{
+		"", "3", "3 0", "3 0 1 2", "3 0 1 2 0 extra", "3 0 1 2 0 0", "3 0 1\n2 0", "3 0 1 2 0\n4 0 0",
+		"3 0 -1 2 0", "3 0 2147483648 2 0", "2147483648 0 1 2 0", "-3 0 1 2 0", "3 0 1 2 0\x00",
+		"+3 -0 +1 02 +0", "\tc ignored\r\n3\t0\v1\f2\t0\r\nc final", "3 0 1 2 0\n3 d 3 0",
+		"3 0 1 2 0\n3 d 3 +0", "3 0 1 2 0\n3 d 3 -0", "3 0 1 2 0\n3 d 3 00", "3 0 1 2 0\n3 d 3 0 0",
+		"3 0 1 2 0\n3 d 0", "3 0 1 2 0\n3 d 3 3 0", "3 0 1 2 0\n3 d -1 0", "3 0 1 2 0\n3 d",
+		"3 0 1 2 0\n3 d 0 1 0", "3 0 1 2 0\n2147483647 d 0", "3 0 1 2 0\n4 1 -1 2147483648 0 0",
+	} {
+		add(fmt.Sprintf("proof-%d", i), cnf, input)
+	}
+	// Every byte class appears in a numeric token and as a token separator.
+	for b := 0; b < 128; b++ {
+		add(fmt.Sprintf("byte-token-%d", b), cnf, "3 0 1 "+string(byte(b))+" 0")
+		add(fmt.Sprintf("byte-space-%d", b), cnf, "3"+string(byte(b))+"0 1 2 0")
+	}
+	return out
 }
-func runOakTextCases(t *testing.T,cases []oakTextCase) {
- t.Helper()
- var source,main strings.Builder
- for _,path:=range []string{"self_hosted_rup.oak","self_hosted_stream.oak","self_hosted_text.oak"} {data,err:=os.ReadFile(path);if err!=nil {t.Fatal(err)};source.Write(data);source.WriteByte('\n')}
- main.WriteString("main: (): i32 {\n")
- for i,c:=range cases {
-  fmt.Fprintf(&source,"text_case_%d: (): Bool {\n",i)
-  for _,a:=range []struct{name,text string}{{"cnf",c.CNF},{"proof",c.Proof}} {
-   capacity:=len(a.text);if capacity==0 {capacity=1}
-   fmt.Fprintf(&source,"%s: [%d]u8\n",a.name,capacity)
-   // Compress repeated bytes (including resource-limit inputs) into loops.
-   for begin:=0;begin<len(a.text); {
-    end:=begin+1;for end<len(a.text)&&a.text[end]==a.text[begin] {end++}
-    if end-begin>8 {fmt.Fprintf(&source,"%s_i_%d: u32 = %d\nwhile %s_i_%d < u32(%d) { %s[%s_i_%d] = u8(%d); %s_i_%d = %s_i_%d + u32(1) }\n",a.name,begin,begin,a.name,begin,end,a.name,a.name,begin,a.text[begin],a.name,begin,a.name,begin)} else {for j:=begin;j<end;j++ {fmt.Fprintf(&source,"%s[%d] = u8(%d)\n",a.name,j,a.text[j])}}
-    begin=end
-   }
-   fmt.Fprintf(&source,"%s_view: []u8 = %s[0:%d]\n",a.name,a.name,len(a.text))
-  }
-  fmt.Fprintf(&source,"rup_text_check(cnf_view, proof_view) == %t\n}\n",c.Expected)
-  // C assertion diagnostics retain the generated case function number.
-  fmt.Fprintf(&main,"assert(text_case_%d())\n",i)
- }
- main.WriteString("42\n}\n");source.WriteString(main.String());runOakStream(t,source.String())
+func runOakTextCases(t *testing.T, cases []oakTextCase) {
+	t.Helper()
+	var source, main strings.Builder
+	for _, path := range []string{"self_hosted_rup.oak", "self_hosted_stream.oak", "self_hosted_text.oak"} {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		source.Write(data)
+		source.WriteByte('\n')
+	}
+	main.WriteString("main: (): i32 {\n")
+	for i, c := range cases {
+		fmt.Fprintf(&source, "text_case_%d: (): Bool {\n", i)
+		for _, a := range []struct{ name, text string }{{"cnf", c.CNF}, {"proof", c.Proof}} {
+			capacity := len(a.text)
+			if capacity == 0 {
+				capacity = 1
+			}
+			fmt.Fprintf(&source, "%s: [%d]u8\n", a.name, capacity)
+			// Compress repeated bytes (including resource-limit inputs) into loops.
+			for begin := 0; begin < len(a.text); {
+				end := begin + 1
+				for end < len(a.text) && a.text[end] == a.text[begin] {
+					end++
+				}
+				if end-begin > 8 {
+					fmt.Fprintf(&source, "%s_i_%d: u32 = %d\nwhile %s_i_%d < u32(%d) { %s[%s_i_%d] = u8(%d); %s_i_%d = %s_i_%d + u32(1) }\n", a.name, begin, begin, a.name, begin, end, a.name, a.name, begin, a.text[begin], a.name, begin, a.name, begin)
+				} else {
+					for j := begin; j < end; j++ {
+						fmt.Fprintf(&source, "%s[%d] = u8(%d)\n", a.name, j, a.text[j])
+					}
+				}
+				begin = end
+			}
+			fmt.Fprintf(&source, "%s_view: []u8 = %s[0:%d]\n", a.name, a.name, len(a.text))
+		}
+		fmt.Fprintf(&source, "rup_text_check(cnf_view, proof_view) == %t\n}\n", c.Expected)
+		// C assertion diagnostics retain the generated case function number.
+		fmt.Fprintf(&main, "assert(text_case_%d())\n", i)
+	}
+	main.WriteString("42\n}\n")
+	source.WriteString(main.String())
+	runOakStream(t, source.String())
 }
 func TestSelfHostedText(t *testing.T) {
- cases:=oakTextCorpus(t);accepted:=0
- for _,c:=range cases {if c.Expected {accepted++}}
- runOakTextCases(t,cases)
- if path:=os.Getenv("OAK_SELF_HOSTED_TEXT_CORPUS_OUT");path!="" {data,err:=json.MarshalIndent(cases,"","  ");if err!=nil {t.Fatal(err)};if err:=os.WriteFile(path,append(data,'\n'),0644);err!=nil {t.Fatal(err)}}
- t.Logf("Oak/Go ASCII agreement: %d cases (%d accepted, %d rejected)",len(cases),accepted,len(cases)-accepted)
+	cases := oakTextCorpus(t)
+	accepted := 0
+	for _, c := range cases {
+		if c.Expected {
+			accepted++
+		}
+	}
+	runOakTextCases(t, cases)
+	if path := os.Getenv("OAK_SELF_HOSTED_TEXT_CORPUS_OUT"); path != "" {
+		data, err := json.MarshalIndent(cases, "", "  ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, append(data, '\n'), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Logf("Oak/Go ASCII agreement: %d cases (%d accepted, %d rejected)", len(cases), accepted, len(cases)-accepted)
 }
 func TestSelfHostedTextProfile(t *testing.T) {
- cnf,proof:="p cnf 1 2\n1 0 -1 0\n","3 0 1 2 0\n"
- cases:=[]oakTextCase{
-  {"zero-variables","p cnf 0 1\n0","",false},
-  {"too-many-variables","p cnf 65 1\n0","",false},
-  {"too-many-clauses","p cnf 1 257\n"+strings.Repeat("0 ",257),"",false},
-  {"large-addition-id",cnf,"257 0 1 2 0",false},
-  {"cnf-byte-limit",cnf+"c"+strings.Repeat(" ",65536),proof,false},
-  {"proof-byte-limit",cnf,proof+"c"+strings.Repeat(" ",65536),false},
-  {"non-ascii-comment",cnf+"c café",proof,false},
-  {"literal-pool-limit","p cnf 1 2\n"+strings.Repeat("1 ",4096)+"0 -1 0",proof,false},
-  {"command-limit",cnf,proof+strings.Repeat("3 d 0\n",256),false},
-  {"reference-pool-limit",cnf,proof+"3 d "+strings.Repeat("1 ",4097)+"0",false},
-  {"max-variable","p cnf 64 2\n64 0 -64 0",proof,true},
-  {"max-initial-clauses","p cnf 1 256\n"+strings.Repeat("0 ",256),"",true},
-  {"max-commands",cnf,proof+strings.Repeat("3 d 0\n",255),true},
-  {"max-literal-pool","p cnf 1 2\n"+strings.Repeat("1 ",4095)+"0 -1 0",proof,true},
- }
- runOakTextCases(t,cases)
- if path:=os.Getenv("OAK_SELF_HOSTED_TEXT_PROFILE_OUT");path!="" {data,err:=json.MarshalIndent(cases,"","  ");if err!=nil {t.Fatal(err)};if err:=os.WriteFile(path,append(data,'\n'),0644);err!=nil {t.Fatal(err)}}
- t.Logf("Oak ASCII profile: %d boundary cases passed",len(cases))
+	cnf, proof := "p cnf 1 2\n1 0 -1 0\n", "3 0 1 2 0\n"
+	cases := []oakTextCase{
+		{"zero-variables", "p cnf 0 1\n0", "", false},
+		{"too-many-variables", "p cnf 65 1\n0", "", false},
+		{"too-many-clauses", "p cnf 1 257\n" + strings.Repeat("0 ", 257), "", false},
+		{"large-addition-id", cnf, "257 0 1 2 0", false},
+		{"cnf-byte-limit", cnf + "c" + strings.Repeat(" ", 65536), proof, false},
+		{"proof-byte-limit", cnf, proof + "c" + strings.Repeat(" ", 65536), false},
+		{"non-ascii-comment", cnf + "c café", proof, false},
+		{"literal-pool-limit", "p cnf 1 2\n" + strings.Repeat("1 ", 4096) + "0 -1 0", proof, false},
+		{"command-limit", cnf, proof + strings.Repeat("3 d 0\n", 256), false},
+		{"reference-pool-limit", cnf, proof + "3 d " + strings.Repeat("1 ", 4097) + "0", false},
+		{"max-variable", "p cnf 64 2\n64 0 -64 0", proof, true},
+		{"max-initial-clauses", "p cnf 1 256\n" + strings.Repeat("0 ", 256), "", true},
+		{"max-commands", cnf, proof + strings.Repeat("3 d 0\n", 255), true},
+		{"max-literal-pool", "p cnf 1 2\n" + strings.Repeat("1 ", 4095) + "0 -1 0", proof, true},
+	}
+	runOakTextCases(t, cases)
+	if path := os.Getenv("OAK_SELF_HOSTED_TEXT_PROFILE_OUT"); path != "" {
+		data, err := json.MarshalIndent(cases, "", "  ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, append(data, '\n'), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Logf("Oak ASCII profile: %d boundary cases passed", len(cases))
 }
 func TestSelfHostedTextCertificate(t *testing.T) {
- cnfPath,proofPath:=os.Getenv("OAK_SELF_HOSTED_TEXT_CNF"),os.Getenv("OAK_SELF_HOSTED_TEXT_PROOF")
- if cnfPath==""&&proofPath=="" {t.Skip("actual certificate replay runs in the opt-in solver gate")}
- cnf,err:=os.ReadFile(cnfPath);if err!=nil {t.Fatal(err)}
- proof,err:=os.ReadFile(proofPath);if err!=nil {t.Fatal(err)}
- if _,err:=lrat.Check(string(cnf),string(proof));err!=nil {t.Fatal(err)}
- cases:=[]oakTextCase{{"actual-certificate",string(cnf),string(proof),true},{"invalid-suffix",string(cnf),string(proof)+"\n2147483647 0 0\n",false},{"wrong-formula","p cnf 1 1\n1 0\n",string(proof),false}}
- runOakTextCases(t,cases)
- if path:=os.Getenv("OAK_SELF_HOSTED_TEXT_CORPUS_OUT");path!="" {data,err:=json.MarshalIndent(cases,"","  ");if err!=nil {t.Fatal(err)};if err:=os.WriteFile(path,append(data,'\n'),0644);err!=nil {t.Fatal(err)}}
- t.Log("Oak ASCII certificate replay: 1 accepted certificate, 2 rejected corruptions")
+	cnfPath, proofPath := os.Getenv("OAK_SELF_HOSTED_TEXT_CNF"), os.Getenv("OAK_SELF_HOSTED_TEXT_PROOF")
+	if cnfPath == "" && proofPath == "" {
+		t.Skip("actual certificate replay runs in the opt-in solver gate")
+	}
+	cnf, err := os.ReadFile(cnfPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proof, err := os.ReadFile(proofPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := lrat.Check(string(cnf), string(proof)); err != nil {
+		t.Fatal(err)
+	}
+	cases := []oakTextCase{{"actual-certificate", string(cnf), string(proof), true}, {"invalid-suffix", string(cnf), string(proof) + "\n2147483647 0 0\n", false}, {"wrong-formula", "p cnf 1 1\n1 0\n", string(proof), false}}
+	runOakTextCases(t, cases)
+	if path := os.Getenv("OAK_SELF_HOSTED_TEXT_CORPUS_OUT"); path != "" {
+		data, err := json.MarshalIndent(cases, "", "  ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, append(data, '\n'), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Log("Oak ASCII certificate replay: 1 accepted certificate, 2 rejected corruptions")
 }

--- a/experiments/verification-poc/verification_test.go
+++ b/experiments/verification-poc/verification_test.go
@@ -1,125 +1,598 @@
 package main
 
 import (
-    "fmt"
-    "math/rand"
-    "os"
-    "path/filepath"
-    "reflect"
-    "strings"
-    "testing"
-    "time"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
 
-    "github.com/SCKelemen/oak/experiments/verification-poc/frontend"
-    "github.com/SCKelemen/oak/experiments/verification-poc/internal/lrat"
+	"github.com/SCKelemen/oak/experiments/verification-poc/frontend"
+	"github.com/SCKelemen/oak/experiments/verification-poc/internal/lrat"
 )
-var cases=[]string{"enum","enum-broken","counter","counter-broken","wrap"}
-func fixture(t *testing.T,name string)*Model{t.Helper();m,e:=loadModel(filepath.Join("examples/native",name+".json"));if e!=nil{t.Fatal(e)};return m}
-func readText(t *testing.T,path string)string{t.Helper();b,e:=os.ReadFile(path);if e!=nil{t.Fatal(e)};return string(b)}
-func TestPythonMigrationParity(t *testing.T){
-    for _,name:=range cases{t.Run(name,func(t *testing.T){
-        m:=fixture(t,name);base:=filepath.Join("testdata/parity",name);var expected frontend.Document
-        if e:=readJSON(filepath.Join(base,"document.json"),&expected);e!=nil{t.Fatal(e)}
-        doc:=*m.Document;doc.SourceHash="";if !reflect.DeepEqual(doc,expected){t.Fatalf("native checked document differs from Python reference\nactual: %s\nexpected: %s",jsonText(doc),jsonText(expected))}
-        files:=project(m)
-        for _,name:=range []string{"initial.cnf","base.cnf","step.cnf","initial.smt2","base.smt2","step.smt2","Model.tla","Model.cfg","Model.lean"}{expected:=readText(t,filepath.Join(base,name));if files[name]!=expected{t.Errorf("projection parity failed: %s\nactual:\n%s\nexpected:\n%s",name,files[name],expected)}}
-        var cert Certificate;if e:=readJSON(filepath.Join(base,"evidence.json"),&cert);e!=nil{t.Fatal(e)}
-        // Migration only: the old certificate is explicitly rebound in this
-        // test, never in the CLI. Its CNF hashes and proof/trace are unchanged.
-        if _,e:=verify(m,&cert);e==nil{t.Fatal("accepted old evidence identity")};cert.Format=evidenceFormat;cert.Digest=m.Digest
-        if _,e:=verify(m,&cert);e!=nil{t.Fatalf("existing Python evidence rejected: %v",e)}
-    })}
+
+var cases = []string{"enum", "enum-broken", "counter", "counter-broken", "wrap"}
+
+func fixture(t *testing.T, name string) *Model {
+	t.Helper()
+	m, e := loadModel(filepath.Join("examples/native", name+".json"))
+	if e != nil {
+		t.Fatal(e)
+	}
+	return m
 }
-func complete(c *Circuit,inputs map[string]bool)map[int]bool{
-    env:=map[int]bool{c.One:true};for name,id:=range c.Inputs{env[id]=inputs[name]}
-    for _,g:=range c.Gates{a,b:=env[absolute(g.Args[0])]==(g.Args[0]>0),env[absolute(g.Args[1])]==(g.Args[1]>0);v:=a!=b;if g.Op=="and"{v=a&&b};if g.Op=="or"{v=a||b};env[g.ID]=v};return env
+func readText(t *testing.T, path string) string {
+	t.Helper()
+	b, e := os.ReadFile(path)
+	if e != nil {
+		t.Fatal(e)
+	}
+	return string(b)
 }
-func bit(env map[int]bool,x int)bool{return env[absolute(x)]==(x>0)}
-func cnfHolds(clauses [][]int,env map[int]bool)bool{for _,c:=range clauses{satisfied:=false;for _,x:=range c{if bit(env,x){satisfied=true;break}};if !satisfied{return false}};return true}
-func TestGateEquivalences(t *testing.T){
-    for _,op:=range []string{"and","or","xor"}{for i:=0;i<6;i++{for j:=0;j<6;j++{c:=newCircuit();x,y:=c.input("x"),c.input("y");ls:=[]int{x,-x,y,-y,c.One,-c.One};root:=c.gate(op,ls[i],ls[j]);for mask:=0;mask<1<<c.Count;mask++{env:=map[int]bool{};for v:=1;v<=c.Count;v++{env[v]=mask&(1<<(v-1))!=0};if !env[c.One]{continue};a,b:=bit(env,ls[i]),bit(env,ls[j]);want:=a!=b;if op=="and"{want=a&&b};if op=="or"{want=a||b};if cnfHolds(c.Clauses,env)!=(bit(env,root)==want){t.Fatalf("unsound %s gate",op)}}}}}
+func TestPythonMigrationParity(t *testing.T) {
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			m := fixture(t, name)
+			base := filepath.Join("testdata/parity", name)
+			var expected frontend.Document
+			if e := readJSON(filepath.Join(base, "document.json"), &expected); e != nil {
+				t.Fatal(e)
+			}
+			doc := *m.Document
+			doc.SourceHash = ""
+			if !reflect.DeepEqual(doc, expected) {
+				t.Fatalf("native checked document differs from Python reference\nactual: %s\nexpected: %s", jsonText(doc), jsonText(expected))
+			}
+			files := project(m)
+			for _, name := range []string{"initial.cnf", "base.cnf", "step.cnf", "initial.smt2", "base.smt2", "step.smt2", "Model.tla", "Model.cfg", "Model.lean"} {
+				expected := readText(t, filepath.Join(base, name))
+				if files[name] != expected {
+					t.Errorf("projection parity failed: %s\nactual:\n%s\nexpected:\n%s", name, files[name], expected)
+				}
+			}
+			var cert Certificate
+			if e := readJSON(filepath.Join(base, "evidence.json"), &cert); e != nil {
+				t.Fatal(e)
+			}
+			// Migration only: the old certificate is explicitly rebound in this
+			// test, never in the CLI. Its CNF hashes and proof/trace are unchanged.
+			if _, e := verify(m, &cert); e == nil {
+				t.Fatal("accepted old evidence identity")
+			}
+			cert.Format = evidenceFormat
+			cert.Digest = m.Digest
+			if _, e := verify(m, &cert); e != nil {
+				t.Fatalf("existing Python evidence rejected: %v", e)
+			}
+		})
+	}
 }
-func TestBitVectorsExhaustive(t *testing.T){
-    c:=newCircuit();a,b:=[]int{},[]int{};for i:=0;i<4;i++{a=append(a,c.input(fmt.Sprintf("a%d",i)));b=append(b,c.input(fmt.Sprintf("b%d",i)))};sum,less,eq:=c.add(a,b),c.less(a,b),c.equal(a,b)
-    for x:=0;x<16;x++{for y:=0;y<16;y++{inputs:=map[string]bool{};for i:=0;i<4;i++{inputs[fmt.Sprintf("a%d",i)]=x&(1<<i)!=0;inputs[fmt.Sprintf("b%d",i)]=y&(1<<i)!=0};env:=complete(c,inputs);n:=0;for i,v:=range sum{if bit(env,v){n|=1<<i}};if n!=(x+y)&15||bit(env,less)!=(x<y)||bit(env,eq)!=(x==y)||!cnfHolds(c.Clauses,env){t.Fatal("bit-vector semantics mismatch",x,y)}}}
+func complete(c *Circuit, inputs map[string]bool) map[int]bool {
+	env := map[int]bool{c.One: true}
+	for name, id := range c.Inputs {
+		env[id] = inputs[name]
+	}
+	for _, g := range c.Gates {
+		a, b := env[absolute(g.Args[0])] == (g.Args[0] > 0), env[absolute(g.Args[1])] == (g.Args[1] > 0)
+		v := a != b
+		if g.Op == "and" {
+			v = a && b
+		}
+		if g.Op == "or" {
+			v = a || b
+		}
+		env[g.ID] = v
+	}
+	return env
 }
-func TestByteArithmeticAllValues(t *testing.T){
-    c:=newCircuit();a:=[]int{};for i:=0;i<8;i++{a=append(a,c.input(fmt.Sprint(i)))};plus,minus:=c.add(a,c.constant(1,8)),c.add(a,c.constant(255,8))
-    for x:=0;x<256;x++{inputs:=map[string]bool{};for i:=0;i<8;i++{inputs[fmt.Sprint(i)]=x&(1<<i)!=0};env:=complete(c,inputs);for i,xs:=range [][]int{plus,minus}{n:=0;for j,v:=range xs{if bit(env,v){n|=1<<j}};want:=(x+1)&255;if i==1{want=(x-1)&255};if n!=want{t.Fatal("byte arithmetic mismatch",x,i)}}}
+func bit(env map[int]bool, x int) bool { return env[absolute(x)] == (x > 0) }
+func cnfHolds(clauses [][]int, env map[int]bool) bool {
+	for _, c := range clauses {
+		satisfied := false
+		for _, x := range c {
+			if bit(env, x) {
+				satisfied = true
+				break
+			}
+		}
+		if !satisfied {
+			return false
+		}
+	}
+	return true
 }
-func TestEncodedObligationsMatchSemantics(t *testing.T){
-    for _,name:=range cases{m:=fixture(t,name);states,e:=m.states();if e!=nil{t.Fatal(e)};if len(states)>10{all:=states;states=nil;for _,i:=range []int{0,1,2,3,4,127,128,254,255}{states=append(states,all[i])}}
-        for _,role:=range []string{"initial","base","step"}{c,root:=encode(m,role);for _,s:=range states{for _,target:=range states{envs:=map[string]State{"s":s,"t":target};inputs:=map[string]bool{}
-            for name:=range c.Inputs{parts:=strings.Split(name,".");i:=0;fmt.Sscan(parts[2],&i);v:=envs[parts[0]][parts[1]];n:=0;for _,f:=range m.Fields{if f.Name!=parts[1]{continue};if f.Type=="Bool"{if v.(bool){n=1}}else if f.Type=="u8"{n,_=number(v)}else{for j,x:=range m.Enums[f.Type]{if x==v{n=j;break}}}};inputs[name]=n&(1<<i)!=0}
-            env:=complete(c,inputs);ini,inv:=truth(m.Terms["initial"],s,target),truth(m.Terms["invariant"],s,target);want:=ini;if role=="base"{want=ini&&!inv};if role=="step"{want=inv&&truth(m.Terms["step"],s,target)&&!truth(m.Terms["invariant"],target,nil)}
-            if bit(env,root)!=want||!cnfHolds(c.Clauses,env){t.Fatalf("%s %s encoding mismatch",name,role)}
-        }}}
-    }
+func TestGateEquivalences(t *testing.T) {
+	for _, op := range []string{"and", "or", "xor"} {
+		for i := 0; i < 6; i++ {
+			for j := 0; j < 6; j++ {
+				c := newCircuit()
+				x, y := c.input("x"), c.input("y")
+				ls := []int{x, -x, y, -y, c.One, -c.One}
+				root := c.gate(op, ls[i], ls[j])
+				for mask := 0; mask < 1<<c.Count; mask++ {
+					env := map[int]bool{}
+					for v := 1; v <= c.Count; v++ {
+						env[v] = mask&(1<<(v-1)) != 0
+					}
+					if !env[c.One] {
+						continue
+					}
+					a, b := bit(env, ls[i]), bit(env, ls[j])
+					want := a != b
+					if op == "and" {
+						want = a && b
+					}
+					if op == "or" {
+						want = a || b
+					}
+					if cnfHolds(c.Clauses, env) != (bit(env, root) == want) {
+						t.Fatalf("unsound %s gate", op)
+					}
+				}
+			}
+		}
+	}
 }
-func TestLocalProofAndCounterexampleChecks(t *testing.T){
-    for _,name:=range []string{"enum","counter","wrap"}{m:=fixture(t,name);c,e:=localProof(m);if e!=nil{t.Fatal(e)};if _,e:=verify(m,c);e!=nil{t.Fatal(e)};original:=c.Proofs["step"];c.Proofs["step"]=Proof{original.SHA,""};if _,e:=verify(m,c);e==nil{t.Fatal("accepted missing proof")};c.Proofs["step"]=Proof{"bad",original.LRAT};if _,e:=verify(m,c);e==nil{t.Fatal("accepted replaced formula")}}
-    for _,name:=range []string{"enum-broken","counter-broken"}{m:=fixture(t,name);c,e:=findTrace(m);if e!=nil{t.Fatal(e)};want:=3;if name=="counter-broken"{want=5};if len(c.States)!=want{t.Fatal("wrong shortest trace")};if _,e:=verify(m,c);e!=nil{t.Fatal(e)};c.States=[]State{c.States[0],c.States[len(c.States)-1]};if _,e:=verify(m,c);e==nil{t.Fatal("accepted illegal edge")}}
-    if _,e:=localProof(fixture(t,"enum-broken"));e==nil{t.Fatal("proved unsafe invariant")};if _,e:=findTrace(fixture(t,"wrap"));e==nil{t.Fatal("found spurious counterexample")}
+func TestBitVectorsExhaustive(t *testing.T) {
+	c := newCircuit()
+	a, b := []int{}, []int{}
+	for i := 0; i < 4; i++ {
+		a = append(a, c.input(fmt.Sprintf("a%d", i)))
+		b = append(b, c.input(fmt.Sprintf("b%d", i)))
+	}
+	sum, less, eq := c.add(a, b), c.less(a, b), c.equal(a, b)
+	for x := 0; x < 16; x++ {
+		for y := 0; y < 16; y++ {
+			inputs := map[string]bool{}
+			for i := 0; i < 4; i++ {
+				inputs[fmt.Sprintf("a%d", i)] = x&(1<<i) != 0
+				inputs[fmt.Sprintf("b%d", i)] = y&(1<<i) != 0
+			}
+			env := complete(c, inputs)
+			n := 0
+			for i, v := range sum {
+				if bit(env, v) {
+					n |= 1 << i
+				}
+			}
+			if n != (x+y)&15 || bit(env, less) != (x < y) || bit(env, eq) != (x == y) || !cnfHolds(c.Clauses, env) {
+				t.Fatal("bit-vector semantics mismatch", x, y)
+			}
+		}
+	}
 }
-func TestSmallCNFSearchAgainstTruthTables(t *testing.T){
-    rng:=rand.New(rand.NewSource(420));for iteration:=0;iteration<100;iteration++{clauses:=[][]int{};for count:=rng.Intn(8)+1;count>0;count--{c:=[]int{};for n:=rng.Intn(4);n>0;n--{lit:=rng.Intn(3)+1;if rng.Intn(2)==0{lit=-lit};c=append(c,lit)};clauses=append(clauses,c)};var text strings.Builder;fmt.Fprintf(&text,"p cnf 3 %d\n",len(clauses));for _,c:=range clauses{for _,x:=range c{fmt.Fprintf(&text,"%d ",x)};text.WriteString("0\n")}
-        sat:=false;for mask:=0;mask<8;mask++{env:=map[int]bool{1:mask&1!=0,2:mask&2!=0,3:mask&4!=0};sat=sat||cnfHolds(clauses,env)};proof,e:=localLRAT(text.String(),nil);if sat{if e==nil{t.Fatal("proved SAT formula")}}else{if e!=nil{t.Fatal(e)};if _,e:=lrat.Check(text.String(),proof);e!=nil{t.Fatal(e)}}
-    }
+func TestByteArithmeticAllValues(t *testing.T) {
+	c := newCircuit()
+	a := []int{}
+	for i := 0; i < 8; i++ {
+		a = append(a, c.input(fmt.Sprint(i)))
+	}
+	plus, minus := c.add(a, c.constant(1, 8)), c.add(a, c.constant(255, 8))
+	for x := 0; x < 256; x++ {
+		inputs := map[string]bool{}
+		for i := 0; i < 8; i++ {
+			inputs[fmt.Sprint(i)] = x&(1<<i) != 0
+		}
+		env := complete(c, inputs)
+		for i, xs := range [][]int{plus, minus} {
+			n := 0
+			for j, v := range xs {
+				if bit(env, v) {
+					n |= 1 << j
+				}
+			}
+			want := (x + 1) & 255
+			if i == 1 {
+				want = (x - 1) & 255
+			}
+			if n != want {
+				t.Fatal("byte arithmetic mismatch", x, i)
+			}
+		}
+	}
 }
-func TestSourceIdentityAndInputRejections(t *testing.T){
-    m:=fixture(t,"wrap");cfg:=m.Config;cfg.Arithmetic="";if _,e:=newModel(m.Document,cfg);e==nil{t.Fatal("implicit arithmetic accepted")}
-    for _,s:=range []State{{"count":true},{"count":256},{"count":-1},{"count":1,"extra":1}}{if m.valid(s)==nil{t.Fatal("invalid byte state accepted")}}
-    for _,raw:=range []string{`{"format":"x","format":"y"}`,`{"unknown":true}`,`{} {}`,`{"proofs":{"base":{"cnf_sha256":"x","cnf_sha256":"y"}}}`}{var c Certificate;if decode([]byte(raw),&c)==nil{t.Fatal("invalid JSON accepted",raw)}}
-    dir:=t.TempDir();source:=readText(t,"examples/native/enum.oak");cfg=fixture(t,"enum").Config
-    if e:=os.WriteFile(filepath.Join(dir,"enum.oak"),[]byte(source+"\n// identity changed\n"),0644);e!=nil{t.Fatal(e)};if e:=os.WriteFile(filepath.Join(dir,"enum.json"),[]byte(jsonText(cfg)),0644);e!=nil{t.Fatal(e)}
-    changed,e:=loadModel(filepath.Join(dir,"enum.json"));if e!=nil{t.Fatal(e)};original:=fixture(t,"enum");cert,e:=localProof(original);if e!=nil{t.Fatal(e)};if _,e:=verify(changed,cert);e==nil{t.Fatal("accepted stale source evidence")}
+func TestEncodedObligationsMatchSemantics(t *testing.T) {
+	for _, name := range cases {
+		m := fixture(t, name)
+		states, e := m.states()
+		if e != nil {
+			t.Fatal(e)
+		}
+		if len(states) > 10 {
+			all := states
+			states = nil
+			for _, i := range []int{0, 1, 2, 3, 4, 127, 128, 254, 255} {
+				states = append(states, all[i])
+			}
+		}
+		for _, role := range []string{"initial", "base", "step"} {
+			c, root := encode(m, role)
+			for _, s := range states {
+				for _, target := range states {
+					envs := map[string]State{"s": s, "t": target}
+					inputs := map[string]bool{}
+					for name := range c.Inputs {
+						parts := strings.Split(name, ".")
+						i := 0
+						fmt.Sscan(parts[2], &i)
+						v := envs[parts[0]][parts[1]]
+						n := 0
+						for _, f := range m.Fields {
+							if f.Name != parts[1] {
+								continue
+							}
+							if f.Type == "Bool" {
+								if v.(bool) {
+									n = 1
+								}
+							} else if f.Type == "u8" {
+								n, _ = number(v)
+							} else {
+								for j, x := range m.Enums[f.Type] {
+									if x == v {
+										n = j
+										break
+									}
+								}
+							}
+						}
+						inputs[name] = n&(1<<i) != 0
+					}
+					env := complete(c, inputs)
+					ini, inv := truth(m.Terms["initial"], s, target), truth(m.Terms["invariant"], s, target)
+					want := ini
+					if role == "base" {
+						want = ini && !inv
+					}
+					if role == "step" {
+						want = inv && truth(m.Terms["step"], s, target) && !truth(m.Terms["invariant"], target, nil)
+					}
+					if bit(env, root) != want || !cnfHolds(c.Clauses, env) {
+						t.Fatalf("%s %s encoding mismatch", name, role)
+					}
+				}
+			}
+		}
+	}
 }
-func TestSyntheticTraceImports(t *testing.T){
-    m:=fixture(t,"counter-broken");bound:=5;query,e:=bmc(m,bound,true);if e!=nil{t.Fatal(e)};pairs:=[]string{};for i:=0;i<=bound;i++{pairs=append(pairs,fmt.Sprintf("(s%d_f_count #x%02x)",i,i))};raw:="sat\n("+strings.Join(pairs," ")+")\n";r:=receipt(m,"z3",query,raw,&bound);cert,e:=importTrace(m,"z3",query,raw,r,&bound);if e!=nil||len(cert.States)!=5{t.Fatal("Z3 trace import failed",e)}
-    if _,e:=importTrace(m,"z3",query,raw+" ",r,&bound);e==nil{t.Fatal("accepted stale output")};bad:=strings.Replace(raw,"#x02","#xff",1);if _,e:=importTrace(m,"z3",query,bad,receipt(m,"z3",query,bad,&bound),&bound);e==nil{t.Fatal("accepted forged transition")}
-    for _,bad:=range []string{"unknown",strings.Replace(raw,"#x00","#b0",1),strings.Replace(raw,"s1_f_count","s0_f_count",1)}{if _,e:=fromZ3(m,bad,bound);e==nil{t.Fatal("accepted malformed SMT trace")}}
-    m=fixture(t,"enum-broken");trace,e:=findTrace(m);if e!=nil{t.Fatal(e)};entries:=[]any{};for i,s:=range trace.States{entries=append(entries,[]any{i+1,map[string]any{"state":map[string]any{"f_phase":"Phase."+s["phase"].(string)}}})};raw=jsonText(map[string]any{"vars":[]string{"state"},"counterexample":map[string]any{"state":entries,"action":[]any{}}});files:=project(m);query=files["Model.tla"]+"\n"+files["Model.cfg"];cert,e=importTrace(m,"tlc",query,raw,receipt(m,"tlc",query,raw,nil),nil);if e!=nil||len(cert.States)!=3{t.Fatal("TLC import failed",e)};if _,e:=fromTLC(m,strings.Replace(raw,"Phase.Idle","Other.Idle",1));e==nil{t.Fatal("accepted wrong enum")}
+func TestLocalProofAndCounterexampleChecks(t *testing.T) {
+	for _, name := range []string{"enum", "counter", "wrap"} {
+		m := fixture(t, name)
+		c, e := localProof(m)
+		if e != nil {
+			t.Fatal(e)
+		}
+		if _, e := verify(m, c); e != nil {
+			t.Fatal(e)
+		}
+		original := c.Proofs["step"]
+		c.Proofs["step"] = Proof{original.SHA, ""}
+		if _, e := verify(m, c); e == nil {
+			t.Fatal("accepted missing proof")
+		}
+		c.Proofs["step"] = Proof{"bad", original.LRAT}
+		if _, e := verify(m, c); e == nil {
+			t.Fatal("accepted replaced formula")
+		}
+	}
+	for _, name := range []string{"enum-broken", "counter-broken"} {
+		m := fixture(t, name)
+		c, e := findTrace(m)
+		if e != nil {
+			t.Fatal(e)
+		}
+		want := 3
+		if name == "counter-broken" {
+			want = 5
+		}
+		if len(c.States) != want {
+			t.Fatal("wrong shortest trace")
+		}
+		if _, e := verify(m, c); e != nil {
+			t.Fatal(e)
+		}
+		c.States = []State{c.States[0], c.States[len(c.States)-1]}
+		if _, e := verify(m, c); e == nil {
+			t.Fatal("accepted illegal edge")
+		}
+	}
+	if _, e := localProof(fixture(t, "enum-broken")); e == nil {
+		t.Fatal("proved unsafe invariant")
+	}
+	if _, e := findTrace(fixture(t, "wrap")); e == nil {
+		t.Fatal("found spurious counterexample")
+	}
 }
-func TestBackendFailsClosed(t *testing.T){
-    m:=fixture(t,"enum");for _,r:=range []Execution{{Stdout:"sat"},{ExitCode:ptr(0),Stdout:"unknown\n"},{ExitCode:ptr(1),Stdout:"sat\n"}}{fake:=func([]string,string,time.Duration)Execution{return r};result:=runBackend(m,"z3",t.TempDir(),true,3,time.Second,"",fake);if result.Passed{t.Fatal("accepted unknown or failed tool")}}
-    t.Setenv("PATH",t.TempDir());if probe("z3",t.TempDir(),"",time.Second).Available{t.Fatal("accepted missing tool")};if versionMatches("z3","Z3 4.13.40")||!versionMatches("z3","Z3 version 4.13.4 - 64 bit"){t.Fatal("version matching error")}
+func TestSmallCNFSearchAgainstTruthTables(t *testing.T) {
+	rng := rand.New(rand.NewSource(420))
+	for iteration := 0; iteration < 100; iteration++ {
+		clauses := [][]int{}
+		for count := rng.Intn(8) + 1; count > 0; count-- {
+			c := []int{}
+			for n := rng.Intn(4); n > 0; n-- {
+				lit := rng.Intn(3) + 1
+				if rng.Intn(2) == 0 {
+					lit = -lit
+				}
+				c = append(c, lit)
+			}
+			clauses = append(clauses, c)
+		}
+		var text strings.Builder
+		fmt.Fprintf(&text, "p cnf 3 %d\n", len(clauses))
+		for _, c := range clauses {
+			for _, x := range c {
+				fmt.Fprintf(&text, "%d ", x)
+			}
+			text.WriteString("0\n")
+		}
+		sat := false
+		for mask := 0; mask < 8; mask++ {
+			env := map[int]bool{1: mask&1 != 0, 2: mask&2 != 0, 3: mask&4 != 0}
+			sat = sat || cnfHolds(clauses, env)
+		}
+		proof, e := localLRAT(text.String(), nil)
+		if sat {
+			if e == nil {
+				t.Fatal("proved SAT formula")
+			}
+		} else {
+			if e != nil {
+				t.Fatal(e)
+			}
+			if _, e := lrat.Check(text.String(), proof); e != nil {
+				t.Fatal(e)
+			}
+		}
+	}
 }
-func ptr(n int)*int{return &n}
-func TestSlowTool(t *testing.T){if len(os.Args)>1&&os.Args[len(os.Args)-1]=="slow-tool-helper"{time.Sleep(time.Second)}}
-func TestToolTimeout(t *testing.T){r:=execute([]string{os.Args[0],"-test.run=^TestSlowTool$","--","slow-tool-helper"},t.TempDir(),20*time.Millisecond);if r.ExitCode!=nil||r.Error==""{t.Fatal("timeout reported as tool result")}}
-func TestCLIAndMalformedImport(t *testing.T){
-    out:=filepath.Join(t.TempDir(),"proof.json");if _,e:=command([]string{"prove-local","--out",out,"examples/native/enum.json"});e!=nil{t.Fatal(e)};if _,e:=command([]string{"verify","examples/native/enum.json",out});e!=nil{t.Fatal(e)};if _,e:=command([]string{"verify","examples/native/enum-broken.json",out});e==nil{t.Fatal("CLI accepted mismatched evidence")}
-    if _,e:=command([]string{"emit","examples/native/enum.json"});e==nil{t.Fatal("missing output accepted")}
+func TestSourceIdentityAndInputRejections(t *testing.T) {
+	m := fixture(t, "wrap")
+	cfg := m.Config
+	cfg.Arithmetic = ""
+	if _, e := newModel(m.Document, cfg); e == nil {
+		t.Fatal("implicit arithmetic accepted")
+	}
+	for _, s := range []State{{"count": true}, {"count": 256}, {"count": -1}, {"count": 1, "extra": 1}} {
+		if m.valid(s) == nil {
+			t.Fatal("invalid byte state accepted")
+		}
+	}
+	for _, raw := range []string{`{"format":"x","format":"y"}`, `{"unknown":true}`, `{} {}`, `{"proofs":{"base":{"cnf_sha256":"x","cnf_sha256":"y"}}}`} {
+		var c Certificate
+		if decode([]byte(raw), &c) == nil {
+			t.Fatal("invalid JSON accepted", raw)
+		}
+	}
+	dir := t.TempDir()
+	source := readText(t, "examples/native/enum.oak")
+	cfg = fixture(t, "enum").Config
+	if e := os.WriteFile(filepath.Join(dir, "enum.oak"), []byte(source+"\n// identity changed\n"), 0644); e != nil {
+		t.Fatal(e)
+	}
+	if e := os.WriteFile(filepath.Join(dir, "enum.json"), []byte(jsonText(cfg)), 0644); e != nil {
+		t.Fatal(e)
+	}
+	changed, e := loadModel(filepath.Join(dir, "enum.json"))
+	if e != nil {
+		t.Fatal(e)
+	}
+	original := fixture(t, "enum")
+	cert, e := localProof(original)
+	if e != nil {
+		t.Fatal(e)
+	}
+	if _, e := verify(changed, cert); e == nil {
+		t.Fatal("accepted stale source evidence")
+	}
 }
-func TestBooleanAndNonPowerOfTwoEnumDomains(t *testing.T){
-    for _,test:=range []struct{name,source string;invalidEncoding bool}{
-        {"boolean",`State: type = { flag: Bool }
+func TestSyntheticTraceImports(t *testing.T) {
+	m := fixture(t, "counter-broken")
+	bound := 5
+	query, e := bmc(m, bound, true)
+	if e != nil {
+		t.Fatal(e)
+	}
+	pairs := []string{}
+	for i := 0; i <= bound; i++ {
+		pairs = append(pairs, fmt.Sprintf("(s%d_f_count #x%02x)", i, i))
+	}
+	raw := "sat\n(" + strings.Join(pairs, " ") + ")\n"
+	r := receipt(m, "z3", query, raw, &bound)
+	cert, e := importTrace(m, "z3", query, raw, r, &bound)
+	if e != nil || len(cert.States) != 5 {
+		t.Fatal("Z3 trace import failed", e)
+	}
+	if _, e := importTrace(m, "z3", query, raw+" ", r, &bound); e == nil {
+		t.Fatal("accepted stale output")
+	}
+	bad := strings.Replace(raw, "#x02", "#xff", 1)
+	if _, e := importTrace(m, "z3", query, bad, receipt(m, "z3", query, bad, &bound), &bound); e == nil {
+		t.Fatal("accepted forged transition")
+	}
+	for _, bad := range []string{"unknown", strings.Replace(raw, "#x00", "#b0", 1), strings.Replace(raw, "s1_f_count", "s0_f_count", 1)} {
+		if _, e := fromZ3(m, bad, bound); e == nil {
+			t.Fatal("accepted malformed SMT trace")
+		}
+	}
+	m = fixture(t, "enum-broken")
+	trace, e := findTrace(m)
+	if e != nil {
+		t.Fatal(e)
+	}
+	entries := []any{}
+	for i, s := range trace.States {
+		entries = append(entries, []any{i + 1, map[string]any{"state": map[string]any{"f_phase": "Phase." + s["phase"].(string)}}})
+	}
+	raw = jsonText(map[string]any{"vars": []string{"state"}, "counterexample": map[string]any{"state": entries, "action": []any{}}})
+	files := project(m)
+	query = files["Model.tla"] + "\n" + files["Model.cfg"]
+	cert, e = importTrace(m, "tlc", query, raw, receipt(m, "tlc", query, raw, nil), nil)
+	if e != nil || len(cert.States) != 3 {
+		t.Fatal("TLC import failed", e)
+	}
+	if _, e := fromTLC(m, strings.Replace(raw, "Phase.Idle", "Other.Idle", 1)); e == nil {
+		t.Fatal("accepted wrong enum")
+	}
+}
+func TestBackendFailsClosed(t *testing.T) {
+	m := fixture(t, "enum")
+	for _, r := range []Execution{{Stdout: "sat"}, {ExitCode: ptr(0), Stdout: "unknown\n"}, {ExitCode: ptr(1), Stdout: "sat\n"}} {
+		fake := func([]string, string, time.Duration) Execution { return r }
+		result := runBackend(m, "z3", t.TempDir(), true, 3, time.Second, "", fake)
+		if result.Passed {
+			t.Fatal("accepted unknown or failed tool")
+		}
+	}
+	t.Setenv("PATH", t.TempDir())
+	if probe("z3", t.TempDir(), "", time.Second).Available {
+		t.Fatal("accepted missing tool")
+	}
+	if versionMatches("z3", "Z3 4.13.40") || !versionMatches("z3", "Z3 version 4.13.4 - 64 bit") {
+		t.Fatal("version matching error")
+	}
+}
+func ptr(n int) *int { return &n }
+func TestSlowTool(t *testing.T) {
+	if len(os.Args) > 1 && os.Args[len(os.Args)-1] == "slow-tool-helper" {
+		time.Sleep(time.Second)
+	}
+}
+func TestToolTimeout(t *testing.T) {
+	r := execute([]string{os.Args[0], "-test.run=^TestSlowTool$", "--", "slow-tool-helper"}, t.TempDir(), 20*time.Millisecond)
+	if r.ExitCode != nil || r.Error == "" {
+		t.Fatal("timeout reported as tool result")
+	}
+}
+func TestCLIAndMalformedImport(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "proof.json")
+	if _, e := command([]string{"prove-local", "--out", out, "examples/native/enum.json"}); e != nil {
+		t.Fatal(e)
+	}
+	if _, e := command([]string{"verify", "examples/native/enum.json", out}); e != nil {
+		t.Fatal(e)
+	}
+	if _, e := command([]string{"verify", "examples/native/enum-broken.json", out}); e == nil {
+		t.Fatal("CLI accepted mismatched evidence")
+	}
+	if _, e := command([]string{"emit", "examples/native/enum.json"}); e == nil {
+		t.Fatal("missing output accepted")
+	}
+}
+func TestBooleanAndNonPowerOfTwoEnumDomains(t *testing.T) {
+	for _, test := range []struct {
+		name, source    string
+		invalidEncoding bool
+	}{
+		{"boolean", `State: type = { flag: Bool }
 initial: (s: State): Bool = !s.flag
 safe: (s: State): Bool = !s.flag
 step: (s: State, t: State): Bool = t.flag == s.flag
-`,false},
-        {"enum3",`E: type = | A | B | C
+`, false},
+		{"enum3", `E: type = | A | B | C
 State: type = { mode: E }
 initial: (s: State): Bool = true
 safe: (s: State): Bool = false
 step: (s: State, t: State): Bool = true
-`,true},
-    }{t.Run(test.name,func(t *testing.T){dir:=t.TempDir();cfg:=Config{Source:"model.oak",Initial:"initial",Step:"step",Invariant:"safe"};if e:=os.WriteFile(filepath.Join(dir,"model.oak"),[]byte(test.source),0644);e!=nil{t.Fatal(e)};if e:=os.WriteFile(filepath.Join(dir,"model.json"),[]byte(jsonText(cfg)),0644);e!=nil{t.Fatal(e)};m,e:=loadModel(filepath.Join(dir,"model.json"));if e!=nil{t.Fatal(e)}
-        if !test.invalidEncoding{proof,e:=localProof(m);if e!=nil{t.Fatal(e)};if _,e:=verify(m,proof);e!=nil{t.Fatal(e)};return}
-        c,root:=encode(m,"base");for n:=0;n<4;n++{inputs:=map[string]bool{};for key:=range c.Inputs{parts:=strings.Split(key,".");i:=0;fmt.Sscan(parts[2],&i);inputs[key]=n&(1<<i)!=0};env:=complete(c,inputs);if bit(env,root)!=(n<3){t.Fatal("invalid enum bit pattern admitted",n)}}
-    })}
+`, true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			cfg := Config{Source: "model.oak", Initial: "initial", Step: "step", Invariant: "safe"}
+			if e := os.WriteFile(filepath.Join(dir, "model.oak"), []byte(test.source), 0644); e != nil {
+				t.Fatal(e)
+			}
+			if e := os.WriteFile(filepath.Join(dir, "model.json"), []byte(jsonText(cfg)), 0644); e != nil {
+				t.Fatal(e)
+			}
+			m, e := loadModel(filepath.Join(dir, "model.json"))
+			if e != nil {
+				t.Fatal(e)
+			}
+			if !test.invalidEncoding {
+				proof, e := localProof(m)
+				if e != nil {
+					t.Fatal(e)
+				}
+				if _, e := verify(m, proof); e != nil {
+					t.Fatal(e)
+				}
+				return
+			}
+			c, root := encode(m, "base")
+			for n := 0; n < 4; n++ {
+				inputs := map[string]bool{}
+				for key := range c.Inputs {
+					parts := strings.Split(key, ".")
+					i := 0
+					fmt.Sscan(parts[2], &i)
+					inputs[key] = n&(1<<i) != 0
+				}
+				env := complete(c, inputs)
+				if bit(env, root) != (n < 3) {
+					t.Fatal("invalid enum bit pattern admitted", n)
+				}
+			}
+		})
+	}
 }
-func TestOriginalBooleanModelsUseNativeOak(t *testing.T){
-    safe,e:=loadModel("examples/borrow.json");if e!=nil{t.Fatal(e)};proof,e:=localProof(safe);if e!=nil{t.Fatal(e)};if _,e:=verify(safe,proof);e!=nil{t.Fatal(e)}
-    broken,e:=loadModel("examples/broken.json");if e!=nil{t.Fatal(e)};trace,e:=findTrace(broken);if e!=nil{t.Fatal(e)};if len(trace.States)!=3{t.Fatal("Boolean model trace changed")};if _,e:=verify(broken,trace);e!=nil{t.Fatal(e)}
+func TestOriginalBooleanModelsUseNativeOak(t *testing.T) {
+	safe, e := loadModel("examples/borrow.json")
+	if e != nil {
+		t.Fatal(e)
+	}
+	proof, e := localProof(safe)
+	if e != nil {
+		t.Fatal(e)
+	}
+	if _, e := verify(safe, proof); e != nil {
+		t.Fatal(e)
+	}
+	broken, e := loadModel("examples/broken.json")
+	if e != nil {
+		t.Fatal(e)
+	}
+	trace, e := findTrace(broken)
+	if e != nil {
+		t.Fatal(e)
+	}
+	if len(trace.States) != 3 {
+		t.Fatal("Boolean model trace changed")
+	}
+	if _, e := verify(broken, trace); e != nil {
+		t.Fatal(e)
+	}
 }
-func TestClosedSetsPreserveReachableSafetyCapability(t *testing.T){
-    m:=fixture(t,"counter");cert,e:=closedSet(m);if e!=nil{t.Fatal(e)};if _,e:=verify(m,cert);e!=nil{t.Fatal(e)}
-    original:=cert.States;cert.States=original[:len(original)-1];if _,e:=verify(m,cert);e==nil{t.Fatal("accepted omitted successor")}
-    cert.States=append(append([]State{},original...),State{"count":4});if _,e:=verify(m,cert);e==nil{t.Fatal("accepted unsafe member")}
-    cert.States=append(append([]State{},original...),original[0]);if _,e:=verify(m,cert);e==nil{t.Fatal("accepted duplicate state")}
-    cert.States=original[1:];if _,e:=verify(m,cert);e==nil{t.Fatal("accepted omitted initial state")}
-    source:=`State: type = { count: u8 }
+func TestClosedSetsPreserveReachableSafetyCapability(t *testing.T) {
+	m := fixture(t, "counter")
+	cert, e := closedSet(m)
+	if e != nil {
+		t.Fatal(e)
+	}
+	if _, e := verify(m, cert); e != nil {
+		t.Fatal(e)
+	}
+	original := cert.States
+	cert.States = original[:len(original)-1]
+	if _, e := verify(m, cert); e == nil {
+		t.Fatal("accepted omitted successor")
+	}
+	cert.States = append(append([]State{}, original...), State{"count": 4})
+	if _, e := verify(m, cert); e == nil {
+		t.Fatal("accepted unsafe member")
+	}
+	cert.States = append(append([]State{}, original...), original[0])
+	if _, e := verify(m, cert); e == nil {
+		t.Fatal("accepted duplicate state")
+	}
+	cert.States = original[1:]
+	if _, e := verify(m, cert); e == nil {
+		t.Fatal("accepted omitted initial state")
+	}
+	source := `State: type = { count: u8 }
 initial: (s: State): Bool = s.count == u8(0)
 safe: (s: State): Bool = s.count <= u8(3)
 step: (s: State, t: State): Bool = s.count ? {
@@ -127,8 +600,36 @@ step: (s: State, t: State): Bool = s.count ? {
   | _ => true
 }
 `
-    dir:=t.TempDir();cfg:=Config{Source:"model.oak",Initial:"initial",Step:"step",Invariant:"safe"}
-    if e:=os.WriteFile(filepath.Join(dir,"model.oak"),[]byte(source),0644);e!=nil{t.Fatal(e)};if e:=os.WriteFile(filepath.Join(dir,"model.json"),[]byte(jsonText(cfg)),0644);e!=nil{t.Fatal(e)}
-    m,e=loadModel(filepath.Join(dir,"model.json"));if e!=nil{t.Fatal(e)};if _,e:=localProof(m);e==nil{t.Fatal("proved noninductive invariant")};cert,e=closedSet(m);if e!=nil{t.Fatal(e)};if len(cert.States)!=1{t.Fatal("wrong reachable closure")};if _,e:=verify(m,cert);e!=nil{t.Fatal(e)}
-    out:=filepath.Join(dir,"closure.json");if _,e:=command([]string{"closed-set","--out",out,filepath.Join(dir,"model.json")});e!=nil{t.Fatal(e)};if _,e:=command([]string{"verify",filepath.Join(dir,"model.json"),out});e!=nil{t.Fatal(e)}
+	dir := t.TempDir()
+	cfg := Config{Source: "model.oak", Initial: "initial", Step: "step", Invariant: "safe"}
+	if e := os.WriteFile(filepath.Join(dir, "model.oak"), []byte(source), 0644); e != nil {
+		t.Fatal(e)
+	}
+	if e := os.WriteFile(filepath.Join(dir, "model.json"), []byte(jsonText(cfg)), 0644); e != nil {
+		t.Fatal(e)
+	}
+	m, e = loadModel(filepath.Join(dir, "model.json"))
+	if e != nil {
+		t.Fatal(e)
+	}
+	if _, e := localProof(m); e == nil {
+		t.Fatal("proved noninductive invariant")
+	}
+	cert, e = closedSet(m)
+	if e != nil {
+		t.Fatal(e)
+	}
+	if len(cert.States) != 1 {
+		t.Fatal("wrong reachable closure")
+	}
+	if _, e := verify(m, cert); e != nil {
+		t.Fatal(e)
+	}
+	out := filepath.Join(dir, "closure.json")
+	if _, e := command([]string{"closed-set", "--out", out, filepath.Join(dir, "model.json")}); e != nil {
+		t.Fatal(e)
+	}
+	if _, e := command([]string{"verify", filepath.Join(dir, "model.json"), out}); e != nil {
+		t.Fatal(e)
+	}
 }


### PR DESCRIPTION
## Summary

Whitespace-only: the Go 1.27.1 toolchain's `gofmt -w` over `experiments/`, which was written in a compressed one-statement-per-line style. With this the whole tree is gofmt-clean. No open PR touches `experiments/`, so nothing in flight conflicts.

## Test plan

- [x] `go build ./...`; `go vet ./experiments/...` clean
- [x] `go test ./experiments/...` green (verification-poc, frontend, lrat)
- [x] `gofmt -l .` reports nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
