### PR TITLE
docs(checklists): extract simdjson, simdutf, and weePickle

### DIFF
--- a/docs/checklists/correctness.md
+++ b/docs/checklists/correctness.md
@@ -135,9 +135,14 @@ simdjson, simdutf, Hyperscan, data-oriented design (DOD), langsec.
       hypervisor note ask 9.
 - [ ] **Errors are values.** Does fallible code return `Result[T, E]` with
       a closed error type, rather than throwing, returning a status code
-      the caller may ignore, or returning an in-band sentinel? (Rust, Go,
-      Zig error unions, Swift `throws` as sugar over results) — Oak:
-      `20-types.md` §11.1a, `resource-contracts-and-results.md`.
+      the caller may ignore, or returning an in-band sentinel? Where a
+      register-return ABI justifies a status word internally, is the
+      sentinel confined to private helpers and the justification written?
+      (Rust, Go, Zig error unions; simdutf `convert_*` returning 0 and
+      `result.count` meaning position or written are the anti-pattern) —
+      Oak: `20-types.md` §11.1a, `resource-contracts-and-results.md`;
+      `stdlib/json.oak` `json_result_value` and `JsonIntegerScan.status`
+      are internal sentinels justified in `71-codecs.md` §18.
 - [ ] **Newtypes for identities and units.** Are ids, offsets, byte
       counts, element counts, durations, and monetary amounts distinct
       types so that an offset cannot be passed as a length? Are units in
@@ -193,6 +198,28 @@ simdjson, simdutf, Hyperscan, data-oriented design (DOD), langsec.
       and a handle (index into an owner), with no implicit conversion from
       owned to borrowed that outlives the owner? (Rust, Zig slices, Odin)
       — Oak: `50-borrowing.md`, `60-effects-allocation.md` §8.
+
+- [ ] **Wire identities are declared, not derived from source names.** Does
+      a discriminator value or field key ever default to a type or field
+      name, so a rename changes the wire format? Is discriminator-name
+      consistency across a hierarchy checked at compile time? (weePickle
+      FQCN default tag, runtime `findTagName`) — Oak: `40-records.md`
+      tags, `30-adts-patterns.md`; ADT wire tags are not derived yet — not
+      stated.
+- [ ] **Defaults consumed by a codec are pure constants.** If a
+      construction default can be omitted on write or filled on read, is it
+      required to be a compile-time constant so omission is deterministic?
+      (weePickle re-evaluates defaults per write for `currentTimeMillis`)
+      — Oak: `40-records.md` construction defaults; purity requirement not
+      stated.
+- [ ] **Callback-scoped borrows are regions, not comments.** When a parser
+      hands a consumer a view into a reusable buffer, is "valid until the
+      buffer refills" a borrow the checker enforces, with refill a mutable
+      borrow that conflicts with any live view? (weePickle
+      `TextBufferCharSequence` "VERY MUTABLE BUFFER"; simdjson
+      `string_view` lifetimes) — Oak: `50-borrowing.md` §8c and
+      `71-codecs.md` §13a for whole inputs; streaming refill is design
+      work (`71-codecs.md` §16).
 
 ## 4. Memory, ownership, and aliasing
 
@@ -495,8 +522,9 @@ simdjson, simdutf, Hyperscan, data-oriented design (DOD), langsec.
       failure? (ml, TB) — Oak: `71-codecs.md` §4 wrapper-absence checks.
 - [ ] **Known-answer vectors.** Are standard test vectors (RFC, NIST,
       Unicode conformance, JSON test suite) run, with the vector file in
