### PR TITLE
docs(checklists): correctness and performance extraction checklists

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 >
 > Measured performance against Go, Rust, and simdjson, with the raw
 > samples and the caveats, is in [`BENCHMARKS.md`](BENCHMARKS.md).
+>
+> Review passes walk the extraction checklists in
+> [`docs/checklists/`](docs/checklists/): [correctness](docs/checklists/correctness.md)
+> and [performance](docs/checklists/performance.md).
 
 Oak is a systems programming language designed for embedded systems, firmware, and low-level programming. It combines strong type safety, memory safety through borrow checking, and expressive type system features while compiling to simple, readable C code.
 

--- a/docs/checklists/README.md
+++ b/docs/checklists/README.md
@@ -1,0 +1,64 @@
+# Extraction checklists
+
+Two documents collect, once, the techniques Oak keeps re-deriving from its
+reference material — Go, Rust, Zig, Odin, Elm, the ML family, Swift,
+Futhark, Mojo, Scala; Idris, Coq, Lean, TLA+, Apalache, Z3; mlx, tinygrad,
+data-oriented design, mechanical sympathy, TigerBeetle and TigerStyle,
+MISRA C, NASA's Power of Ten, simdjson, simdutf, Hyperscan — so that a
+review pass walks a list instead of re-reading the sources.
+
+- [`correctness.md`](correctness.md) — everything that must be true.
+- [`performance.md`](performance.md) — everything that must be fast, and
+  how to know it is.
+
+The constitution orders the two: correctness, then performance, then
+simplicity (`../spec/00-constitution.md`). A performance item is never
+license to weaken a correctness item; the performance list says so where
+the tension is real, and points at the correctness item that wins.
+
+## Shape of an item
+
+```text
+- [ ] **Name.** The question to ask, stated so that "no" is a finding.
+      (source) — Oak: where the rule lives, or `open`, or `not stated`.
+```
+
+- **Name** is what a finding is filed under.
+- The **question** is phrased against a concrete artifact: a spec chapter,
+  a standard-library module, a compiler pass, a benchmark.
+- **(source)** names where the technique comes from, in a word or two.
+  It is provenance, not authority; the constitution and the spec are the
+  authority.
+- **Oak:** is a pointer into `docs/spec/`, `docs/notes/`, `stdlib/`, or
+  `benchmarks/`, so a pass can check the claim against the text.
+  `open` means the spec or a note records the item as not done;
+  `not stated` means no chapter takes a position yet — which is itself a
+  finding worth a line.
+
+## Running a pass
+
+1. Pick one target: a chapter, a module, a lowering, a benchmark. Not the
+   whole language.
+2. Walk one list top to bottom. For each item answer yes, no, or not
+   applicable — write down the "no"s and the "not stated"s.
+3. Record the findings as a `docs/notes/<target>-<yyyy-mm>.md` disposition
+   table in the existing style (ask, disposition, revisit criteria). Every
+   finding names the spec section it changes or the test it adds.
+4. Anything learned about the *technique* — a sharper question, a new
+   source, a case where the item was wrong — goes back into the checklist.
+   The sources are read once; the lists are what accumulate.
+
+A pass over a performance change also walks the correctness list's
+sections on oracles, numeric semantics, and transformation legality. A
+change that makes a benchmark faster and an oracle disagree is a
+correctness finding, not a performance win.
+
+## Adding an item
+
+Add an item when a source teaches something that is not already a line,
+or when a pass finds a class of problem no line would have caught. Merge
+rather than append when a line already covers it: the lists are meant to
+stay walkable in one sitting. Delete items the spec has made unnecessary
+only when the spec enforces them mechanically — a rule the compiler
+checks no longer needs a reviewer to ask about it, but the line should say
+which diagnostic code took over.

