### PR TITLE
docs: record dbs third-round asks and document -max-bytes for tables

### DIFF
--- a/docs/notes/dbs-feedback-2026-09.md
+++ b/docs/notes/dbs-feedback-2026-09.md
@@ -55,3 +55,25 @@ blurred invariant.
   detection obligations, not only durability.
 - An IO surface design exists: the same recovery rule runs against a real
   file, and the simulation and the file agree on the conformance vectors.
+
+## Third round (2026-09-12) — gates for the engine-language decision
+
+Standing constraints, stated by the owner for everything below: every
+landed feature carries a formal model (a Lean module or refinement under
+`spec/lean/Oak/`) or a stated reason it cannot, and runtime paths are
+measured — zero-cost erasure where the feature is static, no allocation,
+benchmarks under `benchmarks/` where code runs.
+
+| # | Ask | Disposition |
+| --- | --- | --- |
+| 1 | Typestate-indexed handles: a handle type carrying its custody state, so `evict` on an `Offloaded` handle is a compile error, not a trap in `custody_next` | **Next.** The other half of terminal-state obligations and `via` modes. Design: a resource type with one phantom parameter is state-indexed (`Segment[S]`); the protocol projects one marker type per state, `via` callables must take `Resource[From]` and return `Resource[To]`, and constructing a state other than the initial one is admitted only inside the transition into it. Erased at run time (`Oak.PhantomRepresentation`); soundness model `Oak.Typestate`: the static index always equals the machine state, so the legality trap is unreachable in a well-typed program. |
+| 2 | `io/sim` and `io/native` per `120-io.md`, with directory sync, agreeing on the dbs conformance rows | **Planned after 1.** Completion rings over `SimDisk`/`SimSched`/`SimProcess`, then `pread`/`pwrite`/`fsync`/`fsyncdir`; the two realizations differ only in the fault model. Rings are caller-owned storage (no allocation); the contract of §3 is the Lean target. |
+| 3 | Quorum predicates in protocol guards: counting or quantification over an array field, multi-field payloads, array-of-records data | **Planned after 1.** Guard forms `count(data.acked) >= N`, `all(data.acked)`, `any(...)` with a bounded fold in Oak and `Cardinality`/`\A`/`\E` in the TLA+ export; payload records; `[N]Record` data. Extends `112-protocols.md` §1 and §4 together so the two gates keep agreeing. |
+| 4 | Interval time source: earliest/latest with an attested bound, layered over timesim's faults | **Planned.** `110-testing.md` "Simulated time" gains an interval clock and a bound-attestation fault; the clock-ordered class refuses on an unattestable bound. |
+| 5 | Conformance of a hand-written TLA+ module (`Custody.tla`) against a projection | **Planned.** Design chosen: compare in the projection's normal form — one action per step, one disjunct per line — after parsing the hand-written module's actions; a checker verdict, not a reviewer's. TLC refinement stays the fallback for modules that use forms the normal form lacks. |
+| 6 | rv64 as a first-class target (AArch64 and RISC-V are dbs's only targets) | **Planned; largest item.** Backend, ABI, memory model (`MemoryOrder.lean` has the RVWMO shape to instantiate), assembler unit. Sequenced after 2 and 3 so the sim/native IO agreement exists to test it against. |
+| 7 | Vector dispatch across AArch64 feature levels and RVV behind one deterministic interface | Wanted. Follows 6; the scalable-vector design in `93-simd.md` is the shape. |
+| 8 | SPSC and MPSC rings as memory-model consumers | Wanted. Follows the C and ISA refinement `MemoryOrder.lean` lists as next; rings then reuse the `io` ring shape. |
+| 9 | Derived binary codec for fixed-layout records with per-field endianness | Wanted. A non-JSON derive in `71-codecs.md`; the header stops being hand-written over `bytes_read_*_be`. |
+| 10 | Document `-max-bytes` in the Table section | **Done** (this round): `110-testing.md` "Table targets" names the flag, the default, and the per-row refusal. |
+

--- a/docs/spec/110-testing.md
+++ b/docs/spec/110-testing.md
@@ -184,6 +184,11 @@ directories and dotfiles, and counts each executed row as a case. `-runs`,
 seeds, and the failure corpus do not apply: the rows are the corpus. A target
 whose rows directory is missing or empty is an error, never a vacuous pass;
 a row larger than `-max-bytes` is an error rather than a truncated case.
+`-max-bytes` is the runner's input ceiling for every target kind (choice
+tapes, corpus inputs, and rows alike); its default is 256 bytes, so a
+table whose rows are longer — a 257-byte conformance vector, say — is run
+as `oak test -max-bytes 4096 ...`, and the refusal names the row and the
+limit rather than truncating it. The ceiling is per row, not per table.
 
 The row's bytes reach the test as the `[]u8` argument. The row format is the
 test's own; `import(testing)` provides little-endian readers `test_row_u32`,


### PR DESCRIPTION
- `docs/notes/dbs-feedback-2026-09.md`: third round of dbs asks with dispositions and sequencing (typestate-indexed handles next; io/sim + io/native and quorum guards after; interval time, TLA+ conformance, rv64 planned; vector dispatch, rings, binary codec wanted), under the owner's standing constraints: a formal model per landed feature and measured, allocation-free runtime paths.
- `docs/spec/110-testing.md` "Table targets": `-max-bytes` named, its default stated, and the per-row refusal explained (ask 10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)