-      tree and its provenance noted? (NIST CAVP, simdjson's JSONTestSuite)
-      — Oak: `stdlib/hash.oak` KATs, `sam/tla-conformance`.
+      tree and its provenance noted? (NIST CAVP, simdjson's JSONTestSuite `minefield`)
+      — Oak: `stdlib/hash.oak` KATs; no in-tree JSONTestSuite vectors for
+      `stdlib/json.oak` — gap.
 - [ ] **Interpreter and every backend agree.** Is each language feature
       differentially tested across the interpreter, the C backend, and any
       other backend at every boundary value? (csmith, TB) — Oak: e2e
@@ -538,9 +566,67 @@ simdjson, simdutf, Hyperscan, data-oriented design (DOD), langsec.
       UI tests, Elm) — Oak: `15-diagnostics.md` §11–§12.
 - [ ] **Race detector and sanitizers in CI.** Are the Go race detector,
       ASan/UBSan on the emitted C, and Miri-equivalent interpretation run
-      on the standard library and compiler tests? (Go, LLVM) — Oak: `-race` in `ci.yml`; ASan and UBSan on emitted
-      C in `stdlib-benchmark.yml` only — extend to the compiler e2e
-      suites.
+      on the standard library and compiler tests? (Go, LLVM; simdutf's compiler × flags × libc matrix with
+      `-fsigned-char`/`-funsigned-char`) — Oak: `-race` in `ci.yml`;
+      ASan/UBSan on emitted C only in `stdlib-benchmark.yml`,
+      `json-benchmark.yml`, and one libFuzzer smoke job — extend to the
+      compiler e2e suites and add a compiler × flags matrix.
+
+- [ ] **Every body is an oracle for every other.** With more than one
+      lowering or ISA body, are tests and fuzzers run once per available
+      body on the same machine with outputs compared bit for bit, is the
+      portable body always compiled in, and does one fuzz target feed the
+      same input to every body and the interpreter? (simdjson
+      `fuzz_implementations`, simdutf per-implementation `TEST`,
+      `SIMDUTF_ALWAYS_INCLUDE_FALLBACK`) — Oak: `93-simd.md` §1.4 runs
+      NEON, `-DOAK_PORTABLE_INTRINSICS`, and the interpreter; §5 states the
+      obligation; no differential fuzz target — gap.
+- [ ] **The test asserts which kernel ran.** When a flag or environment
+      variable forces a lowering, does a test verify the forced path is the
+      active one, and does a nonexistent selection fail loudly? (simdjson
+      `checkimplementation`, `SIMDJSON_FORCE_IMPLEMENTATION=doesnotexist`
+      as a must-fail test) — Oak: `OAK_PORTABLE_INTRINSICS` exists; the
+      assertion of the active path: check.
+- [ ] **Generators produce each error class at every position.** For a
+      validator, does a generator emit one specifically ill-formed input
+      per error class (header bits, too short, too long, overlong 2/3/4,
+      too large, surrogate) at every offset across a block edge, asserting
+      the exact class and offset? Is detection lag — an error in block N
+      reported while scanning block N+1 — its own test class? (simdutf
+      `validate_utf8_with_errors_tests`, `puzzler2`) — Oak:
+      `compiler/e2e_stdlib_utf8_diff_test.go` injects nine damage kinds at
+      one random offset over 16 sizes × 9 alignments — partial.
+- [ ] **Mutation brute force against the reference.** From valid text of
+      each width mix, replace one byte with a random value and, separately,
+      set one random bit, a thousand times per input, requiring the fast
+      and reference validators to agree on every mutant. (simdutf
+      `brute_force_tests`; how issue #514 surfaced) — Oak: not stated.
+- [ ] **Generate with a witness.** Does the valid-input generator return the
+      ground truth the routine must compute (code-point count, expected
+      transcoded bytes), so count and length functions are checked
+      against the generator rather than a second implementation? (simdutf
+      `generate_counted`, `transcode_test_base`) — Oak: `110-testing.md`
+      generators; witnesses per module: check.
+- [ ] **Emulated targets with hostile tail policies.** Are scalable-vector
+      bodies run under emulation with inactive lanes forced to all ones and
+      `vl` shorter than requested, at several vector lengths, so code that
+      observes dead lanes fails? (simdutf qemu `rvv_ta_all_1s`,
+      `rvv_ma_all_1s`, `rvv_vl_half_avl`, VLEN 128/256/1024) — Oak:
+      `93-simd.md` §5 states the obligation; the mechanism is not stated.
+- [ ] **Canaries around fuzzed outputs.** Does the fuzz harness allocate
+      each output separately and check canary bytes past the declared
+      length, so a within-page over-write is a failure rather than luck?
+      Is the fuzz corpus stored and every crash committed as a test named
+      by its hash? (simdutf `use_canary_in_output`; simdjson `fuzz/`) —
+      Oak: `110-testing.md` Fuzzing; canaries and stored corpus not
+      stated.
+- [ ] **Oracle independence.** Is at least one reference witness written by
+      someone else (simdutf's Fuchsia-derived validator), not a
+      transliteration of the same model the fast path came from? — Oak:
+      `is_valid_utf8` in the C backend is a transliteration of the Lean
+      brackets; the Go `unicode/utf8` witness is independent; simdutf is
+      built in `benchmarks/state-machines/cross` but only timed, not
+      compared on invalid inputs.
 
 ## 9. Parsing, input validation, and boundaries
 
@@ -603,6 +689,102 @@ simdjson, simdutf, Hyperscan, data-oriented design (DOD), langsec.
       (Rust FFI, Swift C interop) — Oak: `92-ffi.md` §2.6, §2.10;
       `feat(verify): records and unions at the boundary`.
 
+- [ ] **Padding content is unspecified.** Where a padding contract exists,
+      does the parser depend only on padding being readable, never on its
+      value — copying a scalar that may end at `len` into a filled scratch
+      rather than trusting a NUL or a space? Are the padded and unpadded
+      paths both first-class, selected once per document, with one oracle?
+      (simdjson `visit_root_number`, `parse_unpadded`, `INSUFFICIENT_PADDING`)
+      — Oak: `71-codecs.md` §16 requires a readable-capacity contract;
+      content rule and twin paths not stated.
+- [ ] **Errors carry the byte, the path, and the token.** Does every decode
+      error carry the input offset where it was detected and the
+      structural path (RFC 6901 pointer or field chain), attached once by
+      the root driver rather than threaded through every helper, so the
+      hot scanner's ABI is untouched? Is the position a typed payload,
+      never a count field whose meaning flips on error? (weePickle
+      `TransformException`, simdjson `current_location()`, simdutf
+      `result.count`) — Oak: `stdlib/json.oak` `JsonDecodeError` and
+      `stdlib/strings.oak` `TextError` carry no position; `JsonIntegerScan`
+      (`71-codecs.md` §18) is the ABI to protect — gap.
+- [ ] **Error reporting costs no more than parsing.** Is building the
+      error value linear in depth and bounded in size — no quadratic path
+      rendering, no echoing an unbounded token into the message?
+      (weePickle `toJsonPointer` after an O(depth²) OOM on `"["·100000`,
+      `ToBigInt` digit cap) — Oak: not stated.
+- [ ] **Recoverable and fatal errors are distinct classes.** Can a caller
+      retry a value as another type after a type error while a structural
+      error poisons the iterator so nothing further can be read, and is
+      "which errors are fatal" a stated predicate? (simdjson `is_fatal`,
+      `abandon()`, `INCORRECT_TYPE` never stored) — Oak: `71-codecs.md`
+      §13 fails fast; the class split is not stated.
+- [ ] **Batch boundaries never split a scalar or a UTF-8 sequence.** For a
+      streamed sequence of documents, is the cut placed at a value/value
+      boundary with balanced brackets, are trailing partial UTF-8 bytes
+      trimmed before validation, and is the truncated tail reported to the
+      caller? Is the trim a total primitive with its "otherwise valid"
+      precondition typed? (simdjson `find_next_document_index`,
+      `truncated_bytes()`; simdutf `trim_partial_utf8`) — Oak:
+      `stdlib/strings.oak` `utf8_decode_previous` is the building block;
+      `71-codecs.md` §16 requires streaming APIs to state incomplete-input
+      behavior — open.
+- [ ] **Late discriminators buffer visibly and keep their position.** When
+      an ADT tag is not the first key, is the fallback a caller-sized
+      scratch with an explicit overflow error, does the replayed decode
+      still report the original offset and path, and can the type require
+      tag-first so the streaming path is the only path? (weePickle
+      `taggedObjectContext`, `BufferedValue`, `JsonPointerVisitor`) — Oak:
+      `71-codecs.md` §7 states the buffering contract; ADT variants are
+      not derived; position on replay not stated.
+- [ ] **Container counts are schema facts or buffers, never guesses.** For
+      a format whose container header needs the element or field count, is
+      it taken from the schema (arity minus statically omitted fields) or a
+      declared count pass, and is a schemaless producer that cannot supply
+      it rejected at the type rather than at run time? (weePickle
+      `CaseW.length`, `MsgPackRenderer.require(length != -1)`) — Oak:
+      `71-codecs.md` §4a size pass, §7; `stream[F, S]` in §3 not stated.
+- [ ] **Unknown-field policy is declared per schema.** Is skip-unknown
+      versus reject-unknown an explicit per-type choice, is the skip
+      bounded by a declared depth and size, and is the API-evolution
+      consequence (adding a producer field breaks strict consumers)
+      written next to the choice? (weePickle `NoOpVisitor` skip; OpenAPI
+      additive evolution) — Oak: `71-codecs.md` §13 rejects
+      (`UnknownField`); the policy axis is not stated.
+- [ ] **Duplicate-key semantics are one rule.** First wins, last wins, or
+      error — stated once and identical across every derivation path and
+      backend? (weePickle's Scala 2 first-wins vs Scala 3 last-wins drift)
+      — Oak: `71-codecs.md` §13 `DuplicateField` — yes for JSON.
+- [ ] **Schemaless number transit is lexical.** When transcoding between
+      formats without a target type, is a number carried as its digits with
+      decimal and exponent positions, rather than parsed to a double and
+      reprinted? (weePickle `visitFloat64StringParts`; its MsgPack renderer's
+      lossy `toDouble`) — Oak: `71-codecs.md` §3 `stream[F, S]` not stated.
+- [ ] **Cross-format lowering of non-native values is a declared table.**
+      Binary, timestamps, extension types, 64-bit integers into a format
+      lacking them — is each mapping and its loss written down, or does a
+      default silently pick strings and arrays? (weePickle `JsVisitor`
+      defaults; 2^53) — Oak: not stated.
+- [ ] **Lossy conversion is a separate total API.** Is U+FFFD replacement
+      offered as a distinct always-succeeding function with a matching
+      length function, never as a flag on the strict path? (simdutf
+      `_with_replacement`, `to_well_formed_utf16`; simdjson
+      `allow_replacement`) — Oak: `stdlib/STRINGS.md` transcoders are
+      strict only — not stated.
+- [ ] **Base64 last-chunk policy is a named parameter.** Are `loose`,
+      `strict`, `stop_before_partial`, `only_full_chunks` stated, with the
+      decoder returning both consumed and produced counts so a stream can
+      resume? (simdutf `last_chunk_handling_options`, TC39 ArrayBuffer
+      base64) — Oak: `stdlib/encoding.oak` is strict only; `70-strings.md`
+      §12 says so — one policy, not stated as a choice.
+- [ ] **The validated level is consumed, not just produced.** Does the
+      standard library have functions whose signature takes the validated
+      type (`string`, `Bytes[ValidUtf8]`) and therefore skips
+      re-validation, or does every text function take `[]u8` and re-run
+      the validator? (simdutf `convert_valid_*`) — Oak: `70-strings.md`
+      §13 defines `string`; every `text_*` in `stdlib/strings.oak` takes
+      `[]u8` and re-runs `is_valid_utf8`; the restrictions on `string`
+      values (no rebinding, no aggregates) are the blocker — gap.
+
 ## 10. Errors, failure, and diagnostics
 
 - [ ] **Crash on invariant violation, return on expected failure.** Does
@@ -633,6 +815,14 @@ simdjson, simdutf, Hyperscan, data-oriented design (DOD), langsec.
 - [ ] **No silent truncation or coercion in error paths.** Does an error
       message print values exactly (full width, correct signedness, float
       round-trip digits)? (TB) — Oak: `85-discipline.md` §5.
+
+- [ ] **Use-once materialization is a type rule, not a debug check.** Is
+      "unescape this token once" or "iterate this container once" enforced
+      by consume or typestate rather than by a development-mode assertion?
+      (simdjson `OUT_OF_ORDER_ITERATION` only under
+      `SIMDJSON_DEVELOPMENT_CHECKS`) — Oak: `50-borrowing.md` §9 consume,
+      `112-protocols.md` §5a typestate; a JSON iterator using them: not
+      stated.
 
 ## 11. Compiler and toolchain correctness
 
@@ -689,6 +879,24 @@ simdjson, simdutf, Hyperscan, data-oriented design (DOD), langsec.
       is the trusted computing base written down and minimized? (Thompson
       "Reflections on Trusting Trust", CompCert TCB) — Oak: not stated;
       candidate for `125-verification.md`.
+
+- [ ] **Public signatures are written, not inferred.** Does every `pub`
+      export carry an explicit type, so an inferred narrower type cannot
+      become frozen API by accident? (weePickle `ToDuration:
+      MapStringTo[Duration]` bin-compat comment) — Oak:
+      `82-package-semver.md` snapshots canonical types; the explicitness
+      requirement is not stated.
+- [ ] **Major versions coexist.** Can two major versions of a module be
+      linked into one program (version in the module path or namespace),
+      so a v2 does not wait on every transitive dependency? (weePickle
+      `v1` packages, Go `/v2`) — Oak: `82-package-semver.md`,
+      `83-modules.md` — not stated.
+- [ ] **Wire schema changes are classified too.** Does the SemVer
+      classifier see a change to a derived codec's wire shape (renamed
+      key, new required field, changed discriminator) as an API change,
+      not only a change to the Oak signature? (weePickle: "any API change
+      that requires your consumers to update is breaking") — Oak:
+      `82-package-semver.md` classifies exports only — not stated.
 
 ## 12. Process
 

--- a/docs/checklists/performance.md
+++ b/docs/checklists/performance.md
@@ -84,8 +84,8 @@ oracle agreeing bit for bit. Add rows; do not remove them.
 
 | Domain | Golden implementation(s) | Defining techniques (expressiveness questions in §2) | Oak status |
 | --- | --- | --- | --- |
-| JSON parsing | simdjson (Langdale & Lemire 2019), simdjson On-Demand | two-stage parse (structural index then tape); byte classification by nibble shuffle; prefix-XOR quote masks; `ctz` bitmask-to-index iteration; padded input; Eisel–Lemire float parsing; SWAR integer parse; runtime CPU dispatch; no backtracking | typed decoding measured against simdjson (`71-codecs.md` §16–§19, `benchmarks/json`); On-Demand not modeled; runtime dispatch absent |
-| UTF-8 validation / transcoding | simdutf (Keiser & Lemire), Zig/Rust std validators | three-byte lookup classification with shuffles; range tables; overlapping loads; ASCII fast path by OR-reduce; SWAR fallback; incomplete-tail handling | measured against Go, Rust, Zig, simdutf, simdjson (`benchmarks/state-machines`); fused validation lane in codecs |
+| JSON parsing | simdjson (Langdale & Lemire 2019), simdjson On-Demand | two-stage parse (structural index then tape); byte classification by nibble shuffle; prefix-XOR quote masks and odd/even backslash runs; `ctz` bitmask-to-index with over-write into slack; two-block software pipelining; sentinel-terminated index; padded input with unspecified content; UTF-8 lookup4 fused into stage 1; SWAR eight-digit parse; Eisel–Lemire floats; word-compare atoms; forward-only On-Demand iterator with recoverable vs fatal errors; grow-only parser buffers from a closed form; runtime CPU dispatch; no backtracking | 1.13× simdjson on M1, 1.40× on EPYC for one typed schema (`BENCHMARKS.md`); `71-codecs.md` §16–§19; structural index, On-Demand, float fast path, table lookup, movemask, `ctz`, `mul_hi` absent; runtime dispatch absent; pass recorded in `docs/notes/codec-text-extraction-2026-09.md` |
+| UTF-8 validation / transcoding | simdutf (Keiser & Lemire 2020, 2021, 2022), Zig/Rust std validators | three nibble-table lookups over each adjacent byte pair plus a saturating third/fourth-continuation check; cross-vector byte shift for the previous block; incomplete-tail compare; ASCII fast path by OR/max reduce; reject fast in lanes, locate the error with the scalar oracle; tail copied into an inert-filled stack block (no over-read); mask-indexed generated shuffle tables for transcoding with pattern fast paths; non-validating lane-count sizers with narrow accumulators; `_valid` API level over validated input; `trim_partial_utf8` for stream cuts; runtime dispatch | Oak shift-DFA 1.97 GB/s vs simdutf 13.4 GB/s (`benchmarks/state-machines`); the whole validator gap is three missing `simd` ops (16-lane table lookup, lane shift by immediate, cross-vector byte shift); transcoder is scalar and three-pass (`stdlib/strings.oak`); no error position; `string` as the `_valid` level exists but no stdlib function consumes it |
 | Multi-pattern matching / regex | Hyperscan (Teddy, FDR, shift-or, Rose), RE2, `memchr` crate | SIMD literal prefilters (Teddy: shuffle-based multi-literal); shift-or / bit-parallel NFA; DFA with byte-class compression; no backtracking, linear time; state in registers; streaming with saved state | recorded as a stdlib workstream, not started (`ml-language-requests` "The regex question") |
 | Hashing | BLAKE3, xxh3, wyhash, hardware CRC-32C, SipHash for keyed | wide state in registers; tree hashing for parallelism; hardware CRC/AES instructions; unaligned reads; seeded keys against collision DoS | SHA-256, BLAKE3, CRC-32C within ten percent of Rust (`stdlib/hash.oak`, `benchmarks/kernels`); hardware CRC and seeding: check |
 | Sorting | pdqsort (Peters), ips4o, vqsort (Google, Highway), radix sort | pattern-defeating pivots; branchless partition (Edelkamp–Weiß block partition); insertion sort tail; SIMD sorting networks; radix for keys with known width | pdqsort with laws (`sam/stdlib-pdqsort`, `sam/pdqsort-laws`); branchless partition and vqsort: check |
@@ -169,6 +169,26 @@ remains that a fact could elide" is a finding.
       aligned loads, TB) — Oak: `(align: N)` on fields
       (`40-records.md`); alignment on views/spans: check.
 
+- [ ] **Sentinel-terminated index arrays.** When a consumer walks an index
+      produced by an earlier pass, is the index over-allocated by a
+      constant and terminated with sentinels (`len, len, 0`) so the
+      consumer needs no end check, and is the slack a stated formula
+      (`roundup64(cap) + 9`)? (simdjson stage 1 → stage 2) — Oak: not
+      stated; `71-codecs.md` §11 keeps structural indexes as future work.
+- [ ] **Over-write into slack instead of a counted loop.** Can a compaction
+      write a fixed group of outputs past the true count into declared
+      slack, with the group's bound proven once per block rather than per
+      store? (simdjson `write_indexes_stepped`) — Oak: the extent fact
+      `i + K < len(v)` (`50-borrowing.md`) is the shape; spelling per
+      block: check.
+- [ ] **Constant-offset block loads discharge together.** Under
+      `while at + 64 <= len(src)`, do the four loads at `at`, `at + 16`,
+      `at + 32`, `at + 48` all elide their checks, and does the `len(v) -
+      i >= K` spelling of a bound count as the offset fact `i + (K-1) <
+      len(v)`? (simdutf 64-byte blocks, simdjson `is_made_of_eight_digits_fast`)
+      — Oak: `50-borrowing.md` extent facts cover literal and scaled
+      bounds; the `len - i >= K` form and `+16k` offsets: check emitted C.
+
 ### 2b. Bits and lanes
 
 - [ ] **Bit intrinsics as total functions.** `ctz`, `clz`, `popcnt`,
@@ -190,26 +210,53 @@ remains that a fact could elide" is a finding.
       lacking it (NEON) stated? Is lane compaction (`vcompress`,
       `pext`-based) expressible? (simdjson, Highway) — Oak: not stated;
       `93-simd.md` names neither movemask nor compress.
-- [ ] **Prefix operations on masks.** Prefix-XOR (carryless multiply by
-      all-ones) for quote-state tracking, prefix-sum for compaction
-      indices — expressible, and lowered to `pmull`/`pclmul` where
-      available? (simdjson) — Oak: not stated.
+- [ ] **Prefix operations on masks.** Prefix-XOR for quote-state tracking,
+      prefix-sum for compaction indices — expressible, and lowered to
+      `pclmul` where it pays? simdjson's arm64 path uses six scalar
+      `x ^= x << k` steps, not `pmull`, so the scalar form is the one to
+      have first. (simdjson) — Oak: expressible in safe Oak with
+      constant-folded checked shifts; no `pclmul` lowering.
 - [ ] **Horizontal reductions with fixed grouping.** Is `reduce_add`'s
       pairwise tree the definition, and does the lowering produce
-      `vaddv`/`haddps` sequences whose grouping matches? (F2) — Oak:
-      `93-simd.md` §1.2a, `55-parallelism.md` §4.
+      `vaddv`/`haddps` sequences whose grouping matches? Is there a
+      portable integer horizontal add, or only the arm64 `uaddlv`?
+      (F2, simdutf narrow accumulators) — Oak: `93-simd.md` §1.2a,
+      `55-parallelism.md` §4; integer form only in the arm64 library.
 - [ ] **Branchless select and blend.** Can `cond ? a : b` over scalars
       and lanes lower to `csel`/`bsl` without a branch, with the compiler
       free to choose? Can the author *require* branchless (constant-time)?
       (crypto, Edelkamp–Weiß) — Oak: not stated for the requirement.
 - [ ] **Widening and narrowing lanes.** `u8x16 → u16x8` pairs, saturating
-      narrow, zip/unzip — portable and total? (simdutf transcoding) —
-      Oak: `93-simd.md` §1.2; check the set.
+      narrow, zip/unzip, integer lane extract — portable and total?
+      (simdutf transcoding, `vst2q` zip-with-zero) — Oak: `codegen/simd.go`
+      lowers `add and eq max min or sub xor` only; `extract`/`insert`
+      exist for float lanes only — gap.
 - [ ] **Runtime feature dispatch.** Can one function have per-ISA-level
       bodies (NEON, SVE2, RVV, AVX2, AVX-512) selected once at startup,
       with the dispatch itself deterministic and all bodies tested against
       one oracle? (simdjson, memchr, Highway) — Oak: **absent** (dbs
       ask 6/7 recorded); design in `93-simd.md` §4 is the shape.
+
+- [ ] **Lane shifts by immediate.** Is `shr`/`shl` by a constant on `u8`
+      and `u16` lanes a portable `simd` operation, so a nibble (`x >> 4`)
+      can index a 16-entry table? (simdutf `prev1.shr<4>()`, simdjson
+      `(byte + 3) >> 4`) — Oak: `93-simd.md` §1.2 has no shift;
+      `codegen/simd.go` lowers none — gap.
+- [ ] **Cross-vector byte shift.** Can "the last N bytes of the previous
+      chunk followed by the first 16−N of this one" (`ext`/`palignr`) be
+      formed in one operation rather than through a stack round trip?
+      Every windowed classifier needs it. (simdutf `prev<N>`, simdjson
+      lookup4) — Oak: not stated in `93-simd.md`; emulable via a `[32]u8`
+      store and reload — gap.
+- [ ] **Unsigned lane comparisons beyond equality.** Are `gt`/`ge` masks
+      portable, or is `eq(max(a, b), a)` the stated two-op emulation with
+      its cost recorded? (simdutf `gt_bits`, `is_incomplete`) — Oak:
+      `93-simd.md` §1.2 has `eq`, `min`, `max`; comparison masks reserved
+      for a later revision.
+- [ ] **Lookup with default.** Is a table lookup whose out-of-range lanes
+      take a second vector's value (`vqtbx1q`) available, or stated as
+      lookup plus select? (simdjson whitespace classification) — Oak: not
+      stated; depends on the table-lookup item.
 
 ### 2c. Control flow shapes
 
@@ -317,6 +364,14 @@ remains that a fact could elide" is a finding.
       the caller's stack? (Rust, Swift non-escaping) — Oak:
       `05-ergonomics-and-cost.md` Function values and closures,
       `55-parallelism.md` §7.
+
+- [ ] **Worst-case scratch from a closed form.** Is every parser scratch
+      buffer (index, tape, string buffer, depth arrays) sized by a formula
+      over input length and depth, allocated once, and never touched again
+      on the steady-state path? (simdjson `document::allocate`: tape
+      `cap + 3`, strings `5·(cap/3) + PADDING`) — Oak: `71-codecs.md` §16
+      names reusable bounded work buffers as an investigation item; no
+      formula stated.
 
 ### 2f. Machine-level access
 
@@ -467,6 +522,41 @@ remains that a fact could elide" is a finding.
       against the portable definition on every target (differential, or
       Sail for the ISA)? — Oak: `93-simd.md` §5, `spec/sail`.
 
+- [ ] **Software-pipeline the block loop.** Does the block loop emit the
+      previous block's results while the current block's masks are
+      computing, so the serial mask-to-index tail overlaps the next loads?
+      (simdjson `step<128>`, "PERF NOTES") — Oak: not stated; `93-simd.md`
+      §3 shows one block per iteration.
+- [ ] **Copy-the-tail tail policy.** When the block kernel must not
+      over-read and predication is unavailable, is the remainder copied
+      into a stack block pre-filled with a semantically inert byte
+      (simdutf: 0x20, so a dangling lead reads as too short) and run
+      through the *same* block code, so tail and body cannot diverge?
+      (simdutf `buf_block_reader::get_remainder`, simdjson last block) —
+      Oak: `93-simd.md` §4.1 names predication, overlap, and scalar tail
+      only; `stdlib/json.oak` and `stdlib/strings.oak` use scalar tails.
+- [ ] **Reject fast, locate slow.** Does the vector validator accumulate
+      errors in lanes and decide once per block, with the error position
+      and class produced by the scalar oracle re-run from the last
+      known-good block (rewinding at most three continuation bytes), and
+      is the "detected one block late" case tested? (simdutf
+      `rewind_and_validate_with_errors`, `puzzler2`) — Oak:
+      `stdlib/strings.oak` returns at the first bad step and `TextError`
+      carries no position — not stated.
+- [ ] **Structure mask indexes a generated shuffle table.** For
+      transcoding, is the per-block continuation bitmask the index into a
+      generated (shuffle, consumed) table over ≤12-bit patterns, with the
+      most frequent patterns branch-tested first, and does the writer stay
+      memory-safe when the mask came from invalid bytes? (simdutf
+      `utf8bigindex[4096][2]`, `shufutf8[209][16]`, issue #514) — Oak:
+      `stdlib/strings.oak` transcodes one scalar at a time — not started.
+- [ ] **Speculative writer, validated after.** May the transcoder write a
+      block's output before the block's validity is known, provided the
+      write is bounds-safe on garbage and the output is pre-sized so
+      failure leaves the contract intact? (simdutf `validating_transcoder`)
+      — Oak: `71-codecs.md` §7 unchanged-on-failure requires pre-sizing;
+      a fact relating remaining input to remaining output: not stated.
+
 ## 7. Parallelism and concurrency
 
 - [ ] **Work and span stated.** Does every parallel operation document
@@ -589,6 +679,13 @@ remains that a fact could elide" is a finding.
       benchmark harness build with LTO and PGO where the C toolchain
       supports them, and is the gain recorded? — Oak: not stated.
 
+- [ ] **Consumer chains monomorphize to one loop.** Can a
+      redact→convert→sum pipeline over one parse be written as composed
+      sink types and lower to a single pass with no sink object, as a
+      visitor chain does with virtual calls? (weePickle/uPickle "Chaining
+      Visitors") — Oak: `71-codecs.md` §3 `stream[F, S]`, §11 fusion is
+      design work; needs a method-set constraint for `S`.
+
 ## 10. Parsing and text
 
 - [ ] **Two stages, one pass each.** Structural indexing first, then
@@ -598,9 +695,11 @@ remains that a fact could elide" is a finding.
       fields it reads, skipping the rest by structural index? (simdjson
       On-Demand, Cap'n Proto) — Oak: not modeled; direction.
 - [ ] **Number parsing state of the art.** Eisel–Lemire for floats, SWAR
-      for eight digits at a time, with correctness against the exact
-      decimal? (fast_float, simdjson) — Oak: `71-codecs.md` §18 compact
-      integer scans; floats: check.
+      for eight digits at a time, Clinger's fast path, with correctness
+      against the exact decimal? (fast_float, simdjson) — Oak:
+      `71-codecs.md` §18–§19 have the SWAR integer scan; `stdlib/float.oak`
+      is the exact slow path only, derived codecs do not decode floats,
+      and there is no `mul_hi` 64×64→128 — the fast path is absent.
 - [ ] **DFA with byte-class compression for matching.** Small
       transition tables, one load per byte, no branches? (Hyperscan, RE2)
       — Oak: UTF-8 state machines in `stdlib/strings.oak`; regex not
@@ -614,6 +713,35 @@ remains that a fact could elide" is a finding.
 - [ ] **Grapheme, normalization, case tables generated, not hand-written.**
       (Unicode) — Oak: `sam/stdlib-grapheme`, `sam/stdlib-normalize`,
       `sam/unicode-generator-pub`.
+
+- [ ] **Match keys on raw bytes, fall back on escapes.** Are object keys
+      compared against the expected spelling byte for byte (quotes
+      included, length checked), with Unicode-scalar comparison reached
+      only when the raw bytes contain a backslash or non-ASCII? (simdjson
+      `find_field_raw`) — Oak: `71-codecs.md` §18, `stdlib/json.oak`
+      `json_key_equal`.
+- [ ] **Key dispatch by length then prefix.** Does derived field matching
+      switch on key length and compare shared prefixes once (a radix
+      tree), with the length fact discharging the compare's bounds, rather
+      than a linear list of full compares? (weePickle
+      `getKeyIndexUsingRadix`, 20–60%) — Oak: `71-codecs.md` §13, §18
+      linear dispatch; §16 lists schema-specialized matching as open.
+- [ ] **Parse to the requested type, never through a type switch.** Does
+      the consumer name the type first so the scalar parser is the one for
+      that type, with "wrong type" a recoverable result rather than a fatal
+      error? (simdjson On-Demand use-specific parsing) — Oak:
+      `71-codecs.md` §13 `TypeMismatch`, §17.
+- [ ] **Skip is as cheap as parse.** Is skipping an unwanted subtree a
+      structural scan with no value materialization and a declared depth
+      bound? (simdjson `skip_child`, weePickle `NoOpVisitor`) — Oak: no
+      skip primitive in `stdlib/json.oak` — not stated.
+- [ ] **Sizing is a non-validating count.** Once validity is established,
+      are output-size functions O(n) lane counts (non-continuation bytes,
+      bytes ≥ 0xF0, `min(x & 0xFF80, 1)` for UTF-16) with narrow
+      accumulators flushed before overflow, rather than a second decode?
+      (simdutf `*_length_from_*_bytemask`) — Oak: `stdlib/strings.oak`
+      `utf8_to_utf16_size` decodes every scalar and `utf8_to_utf16`
+      decodes again — three passes.
 
 ## 11. Numerics
 
@@ -632,6 +760,11 @@ remains that a fact could elide" is a finding.
       debate, TB) — Oak: `20-types.md` §11.1a; measure.
 - [ ] **Mixed-width avoided in hot loops.** (MS) — Oak: rejected by the
       type system (no implicit promotion).
+- [ ] **Wide multiply is a total operation.** Is a 64×64→128 multiply
+      (high and low halves) available as a builtin, since Eisel–Lemire
+      float parsing, fast modular reduction, and wide hashes all need it?
+      (simdjson `full_multiplication`, Lemire fastmod, wyhash) — Oak: no
+      `mul_hi_u64` or `u128` in `stdlib` or `20-types.md` — gap.
 
 ## 12. Measurement discipline
 
@@ -648,9 +781,12 @@ remains that a fact could elide" is a finding.
       misses, cache misses per run, so the cause of a gap is measured.
       (simdjson's `event_counter`, `perf stat`) — Oak: §2f counters not
       stated.
-- [ ] **Regression gate.** Does CI fail (or flag) a benchmark that regresses
-      past a threshold against the checked-in baseline? — Oak: not
-      stated.
+- [ ] **Regression gate.** Does CI fail a benchmark that regresses against
+      the checked-in baseline, with a rule that tolerates noise — simdjson's
+      `perfdiff` runs seven interleaved samples and fails only when the
+      new maximum is below the reference minimum? — Oak:
+      `benchmarks/json/compare.py` does paired runs but is explicitly not
+      a gate.
 - [ ] **Adversarial inputs benchmarked too.** Worst-case inputs (deep
       nesting, all-escapes, hash collisions) measured alongside typical
       ones, so bounded work per byte is a number. (Hyperscan, langsec) —
@@ -665,3 +801,16 @@ remains that a fact could elide" is a finding.
 - [ ] **The gap has a cause.** Each remaining ratio against the golden
       implementation in §1 is attributed to a specific §2 item or accepted
       with a stated reason. An unattributed gap is an open finding.
+
+- [ ] **Setup outside the timed region, stated.** Does the harness exclude
+      allocation, first touch, and padding copies from the timed region
+      and say so, with a second number that includes them? (simdjson
+      `doc/performance.md`) — Oak: `benchmarks/json/README.md` keeps setup
+      outside timing; allocation counts unknown.
+- [ ] **Per-script corpora and a noise margin.** Are text benchmarks run
+      per writing system (ASCII, Latin-1, Arabic, CJK, emoji), since the
+      byte mix decides the path taken, and does the harness print best of
+      N with `mean/best − 1` as a noise figure and warn above a threshold?
+      (simdutf `unicode_lipsum`, `benchmark_base.cpp`) — Oak:
+      `benchmarks/state-machines` uses one random mix, best of five.
+

--- a/docs/notes/codec-text-extraction-2026-09.md
+++ b/docs/notes/codec-text-extraction-2026-09.md
@@ -1,0 +1,157 @@
+# Note: what simdjson, simdutf, and weePickle teach the codecs and text libraries
+
+**Status: record of a pass.** 2026-09-12, `specification` branch. Method:
+`docs/checklists/README.md`, applied as three parallel reads of the
+sources against `71-codecs.md`, `70-strings.md`, `93-simd.md`,
+`stdlib/json.oak`, `stdlib/strings.oak`, `codegen/simd.go`, and the
+benchmarks. Sources: simdjson `master` (stage 1 and stage 2 generic
+kernels, arm64 `simd.h`, `numberparsing.h`, On-Demand, `padded_string`,
+`implementation.cpp`, `fuzz/`, `benchmark/`), the 2019 and 2023 papers;
+simdutf `master` (lookup4 validator, the UTF-8→UTF-16 transcoder and its
+generated tables, `implementation.cpp`, `tests/`, `fuzz/`, workflows,
+`benchmark_base.cpp`), the 2020, 2021, and 2022 papers; weePickle v1.9.1
+(`weepickle-core`, the Scala 2 and 3 macros, `weejson-jackson`,
+`weepack`, `differences.md`), Li Haoyi's visitor write-up, jackson-core
+2.15 `StreamReadConstraints` and `ByteQuadsCanonicalizer`.
+
+The checklists absorbed the techniques: 22 new items in
+`performance.md` and 29 in `correctness.md`, with pointer corrections
+where the reads found something sharper. This note records what the pass
+found about *Oak*, in the order the evidence suggests acting.
+
+## The measured gap and what closes it
+
+| Workload | Oak | Golden | Ratio |
+| --- | ---: | ---: | ---: |
+| UTF-8 validation, 1 MiB random mix (`benchmarks/state-machines`) | 1.97 GB/s shift-DFA | simdutf 13.4 GB/s | 6.8× |
+| Typed JSON decode, one schema, M1 (`benchmarks/json`) | 119.9 ns/doc | simdjson On-Demand 105.9 ns/doc | 1.13× |
+| Same, EPYC 7763 | 178.7 ns/doc | 127.6 ns/doc | 1.40× |
+
+The UTF-8 gap is not an algorithm gap. The lookup4 validator is
+expressible in safe Oak — error lanes OR-accumulated per block, the tail
+copied into an inert-filled stack block, no over-read, no `unsafe` —
+except for three `simd` operations the portable catalog lacks. Every
+other technique in simdutf's validator (ASCII test by `max < 0x80`,
+saturating compares via `eq(max(a,b),a)`, wrapping arithmetic) is
+already expressible.
+
+## Expressiveness findings, ordered
+
+Classification per `performance.md` §0: (a) missing operation, (b)
+unsafe-only, (c) unproven precondition leaves a check, (d) lowering loss,
+(e) relies on undefined behavior.
+
+| # | Finding | Class | The fact or operation that closes it | Unlocks |
+| --- | --- | --- | --- | --- |
+| 1 | No 16-lane table lookup (`tbl`/`pshufb`) in `93-simd.md` | (a) | `simd.lookup16_u8x16(table, idx)`, total, with one stated out-of-range rule proven on both NEON (index ≥ 16 → 0) and SSE (bit 7 → 0) lowerings; a lookup-with-default form (`vqtbx1q`) or lookup plus select | lookup4 UTF-8 validation, simdjson byte classification, Teddy prefilters, base64 classification |
+| 2 | No lane shift by immediate | (a) | `shr_u8x16`/`shl_u8x16` by constant, total | nibble extraction for #1 |
+| 3 | No cross-vector byte shift (`ext`/`palignr`) | (a) | `simd.ext_u8x16(prev, cur, N)`; emulable today through a `[32]u8` store and reload | the previous-block window in every carried classifier |
+| 4 | No movemask, no compress | (a) | `bitmask_u8x16 → u16` (NEON: AND with a bit table plus three `vpaddq` folds — state the cost), `compress` where the ISA has it | simdjson structural masks, simdutf structure masks and UTF-16 validation, base64 whitespace removal |
+| 5 | `ctz`, `popcount`, `rbit`, `bswap`, `rotr` not builtins (only `clz32`/`clz64`; `rotl64` hand-written in `stdlib/random.oak`) | (a) | total functions with `ctz(0) = 64`; simdjson calls `ctz(0)` under a sanitizer suppression — Oak defines it instead | bitmask-to-index loops, error positions from mismatch masks |
+| 6 | `while bits != 0 { i = ctz(bits); bits &= bits - 1 }` is not a canonical bounded shape | (c) | the ranking law `iterations ≤ popcount(bits) ≤ 64` for `Oak.Loops`, recognized by the discipline analysis | the same loops in the strict profile |
+| 7 | Integer lane extract, narrow, zip, and a portable integer horizontal add are absent (`extract`/`insert` are float-only; `uaddlv` is arm64-only) | (a) | integer forms in the portable catalog | simdutf transcoding, narrow-accumulator counts |
+| 8 | No 64×64→128 multiply | (a) | `mul_hi_u64` builtin | Eisel–Lemire float parsing (`stdlib/float.oak` is the exact slow path only; derived codecs do not decode floats), fastmod, wide hashes |
+| 9 | Extent facts cover `i + K < len(v)` but not the `len(v) - i >= K` spelling, and constant-offset block loads (`at + 16k` under `at + 64 <= len`) may each keep a check | (c) | recognize the subtraction form as the offset fact; assert the emitted C for the four-load block | check-free 64-byte blocks, the eight-digit SWAR guard in `stdlib/json.oak` |
+| 10 | Static-table value ranges cannot be stated (`shufutf8[utf8bigindex[m][0]]` needs "every entry < 209") | (c) | a refinement on the element type of a static initializer, checked at initialization | mask-indexed shuffle transcoding |
+| 11 | The `_valid` API level exists as a type (`string`, `Bytes[ValidUtf8]`) but no stdlib function consumes it: every `text_*` in `stdlib/strings.oak` takes `[]u8` and re-runs `is_valid_utf8`; transcoding is validate, size, decode — three passes | (d) at the library | signatures over `string`; the blocker is `70-strings.md` §13's restrictions on `string` values (no rebinding, no aggregates), which push the stdlib to `[]u8` | removes a full pass from every text operation |
+| 12 | Errors carry no position: `TextError` and `JsonDecodeError` are bare enums; the differential test recovers the offset by stepping | (a) at the library | `InvalidEncoding(at: u32)` payloads (ADT payloads exist); attach offset and path at the root driver, as weePickle does, so `JsonIntegerScan`'s 16-byte register-return ABI (`71-codecs.md` §18) is untouched | negative tests assert position; users get a location |
+| 13 | Oak's hot paths use in-band sentinels (`json_result_value` returns `4294967295`, `json_hex4`, `JsonIntegerScan.status`) | disposition | acceptable as *private* helpers under a register-return ABI, and the justification in §18 should say so explicitly; the `Errors are values` item now records the rule | — |
+| 14 | Late ADT discriminators: `71-codecs.md` §7 states the buffering contract, but ADT variants are not derived and "one bounds check per record" cannot hold when the variant is unknown before the object ends | (a) | either a format/policy phantom `TagFirst` (streaming legal) or a schema-level object size bound `N` (buffered legal); replay must re-establish position | derived ADT codecs |
+| 15 | Composed consumers (`stream[F, S]`) have no stated lowering to one loop; only `encode`/`decode`/`from().to()` are derived | (d) | a method-set constraint for `S` so each stage is a monomorphized call | visitor-chain pipelines without objects |
+| 16 | No skip primitive in `stdlib/json.oak` (only `json_skip_space`); unknown fields are rejected, so adding a producer field is a breaking change and `82-package-semver.md` does not see wire shapes | (a) | a bounded structural skip (declared depth and size) and a per-schema unknown-field policy; classify wire changes in the SemVer snapshot | tolerant readers, API evolution |
+| 17 | Schemaless `stream[F, S]` has no number, count, or non-native-value policy | not stated | lexical number transit (digits plus dot and exponent offsets); a `CountsUpFront` format property selecting the buffered form; a declared cross-format lowering table | JSON→MsgPack without loss |
+| 18 | Speculative transcoder writes (six valid of eight lanes stored, reclaimed by later stores) | (c) | a fact relating remaining input to remaining output is unstatable; keep pre-sizing and accept the per-store check, which also preserves unchanged-on-failure | — |
+| 19 | Runtime ISA dispatch absent (recorded before) | (a) | simdjson's arm64 path has no dispatch either; costs nothing on M-series until SVE2 | x86 targets |
+| 20 | Two-block software pipelining and the C backend's emission of `restrict`, `cold`, and `musttail` | (d) | assert the emitted code per `performance.md` §0 | — |
+
+## Audit of `71-codecs.md` §1 against weePickle
+
+The chapter's description is accurate and, if anything, understated:
+weePickle's derived readers hold `To[...]` instances behind one interface
+and call through `Visitor` virtuals, so "the abstraction disappears" is a
+JIT hope at megamorphic call sites. Oak was right to reject runtime
+visitor objects, boxing through `visitValue(v: Any)`, `asInstanceOf`
+narrowing, `ClassTag` checks on write, exceptions as the error channel,
+implicit resolution with priority traits, and the runtime recovery of
+tagged-ness in `FromTo.join`.
+
+Two premises in this pass's brief were wrong and are corrected here so
+they are not repeated: weePickle has **no** `index` parameter on visit
+methods (uPickle does; weePickle removed it and attaches offset, line,
+column, token, and an RFC 6901 pointer from the *driver*), and `NullSafe`
+and `Transmogrifier` do not exist in the codebase.
+
+What §1 leaves out, each now a checklist item and a candidate spec edit:
+
+1. Position comes from the driver, not from threading. The root wrapper
+   knows the failing helper's `from` when it returns before advancing, so
+   offset and path attach at the root at zero cost to the scanner ABI.
+2. Discriminator ordering is a fast path (tag first, delegate the rest)
+   and a slow path (buffer, find the tag at end, replay) — and the replay
+   loses position unless re-established. Naming tags to sort first under
+   key-sorting formats is the cheap trick.
+3. Defaults are read semantics; omission on write is a wire-compatibility
+   decision that must be opt-in and is only sound for constant defaults.
+4. Unknown-field tolerance is an API-evolution policy, not a strictness
+   preference.
+5. The derived traversal should be written once against a format
+   operation set and specialized per format, not regenerated per format;
+   `compiler/codecs.go` rejects any format but `Json` today.
+6. Count-bearing container headers (MsgPack) decide whether a direct
+   `stream[Json, MsgPack]` is streaming or buffered.
+7. Non-native values need a declared cross-format lowering table.
+
+## Stated refusals
+
+- **Stage-1 worker thread** (simdjson `parse_many`): `71-codecs.md` §11
+  forbids implicit workers in codec paths. Not a gap.
+- **"Free padding" by page-boundary check** (simdjson `doc/performance.md`):
+  relies on reading past an allocation when it stays inside the page —
+  class (e); sanitizers flag it. Oak's padding fact, when it lands, is a
+  readable-capacity contract the caller provides, never an inference.
+- **Tile choice, predicated zero-fill tails, lane mapping** were already
+  refused in `codec-fusion-lessons-2026-09.md` and stand.
+- **`convert_valid_*` as undefined behavior on invalid input**: Oak has
+  the fact as a type; the level should be a signature over `string`, not
+  a precondition comment.
+
+## Testing practices adopted into the correctness list
+
+Every body an oracle for every other with one differential fuzz target;
+the test asserts which kernel ran and a nonexistent forced kernel fails;
+generators produce each error class at every offset across a block edge
+with detection lag as its own class; mutation brute force (byte replace,
+bit set) against the reference; generators that return the witness;
+hostile emulation for scalable vectors (`rvv_ta_all_1s`,
+`rvv_ma_all_1s`, `rvv_vl_half_avl`, several VLENs); canaries around
+fuzzed outputs and a stored corpus; oracle independence (simdutf is built
+in `benchmarks/state-machines/cross` but only timed — compare it on
+invalid inputs too); in-tree JSONTestSuite vectors for `stdlib/json.oak`;
+ASan/UBSan and a compiler × flags matrix over the compiler e2e suites,
+not only the benchmark workflows; the simdjson `perfdiff` rule (seven
+interleaved samples, fail only when the new maximum is below the
+reference minimum) to turn `benchmarks/json/compare.py` into a gate.
+
+## If taken up
+
+Order by evidence: findings 1–5 are one `93-simd.md` revision (table
+lookup, lane shift, cross-vector shift, movemask, bit builtins) and they
+alone close the 6.8× UTF-8 gap with a validator that is safe Oak; then 9
+(extent-fact spelling) so the block loop is check-free and asserted;
+then 12 (error position) because every negative test after that asserts
+it; then 11 (`string` as the consumed validated level) because it
+removes a pass from every text operation; then 8 (`mul_hi`) with float
+decoding in derived codecs; then 14–17 as the codec chapter's next
+design round, with the §1 additions above landing in `71-codecs.md`
+together.
+
+## Revisit criteria
+
+- `93-simd.md` gains the five operations: rewrite `is_valid_utf8` as
+  the lookup4 validator in Oak, delete the C helper the backend emits,
+  and re-measure `benchmarks/state-machines`.
+- `TextError` and `JsonDecodeError` carry positions: extend
+  `compiler/e2e_stdlib_utf8_diff_test.go` to sweep every error class
+  across offsets 0..128 and assert class and offset.
+- A second derived format exists: the §1 additions on format
+  independence, counts, and lexical numbers become testable.


### PR DESCRIPTION
## Summary

Second extraction pass, following the method in `docs/checklists/README.md`: three parallel reads of simdjson (kernels, On-Demand, papers, fuzz and benchmark tooling), simdutf (lookup4 validator, transcoder tables, tests, CI matrix, papers), and weePickle v1.9.1 (core visitor, Scala 2/3 macros, Jackson integration) against `71-codecs.md`, `70-strings.md`, `93-simd.md`, the stdlib, and the benchmarks.

- `docs/checklists/performance.md`: +22 items (lane shifts, cross-vector shift, unsigned lane compares, lookup with default, sentinel indexes, over-write into slack, closed-form scratch, software pipelining, copy-the-tail policy, reject-fast/locate-slow, mask-indexed shuffle tables, speculative writer, consumer-chain monomorphization, raw-byte key match, radix key dispatch, type-first parsing, skip primitive, non-validating sizers, wide multiply, setup outside timing, per-script corpora). JSON and UTF-8 golden rows rewritten with the measured ratios and the exact missing operations.
- `docs/checklists/correctness.md`: +29 items (wire identities declared, pure defaults, callback-scoped borrows as regions, every body an oracle, kernel assertion, per-class-per-offset generators with detection lag, mutation brute force, witnesses, hostile emulation, canaries, oracle independence, padding content unspecified, errors carry byte/path/token, error cost bound, recoverable vs fatal, batch cuts, late discriminators, container counts, unknown-field policy, duplicate keys, lexical numbers, cross-format lowering table, lossy API, base64 chunk policy, consumed validated level, use-once as a type rule, explicit public signatures, coexisting majors, wire schema in SemVer).
- `docs/notes/codec-text-extraction-2026-09.md`: the disposition — twenty expressiveness findings classified per §0 and ordered by evidence, an audit of `71-codecs.md` §1 against the real weePickle (two wrong premises corrected), stated refusals, and revisit criteria.

Headline: the 6.8× UTF-8 validation gap against simdutf is five missing `simd` operations, not an algorithm gap; the lookup4 validator is otherwise safe Oak with no over-read and no `unsafe`.

No code or normative spec changes; the §1 additions to `71-codecs.md` and the `93-simd.md` operations are the proposed next work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)