--- a/docs/checklists/correctness.md
+++ b/docs/checklists/correctness.md
@@ -1,0 +1,709 @@
+# Correctness checklist
+
+Everything that must be true. One flat list, grouped by where the question
+bites. Each item is a question; "no" is a finding. See [README](README.md)
+for the shape of an item and how to run a pass.
+
+Sources, abbreviated in parentheses: TigerStyle/TigerBeetle (TB), NASA
+Power of Ten (P10), MISRA C (MISRA), Rust, Zig, Odin, Go, Swift, Elm, the
+ML family (ML), Scala, Futhark, Mojo, Idris, Coq, Lean, TLA+, Apalache, Z3,
+simdjson, simdutf, Hyperscan, data-oriented design (DOD), langsec.
+
+---
+
+## 1. Principles the rest depends on
+
+- [ ] **Correctness first.** When a design trades correctness for speed or
+      simplicity, is the trade written down and rejected? A faster design
+      whose invariants cannot be stated and checked is not acceptable.
+      (constitution) — Oak: `00-constitution.md` Priorities.
+- [ ] **One fact, many projections.** Does every semantic fact — field
+      order, a refinement, a protocol transition, a layout — have exactly
+      one authoritative statement from which type checking, layout, proof
+      assumptions, runtime checks, tests, and debugger output are derived?
+      Is the compiler ever reconstructing a lost fact by guesswork?
+      (constitution, Idris/Lean: definition once, theorems many) —
+      Oak: `00-constitution.md`, `125-verification.md` §1.
+- [ ] **Five axes stay separate.** Does a feature overload one axis (type,
+      representation, authority, proposition, protocol) to smuggle in
+      another — a doc tag that changes ABI, a default that acts as a wire
+      discriminant? (constitution) — Oak: `00-constitution.md`.
+- [ ] **Safe by default, unsafe visible.** Can safe code reach undefined
+      behavior by any ordinary operation? Does every unsafe operation cross
+      a syntactically visible boundary that records exactly which
+      assumption it introduces, leaving every unrelated invariant checked?
+      (Rust, Zig, constitution) — Oak: `00-constitution.md`,
+      `50-borrowing.md`, `OAK-B0110`/`OAK-B0122` recorded assumptions.
+- [ ] **No hidden work.** Does any ordinary operation silently allocate,
+      block, do I/O, take a contended lock, dispatch dynamically without
+      bound, or copy unbounded data? Hidden work is a correctness problem
+      before it is a performance one: it is an effect the checker cannot
+      see. (constitution, Zig) — Oak: `00-constitution.md`,
+      `60-effects-allocation.md` §3.
+- [ ] **Machine semantics are semantics.** Are width, overflow behavior,
+      alignment, endianness, pointer size, atomics, and volatile access
+      specified as language semantics rather than left to a backend? Is a
+      mathematical integer ever confused with a machine integer?
+      (constitution, MISRA essential types) — Oak: `00-constitution.md`,
+      `20-types.md` §11.
+- [ ] **Sugar normalizes to a core.** Does every surface convenience lower
+      to a smaller core with one semantics, or does it create a parallel
+      semantics that must be kept in sync by hand? (constitution, Elm's
+      small core, Scala's desugaring pitfalls) — Oak: `00-constitution.md`
+      Syntax equivalence.
+- [ ] **Fail closed on unknowns.** When the checker cannot know something
+      — the effects of a call through an unknown value, the independence of
+      loop iterations, the layout of a foreign type — does it reject rather
+      than assume? (TB, P10 rule 10) — Oak: `60-effects-allocation.md` §2
+      (`OAK-E0103`), `55-parallelism.md` §2.
+
+## 2. Specify and model before you build
+
+- [ ] **Design document first.** Is there a written statement of what the
+      component must do, its invariants, and its failure modes, before
+      code? TB: the time spent designing is the cheapest time in the
+      project. (TB) — Oak: `docs/spec/` is normative; legacy docs retire
+      only after reconciliation (`docs/spec/README.md`).
+- [ ] **Five layers named.** For the feature, which of surface syntax,
+      static semantics, dynamic/machine semantics, formal model, and
+      implementation correspondence exist, and which are missing? Is the
+      maturity stated with the exact vocabulary — specified, implemented,
+      tested, modeled, proved, refined — and never rounded up? (Lean, Coq,
+      constitution) — Oak: `docs/spec/README.md`, `STATUS.md`.
+- [ ] **A proof of the model is not a proof of the compiler.** Where a
+      Lean or TLA+ result is cited, is the gap to the implementation
+      stated: extraction faithfulness, refinement, or differential testing
+      against the model? (Coq/CompCert lesson, TB's "simulation is a
+      witness, not a proof") — Oak: `00-constitution.md` Verification
+      discipline, `95-extraction.md`, `125-verification.md` §3.
+- [ ] **Invariants stated, not implied.** Does every stateful component
+      write down its invariants as predicates over its state — the TLA+
+      `TypeOK` plus safety properties — in a form a test, an assertion, and
+      a model checker can all consume? (TLA+, TB) — Oak:
+      `112-protocols.md` (invariant obligations, `oak prove`).
+- [ ] **Inductive, not just true.** Is the stated invariant inductive
+      (preserved by every step from any state satisfying it), or merely
+      true of reachable states? A non-inductive invariant will not
+      discharge in Apalache or Lean and hides which step is dangerous.
+      (TLA+, Apalache) — Oak: `125-verification.md` §2a.
+- [ ] **Temporal properties separated from safety.** Are liveness and
+      fairness stated separately from safety, with the fairness assumption
+      explicit? Most bugs are safety bugs; most unprovable claims are
+      liveness claims with hidden fairness. (TLA+) — Oak: `112-protocols.md`
+      §7 direction.
+- [ ] **Small model, then big test.** Was the protocol model-checked with a
+      small finite instance (two or three nodes, tiny data) before being
+      property-tested at scale? Exhaustive on the small model, statistical
+      on the large one. (TLA+/TLC, Apalache bounded symbolic) — Oak:
+      `112-protocols.md`, TLA+ export.
+- [ ] **Refinement mapping written.** Where an optimized implementation
+      claims to implement a simpler specification, is the refinement
+      mapping (abstraction function from concrete to abstract state)
+      written down and checked, not argued? (TLA+, Lamport; Coq) — Oak:
+      `112-protocols.md` §4a conformance, `STATUS.md` refinement policy.
+- [ ] **Decidable fragment chosen deliberately.** For each obligation sent
+      to an SMT solver, is it in a decidable fragment (linear integer
+      arithmetic, bit-vectors, arrays) so the answer is yes/no rather than
+      unknown/timeout? Quantifiers and non-linear arithmetic are where
+      solvers become oracles. (Z3, Apalache) — Oak: `125-verification.md`
+      §3 discharge ladder.
+- [ ] **Counterexamples are first-class.** When a check fails — pattern
+      exhaustiveness, a protocol invariant, a property test — does the tool
+      hand back a concrete, minimal counterexample the author can run?
+      (TLA+, Elm, property testing) — Oak: `35-pattern-analysis.md`,
+      `110-testing.md` shrinking, `15-diagnostics.md`.
+- [ ] **Assumptions have an audit trail.** Is every admitted assumption
+      listed in one place, reviewable, and stated as a theorem the proof
+      layer could later discharge? An assumption that is not listed is a
+      hidden axiom. (Lean `sorry`, Coq `Admitted`, TB) — Oak:
+      `85-discipline.md` §7 `admit`, `oak vet`, `:obligations`, `:lean`.
+
+## 3. Make illegal states unrepresentable
+
+- [ ] **Sum types for alternatives.** Are mutually exclusive states a
+      closed ADT rather than a record with flags and nullable fields whose
+      combinations are mostly invalid? (Elm, ML, Rust, Swift) — Oak:
+      `30-adts-patterns.md`.
+- [ ] **Exhaustive matching, no default arm.** Is every match over a sum
+      exhaustive without a wildcard, so adding a constructor is a compile
+      error at every consumer? Is redundancy also an error? (Elm, ML,
+      Rust, Swift; MISRA's "every switch has a default" is the weaker C
+      form) — Oak: `35-pattern-analysis.md`.
+- [ ] **No null.** Is absence `Option[T]`, with no nullable reference,
+      sentinel integer, or zero-length-means-missing convention? (Elm,
+      Rust, Swift, Odin/Zig optionals) — Oak: `30-adts-patterns.md` §1a,
+      hypervisor note ask 9.
+- [ ] **Errors are values.** Does fallible code return `Result[T, E]` with
+      a closed error type, rather than throwing, returning a status code
+      the caller may ignore, or returning an in-band sentinel? (Rust, Go,
+      Zig error unions, Swift `throws` as sugar over results) — Oak:
+      `20-types.md` §11.1a, `resource-contracts-and-results.md`.
+- [ ] **Newtypes for identities and units.** Are ids, offsets, byte
+      counts, element counts, durations, and monetary amounts distinct
+      types so that an offset cannot be passed as a length? Are units in
+      names when the type does not carry them (`timeout_ms`)? (TB, Rust,
+      F# units of measure, Haskell newtypes) — Oak: `80-metadata.md`
+      phantom semantic types, `20-types.md` nominal identity.
+- [ ] **Validated state lives in the type.** Once input is validated
+      (UTF-8 checked, JSON parsed, signature verified), is the fact carried
+      as a phantom type parameter or a distinct type so it cannot be
+      re-validated or skipped by accident — "parse, don't validate"? Is
+      the validated type constructible *only* through the validator?
+      (Alexis King, simdjson, Idris) — Oak: `71-codecs.md` §2, §6;
+      `70-strings.md`.
+- [ ] **Typestate for protocols.** Where a value must be used in a fixed
+      order (open→read→close, Host→Device custody), is the state an index
+      on the type so a misordered call fails to compile, with the index
+      erased at run time? (Rust typestate, Idris, session types) — Oak:
+      `112-protocols.md` §5a, `Oak.Typestate`, `92-ffi.md` §2.8.5.
+- [ ] **Refinements over raw scalars.** Where an integer must be nonzero,
+      in range, aligned, or a power of two, is that a proposition the
+      checker knows (and elides checks from) rather than a comment?
+      (Idris, Liquid Haskell, Z3-backed refinement) — Oak: proposition
+      axis, extent facts in `50-borrowing.md`, `20-types.md`.
+- [ ] **Sizes in types.** Are fixed capacities const parameters
+      (`[N]T`, `Ring[T, N]`) rather than runtime fields checked at every
+      access? Are size relations (`[M*K]T`) folded at instantiation?
+      (Futhark size types, Idris vectors, Zig comptime, Rust const
+      generics) — Oak: `20-types.md` §11.0.
+- [ ] **Effects in types.** Does a function's type say what it may do
+      (allocate, block, read host memory, touch a device) so a caller's
+      `forbids` sees through the call, including through function values?
+      (Koka, effect rows; TB's "no allocation after init") — Oak:
+      `60-effects-allocation.md` §2, §2a.
+- [ ] **Uniqueness or ownership for in-place update.** When a function
+      mutates its argument in place, does the type system guarantee no
+      other reader sees the mutation — uniqueness types, `&mut`, or a
+      consuming parameter mode? (Futhark uniqueness, Rust `&mut`, Clean)
+      — Oak: `50-borrowing.md`, receiver/parameter modes.
+- [ ] **Closed by default.** Are types, modules, and enumerations closed
+      unless explicitly opened, so exhaustiveness and layout facts hold?
+      Is `pub` opt-in and `pub(opaque)` available so representation does
+      not leak? (Elm, Rust, Go, Swift `final`) — Oak: `83-modules.md`.
+- [ ] **No implicit conversions.** Is every change of width, signedness,
+      or numeric kind spelled out, with truncating, saturating, checked,
+      and bit-reinterpreting forms distinct? (Swift, Rust, MISRA essential
+      types, Go) — Oak: `20-types.md` §11.1.
+- [ ] **Literals are typed exactly.** Does an out-of-range literal fail to
+      compile rather than wrap or promote? Do integer constructors over
+      literals fold without changing meaning? (Rust, Swift, MISRA) — Oak:
+      `25-type-inference.md` §3a.
+- [ ] **Structural sharing is explicit.** Does the type distinguish a view
+      (borrowed, read-only), a span (borrowed, writable), an owned value,
+      and a handle (index into an owner), with no implicit conversion from
+      owned to borrowed that outlives the owner? (Rust, Zig slices, Odin)
+      — Oak: `50-borrowing.md`, `60-effects-allocation.md` §8.
+
+## 4. Memory, ownership, and aliasing
+
+- [ ] **Every access bounds-checked or proven.** Is every indexed access
+      either checked at run time or discharged by a fact the checker holds
+      (`i < len`)? Is the elided check recorded as a proof obligation, not
+      a flag? (Rust, Zig, Swift, TB) — Oak: `50-borrowing.md` extents,
+      `56-kernels.md` §3 (elision open).
+- [ ] **No dangling, no use-after-free, no double free.** Is every borrow
+      bounded by its owner's region, every consuming operation invalidating
+      its binding, every owner freed exactly once? Is this checked, not
+      convention? (Rust, Cyclone regions) — Oak: `50-borrowing.md` §8c
+      regions, `Oak.Escape`.
+- [ ] **Mutable aliasing forbidden.** Can two live paths write the same
+      memory without an atomic or a proven disjointness fact? Are
+      writable-disjointness assumptions on unsafe blocks recorded?
+      (Rust, Futhark, MISRA restrict) — Oak: `50-borrowing.md`,
+      `OAK-B0110`.
+- [ ] **No uninitialized reads.** Is every variable, field, and buffer
+      element initialized before any read, including padding that a
+      serializer might copy? Is "zero is a valid value" true for every
+      zero-initialized type, or is zero-init forbidden for that type?
+      (Rust, Zig `undefined` is explicit, MISRA 9.1, TB) — Oak:
+      `60-effects-allocation.md` §10a static initializers.
+- [ ] **Alignment and layout are facts.** Is every record layout derived
+      from one stated rule, exposed via `size_of`/`offset_of`, asserted in
+      the emitted code, and ratified against the C compiler? Do `(align:
+      N)` annotations produce an emitted assertion? (Zig, Rust
+      `#[repr(C)]`, DOD) — Oak: `40-records.md`, `45-representations.md`,
+      `92-ffi.md` §2.6.
+- [ ] **Endianness explicit at every byte boundary.** Is every multi-byte
+      read or write from a byte buffer through a named-endianness function
+      that returns a result, never a cast or a reinterpret? (TB, MISRA,
+      Zig `readInt`) — Oak: `bytes_read_*_le/be` in `stdlib/std.oak`,
+      hypervisor note ask 12.
+- [ ] **Pointer arithmetic only in unsafe, and rarely.** Does safe code
+      compute offsets over views and spans, with pointer arithmetic
+      confined to the FFI and MMIO layers under a recorded contract?
+      (P10 rule 9, MISRA 18.x, Rust) — Oak: `92-ffi.md`, `96-aarch64-mmio.md`.
+- [ ] **Handles over pointers, with generations.** For pooled objects, is
+      the reference a typed index plus a generation counter so a stale
+      handle is detected rather than dereferencing freed storage?
+      (DOD, TB, Andre Weissflog's handles) — Oak:
+      `60-effects-allocation.md` §8, `standard-library-design.md` §6.
+- [ ] **Capacity is declared, exhaustion is a value.** Does every
+      fixed-capacity container declare its capacity and return a result on
+      exhaustion rather than growing or trapping? (TB static allocation,
+      P10 rule 3) — Oak: `60-effects-allocation.md` §6–§9,
+      `85-discipline.md` §4.
+- [ ] **Resource cleanup is guaranteed and ordered.** Is every acquired
+      resource released on every path, including error paths, in reverse
+      acquisition order, with the release visible at the acquisition site?
+      (Zig/Go `defer`, Rust `Drop`, Odin) — Oak: `defer` in
+      `10-syntax.md` (block-scoped, one statement); terminal-state
+      obligations in `112-protocols.md`.
+- [ ] **Foreign memory is a contract, not a type cast.** Does every buffer
+      that crosses the FFI carry pointer, count, and ownership as a typed
+      triple, with the foreign side's aliasing and lifetime assumptions
+      recorded per borrow? (Rust FFI, Zig extern, Swift unsafe pointers) —
+      Oak: `92-ffi.md` §2.6–§2.8, `c.borrow`.
+- [ ] **Custody across devices is a state, not a comment.** When memory
+      moves between host and device, or between processes, is the custody a
+      typestate whose transition is the only place the side effect can
+      occur? (mlx unified memory pitfalls, CUDA) — Oak: `92-ffi.md`
+      §2.8.5 `Buffer[T, S]`.
+- [ ] **MMIO and volatile are effects with barriers.** Is every device
+      register access typed (width, access kind, side effect), volatile,
+      ordered by an explicit barrier, and never merged, reordered, or
+      elided by the optimizer? (MISRA volatile, Linux kernel memory
+      barriers doc) — Oak: `65-machine-memory.md` §9, `95-aarch64-barriers.md`,
+      `96-aarch64-mmio.md`.
+
+## 5. Control-flow and coding discipline
+
+- [ ] **Every loop has a static bound.** Does each loop carry a bound the
+      compiler can see (canonical counter, declared bound with runtime
+      guard, or a ranking function proven decreasing), so a runaway loop
+      is impossible by construction? (P10 rule 2, TB, MISRA 14.x) — Oak:
+      `85-discipline.md` §3, `OAK-D0103`, `Oak.BoundedLoop`.
+- [ ] **Recursion is bounded or absent.** Is stack depth statically
+      bounded — tail calls lowered to loops or trampolines, stack-consuming
+      cycles rejected, declared depth bounds with runtime checks otherwise?
+      (P10 rule 1, MISRA 17.2, TB) — Oak: `85-discipline.md` §2,
+      `Oak.Discipline`.
+- [ ] **No allocation after initialization.** Does every steady-state
+      entry point (event loop, request handler, interrupt path) forbid
+      allocation, with the compiler rejecting any reachable allocation
+      including through externs? (P10 rule 3, TB, MISRA 21.3) — Oak:
+      `85-discipline.md` §4, `steady` manifest lines, `OAK-E0104`.
+- [ ] **Functions are short and do one thing.** Is any function over
+      roughly seventy lines, or doing two things a name cannot cover?
+      Long functions hide the control flow a reviewer must hold in mind.
+      (P10 rule 4, TB) — Oak: not stated as a rule; a strict-profile lint
+      is a candidate.
+- [ ] **Assertion density.** Does every function assert its preconditions,
+      postconditions, and the invariants it relies on — at least two per
+      function — and are assertions compiled in for every build mode?
+      (P10 rule 5, TB) — Oak: `85-discipline.md` §5 (density lint
+      planned).
+- [ ] **Pair assertions.** Where a property is established in one place
+      and relied on in another, is it asserted at both — the producer
+      asserting what it guarantees, the consumer asserting what it needs —
+      so a violation is caught at the boundary it crosses? (TB) — Oak:
+      practice; not stated.
+- [ ] **Assertions name both values.** Does a failed comparison report
+      got and want, not just "assertion failed"? Does a trap say which
+      source line? (TB, Go testing) — Oak: `85-discipline.md` §5
+      `assert_eq`/`assert_ne`.
+- [ ] **Assertions may not have side effects.** Is every assertion
+      condition pure, so compiling it in or out cannot change behavior?
+      (MISRA 13.x, P10) — Oak: assertions are always on, which makes this
+      moot only if the language forbids effects in the condition; check.
+- [ ] **Every result is used or discarded on purpose.** Is a non-unit
+      result that is neither consumed nor explicitly discarded (`_ =`) a
+      rejection? Is discarding a unit value itself an error, so `_ =`
+      always marks a real choice? (P10 rule 7, MISRA 17.7, Rust
+      `#[must_use]`, Go `errcheck`) — Oak: `85-discipline.md` §6
+      (`OAK-D0104` planned).
+- [ ] **Data scope is minimal.** Is every variable declared at the
+      smallest scope, every block its own scope, and shadowing either
+      forbidden or confined? Is mutable global state absent or a typed
+      static with an explicit initializer? (P10 rule 6, MISRA 8.x) — Oak:
+      block scoping (hypervisor note ask 6), `60-effects-allocation.md`
+      §10a.
+- [ ] **No side effects in conditions or operands.** Is the order of
+      evaluation of operands irrelevant to the result because operands are
+      pure, or is the order specified and the effects visible? (MISRA
+      13.x, Go's spec on evaluation order) — Oak: `10-syntax.md` fixes
+      left-to-right for operands and call arguments; effects in operands
+      are otherwise unrestricted — a strict-profile lint is a candidate.
+- [ ] **Simple control flow.** No `goto`, no `setjmp`/`longjmp`, no
+      exceptions, no non-local exit other than a result value; `break`
+      leaves exactly one loop. (P10 rule 1, MISRA 15.x) — Oak:
+      `85-discipline.md` §3a.
+- [ ] **No dead or unreachable code.** Is unreachable code (an
+      unreachable match arm, code after a diverging call) a diagnostic,
+      and is dead code deleted rather than commented out? (MISRA 2.x) —
+      Oak: `35-pattern-analysis.md` unreachable arms.
+- [ ] **Magic numbers named.** Is every literal that carries meaning a
+      named constant with its unit, and does the compiler fold it? (MISRA,
+      TB) — Oak: `sam/literals-and-constants` branch.
+- [ ] **Zero warnings, all checkers.** Does the build reject every warning
+      under the strict profile, with each accepted assumption an explicit
+      `admit` line that keeps its audit trail? Are all available static
+      analyzers run every day? (P10 rule 10, MISRA, TB) — Oak:
+      `85-discipline.md` §7.
+- [ ] **Naming carries meaning.** Do names avoid abbreviations, carry units
+      or qualifiers where the type does not, and put the most significant
+      word first so related names sort together? (TB, Go) — Oak: style;
+      not stated.
+- [ ] **Comments say why, not what.** Is every non-obvious decision,
+      especially every unsafe block and every admitted assumption, given a
+      reason a future reader can test? Are specification references linked
+      with section numbers? (TB, P10) — Oak: practice.
+
+## 6. Integer and floating-point semantics
+
+- [ ] **Overflow behavior is chosen per operation.** Is the default
+      (wrap) stated, and are checked, saturating, and truncating forms
+      distinct named operations with total semantics — no
+      implementation-defined C? Does `MIN / -1` have a stated answer?
+      (Rust, Zig, Swift traps, MISRA) — Oak: `20-types.md` §11.1, §11.1a;
+      `90-backend.md` §7.
+- [ ] **Division by zero traps, everywhere.** Does the interpreter, the C
+      backend, the Metal lowering, and the Lean model agree? (Zig, Rust)
+      — Oak: `20-types.md` §11.1, `56-kernels.md` §3 fault word.
+- [ ] **Shifts are bounded.** Is a shift by more than the width a compile
+      error for constants and a trap or defined result for variables, never
+      C's undefined behavior? (MISRA 12.2, Rust) — Oak: `20-types.md`
+      §11 requires shift semantics to be specified per operation; the
+      rule itself is not written — gap.
+- [ ] **No signed/unsigned mixing.** Are comparisons and arithmetic across
+      signedness or width rejected rather than promoted? (MISRA essential
+      types, Go, Rust) — Oak: `20-types.md`; `OAK-T0601` for assertions.
+- [ ] **Float addition is not associative, and the language knows it.**
+      Is the grouping of every reduction a stated fact (`reduce.tree`'s
+      balanced counter tree, `reduce.left`), so two backends and the Lean
+      model produce the same bits? Is regrouping permitted only by a
+      declared law? (ml pilot F2/F3, Futhark, numerical analysis) — Oak:
+      `55-parallelism.md` §4, `stdlib/reduce.oak`, `10-syntax.md` §14a
+      `laws { associative }`.
+- [ ] **No fast-math.** Are FMA contraction, reassociation, reciprocal
+      approximation, flush-to-zero, and NaN assumptions all off unless
+      explicitly requested per operation, and is the request visible in
+      the type or the call? (LLVM fast-math hazards, Mojo, mlx) — Oak:
+      `56-kernels.md` §4, `93-simd.md` §1.2a.
+- [ ] **NaN, infinities, and signed zero have stated behavior.** Does
+      every comparison, min/max, sort, and hash on floats say what it does
+      with NaN and `-0.0`? Is the ordering total where a sort needs it?
+      (IEEE 754, Rust `total_cmp`, Swift) — Oak: `20-types.md` §11.3.3
+      semantics fixed in the specification; `stdlib/float`; the Lean
+      float model.
+- [ ] **Float text round-trips.** Does printing use enough digits
+      (`%.9g`/`%.17g` or shortest-round-trip) and does parsing produce the
+      correctly rounded value? (Ryu, Eisel-Lemire, simdjson) — Oak:
+      `85-discipline.md` §5 assertion printing; parsing in codecs.
+- [ ] **Denormals and rounding mode are not assumed.** Does any kernel
+      depend on the default rounding mode or on denormals being preserved
+      without saying so? Does the Metal target differ from C here, and is
+      the difference stated? (mlx, Metal shading language spec) — Oak:
+      `56-kernels.md` §4.
+- [ ] **Differential float testing against the model.** Is every float
+      operation tested bit-for-bit against the interpreter and against the
+      Lean model's definition, not just against "close enough"? (simdutf,
+      TB) — Oak: `20-types.md` §11.3.5 three-witness rule (interpreter,
+      C, Lean), §11.3.6 fourth witness for transcendentals.
+
+## 7. Concurrency and the memory model
+
+- [ ] **A data race is undefined, so it is forbidden.** Are conflicting
+      unsynchronized accesses rejected by ownership or typed as atomics,
+      never permitted with a comment? (Rust, C11/C++11, Go race detector)
+      — Oak: `66-memory-model.md` §7.
+- [ ] **Happens-before is the vocabulary.** Are synchronization arguments
+      written in terms of sequenced-before, synchronizes-with, and
+      happens-before, with the executions model the Lean theorems use,
+      rather than in terms of "the compiler won't reorder this"?
+      (C11, Java memory model, herd/litmus) — Oak: `66-memory-model.md`
+      §1–§5, `MemoryOrder.lean`.
+- [ ] **Orders are explicit and minimal but never weaker than proven.**
+      Does every atomic operation name its order? Is relaxed used only
+      with an argument the model checks? Is sequential consistency the
+      default when no argument is given? (Rust, C11, Preshing) — Oak:
+      `65-machine-memory.md` §2, `67-memory-ordering.md`,
+      `68-sequential-consistency.md`.
+- [ ] **Litmus tests per target.** Does each target's refinement (C11
+      atomics, AArch64 barriers, RISC-V RVWMO) come with the standard
+      litmus shapes (message passing, store buffering, load buffering,
+      IRIW) run against the model and against hardware or a simulator?
+      (herd7, Sail, ARM ARM) — Oak: `69-aarch64-memory-refinement.md`,
+      `spec/sail`.
+- [ ] **Single writer where possible.** Does the design prefer
+      single-producer single-consumer rings, per-core ownership, and
+      message passing over shared mutable state and locks? (TB, LMAX
+      Disruptor, DOD) — Oak: `standard-library-design.md` Ring, dbs asks
+      8.
+- [ ] **Ownership transfer across threads is a protocol.** When a value
+      changes owner across a synchronization edge, is that a typed
+      transition with the barrier at the transition, model-checked as a
+      state machine? (Rust `Send`, TLA+) — Oak: `112-protocols.md`,
+      `Buffer[T, S]` custody.
+- [ ] **No blocking in bounded paths.** Is blocking (locks, I/O, sleeps)
+      an effect that realtime and interrupt entry points forbid? (TB,
+      realtime audio rules) — Oak: `60-effects-allocation.md` §12,
+      `55-parallelism.md` §8.
+- [ ] **Parallel iterations are proven independent.** Is a parallel loop
+      admitted only when the checker proves iterations do not conflict
+      (one element per thread, tiles disjoint), failing closed otherwise?
+      Is the theorem named? (Futhark, ml pilot, OpenMP's unchecked
+      `parallel for` as the anti-pattern) — Oak: `55-parallelism.md` §2,
+      `Oak.Kernel.run_perm` (checker rule open).
+- [ ] **Deterministic under simulation.** Can every concurrent component
+      run under a simulated scheduler with a seed so that any interleaving
+      bug is replayable? (TB VOPR, FoundationDB) — Oak: `110-testing.md`
+      Deterministic event simulation, Crashes and scheduling.
+
+## 8. Testing as an engineering discipline
+
+- [ ] **Deterministic simulation testing.** Does the component run under
+      simulated time, storage, network, and scheduling from a single seed,
+      so a failure replays exactly and shrinks? Is production code and
+      test code the same code with the I/O port swapped? (TB VOPR,
+      FoundationDB, dbs) — Oak: `110-testing.md`, `120-io.md` `io/sim`
+      vs `io/native`, `stdlib/sim_storage.oak`.
+- [ ] **Fault injection covers the real fault model.** Are the faults
+      injected the ones hardware and operating systems actually produce —
+      torn writes, misdirected writes, dropped writes, lost fsync, bit
+      flips, latent sector errors, crashes between write and sync, clock
+      jumps, partitions — not just "the call returned an error"? (TB, dbs,
+      "Protocol-Aware Recovery") — Oak: `110-testing.md` Simulated
+      storage (six kinds), Simulated time.
+- [ ] **Durability and detection are separate obligations.** Does the
+      storage test distinguish "this block must survive" from "corruption
+      of this block must be detected", tracked by provenance, so neither
+      hides the other? (dbs note) — Oak: `110-testing.md` provenance
+      ledger.
+- [ ] **Property tests with shrinking and replay.** Does every generated
+      input come from a choice tape that shrinks toward a minimal failing
+      case, and is the failing tape stored in a corpus and replayed on
+      every run thereafter? (QuickCheck, Hypothesis, TB) — Oak:
+      `110-testing.md` Choice tapes, Corpus and replay.
+- [ ] **Stateful command testing.** Are stateful components tested by
+      generated command sequences against a model with invariants checked
+      after every command, with shrinking that removes commands? (Erlang
+      QuickCheck, Hypothesis stateful) — Oak: `110-testing.md` Stateful
+      command properties, typed commands.
+- [ ] **Differential testing against references.** Is every codec, hash,
+      sort, UTF-8 validator, and numeric routine tested bit-for-bit
+      against at least one independent implementation (Go, Rust, Zig,
+      simdjson, simdutf) on the same inputs? (simdutf, TB, csmith for
+      compilers) — Oak: `stdlib/hash.oak` differential vs Go,
+      `benchmarks/state-machines`, `sam/float-differential`.
+- [ ] **Oracle is the slow path, kept in tree.** Does every optimized
+      routine keep its pre-optimization form as an oracle and test the two
+      agree on generated inputs, including adversarial ones? (simdjson, ml
+      fusion oracle) — Oak: `71-codecs.md` §4a, codec-fusion note.
+- [ ] **Counters prove the optimization fired.** Does a test assert that
+      the fast path was actually taken (a counter, an absence check over
+      the emitted C), so a silent fallback to the slow path is a test
+      failure? (ml, TB) — Oak: `71-codecs.md` §4 wrapper-absence checks.
+- [ ] **Known-answer vectors.** Are standard test vectors (RFC, NIST,
+      Unicode conformance, JSON test suite) run, with the vector file in
+      tree and its provenance noted? (NIST CAVP, simdjson's JSONTestSuite)
+      — Oak: `stdlib/hash.oak` KATs, `sam/tla-conformance`.
+- [ ] **Interpreter and every backend agree.** Is each language feature
+      differentially tested across the interpreter, the C backend, and any
+      other backend at every boundary value? (csmith, TB) — Oak: e2e
+      tests in `compiler/`, hypervisor note ask 2.
+- [ ] **Boundary values every time.** Zero, one, capacity, capacity minus
+      one, capacity plus one, empty, maximum width, minimum signed,
+      unaligned offset, input exactly at a SIMD block edge, input one byte
+      past padding. (classic, simdjson block edges) — Oak: `110-testing.md`
+      generated inputs; check per module.
+- [ ] **Negative tests.** Does every validator have tests that must
+      reject, with the exact error and precedence asserted, not just tests
+      that must accept? (langsec, simdjson) — Oak: `71-codecs.md` error
+      precedence (`InvalidEncoding` over `InvalidSyntax`).
+- [ ] **Roundtrip and algebraic laws.** Are encode∘decode = id,
+      decode∘encode = canonicalize, sort idempotence and permutation
+      preservation, hash determinism, and ordering laws stated as
+      properties and, where possible, as Lean theorems over the same
+      definition? (QuickCheck, Lean) — Oak: `sam/codec-laws`,
+      `sam/pdqsort-laws`, `sam/sort-laws-universal`, `sam/stdlib-laws-*`.
+- [ ] **Exhaustive on small domains.** Where the input space is small
+      (all byte pairs, all u8 values, all three-node protocol states), is
+      it enumerated rather than sampled? (Hyperscan's byte-class tests,
+      TLC) — Oak: practice per module.
+- [ ] **Every bug becomes a test first.** Is the reproducer committed
+      before the fix, in the corpus if generated, as a table row if
+      hand-written? (classic) — Oak: `110-testing.md` Corpus, Table
+      targets.
+- [ ] **Tests are hermetic and deterministic.** No wall clock, no real
+      network, no shared temp state, no order dependence; a failing seed
+      is printed and re-runnable. Flakiness is a bug filed against the
+      test. (Go, TB) — Oak: `110-testing.md` Isolation.
+- [ ] **Fuzz continuously, structure-aware.** Is every parser exported to
+      a fuzzer (libFuzzer) with a structure-aware generator, run
+      continuously, with the corpus checked in? (simdjson, Hyperscan,
+      oss-fuzz) — Oak: `110-testing.md` Fuzzing.
+- [ ] **Diagnostics are tested.** Does every stable diagnostic code have a
+      test asserting the code, the primary label location, and the help
+      text, and is output deterministic across runs and machines? (Rust's
+      UI tests, Elm) — Oak: `15-diagnostics.md` §11–§12.
+- [ ] **Race detector and sanitizers in CI.** Are the Go race detector,
+      ASan/UBSan on the emitted C, and Miri-equivalent interpretation run
+      on the standard library and compiler tests? (Go, LLVM) — Oak: `-race` in `ci.yml`; ASan and UBSan on emitted
+      C in `stdlib-benchmark.yml` only — extend to the compiler e2e
+      suites.
+
+## 9. Parsing, input validation, and boundaries
+
+- [ ] **Validate once, at the boundary, and record it.** Is every external
+      input (bytes from disk, network, FFI, user) validated exactly once
+      on entry, with the result a distinct type, and is the interior of the
+      program free of re-validation and of unvalidated data? (langsec,
+      "parse, don't validate", simdjson) — Oak: `71-codecs.md` §6,
+      `70-strings.md`.
+- [ ] **Never read past the input.** Is the padding contract (if any)
+      explicit in the type or the call, and is reading beyond `len`
+      impossible in safe code even when the SIMD block would? (simdjson's
+      `SIMDJSON_PADDING`, simdutf) — Oak: `71-codecs.md` §11, §16 forbid
+      over-read.
+- [ ] **Output unchanged on failure.** When an encoder or writer fails
+      partway, is the destination left exactly as it was (two-pass
+      size-then-write, or a rollback), so the caller cannot see a partial
+      record? (TB, codec note) — Oak: `71-codecs.md` §7 contracts.
+- [ ] **Length before content.** Is every length prefix checked against
+      the remaining input and against a declared maximum before any
+      allocation or loop uses it? (langsec, every CVE) — Oak:
+      `bytes_read_*` return results; check derived binary codec (dbs ask
+      9, wanted).
+- [ ] **Depth and size limits.** Does every recursive format (JSON
+      nesting, ASN.1, protocol payload trees) have a declared depth limit
+      and total size limit, enforced before recursion? (simdjson depth,
+      P10 recursion rule) — Oak: derived codecs nest only as deep as
+      the finite schema, so no runtime depth stack exists
+      (`71-codecs.md`); a schemaless JSON reader would need the limit;
+      `110-testing.md` `-max-bytes` bounds input size.
+- [ ] **Canonical encodings only.** Are non-canonical forms (overlong
+      UTF-8, non-minimal varints, leading zeros where forbidden, duplicate
+      keys) rejected rather than normalized silently, so two encodings of
+      one value cannot bypass a check? (WHATWG, RFC 3629, Protobuf
+      pitfalls) — Oak: `sam/varint-canonical`, `70-strings.md`.
+- [ ] **Error precedence is specified.** When an input is wrong in two
+      ways, which error is reported? Is that order stated, tested, and
+      preserved by every fast path? (simdjson, codec note) — Oak:
+      `71-codecs.md` §4a.
+- [ ] **Total functions on untrusted input.** Does any input, however
+      adversarial, cause a trap rather than a result in a parser? A trap on
+      external input is a denial-of-service bug; a trap on an internal
+      invariant is correct. (langsec, TB's distinction) — Oak: check every
+      `assert` in `stdlib/json.oak`, `stdlib/strings.oak` is on an
+      internal invariant, not on input.
+- [ ] **Bounded work per byte.** Is the worst-case work of every parser
+      linear in input size with no backtracking, no quadratic string
+      building, no hash-collision blowup on attacker-chosen keys?
+      (Hyperscan's no-backtracking DFA/NFA, simdjson two-stage) — Oak:
+      `71-codecs.md` §11, §19; hash seeding in `stdlib/hash.oak` — check.
+- [ ] **UTF-8 validation is exact and tested against the table.** Does the
+      validator reject every ill-formed sequence in Unicode Table 3-7
+      (overlongs, surrogates, above U+10FFFF, truncated sequences) and is
+      it differentially tested against simdutf? (simdutf, Keiser–Lemire)
+      — Oak: `benchmarks/state-machines` UTF-8 against Go, Rust, Zig,
+      simdutf, simdjson.
+- [ ] **FFI boundary is a validator.** Does every value entering from C —
+      spans, records, unions, function pointers — get its contract checked
+      or recorded at the boundary, with an unknown layout a rejection?
+      (Rust FFI, Swift C interop) — Oak: `92-ffi.md` §2.6, §2.10;
+      `feat(verify): records and unions at the boundary`.
+
+## 10. Errors, failure, and diagnostics
+
+- [ ] **Crash on invariant violation, return on expected failure.** Does
+      the code trap (fail fast, loudly, with location) when an internal
+      invariant is broken, and return a result when the environment does
+      something legal but unwelcome? Is the line between the two written
+      down per module? (TB, Erlang "let it crash", Go panics vs errors) —
+      Oak: `85-discipline.md` §5; state the line per stdlib module.
+- [ ] **Errors carry cause and location.** Does every error value and every
+      diagnostic identify the primary cause, secondary causes, and exact
+      source positions, and explain in the programmer's concepts rather
+      than the solver's? (Elm, Rust) — Oak: `15-diagnostics.md` §1–§4,
+      §10.
+- [ ] **Stable codes.** Does every diagnostic have a stable code that
+      tests, documentation, `admit` lines, and users can name, and is a
+      code never reused for a different meaning? (Rust `E0xxx`, MISRA
+      rule numbers) — Oak: `15-diagnostics.md` §2.
+- [ ] **Help is mechanically credible.** Does a suggested fix compile and
+      preserve meaning, or is it labeled as a hint? A wrong "help" is worse
+      than none. (Elm, Rust `rustfix`) — Oak: `15-diagnostics.md` §8.
+- [ ] **Cascades suppressed.** Does one root error produce one diagnostic,
+      with dependent errors suppressed, so the first line printed is the
+      thing to fix? (Elm, Rust) — Oak: `15-diagnostics.md` §9.
+- [ ] **Internal compiler errors are bugs, not diagnostics.** Is an ICE
+      reported with a reproducer request and never as a user error, and
+      does the compiler never emit code after an ICE? (Rust) — Oak:
+      `15-diagnostics.md` §13.
+- [ ] **No silent truncation or coercion in error paths.** Does an error
+      message print values exactly (full width, correct signedness, float
+      round-trip digits)? (TB) — Oak: `85-discipline.md` §5.
+
+## 11. Compiler and toolchain correctness
+
+- [ ] **Deterministic output.** Does the same input produce byte-identical
+      emitted C, diagnostics, API snapshots, and Lean extraction, across
+      runs, machines, and map iteration orders? (reproducible builds, Go)
+      — Oak: `15-diagnostics.md` §11; check emitted C ordering.
+- [ ] **Public API snapshots gate SemVer.** Is every public surface
+      snapshotted, diffed on every change, and the version bump computed
+      rather than chosen? (Elm's enforced SemVer, Rust `cargo semver-checks`)
+      — Oak: `82-package-semver.md`, `feat/canonical-api-snapshots`.
+- [ ] **Extraction is faithful and fails closed.** Does the Lean
+      extraction reject any construct it cannot model rather than
+      approximating, and are the modeling choices (traps as `none`, wrap
+      semantics) stated? Is faithfulness itself tested? (CompCert, hs-to-coq)
+      — Oak: `95-extraction.md` §3–§4, `feat(lean)` faithfulness.
+- [ ] **Foundational laws refined first.** Are the smallest load-bearing
+      components — type lattice, parser cursor contract, borrow-state
+      transitions, effect subsumption, span conversions, diagnostic
+      structure — the ones with machine-checked refinement, before larger
+      features claim proofs? (constitution) — Oak: `docs/spec/README.md`
+      Proof/code relationship, `STATUS.md`.
+- [ ] **Transformations are licensed.** Is every optimization (fusion,
+      inlining, vectorization, tiling, reassociation, check elision)
+      permitted only by a stated legality rule — values, machine numerics,
+      borrow flow, effect order, observable traps, synchronization, ABI —
+      and ideally by a theorem? (ml license theorem, Futhark, CompCert) —
+      Oak: `05-ergonomics-and-cost.md` Optimization is constrained by
+      semantics, `55-parallelism.md` §6.
+- [ ] **Generic code is checked once, instantiated many.** Are constraints
+      checked at the definition (no C++-style post-monomorphization
+      errors), and is every instantiation's specialized code differentially
+      tested against the generic semantics? (Rust, ML modules, Swift) —
+      Oak: `25-type-inference.md`, `feat(nativegen): generic
+      instantiations`.
+- [ ] **Type inference is predictable and local.** Does inference never
+      generalize unsoundly (value restriction), never depend on declaration
+      order across a module boundary, and always admit an explicit
+      annotation that means exactly what inference would have chosen?
+      (ML value restriction, Go's locality, Swift's inference blowups as
+      the anti-pattern) — Oak: `25-type-inference.md` safe generalization.
+- [ ] **The spec and the implementation are reconciled continuously.** Is
+      every behavior in the compiler traceable to a spec section, and every
+      spec sentence either implemented, marked planned, or marked
+      direction? Are legacy documents retired only after reconciliation?
+      (TB "the code is the design, the design is the code") — Oak:
+      `docs/spec/README.md`, `LEGACY_RECONCILIATION.md`, `STATUS.md`.
+- [ ] **Obligations are enumerable.** Can a user list every unproven
+      assumption in a build — unsafe contracts, unbounded loops, tail
+      obligations, admitted warnings — with one command? (Lean `#print
+      axioms`, TB) — Oak: `oak vet`, `:obligations`.
+- [ ] **Bootstrap trust is stated.** Which parts of the toolchain (the Go
+      compiler, the C compiler, Lean, the Metal compiler) are trusted, and
+      is the trusted computing base written down and minimized? (Thompson
+      "Reflections on Trusting Trust", CompCert TCB) — Oak: not stated;
+      candidate for `125-verification.md`.
+
+## 12. Process
+
+- [ ] **Small commits, always green.** Is every commit buildable and
+      tested, small enough to review in one sitting, with the spec change
+      and the code change together? (TB, Go) — Oak: practice.
+- [ ] **Review walks the list.** Does a review of a security- or
+      correctness-sensitive change walk this checklist's relevant sections
+      and record the "no"s in the note? (MISRA compliance matrix, P10) —
+      Oak: this document.
+- [ ] **Feedback from consumers is dispositioned, not lost.** Is every
+      ask from the os, dbs, and ml consumers recorded with a disposition
+      and revisit criteria, so the same gap is not rediscovered?
+      (practice) — Oak: `docs/notes/*-feedback-*.md`.
+- [ ] **Every pass writes back.** When a pass over a source teaches a new
+      question, is the question added here with provenance, so the next
+      pass starts from the list and not from the source? (this README) —
+      Oak: `docs/checklists/README.md`.

--- a/docs/checklists/performance.md
+++ b/docs/checklists/performance.md
@@ -1,0 +1,667 @@
+# Performance checklist
+
+Everything that must be fast, and how to know it is. One flat list,
+grouped by where the question bites. Each item is a question; "no" is a
+finding. See [README](README.md) for the shape of an item and how to run a
+pass. The [correctness list](correctness.md) wins every conflict; items
+here say where the tension is real.
+
+Sources, abbreviated in parentheses: TigerStyle/TigerBeetle (TB),
+data-oriented design (DOD), mechanical sympathy (MS), simdjson, simdutf,
+Hyperscan, mlx, tinygrad, Futhark, Mojo, Zig, Odin, Rust, Go, Swift,
+Halide, and the papers named inline.
+
+---
+
+## 0. The method: golden implementations and the expressiveness gap
+
+The organizing question is not "how do we make this fast?" but:
+
+> The fastest known implementation of this exists, in C, Zig, Rust, or
+> intrinsics. **Why can it not be written in Oak, with its correctness
+> checked?** Every "because Oak cannot say X" is an expressiveness gap,
+> and the gap — not the benchmark — is the finding.
+
+This is the ml pilot's principle made general: find the optimal structure
+for the golden use case, wrap it in correctness proofs, and make that the
+simplest thing a user can write, so the language dictates the fast
+implementation and the user never fights for performance
+(`docs/notes/ml-language-requests-2026-09.md`).
+
+- [ ] **Name the golden implementation.** For the domain under review, is
+      the state-of-the-art implementation identified by name and version,
+      with its measured throughput on a stated machine, before any Oak
+      design work? "Fast" without a named competitor is a feeling.
+      — Oak: `BENCHMARKS.md`, `benchmarks/`.
+- [ ] **List its defining techniques.** Has the golden implementation
+      been read (not skimmed) and its techniques written down as a list —
+      the ten things without which it would be ordinary? Each becomes a
+      row in §1 and a question in §2.
+- [ ] **Port it literally first.** Has the golden implementation been
+      ported to Oak as closely as the language allows, before any
+      "idiomatic" rewrite? The places the port had to deviate are the
+      expressiveness findings; an idiomatic rewrite hides them.
+      (ml pilot, dbs frame scan, hypervisor ports) — Oak:
+      `docs/notes/hypervisor-port-feedback-2026-09.md` is the pattern.
+- [ ] **Classify every deviation.** For each place the port could not
+      follow the original, which is it: (a) Oak lacks the operation, (b)
+      Oak has it only in `unsafe`, (c) Oak has it but the checker cannot
+      prove the precondition so a check remains, (d) Oak has it but the
+      lowering does not produce the same machine code, (e) the original
+      relies on undefined behavior and the technique needs a stated
+      semantics. Only (e) is a reason to accept slower code; each of the
+      others is a language or compiler item.
+- [ ] **Ask what fact would make it safe.** For each (b) and (c), which
+      single semantic fact — a bound, a disjointness, an alignment, a
+      padding contract, a declared law, a validated state — would let the
+      checker discharge the obligation? Is that fact a phantom type,
+      a refinement, an effect, or a protocol state? (constitution: one
+      fact, many projections) — Oak: `00-constitution.md`.
+- [ ] **Measure the port against the golden, per byte or per element.**
+      Is the gap stated as a ratio on the same machine and input, with the
+      cause attributed (a remaining check, a missed vectorization, a
+      call not inlined) rather than guessed? — Oak: `BENCHMARKS.md`
+      keeps Go, Rust, Zig, simdjson, simdutf comparisons.
+- [ ] **Assert the emitted code.** Does a test inspect the emitted C or
+      assembly and assert the technique survived lowering (no bounds
+      check in the inner loop, a `vld1q` where a vector load was meant,
+      no call in the hot path)? Counters that the fast path fired belong
+      here too. (ml counters, simdjson) — Oak: `71-codecs.md` §4
+      wrapper-absence checks.
+- [ ] **Make it the simplest spelling.** Once the golden structure is
+      expressible and checked, is it what the obvious Oak program lowers
+      to — or does the user still have to know the trick? A trick the
+      compiler knows is a language feature; a trick the user must know is
+      folklore. — Oak: `05-ergonomics-and-cost.md` Performance
+      transparency.
+
+## 1. Golden implementations by domain
+
+The table is the standing agenda. A row is closed when the Oak version is
+within its stated target of the golden implementation, with the
+techniques expressible in safe Oak or under a recorded contract, and the
+oracle agreeing bit for bit. Add rows; do not remove them.
+
+| Domain | Golden implementation(s) | Defining techniques (expressiveness questions in §2) | Oak status |
+| --- | --- | --- | --- |
+| JSON parsing | simdjson (Langdale & Lemire 2019), simdjson On-Demand | two-stage parse (structural index then tape); byte classification by nibble shuffle; prefix-XOR quote masks; `ctz` bitmask-to-index iteration; padded input; Eisel–Lemire float parsing; SWAR integer parse; runtime CPU dispatch; no backtracking | typed decoding measured against simdjson (`71-codecs.md` §16–§19, `benchmarks/json`); On-Demand not modeled; runtime dispatch absent |
+| UTF-8 validation / transcoding | simdutf (Keiser & Lemire), Zig/Rust std validators | three-byte lookup classification with shuffles; range tables; overlapping loads; ASCII fast path by OR-reduce; SWAR fallback; incomplete-tail handling | measured against Go, Rust, Zig, simdutf, simdjson (`benchmarks/state-machines`); fused validation lane in codecs |
+| Multi-pattern matching / regex | Hyperscan (Teddy, FDR, shift-or, Rose), RE2, `memchr` crate | SIMD literal prefilters (Teddy: shuffle-based multi-literal); shift-or / bit-parallel NFA; DFA with byte-class compression; no backtracking, linear time; state in registers; streaming with saved state | recorded as a stdlib workstream, not started (`ml-language-requests` "The regex question") |
+| Hashing | BLAKE3, xxh3, wyhash, hardware CRC-32C, SipHash for keyed | wide state in registers; tree hashing for parallelism; hardware CRC/AES instructions; unaligned reads; seeded keys against collision DoS | SHA-256, BLAKE3, CRC-32C within ten percent of Rust (`stdlib/hash.oak`, `benchmarks/kernels`); hardware CRC and seeding: check |
+| Sorting | pdqsort (Peters), ips4o, vqsort (Google, Highway), radix sort | pattern-defeating pivots; branchless partition (Edelkamp–Weiß block partition); insertion sort tail; SIMD sorting networks; radix for keys with known width | pdqsort with laws (`sam/stdlib-pdqsort`, `sam/pdqsort-laws`); branchless partition and vqsort: check |
+| Hash tables | Swiss table (abseil), F14 (folly), hashbrown | open addressing with SIMD group probing over control bytes; metadata separate from slots; power-of-two masks; robin hood / linear probing with SSE compare | not stated; `standard-library-design.md` first containers are Ring, BitSet, Pool |
+| Memory allocation | mimalloc, jemalloc, TB static allocation, Zig `std.heap` | free-list sharding; thread-local heaps; size classes; bump/arena; no allocation after init | arenas, slabs, pools, handles as types (`60-effects-allocation.md` §5–§9); allocation phase enforced (`85-discipline.md` §4) |
+| Dense linear algebra | mlx (Metal), CUTLASS, BLIS, tinygrad, Halide | tiling by cache/register level; packing; FMA microkernels; threadgroup memory; fusion of epilogues; lazy graphs; kernel caching by structure hash; unified memory zero-copy | kernels with Metal and C realizations (`56-kernels.md`), `stdlib/tensor.oak`; check elision, threadgroup reductions, records as kernel params open |
+| Reductions | Futhark, mlx `reduce`, CUB | fixed-tree grouping as semantics; lane-wise partials then horizontal; segmented reductions; regrouping licensed by declared laws | `reduce.tree` balanced-counter tree, `laws {associative}` (`55-parallelism.md` §4, `10-syntax.md` §14a); no backend consumes laws yet |
+| Storage engine / WAL | TigerBeetle, LMDB, RocksDB (for contrast) | static allocation; batched fsync; direct I/O with aligned buffers; checksums on every block; zero-copy frame views; io_uring completion rings; deterministic simulation | `io/sim` and `io/native` completion rings (`120-io.md`); `SimDisk` six faults; borrowed decoded frame views; direct I/O alignment: check |
+| Network / rings | LMAX Disruptor, io_uring, DPDK, TB message bus | SPSC/MPSC rings with power-of-two masks; cache-line-padded heads and tails; batching; single writer; no locks | SPSC expressible with `Atomic[T]` and `(align: 64)` (hypervisor ask 11); rings as memory-model consumers wanted (dbs ask 8) |
+| Compression | zstd, LZ4, FSE/ANS | hash-chain matching; SWAR copies with overlap; table-driven entropy decoding; branchless decode loops | not stated |
+| Number formatting / parsing | Ryu, Dragonbox, Eisel–Lemire, fast_float | 128-bit multiply; precomputed power tables; shortest round-trip | float printing with round-trip digits (`85-discipline.md` §5); Eisel–Lemire in codecs: check |
+| Interpreters / VMs | LuaJIT, wasm3, CPython 3.11 (computed goto), CoreCLR | threaded dispatch (computed goto or tail calls); register VM; inline caches; NaN-boxing; tagged pointers | trampolines for mutual tail recursion (`85-discipline.md` §2) is the safe form; pointer tagging: `standard-library-design.md` §10 |
+| Hypervisor / kernel paths | seL4, Linux fast paths, the `os` repo's Zig modules | MMIO with exact barriers; per-CPU state; interrupt paths with no allocation; fixed-capacity intrusive containers; bitmaps | `os-structures-survey.md` gap list; EL2 chapters `99`–`101` |
+| Cryptographic constant time | BoringSSL, libsodium, HACL* | no secret-dependent branches or indices; constant-time select by mask; verified against a model | not stated; a `secret` phantom on scalars is the obvious fact to add |
+
+## 2. Expressiveness inventory: can Oak say this, and check it?
+
+Each item is a technique the golden implementations rely on. The question
+is whether safe Oak (or Oak under a *recorded* contract) can express it
+so that the lowering is the same machine code C would produce. "Only in
+`unsafe` with no recorded fact" is a finding; "expressible, but a check
+remains that a fact could elide" is a finding.
+
+### 2a. Memory access shapes
+
+- [ ] **Unchecked indexing under a discharged bound.** When the checker
+      holds `i < len(x)`, does the access lower to a bare load? Is the
+      elision recorded as a discharged obligation? (simdjson, every inner
+      loop) — Oak: `50-borrowing.md` "Extent facts and proof-based
+      bounds-check elision (implemented subset)"; kernel check elision
+      open (`56-kernels.md` §3).
+- [ ] **Overlapping and unaligned vector loads.** Can a 16-byte load at
+      an arbitrary offset be expressed over a view, with the in-bounds
+      fact `off + 16 <= len` discharged or a stated padding contract
+      standing in? Can two overlapping loads cover a tail without a
+      scalar loop? (simdutf, memchr, simdjson) — Oak: `93-simd.md`,
+      `71-codecs.md` §11; padding contract: check.
+- [ ] **Padded input as a type-level fact.** Can a buffer promise
+      "readable for N bytes past `len`" as a phantom parameter, so a
+      block loop's over-read is safe by type rather than by convention?
+      (simdjson `SIMDJSON_PADDING`) — Oak: not stated; §16 forbids
+      over-read; the fact would lift the ban where the caller provides
+      padding.
+- [ ] **Predicated tails.** Can a masked load with zero fill be expressed
+      for element types where zero is a semantic identity, with the
+      compiler choosing predication or a scalar tail per target? (ml,
+      SVE/RVV) — Oak: `93-simd.md` §4.1 tail and mask policy.
+- [ ] **Fault-only-first loads.** For scalable vectors, can a
+      restartable load be expressed for strings of unknown length?
+      (RVV, SVE `ldff1`) — Oak: `93-simd.md` §4.2.
+- [ ] **Small fixed-size copies as register moves.** Does copying a
+      record of 16 or 32 bytes lower to register moves, not a `memcpy`
+      call? Does a `[N]u8` copy of constant N lower to wide loads and
+      stores? (Zig, Rust) — Oak: check emitted C for
+      `record`/`[N]T` copies.
+- [ ] **Overlapping stores for copies.** Can an LZ-style copy that
+      overlaps its own source (match distance smaller than length) be
+      expressed with defined semantics? (LZ4, zstd) — Oak: not stated;
+      needs a stated byte-at-a-time semantics or a `span` op.
+- [ ] **Type punning with a stated result.** Can `f32` bits be read as
+      `u32`, or a `[4]u32` as a `U32x4`, with a total, defined bitcast
+      rather than a union or pointer cast? (Zig `@bitCast`, Rust
+      `transmute` for POD) — Oak: `{target}_bits_{source}` in
+      `20-types.md` §11.1 for scalars; vectors and arrays: check.
+- [ ] **SWAR on machine words.** Can eight bytes be loaded as one `u64`
+      and processed with masks (has-zero-byte, has-byte-less-than, digit
+      pack) with the endianness stated? (Lemire, Mycroft) — Oak:
+      `71-codecs.md` §19 word-parallel scanning.
+- [ ] **Restrict / no-alias as a checked fact.** Does the borrow checker's
+      disjointness of two spans reach the C backend as `restrict`, so the
+      C compiler vectorizes? (Rust `&mut` → `noalias`) — Oak: the fact
+      exists (`50-borrowing.md` §6 disjoint mutable regions) but the C
+      backend does not emit `restrict` (it appears only in the reserved
+      word list, `codegen/identifiers.go`) — gap.
+- [ ] **Prefetch and non-temporal hints.** Are software prefetch and
+      streaming stores expressible as effect-free hints that the lowering
+      may drop? (MS, DPDK) — Oak: not stated.
+- [ ] **Alignment as a precondition.** Can a function require a
+      64-byte-aligned span, with the alignment a fact the caller proves
+      or asserts once, so aligned loads are emitted? (direct I/O, AVX
+      aligned loads, TB) — Oak: `(align: N)` on fields
+      (`40-records.md`); alignment on views/spans: check.
+
+### 2b. Bits and lanes
+
+- [ ] **Bit intrinsics as total functions.** `ctz`, `clz`, `popcnt`,
+      `bswap`, `rotl/rotr`, `pdep/pext`, `bit_reverse` — all present,
+      total (zero input defined), and lowered to single instructions?
+      (simdjson `ctz` loop, Hyperscan) — Oak: `clz`, `popcount`, `rotl`
+      present in `stdlib`; `ctz`, `bswap`, `rotr`, `pdep`/`pext`,
+      `bit_reverse` not found — gap.
+- [ ] **Bitmask iteration.** Can `while mask != 0 { i = ctz(mask); mask
+      &= mask - 1 }` be written in the strict profile with its bound
+      recognized (popcount of the initial mask)? (simdjson stage 1) —
+      Oak: `85-discipline.md` §3 canonical shapes; this shape: check.
+- [ ] **Shuffle-based table lookup.** Is a 16-entry nibble lookup
+      (`pshufb`/`tbl`) a portable `simd` operation with a stated
+      out-of-range lane result? (simdjson classification, simdutf, Teddy)
+      — Oak: not stated; `93-simd.md` names no table-lookup operation.
+- [ ] **Movemask / compress.** Is lane-compare-to-bitmask a portable
+      operation on every target, with the emulation cost on targets
+      lacking it (NEON) stated? Is lane compaction (`vcompress`,
+      `pext`-based) expressible? (simdjson, Highway) — Oak: not stated;
+      `93-simd.md` names neither movemask nor compress.
+- [ ] **Prefix operations on masks.** Prefix-XOR (carryless multiply by
+      all-ones) for quote-state tracking, prefix-sum for compaction
+      indices — expressible, and lowered to `pmull`/`pclmul` where
+      available? (simdjson) — Oak: not stated.
+- [ ] **Horizontal reductions with fixed grouping.** Is `reduce_add`'s
+      pairwise tree the definition, and does the lowering produce
+      `vaddv`/`haddps` sequences whose grouping matches? (F2) — Oak:
+      `93-simd.md` §1.2a, `55-parallelism.md` §4.
+- [ ] **Branchless select and blend.** Can `cond ? a : b` over scalars
+      and lanes lower to `csel`/`bsl` without a branch, with the compiler
+      free to choose? Can the author *require* branchless (constant-time)?
+      (crypto, Edelkamp–Weiß) — Oak: not stated for the requirement.
+- [ ] **Widening and narrowing lanes.** `u8x16 → u16x8` pairs, saturating
+      narrow, zip/unzip — portable and total? (simdutf transcoding) —
+      Oak: `93-simd.md` §1.2; check the set.
+- [ ] **Runtime feature dispatch.** Can one function have per-ISA-level
+      bodies (NEON, SVE2, RVV, AVX2, AVX-512) selected once at startup,
+      with the dispatch itself deterministic and all bodies tested against
+      one oracle? (simdjson, memchr, Highway) — Oak: **absent** (dbs
+      ask 6/7 recorded); design in `93-simd.md` §4 is the shape.
+
+### 2c. Control flow shapes
+
+- [ ] **Threaded dispatch.** Can a state machine or interpreter loop be
+      written so each state jumps directly to the next (computed goto /
+      tail call) rather than through a central switch, in the strict
+      profile? (LuaJIT, CPython, Hyperscan DFA) — Oak: mutual tail
+      recursion lowers to a trampoline (`85-discipline.md` §2), one
+      state switch per step; the backend does not emit `musttail` or
+      computed goto — measure the trampoline against a threaded C DFA.
+- [ ] **Loop unswitching and versioning by the author.** Can a loop be
+      specialized on a runtime-constant predicate (all-ASCII, statically
+      sized) with the classification once and the body twice, without
+      duplicating source? (simdjson, codec classification pass) — Oak:
+      `71-codecs.md` classification pass (remaining item).
+- [ ] **Early exit that keeps the bound.** Can a bounded loop `break` on
+      the first mismatch while keeping the strict profile's certificate?
+      (every search loop) — Oak: `85-discipline.md` §3a, yes.
+- [ ] **Speculation with rollback.** Can a parser speculate (parse as
+      integer, fall back to float) without copying the input or violating
+      "output unchanged on failure"? (simdjson number parsing) — Oak:
+      two-pass codecs (`71-codecs.md` §7); a speculative form: check.
+- [ ] **Unrolling with proof.** Can an author unroll by four with the
+      remainder handled and the bound still recognized, or must the
+      compiler be trusted? (every kernel) — Oak: check whether `i = i +
+      4` with bound `n - 3` is a canonical shape.
+- [ ] **Cold paths out of line.** Can error and slow paths be marked cold
+      so the hot loop stays in the instruction cache? (`__builtin_expect`,
+      Rust `#[cold]`) — Oak: not stated.
+
+### 2d. Data layout shapes
+
+- [ ] **Struct-of-arrays as a derived layout.** Can a record type be
+      stored as parallel arrays with one declaration, the field access
+      syntax unchanged, and the layout a representation choice?
+      (DOD, Zig `MultiArrayList`, Mojo, Jai) — Oak:
+      `45-representations.md` §7.1 names AoS, SoA, and AoSoA as explicit
+      collection representations; only AoS is implemented.
+- [ ] **Field reordering by the compiler vs. by the author.** Is field
+      order semantic (serialization, FFI) or may the representation layer
+      reorder to remove padding, and is the choice per type? (Rust
+      default reorder vs `repr(C)`) — Oak: `40-records.md` order/layout
+      separation.
+- [ ] **Hot/cold splitting.** Can a record's rarely-touched fields be
+      moved to a side table without changing call sites? (DOD) — Oak:
+      representation axis; not stated as a mechanism.
+- [ ] **Niche and tag compression.** Does `Option[View]` cost zero extra
+      bytes (null niche), does a tag share storage with padding or an
+      unused range, and is the optimization proof-preserving? (Rust
+      niche optimization) — Oak: `45-representations.md` lists niche/tag
+      elision as a representation; `05-ergonomics-and-cost.md` permits it
+      when proof-preserving; what is implemented: check `Option` layout.
+- [ ] **Packed and bitfield layouts.** Can hardware tables (page table
+      entries, descriptors, register images) be declared with exact bit
+      positions, with reads and writes lowering to shifts and masks and
+      the layout asserted? (os, MISRA bitfield warnings) — Oak:
+      `os-structures-survey.md` §3, §6; `97-aarch64-system-registers.md`.
+- [ ] **Intrusive links.** Can a node live in two lists at once via
+      embedded links without a wrapper allocation, with ownership of the
+      node clear? (Linux `list_head`, TB, os) — Oak:
+      `os-structures-survey.md` §2 pools plus index links;
+      `standard-library-design.md` §7.
+- [ ] **Tagged pointers and pointer authentication.** Can spare pointer
+      bits carry a tag, with the untagging total and PAC on Apple Silicon
+      respected? (LuaJIT NaN boxing, ARM PAC) — Oak:
+      `standard-library-design.md` §10.
+- [ ] **Cache-line placement and padding.** Can a field or a static be
+      aligned to a cache line, padded to avoid false sharing, and placed
+      in a named section, with the emitted offsets asserted? (MS, TB) —
+      Oak: `(align: 64)` (`40-records.md`), placement of statics
+      (`65-machine-memory.md`).
+- [ ] **Compile-time table generation.** Can lookup tables (CRC, UTF-8
+      classes, DFA transitions, powers of ten) be computed at compile
+      time from a definition and placed in read-only storage, so the
+      table and its generator cannot drift? (Zig comptime, Mojo
+      parameters, Rust const eval) — Oak: static initializers
+      (`60-effects-allocation.md` §10a); const evaluation breadth: check.
+
+### 2e. Allocation and ownership shapes
+
+- [ ] **Bump allocation with bulk free.** Is an arena a type whose
+      allocate is a pointer bump and whose free is a reset, with every
+      borrow from it bounded by the arena's region? (Zig, Odin
+      `context.allocator`, Cyclone) — Oak: `60-effects-allocation.md`
+      §6.
+- [ ] **Caller-provided storage everywhere.** Does every stdlib function
+      that produces data write into a caller span rather than allocate,
+      with the required size computable up front? (Zig std, TB) — Oak:
+      `60-effects-allocation.md` §9; audit stdlib.
+- [ ] **Zero-copy views through every layer.** Can a decoded frame,
+      string token, or record field be handed back as a view into the
+      input across function and package boundaries, with the region
+      carried in the type? (Cap'n Proto, dbs frame scan) — Oak:
+      `50-borrowing.md` §8c, `71-codecs.md` §13a.
+- [ ] **Views inside records that cross calls.** Can a cursor or a frame
+      record hold a view and travel through calls with its region?
+      More than one region per record? (Rust structs with lifetimes) —
+      Oak: `50-borrowing.md` §8c increment 4; multi-region open.
+- [ ] **Move semantics without copies.** Does returning a record, union,
+      or owned array by value lower to no copy (return slot / RVO), and
+      is a consumed parameter's storage reused? (Rust, C++ RVO) — Oak:
+      `90-backend.md` §10 values at boundaries; check the emitted C.
+- [ ] **Closures without heap.** Can a lambda passed to a known
+      combinator specialize away to a direct call with its captures on
+      the caller's stack? (Rust, Swift non-escaping) — Oak:
+      `05-ergonomics-and-cost.md` Function values and closures,
+      `55-parallelism.md` §7.
+
+### 2f. Machine-level access
+
+- [ ] **Inline assembly units beside sources.** Can a routine be written
+      in typed abstract assembly when the compiler cannot reach the
+      golden code, with register types checked and the unit's contract
+      stated? (Zig, Rust `asm!`) — Oak: `94-assembler.md`.
+- [ ] **Hardware instructions as typed functions.** CRC32, AES, SHA,
+      PMULL, dot-product, `fcvtzs` rounding modes, atomics variants —
+      exposed per architecture with total semantics? (Zig
+      `@intrinsic`-style, Rust `core::arch`) — Oak: `93-simd.md` §2
+      arm64 functions; hash hardware in `sam/stdlib-hash-hw`.
+- [ ] **Performance counters reachable.** Can a benchmark read cycle
+      and instruction counters in-process on the targets Oak supports
+      (Apple Silicon `kperf`, Linux `perf_event`)? (simdjson's counters)
+      — Oak: not stated.
+
+## 3. Know the machine
+
+- [ ] **Napkin math before design.** Has the back-of-envelope been done —
+      bytes moved, cache lines touched, branches per element, syscalls per
+      operation — and does the design's shape follow from it? Latency
+      numbers every engineer should know, per target. (TB, Jeff Dean) —
+      Oak: practice; record in the note for each pass.
+- [ ] **Memory-bound or compute-bound?** Is it known which, by a roofline
+      estimate (arithmetic intensity against bandwidth and peak), so
+      effort goes to the binding constraint? (Williams et al. roofline,
+      MS) — Oak: `BENCHMARKS.md` workload shapes.
+- [ ] **Cache line size is not 64 everywhere.** Apple Silicon has 128-byte
+      lines; is padding and alignment a per-target constant, not a
+      literal? (MS) — Oak: `(align: 64)` today; a target constant is the
+      fact.
+- [ ] **Sequential over random.** Does every hot path walk memory
+      sequentially or with a fixed stride the prefetcher can follow, with
+      pointer chasing confined to cold paths? (DOD, MS) — Oak: handles
+      and indices over pointers (`60-effects-allocation.md` §8).
+- [ ] **Branch predictability.** Are data-dependent branches in inner
+      loops replaced by masks, tables, or sorting the input; are the
+      remaining branches overwhelmingly one-sided? (simdjson, MS) — Oak:
+      §2b branchless select.
+- [ ] **Instruction cache and code size.** Does monomorphization or
+      unrolling blow the hot loop past the instruction cache or the
+      decoded-µop cache? Is code size measured per benchmark? (Rust
+      monomorphization bloat, Go's restraint) — Oak:
+      `05-ergonomics-and-cost.md` acknowledges the trade; measure.
+- [ ] **TLB and huge pages.** Do large working sets use large pages, and
+      are allocations aligned to them? (MS, databases) — Oak: not stated;
+      allocator design item.
+- [ ] **Memory-level parallelism.** Do independent loads issue together
+      (multiple accumulators, unrolled independent chains) rather than
+      serialize on one dependency chain? (MS, hash table probing) — Oak:
+      author-level; §2c unrolling.
+- [ ] **Store forwarding and false sharing.** Are producer and consumer
+      indices on separate lines; are small stores followed by wider loads
+      of the same bytes avoided? (Disruptor, MS) — Oak: `(align: 64)`.
+- [ ] **NUMA and core affinity.** Where multiple cores are used, is
+      memory allocated near the core that uses it and are threads pinned?
+      (MS, DPDK) — Oak: not stated; out of scope until a scheduler exists.
+- [ ] **Unified memory on Apple Silicon.** Does the host↔device story
+      avoid copies where memory is shared, with custody the only
+      transition cost? (mlx) — Oak: `Buffer[T, S]` custody, `92-ffi.md`
+      §2.8.5.
+- [ ] **Syscall and context-switch counts.** Are syscalls batched
+      (completion rings, `writev`, batched fsync), and is the count per
+      operation measured? (io_uring, TB) — Oak: `120-io.md` rings.
+
+## 4. Data-oriented design
+
+- [ ] **Design for the common case's data, not the object.** Are
+      transformations written over arrays of the data they touch, rather
+      than methods over objects that carry data they do not? (Acton, DOD)
+      — Oak: culture; §2d SoA.
+- [ ] **Existence-based processing.** Is "which state is this in" encoded
+      by which array an item sits in, so processing a state is a loop
+      with no branch? (Fabian, DOD) — Oak: typestate plus pools.
+- [ ] **Smallest sufficient index type.** Are indices `u32` (or smaller)
+      when the capacity allows, halving memory traffic versus pointers?
+      (TB, DOD) — Oak: handles as typed indices.
+- [ ] **Batch everything.** Does every operation accept a batch so
+      per-call overhead (syscall, lock, dispatch, bounds check) is
+      amortized? Is the batch size bounded and part of the type? (TB) —
+      Oak: `120-io.md`; audit stdlib APIs for batch forms.
+- [ ] **Separate hot and cold data.** Are rarely-read fields out of the
+      cache lines the hot loop touches? (DOD) — Oak: §2d hot/cold.
+- [ ] **Bitsets over arrays of bool.** (DOD, os bitmaps) — Oak:
+      `standard-library-design.md` BitSet.
+- [ ] **Generation-stamped handles over reference counting.** Does
+      lifetime management cost an integer compare, not an atomic
+      increment on every share? (DOD, TB) — Oak:
+      `60-effects-allocation.md` §8; `05-ergonomics-and-cost.md` no
+      mandatory refcounting.
+
+## 5. Algorithms and data structures
+
+- [ ] **Best-known algorithm named.** For each stdlib routine, is the
+      chosen algorithm the state of the art for its constraints, with the
+      citation in the source? (pdqsort, Swiss table, BLAKE3) — Oak: §1
+      table; audit `stdlib/`.
+- [ ] **Power-of-two capacities and masks.** Do rings and tables use
+      `& (cap - 1)` with the power-of-two fact proven at the type? (every
+      ring) — Oak: `Ring[T, N]` const parameter; the power-of-two
+      refinement: check.
+- [ ] **Open addressing over chaining; B-trees over binary trees; arrays
+      over linked lists.** Is the cache-friendly structure the default,
+      with the alternative justified? (DOD, MS) — Oak:
+      `standard-library-design.md`.
+- [ ] **Hash function fit for purpose.** Is the fast hash (wyhash/xxh3)
+      used for tables and a keyed hash (SipHash) where keys are
+      attacker-chosen, with seeding? (Rust `HashMap` default,
+      collision-DoS history) — Oak: `stdlib/hash.oak` has SHA-256, BLAKE3,
+      CRC-32C; no fast table hash and no seeded hash — gap once a hash
+      table exists.
+- [ ] **Radix and counting sorts for fixed-width keys.** (ips4o, TB) —
+      Oak: not stated.
+- [ ] **Amortized structures declare their worst case.** Does any
+      "amortized O(1)" hide a pause the realtime profile forbids? (TB) —
+      Oak: `60-effects-allocation.md` §12.
+
+## 6. SIMD and vectorization
+
+- [ ] **Data-parallel structure first, instructions second.** Is the
+      algorithm reshaped so independent items are processed together
+      (block classification, multi-accumulator), before any intrinsic is
+      chosen? (simdjson's stage 1, Futhark) — Oak: `93-simd.md` §3
+      program shape.
+- [ ] **Autovectorizable loop shape.** Countable trip, no early exit
+      unless via mask, no aliasing, no cross-iteration dependency other
+      than a declared reduction — and a test asserting vectorization
+      happened? (LLVM loop vectorizer rules) — Oak: §0 assert emitted
+      code.
+- [ ] **Portable vector types with per-target lowering stated.** Is each
+      `simd` operation's lowering on NEON, SVE, RVV, AVX2 documented,
+      including which are emulated and at what cost? (Highway) — Oak:
+      `93-simd.md` §1.4.
+- [ ] **Scalar tail policy chosen per algorithm.** Predicated zero-fill
+      where the semantics permit, overlapping last-block otherwise,
+      scalar loop as the last resort — and the choice stated. (ml,
+      simdutf) — Oak: `93-simd.md` §4.1; codec note "what does not
+      transfer".
+- [ ] **Fusion of independent lanes.** Two accumulators over one load
+      (structure and UTF-8 validity) rather than two passes? (simdjson,
+      codec fused validation lane) — Oak: `71-codecs.md` §4a.
+- [ ] **Vector float order is semantics.** Lane and run counts named,
+      results bit-reproducible across widths? (ml, F2) — Oak:
+      `93-simd.md` §1.2a, `56-kernels.md` §4.
+- [ ] **No gathers where a shuffle will do.** (MS) — author-level.
+- [ ] **Cross-target verification.** Is each vector lowering checked
+      against the portable definition on every target (differential, or
+      Sail for the ISA)? — Oak: `93-simd.md` §5, `spec/sail`.
+
+## 7. Parallelism and concurrency
+
+- [ ] **Work and span stated.** Does every parallel operation document
+      total work and critical path, and is the sequential lowering the
+      default? (Blelloch, `55-parallelism.md`) — Oak:
+      `05-ergonomics-and-cost.md` Explicit parallel cost.
+- [ ] **No hidden scheduler.** Is any thread pool, task queue, or
+      allocation a parallel operation needs part of its declared contract?
+      (constitution) — Oak: `55-parallelism.md`.
+- [ ] **Single-threaded core, parallel edges.** Does the design keep the
+      state machine single-threaded and push parallelism to I/O and
+      stateless stages? (TB, Redis, LMAX) — Oak: `120-io.md` model.
+- [ ] **Sharding over locking.** Per-core or per-shard ownership with
+      message passing, before any lock? (DOD, TB) — Oak: §2e ownership.
+- [ ] **Lock-free only when measured.** Is a lock-free structure adopted
+      because a benchmark showed the lock was contended, and is its memory
+      ordering proven? (Preshing, correctness §7) — Oak:
+      `66-memory-model.md`.
+- [ ] **Amdahl checked.** Is the serial fraction measured before adding
+      cores? — practice.
+- [ ] **GPU: occupancy, threadgroup memory, coalesced access.** Are
+      kernel launches sized to the device, tiles staged through
+      threadgroup memory, and global accesses coalesced? Is the launch
+      descriptor a checked artifact? (mlx, CUTLASS) — Oak:
+      `56-kernels.md` §5; threadgroup memory open.
+
+## 8. I/O and storage
+
+- [ ] **Batch and coalesce.** Writes coalesced, fsyncs batched, reads
+      grouped into one submission? (TB, io_uring) — Oak: `120-io.md`.
+- [ ] **Direct I/O with aligned buffers.** Are block buffers
+      sector-aligned and sized so the kernel page cache is bypassed
+      deliberately, with alignment a type fact? (TB, databases) — Oak:
+      §2a alignment; check `120-io.md`.
+- [ ] **Zero-copy from device to consumer.** Does data cross layers as
+      views into the receive buffer, never re-copied for convenience?
+      (dbs, DPDK) — Oak: `71-codecs.md` §13a.
+- [ ] **Checksums where the hardware helps.** CRC-32C via hardware,
+      computed once per block, verified on every read? (TB) — Oak:
+      `stdlib/hash.oak`, `sam/stdlib-hash-hw`.
+- [ ] **Bounded queues everywhere.** Backpressure by capacity, never
+      unbounded buffering? (TB, Reactive Streams) — Oak: rings with
+      declared capacity.
+- [ ] **Simulated and native I/O agree on cost shape.** Does the
+      simulation model the *latency and batching* the native path has,
+      so a design validated in sim is not slow in native? (TB VOPR) —
+      Oak: `120-io.md` two realizations differ only in fault model —
+      cost model: check.
+
+## 9. Compilers, fusion, and specialization
+
+- [ ] **Specialize by default; dispatch by choice.** Do generics
+      monomorphize to direct calls, with dynamic dispatch never introduced
+      silently? (Rust, Zig, Mojo) — Oak: `05-ergonomics-and-cost.md`
+      Generics specialize by default.
+- [ ] **Fusion by boundaries, not by search.** Are fusion decisions
+      structural (what is a boundary) rather than a search over a schedule
+      IR, and is every fusion licensed by one theorem and checked by an
+      oracle? (ml, tinygrad's lazy graph, Halide's explicit schedule as
+      the contrast) — Oak: codec-fusion note; `55-parallelism.md` §6.
+- [ ] **Recompute versus materialize decided by a stated limit.** (ml
+      `RECOMPUTE_LIMIT`, tinygrad) — Oak: codec-fusion note.
+- [ ] **Carry, do not fuse, across contract boundaries.** Where a
+      contract (output unchanged on failure) needs two passes, is the
+      first pass's result carried in registers rather than the passes
+      merged? (codec note) — Oak: `71-codecs.md` §7.
+- [ ] **Classify then emit.** Do structural predicates over the type pick
+      an emitter (statically sized, all-ASCII keys, tile shape), rather
+      than a general IR trying to discover the shape? (ml, codec
+      classification) — Oak: `71-codecs.md` classification pass
+      (remaining item).
+- [ ] **Kernel identity by structure hash.** Are identical kernels or
+      derived codecs emitted once? (ml, tinygrad) — Oak: monomorphization
+      at compile time; check dedup of derived helpers.
+- [ ] **Declared laws are the only permission to reorder.** Does a backend
+      regroup a reduction or reassociate only under `laws { associative,
+      commutative }`, and is there a backend that consumes them yet?
+      (F3, Futhark's `reduce` requiring associativity) — Oak:
+      `10-syntax.md` §14a; consumer open.
+- [ ] **Higher-order specialization.** Does a lambda passed to a known
+      combinator inline, leaving no indirect call, closure object, or heap
+      environment? (Rust iterators, Futhark) — Oak: `55-parallelism.md`
+      §7.
+- [ ] **Flattening for nested parallelism.** Where nested data parallelism
+      appears, is Futhark's incremental flattening the model, with the
+      choice of version by runtime size? (Futhark) — Oak: not stated;
+      kernels are flat today.
+- [ ] **Tiles as gated constants.** Are tile sizes hand-picked constants
+      gated by structural pattern matches and measured thresholds, with
+      the measurement checked in? (ml, BLIS) — Oak: codec-fusion note.
+- [ ] **Compile-time parameters over runtime flags.** Are width, tile,
+      and shape parameters const generics resolved at instantiation, so
+      the inner loop has no runtime `if`? (Mojo, Zig comptime, Futhark
+      size types) — Oak: `20-types.md` §11.0.
+- [ ] **Check elision from discharged facts.** Does every bounds, tag, or
+      alignment check the checker has discharged actually disappear from
+      the emitted code, and is that asserted? (Rust/LLVM range analysis,
+      Idris erasure) — Oak: `56-kernels.md` §3 open; §0 assert emitted
+      code.
+- [ ] **Erasure of phantoms is verified.** Do phantom parameters,
+      typestates, and regions cost zero bytes and zero instructions, with
+      a Lean statement and an emitted-code check? (Idris erasure, Rust
+      `PhantomData`) — Oak: `Oak.PhantomRepresentation`; `71-codecs.md`
+      §4 Zero cost, defined.
+- [ ] **Tail calls guaranteed, not hoped.** Are tail calls lowered by Oak
+      to loops or trampolines rather than trusting the C compiler?
+      (Zig `@call(.always_tail)`, Scheme) — Oak: `85-discipline.md` §2.
+- [ ] **Inlining under control.** Can the author require or forbid
+      inlining at a call, and does the C backend emit the corresponding
+      attribute? (Zig `inline`/`noinline`, Rust) — Oak: the backend
+      marks private leaf helpers `OAK_INLINE` (`always_inline`,
+      `codegen/codegen.go`); no author-level control, no `noinline`.
+- [ ] **The C backend is a real backend.** Are `restrict`, `__builtin_*`,
+      alignment attributes, `musttail`, `cold`, vector extensions and
+      `-ffast-math`-free flags emitted so the C compiler is helped, not
+      fought? Is a native backend (AArch64, rv64) on the roadmap where C
+      cannot express the lowering? (Zig's move off LLVM as the contrast)
+      — Oak: `90-backend.md`, `feat(nativegen)`, rv64 planned (dbs ask 6).
+- [ ] **Profile-guided and link-time optimization measured.** Does the
+      benchmark harness build with LTO and PGO where the C toolchain
+      supports them, and is the gain recorded? — Oak: not stated.
+
+## 10. Parsing and text
+
+- [ ] **Two stages, one pass each.** Structural indexing first, then
+      typed consumption over the index, neither backtracking? (simdjson)
+      — Oak: `71-codecs.md` §11, §16.
+- [ ] **On-demand over materialized.** Can a consumer decode only the
+      fields it reads, skipping the rest by structural index? (simdjson
+      On-Demand, Cap'n Proto) — Oak: not modeled; direction.
+- [ ] **Number parsing state of the art.** Eisel–Lemire for floats, SWAR
+      for eight digits at a time, with correctness against the exact
+      decimal? (fast_float, simdjson) — Oak: `71-codecs.md` §18 compact
+      integer scans; floats: check.
+- [ ] **DFA with byte-class compression for matching.** Small
+      transition tables, one load per byte, no branches? (Hyperscan, RE2)
+      — Oak: UTF-8 state machines in `stdlib/strings.oak`; regex not
+      started.
+- [ ] **SIMD prefilter before the exact matcher.** Literal fragments
+      found with Teddy/shift-or, exact engine run only on candidates?
+      (Hyperscan) — Oak: not started.
+- [ ] **ASCII fast path.** Is the all-ASCII block detected with one
+      OR-reduce and handled without the multibyte machinery? (simdutf) —
+      Oak: `71-codecs.md` §4a fused lane.
+- [ ] **Grapheme, normalization, case tables generated, not hand-written.**
+      (Unicode) — Oak: `sam/stdlib-grapheme`, `sam/stdlib-normalize`,
+      `sam/unicode-generator-pub`.
+
+## 11. Numerics
+
+- [ ] **Integer division by constants becomes multiply-shift.** Does the
+      lowering (or the C compiler) do this, and is it checked? (Hacker's
+      Delight, Lemire fastmod) — Oak: check emitted code.
+- [ ] **FMA available and explicit.** Is fused multiply-add a named
+      operation the author chooses, never contracted silently? (IEEE,
+      correctness §6) — Oak: `56-kernels.md` §4.
+- [ ] **Denormal cost known.** Do kernels that may produce denormals
+      state whether flush-to-zero is on, and measure the cliff? (DSP,
+      mlx) — Oak: `56-kernels.md` §4.
+- [ ] **Checked arithmetic cost measured.** Is the overhead of
+      `checked_add` over `+` measured and is the checked form used only
+      where the value is externally influenced? (Rust overflow-checks
+      debate, TB) — Oak: `20-types.md` §11.1a; measure.
+- [ ] **Mixed-width avoided in hot loops.** (MS) — Oak: rejected by the
+      type system (no implicit promotion).
+
+## 12. Measurement discipline
+
+- [ ] **Benchmarks in tree, versus named competitors, on named hardware.**
+      Go, Rust, Zig, simdjson, simdutf, with versions and the machine
+      recorded in the results. — Oak: `BENCHMARKS.md`, `benchmarks/`.
+- [ ] **Throughput per byte or per element, not wall time alone.**
+      Cycles per byte, GB/s, ns per operation, with input size and shape.
+      (simdjson) — Oak: `BENCHMARKS.md` workload shapes.
+- [ ] **Min and median, never mean; repetitions and warm/cold stated.**
+      (benchmark hygiene) — Oak: the `run.py` harnesses report medians;
+      warm/cold and repetition counts: check per harness.
+- [ ] **Hardware counters, not guesses.** Instructions, cycles, branch
+      misses, cache misses per run, so the cause of a gap is measured.
+      (simdjson's `event_counter`, `perf stat`) — Oak: §2f counters not
+      stated.
+- [ ] **Regression gate.** Does CI fail (or flag) a benchmark that regresses
+      past a threshold against the checked-in baseline? — Oak: not
+      stated.
+- [ ] **Adversarial inputs benchmarked too.** Worst-case inputs (deep
+      nesting, all-escapes, hash collisions) measured alongside typical
+      ones, so bounded work per byte is a number. (Hyperscan, langsec) —
+      Oak: check `benchmarks/json`.
+- [ ] **Code size and compile time tracked.** Monomorphization and
+      derived codecs measured in bytes and seconds, not only in speed.
+      (Rust, Go) — Oak: not stated.
+- [ ] **Every optimization ships with its oracle and its counter.** The
+      slow path stays, the fast path proves it fired, and the benchmark
+      shows the delta — all in one change. (ml, simdjson) — Oak:
+      `71-codecs.md` §4a; codec-fusion note "the part to do first".
+- [ ] **The gap has a cause.** Each remaining ratio against the golden
+      implementation in §1 is attributed to a specific §2 item or accepted
+      with a stated reason. An unattributed gap is an open finding.


### PR DESCRIPTION
## Summary

Adds `docs/checklists/` with two walkable lists that extract, once, the techniques Oak keeps re-deriving from its reference material, so review passes start from the list rather than from the sources.

- `correctness.md` — 134 items across principles, spec-and-model first, illegal states unrepresentable, memory and aliasing, control-flow discipline, integer and float semantics, memory model, testing, input validation, errors, toolchain, and process.
- `performance.md` — 137 items. Opens with the golden-implementation method: name the fastest known implementation, port it literally, classify every deviation as an expressiveness gap, and ask which single fact would make it safe. Includes a standing table of sixteen domains with their best-in-class implementations and Oak status, and an expressiveness inventory of "can Oak say this and check it" questions.
- `README.md` — item shape, how to run a pass, how findings flow back.

Every item names its source and points at the spec chapter, note, or module where Oak takes a position, or says `open` / `not stated`. The pointers were verified against the tree; the gaps that surfaced are recorded as findings (no `restrict` emission, missing `ctz`/`bswap`/`pdep`, no SIMD table lookup or movemask, no runtime ISA dispatch, unwritten shift semantics, SoA named but not implemented, no seeded table hash, ASan/UBSan only in the benchmark workflow).

Root README links the directory. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)