### PR TITLE
docs(checklists): TigerBeetle pass — mechanized style, VOPR phases, journal and superblock lessons

### DIFF
--- a/docs/checklists/correctness.md
+++ b/docs/checklists/correctness.md
@@ -220,6 +220,22 @@ simdjson, simdutf, Hyperscan, data-oriented design (DOD), langsec.
       `string_view` lifetimes) — Oak: `50-borrowing.md` §8c and
       `71-codecs.md` §13a for whole inputs; streaming refill is design
       work (`71-codecs.md` §16).
+- [ ] **Root metadata has copies with intersecting quorums.** Is
+      fixed-position root state stored as N copies, written to a write
+      quorum and opened from a read quorum with write + read = N + 1, the
+      copy index outside the checksum, sequence plus parent checksum
+      ordering versions, and broken copies repaired on open? (TB
+      `superblock_quorums.zig`) — Oak: not stated.
+- [ ] **Staging is never externalized.** Is state that is not yet durable
+      held apart from working state, so no reply, ack, or in-memory
+      guarantee depends on it? (TB `superblock.zig` `working`/`staging`)
+      — Oak: `120-io.md` §3 durability clause; the program-side rule: not
+      stated.
+- [ ] **Checksums point outward.** Is every block reached by pointer
+      checksummed by its parent (address, checksum pairs), with
+      self-checksum reserved for the root, so a misdirected write of
+      well-formed data is detected? (TB `BlockReference`, `data_file.md`)
+      — Oak: not stated.
 
 ## 4. Memory, ownership, and aliasing
 
@@ -247,9 +263,13 @@ simdjson, simdutf, Hyperscan, data-oriented design (DOD), langsec.
 - [ ] **Alignment and layout are facts.** Is every record layout derived
       from one stated rule, exposed via `size_of`/`offset_of`, asserted in
       the emitted code, and ratified against the C compiler? Do `(align:
-      N)` annotations produce an emitted assertion? (Zig, Rust
-      `#[repr(C)]`, DOD) — Oak: `40-records.md`, `45-representations.md`,
-      `92-ffi.md` §2.6.
+      N)` annotations produce an emitted assertion? Is a padding-free,
+      unique-representation predicate asserted for every record compared
+      by bytes or written to a device, with checksum fields at 16- or
+      32-byte offsets asserted? (Zig, Rust `#[repr(C)]`, DOD, TB
+      `stdx.no_padding`) — Oak: `40-records.md` §6a–§6b,
+      `45-representations.md`, `92-ffi.md` §2.6; the predicate: not
+      stated.
 - [ ] **Endianness explicit at every byte boundary.** Is every multi-byte
       read or write from a byte buffer through a named-endianness function
       that returns a result, never a cast or a reinterpret? (TB, MISRA,
@@ -266,9 +286,11 @@ simdjson, simdutf, Hyperscan, data-oriented design (DOD), langsec.
       `60-effects-allocation.md` §8, `standard-library-design.md` §6.
 - [ ] **Capacity is declared, exhaustion is a value.** Does every
       fixed-capacity container declare its capacity and return a result on
-      exhaustion rather than growing or trapping? (TB static allocation,
-      P10 rule 3) — Oak: `60-effects-allocation.md` §6–§9,
-      `85-discipline.md` §4.
+      exhaustion rather than growing or trapping? Is the capacity a
+      written sum of named per-consumer maxima, asserted sufficient for
+      progress, rather than a round number? (TB static allocation,
+      `message_pool.zig`, P10 rule 3) — Oak: `60-effects-allocation.md`
+      §6–§9, `85-discipline.md` §4; the sum discipline: not stated.
 - [ ] **Resource cleanup is guaranteed and ordered.** Is every acquired
       resource released on every path, including error paths, in reverse
       acquisition order, with the release visible at the acquisition site?
@@ -291,6 +313,19 @@ simdjson, simdutf, Hyperscan, data-oriented design (DOD), langsec.
       elided by the optimizer? (MISRA volatile, Linux kernel memory
       barriers doc) — Oak: `65-machine-memory.md` §9, `95-aarch64-barriers.md`,
       `96-aarch64-mmio.md`.
+- [ ] **Wire and disk records have no implicit padding, and reserved bytes
+      are zero on both sides.** Is every on-disk or on-wire record declared
+      with a layout clause and asserted padding-free, with reserved fields
+      asserted zero before write and checked zero after read, and paddings
+      zeroed before they reach a device ("buffer bleed")? (TB
+      `stdx.no_padding`, `Header.invalid()`, `journal.zig`) — Oak:
+      `40-records.md` §6a `struct(packed)`, §6b `static_assert`; reserved
+      field checks: not stated.
+- [ ] **Reserved slots name their own address.** Does an empty slot in a
+      ring or table carry its own index (as the op, address, or copy
+      number) so a misdirected read of a valid-looking empty slot is
+      detected? (TB `journal.zig` reserved headers, `SuperBlockHeader.copy`)
+      — Oak: not stated; the dbs frame scan needs it.
 
 ## 5. Control-flow and coding discipline
 
@@ -310,20 +345,56 @@ simdjson, simdutf, Hyperscan, data-oriented design (DOD), langsec.
       including through externs? (P10 rule 3, TB, MISRA 21.3) — Oak:
       `85-discipline.md` §4, `steady` manifest lines, `OAK-E0104`.
 - [ ] **Functions are short and do one thing.** Is any function over
-      roughly seventy lines, or doing two things a name cannot cover?
-      Long functions hide the control flow a reviewer must hold in mind.
-      (P10 rule 4, TB) — Oak: not stated as a rule; a strict-profile lint
-      is a candidate.
-- [ ] **Assertion density.** Does every function assert its preconditions,
-      postconditions, and the invariants it relies on — at least two per
-      function — and are assertions compiled in for every build mode?
-      (P10 rule 5, TB) — Oak: `85-discipline.md` §5 (density lint
-      planned).
+      seventy lines, or doing two things a name cannot cover? Is the
+      limit mechanical, with a ratchet so a small function cannot grow
+      past it while legacy exceptions shrink? Do long functions keep the
+      branching in the parent and pure leaves below ("push ifs up, fors
+      down")? (P10 rule 4, TB `tidy.zig` red zone 70–73) — Oak: not
+      stated as a rule; a strict-profile lint is a candidate.
+- [ ] **Assertion density.** Does every function assert its arguments,
+      results, and the invariants it relies on — at least two per
+      function on average (TB `replica.zig`: about seven) — one condition
+      per assertion, the negative space as well as the positive, with
+      relationships between compile-time constants asserted at compile
+      time? Are assertions on in every build mode, and does the simulator
+      refuse a mode that strips them? (P10 rule 5, TB) — Oak:
+      `85-discipline.md` §5, `40-records.md` §6b `static_assert`
+      (density lint planned).
 - [ ] **Pair assertions.** Where a property is established in one place
       and relied on in another, is it asserted at both — the producer
       asserting what it guarantees, the consumer asserting what it needs —
-      so a violation is caught at the boundary it crosses? (TB) — Oak:
-      practice; not stated.
+      so a violation is caught at the boundary it crosses? The canonical
+      pair: assert validity immediately before writing to disk or sending,
+      and immediately after reading or receiving. (TB) — Oak: practice;
+      not stated.
+- [ ] **Assert the negative space, one condition per assert.** Does every
+      function assert what must *not* be true as well as what must, with
+      compound conditions split (`assert(a); assert(b)`) and implications
+      written `if a { assert(b) }`, so a failure names one condition? (TB
+      `TIGER_STYLE.md` §Safety, `journal.zig` recovery matchers) — Oak:
+      `85-discipline.md` §5 has `assert`/`assert_eq`; the rule: not
+      stated.
+- [ ] **Two assertion tiers.** Are cheap invariant asserts always on, and
+      O(N) verification of O(1) operations behind one named build
+      constant that CI and the simulator turn on? (TB `constants.verify`)
+      — Oak: only always-on `assert`; not stated.
+- [ ] **Possibly-false conditions are marked.** Where a condition may
+      legitimately be true or false, is that written as `maybe(cond)`
+      beside the asserts, so a reader can tell "not asserted" from
+      "forgot to assert"? (TB `stdx.maybe`) — Oak: not stated.
+- [ ] **Division rounding is spelled.** Does every division that can round
+      name its rounding (`div_exact`, `div_floor`, `div_ceil`) rather than
+      use `/`? (TB §Off-By-One, `stdx.div_ceil`) — Oak: `20-types.md`
+      §11.1 has `/` only; not stated.
+- [ ] **Result dimensionality is minimized.** Is the simplest sufficient
+      result type used (`()` over `Bool` over `u64` over `Option` over
+      `Result`), so callers branch on the fewest cases? (TB §Cache
+      Invalidation) — Oak: not stated.
+- [ ] **The hot loop performs no I/O.** Is the apply or commit step
+      declared to forbid syscalls, blocking, and allocation, with every
+      read done in a preceding prefetch phase? (TB `ARCHITECTURE.md`
+      §Synchronous Execution) — Oak: `60-effects-allocation.md` §2
+      `forbids` can state it; the storage-engine use: not stated.
 - [ ] **Assertions name both values.** Does a failed comparison report
       got and want, not just "assertion failed"? Does a trap say which
       source line? (TB, Go testing) — Oak: `85-discipline.md` §5
@@ -368,8 +439,25 @@ simdjson, simdutf, Hyperscan, data-oriented design (DOD), langsec.
       `85-discipline.md` §7.
 - [ ] **Naming carries meaning.** Do names avoid abbreviations, carry units
       or qualifiers where the type does not, and put the most significant
-      word first so related names sort together? (TB, Go) — Oak: style;
-      not stated.
+      word first so related names sort together — units and qualifiers
+      last in descending significance (`latency_ms_max`), related names
+      the same length (`source`/`target`), a helper prefixed with its
+      caller's name, callbacks last, an options record when two adjacent
+      parameters share a type? (TB §Naming, Go) — Oak: style; not stated.
+- [ ] **Ambiguous operator mixes are rejected.** Is mixing bitwise and
+      arithmetic operators in one expression without parentheses a
+      diagnostic? (TB `tidy.zig`) — Oak: `10-syntax.md`; not stated.
+- [ ] **Style rules are tests with a ratchet.** Are line length, banned
+      spellings with a named replacement, leftover `FIXME`s and debug
+      prints, dead private declarations and dead files, and function
+      length enforced by a test, with limits ratcheted from the bottom so
+      legacy exceptions cannot grow? (TB `src/tidy.zig` under `zig build
+      test`) — Oak: `oak vet` lists obligations only; not stated.
+- [ ] **Tooling in the language.** Are generators, CI scripts, and release
+      checks written in Oak or in the compiler's language rather than
+      shell or Python, so they are typed and portable? (TB
+      `src/scripts/*.zig`) — Oak: `stdlib/generate_*.py`,
+      `stdlib/extract_*.py` are Python — finding.
 - [ ] **Comments say why, not what.** Is every non-obvious decision,
       especially every unsafe block and every admitted assumption, given a
       reason a future reader can test? Are specification references linked
@@ -481,16 +569,62 @@ simdjson, simdutf, Hyperscan, data-oriented design (DOD), langsec.
 - [ ] **Deterministic simulation testing.** Does the component run under
       simulated time, storage, network, and scheduling from a single seed,
       so a failure replays exactly and shrinks? Is production code and
-      test code the same code with the I/O port swapped? (TB VOPR,
-      FoundationDB, dbs) — Oak: `110-testing.md`, `120-io.md` `io/sim`
-      vs `io/native`, `stdlib/sim_storage.oak`.
+      test code the same code with the I/O port swapped? Does one `u64`
+      seed reproduce the run, is it printed on failure, does the tool
+      refuse to run unseeded in a mode that strips assertions, and can the
+      simulator speed time arbitrarily? (TB VOPR, FoundationDB, dbs) —
+      Oak: `110-testing.md`, `120-io.md` `iosim` vs `ionative`,
+      `stdlib/sim_storage.oak`.
 - [ ] **Fault injection covers the real fault model.** Are the faults
       injected the ones hardware and operating systems actually produce —
       torn writes, misdirected writes, dropped writes, lost fsync, bit
       flips, latent sector errors, crashes between write and sync, clock
-      jumps, partitions — not just "the call returned an error"? (TB, dbs,
-      "Protocol-Aware Recovery") — Oak: `110-testing.md` Simulated
-      storage (six kinds), Simulated time.
+      jumps, partitions — not just "the call returned an error"? Is
+      corruption sticky under retry (its position seeded from the
+      pristine bytes), does a misdirect keep the target's old data, are
+      faults off during first format, and are the double faults the
+      design does not claim to survive listed? (TB `testing/storage.zig`,
+      dbs, "Protocol-Aware Recovery") — Oak: `110-testing.md` Simulated
+      storage (six kinds, flipped/latent persist), Simulated time.
+- [ ] **Swarm the configuration.** Does the simulation draw every knob —
+      counts, capacities, latencies, fault probabilities, which fault
+      kinds are enabled — from the seed, with some kinds disabled entirely
+      per run, so no fixed mask hides an interaction? (TB `vopr.zig`
+      `options_swarm`, `fuzz.random_enum_weights`; Regehr's swarm
+      testing) — Oak: `sim_storage.oak` takes a caller-fixed fault mask
+      and rate; not stated.
+- [ ] **Heavy-tailed simulated latency and bursty ids.** Are simulated
+      delays minimum plus exponential(mean), and ids drawn bimodally
+      (hot/cold) or Zipfian so caches overflow and collide? (TB
+      `fuzz.random_int_exponential`, `random_id`, `stdx/zipfian.zig`) —
+      Oak: `sim_schedule_delayed` and `test_range` are uniform; no
+      exponential or Zipfian generator — gap.
+- [ ] **Liveness is checked after the faults stop, against a named core.**
+      After the safety phase, does the scenario pick a fault-free, fully
+      connected quorum, make every other failure permanent, and require
+      convergence within a stated budget, diagnosing *why* not (which op
+      or block the core lacks)? (TB `vopr.zig` liveness mode) — Oak:
+      `112-protocols.md` §1 `eventually`, `sim_sched_max_wait`; a
+      simulation-level convergence phase: not stated.
+- [ ] **Failures are classified.** Does a failing run say crash, liveness,
+      or correctness (distinct exit codes or signatures), so triage and
+      corpus routing differ? (TB `Failure{crash=127, liveness=128,
+      correctness=129}`) — Oak: `110-testing.md` signatures
+      `invariant:<id>` vs signal; classes: not stated.
+- [ ] **The fault atlas matches the redundancy claim.** Is fault placement
+      constrained so the design's redundancy can recover (at least one
+      good copy across replicas; a single-disk log corrupted only by
+      crash), with out-of-model double faults listed? (TB
+      `ClusterFaultAtlas`) — Oak: `110-testing.md` "three a single-disk
+      log can honestly keep"; per-zone atlas: not stated.
+- [ ] **Exhaustive tapes for small choice spaces.** Where a scenario's
+      choices are few, are all tapes enumerated rather than sampled? (TB
+      `exhaustigen.zig`; matklad) — Oak: `oak prove` enumerates theorem
+      domains (`125-verification.md` §3); tape enumeration for `Sim`
+      tests: not stated.
+- [ ] **A canary fuzzer.** Does the fuzz registry include a target that
+      must fail, so a green board proves the harness can see failures?
+      (TB `fuzz_tests.zig` `canary`) — Oak: not stated.
 - [ ] **Durability and detection are separate obligations.** Does the
       storage test distinguish "this block must survive" from "corruption
       of this block must be detected", tracked by provenance, so neither
@@ -519,12 +653,18 @@ simdjson, simdutf, Hyperscan, data-oriented design (DOD), langsec.
 - [ ] **Counters prove the optimization fired.** Does a test assert that
       the fast path was actually taken (a counter, an absence check over
       the emitted C), so a silent fallback to the slow path is a test
-      failure? (ml, TB) — Oak: `71-codecs.md` §4 wrapper-absence checks.
+      failure? Is each hot-path log line bound to one named test that
+      must hit it, so traceability rather than coverage percent is the
+      claim? (ml, TB `marks.zig`) — Oak: `71-codecs.md` §4
+      wrapper-absence checks; `testing_classify` labels.
 - [ ] **Known-answer vectors.** Are standard test vectors (RFC, NIST,
       Unicode conformance, JSON test suite) run, with the vector file in
-      tree and its provenance noted? (NIST CAVP, simdjson's JSONTestSuite `minefield`)
-      — Oak: `stdlib/hash.oak` KATs; no in-tree JSONTestSuite vectors for
-      `stdlib/json.oak` — gap.
+      tree and its provenance noted? Is an on-disk hash frozen by a
+      change detector (hundreds of structured cases hashed to one
+      constant) and shown independent of buffer alignment? (NIST CAVP,
+      simdjson's JSONTestSuite `minefield`, TB `checksum.zig`) — Oak:
+      `stdlib/hash.oak` KATs; no in-tree JSONTestSuite vectors for
+      `stdlib/json.oak` — gap; stability constant: not stated.
 - [ ] **Interpreter and every backend agree.** Is each language feature
       differentially tested across the interpreter, the C backend, and any
       other backend at every boundary value? (csmith, TB) — Oak: e2e
@@ -555,7 +695,14 @@ simdjson, simdutf, Hyperscan, data-oriented design (DOD), langsec.
 - [ ] **Tests are hermetic and deterministic.** No wall clock, no real
       network, no shared temp state, no order dependence; a failing seed
       is printed and re-runnable. Flakiness is a bug filed against the
-      test. (Go, TB) — Oak: `110-testing.md` Isolation.
+      test. Does CI seed each simulation run from the commit hash, and
+      does the merge queue test the merge commit? (Go, TB
+      `fuzz.parse_seed`) — Oak: `110-testing.md` Isolation; `-seed`
+      flag; commit seeding: not stated.
+- [ ] **Release artifacts rebuild bit-identically.** Is a published binary
+      rebuilt from its tag and required to hash-match? (TB
+      `scripts/ci.zig validate_release`) — Oak: `15-diagnostics.md` §11
+      covers emitted C only.
 - [ ] **Fuzz continuously, structure-aware.** Is every parser exported to
       a fuzzer (libFuzzer) with a structure-aware generator, run
       continuously, with the corpus checked in? (simdjson, Hyperscan,
@@ -633,9 +780,10 @@ simdjson, simdutf, Hyperscan, data-oriented design (DOD), langsec.
 - [ ] **Validate once, at the boundary, and record it.** Is every external
       input (bytes from disk, network, FFI, user) validated exactly once
       on entry, with the result a distinct type, and is the interior of the
-      program free of re-validation and of unvalidated data? (langsec,
-      "parse, don't validate", simdjson) — Oak: `71-codecs.md` §6,
-      `70-strings.md`.
+      program free of re-validation and of unvalidated data? Are bytes
+      never reinterpreted as a record before the checksum over them is
+      verified? (langsec, "parse, don't validate", simdjson, TB) — Oak:
+      `71-codecs.md` §6, `70-strings.md`.
 - [ ] **Never read past the input.** Is the padding contract (if any)
       explicit in the type or the call, and is reading beyond `len`
       impossible in safe code even when the SIMD block would? (simdjson's
@@ -826,6 +974,15 @@ simdjson, simdutf, Hyperscan, data-oriented design (DOD), langsec.
       `SIMDJSON_DEVELOPMENT_CHECKS`) — Oak: `50-borrowing.md` §9 consume,
       `112-protocols.md` §5a typestate; a JSON iterator using them: not
       stated.
+- [ ] **Recovery is a total decision table.** Is crash recovery a table
+      over the observable predicates (header valid, body valid, reserved,
+      op relations, epoch) with every impossible combination asserted and
+      one decision per row, rather than nested ifs? Does a single-copy
+      store report "corrupt, cannot recover safely" instead of truncating
+      on a checksum mismatch alone? (TB `journal.zig` cases `@A..@P`,
+      "Protocol-Aware Recovery") — Oak: expressible as a `theorem` over
+      `Bool` parameters decided exhaustively (`125-verification.md` §3);
+      not stated as practice.
 
 ## 11. Compiler and toolchain correctness
 

--- a/docs/checklists/performance.md
+++ b/docs/checklists/performance.md
@@ -309,6 +309,25 @@ remains that a fact could elide" is a finding.
 - [ ] **Hot/cold splitting.** Can a record's rarely-touched fields be
       moved to a side table without changing call sites? (DOD) — Oak:
       representation axis; not stated as a mechanism.
+- [ ] **Wire records as typed views over bytes, with wide scalars.** Can
+      a 256-byte header be declared padding-free with `u128` checksum and
+      id fields at 16- and 32-byte alignment, its layout asserted at
+      compile time, and read as a borrowed record view at an offset into
+      a `[]u8` after its checksum is verified? (TB `message_header.zig`
+      `extern struct`, `stdx.no_padding`) — Oak: `struct(packed)`,
+      `static_assert(size_of/offset_of)` (`40-records.md` §6a–§6b), C
+      header asserts (`92-ffi.md` §2.6); no `u128`/`u256`
+      (`20-types.md`), no no-padding predicate, record views only for
+      JSON-derived fields (`71-codecs.md` §13a); the fixed-layout binary
+      codec is wanted (dbs note round 3 ask 9) — gap, class (a).
+- [ ] **Bounded arrays and busy-bitset pools.** Can a fixed array carry
+      its count as a refinement bounded by its capacity, and a pool hand
+      out slots by index with acquire returning "none" when full? (TB
+      `BoundedArrayType`, `IOPSType`) — Oak: `count: u32 where value <=
+      N` (`20-types.md` §12) can carry the bound, `stdlib/slab.oak` is
+      the generational form; `Ring`/`BitSet` planned
+      (`standard-library-design.md`); pointer-to-index recovery is (b) by
+      design — handles replace it.
 - [ ] **Niche and tag compression.** Does `Option[View]` cost zero extra
       bytes (null niche), does a tag share storage with padding or an
       unused range, and is the optimization proof-preserving? (Rust
@@ -596,8 +615,14 @@ remains that a fact could elide" is a finding.
       grouped into one submission? (TB, io_uring) — Oak: `120-io.md`.
 - [ ] **Direct I/O with aligned buffers.** Are block buffers
       sector-aligned and sized so the kernel page cache is bypassed
-      deliberately, with alignment a type fact? (TB, databases) — Oak:
-      §2a alignment; check `120-io.md`.
+      deliberately, with alignment a type fact? Is the sector size a
+      named constant, every file size and I/O offset asserted a multiple,
+      alignment carried in the buffer's type, Direct I/O a tri-state
+      (required, optional, disabled) with a filesystem probe, and `pread`
+      size capped by the OS limit constant? (TB `io/linux.zig`,
+      databases) — Oak: §2a alignment on records only; `120-io.md` §5
+      Direct I/O is increment two; no alignment fact on an `IoBuffer`
+      window — gap.
 - [ ] **Zero-copy from device to consumer.** Does data cross layers as
       views into the receive buffer, never re-copied for convenience?
       (dbs, DPDK) — Oak: `71-codecs.md` §13a.
@@ -608,10 +633,12 @@ remains that a fact could elide" is a finding.
       unbounded buffering? (TB, Reactive Streams) — Oak: rings with
       declared capacity.
 - [ ] **Simulated and native I/O agree on cost shape.** Does the
-      simulation model the *latency and batching* the native path has,
-      so a design validated in sim is not slow in native? (TB VOPR) —
-      Oak: `120-io.md` two realizations differ only in fault model —
-      cost model: check.
+      simulation model the *latency and batching* the native path has —
+      minimum plus exponential(mean) per operation, per-path clogging,
+      capacity drop — so a design validated in sim is not slow in
+      native? (TB VOPR `packet_simulator.zig`) — Oak: `120-io.md` two
+      realizations differ only in fault model; `SimSched` delays are
+      uniform — cost model: check.
 
 ## 9. Compilers, fusion, and specialization
 

--- a/docs/notes/dbs-feedback-2026-09.md
+++ b/docs/notes/dbs-feedback-2026-09.md
@@ -125,4 +125,11 @@ on AArch64.
 - A `Bool` data fact refining a typestate index (the engine's caveat on
   ask 1 of the third round) is a proposition-axis question: whether a
   refinement on protocol data can select the state marker.
-
+- The frame-scan port's WAL and recovery should copy TigerBeetle's journal
+  and superblock designs rather than rediscover them; the twelve lessons
+  (redundant header ring written after the body, reserved slots naming
+  their slot, recovery as a total table decided by `oak prove`, the
+  torn-tail rule, faulty ≠ dirty, outward checksums) and the
+  expressiveness gaps they expose (`u128`, a no-padding predicate, an
+  alignment fact on `IoBuffer` windows) are in
+  `docs/notes/tigerbeetle-2026-09.md`.

--- a/docs/notes/tigerbeetle-2026-09.md
+++ b/docs/notes/tigerbeetle-2026-09.md
@@ -1,0 +1,151 @@
+# Note: what TigerBeetle teaches the storage-engine port
+
+**Status: extracted into the checklists.** 2026-09-12, `specification`
+branch. Source: a read of `github.com/tigerbeetle/tigerbeetle` at `main` —
+`docs/TIGER_STYLE.md`, `docs/ARCHITECTURE.md`, `docs/concepts/`,
+`docs/internals/{vsr,sync,data_file,testing,vopr,HACKING}.md`,
+`src/vsr/{journal,superblock,superblock_quorums,checksum,message_header,replica,client,grid,free_set}.zig`,
+`src/{vopr,tidy,constants,message_pool,state_machine,static_allocator,storage,aof,fuzz_tests,io}.zig`,
+`src/stdx/{stdx,prng,bounded_array,iops,ring_buffer}.zig`,
+`src/testing/{storage,cluster,packet_simulator,time,fuzz,exhaustigen,marks}.zig`,
+`src/lsm/{tree,compaction,manifest_log}.zig`, `src/scripts/ci.zig` —
+against `docs/spec/`, `docs/checklists/`, `stdlib/`, and the dbs
+feedback note. Every Oak pointer below was checked by grep against the
+text it names.
+
+The checklists already credited TigerBeetle for the bounded loops, the
+static allocation rule, assertion density, pair assertions, deterministic
+simulation, the real fault model, and the storage rows of the performance
+list. This pass is the second reading: the *mechanized* rules (`tidy.zig`,
+`constants.verify`, `maybe`), the VOPR's swarm and liveness phases, and the
+journal and superblock designs in enough detail that the dbs frame-scan
+port can copy them rather than rediscover them. The checklist changes are
+in `docs/checklists/correctness.md` (§3 root quorums, staging, outward
+checksums; §4 padding-free wire records, self-naming reserved slots; §5
+negative-space asserts, two tiers, `maybe`, spelled division, minimal
+result types, no-I/O hot loop, operator-mix diagnostic, style tests with a
+ratchet, tooling in the language; §8 swarm, heavy-tailed latency, liveness
+against a core, failure classes, fault atlas, exhaustive tapes, canary
+fuzzer, release rebuilds; §10 recovery as a total table) and
+`docs/checklists/performance.md` (§2d wire records with `u128`, bounded
+arrays and pools; §8 Direct I/O and cost shape sharpened). The sharpened
+items name their additions in place.
+
+## Expressiveness findings
+
+Class letters are the performance checklist's §0: (a) the language cannot
+say it, (b) it can say it but no fact makes the check elidable, (c) it is
+expressible with a recorded contract that a fact could replace.
+
+| # | TigerBeetle technique | Oak today | Class |
+| --- | --- | --- | --- |
+| 1 | `extern struct` wire formats: 256-byte header, `u128` checksum and ids at `u256` alignment, `no_padding` and `has_unique_representation` asserted at compile time, bytes cast to the record after the checksum is verified | `struct(packed)`, `struct(align: N)`, per-field `align` (`40-records.md` §6a); `static_assert(size_of/offset_of/align_of)` (§6b) and the same asserts in the emitted C header (`92-ffi.md` §2.6). No `u128`/`u256` (`20-types.md`). No no-padding predicate — `static_assert(packed_size == size)` approximates it. A borrowed record view at an offset into `[]u8` exists only for JSON-derived `View[u8, R]` fields (`71-codecs.md` §13a); the fixed-layout binary codec is wanted (dbs round 3 ask 9), so headers are read field by field through `bytes_read_*_be`. | (a) wide scalars and the predicate; (c) the view |
+| 2 | Sector-aligned Direct I/O buffers, alignment in the pointer type (`*align(4096) [N]u8`), file size asserted a sector multiple, `pread` capped by the OS constant, Direct I/O tri-state with a filesystem probe | Alignment is a fact on records and fields only; no alignment fact on a view, span, or `IoBuffer` window (`50-borrowing.md`, `120-io.md`, `93-simd.md` §1: unaligned element access is legal). `ionative` Direct I/O is `120-io.md` §5 increment two. The fact that would make it safe is a refinement on `IoBuffer.base` plus an alignment fact on the registered region. | (a) |
+| 3 | VOPR network simulation: per-path priority queue, exponential delay with a minimum, loss, replay, capacity drop, clog, partition modes × symmetry with stability windows, recorded packets | No network model: `110-testing.md` has no partition/packet/reorder/replay vocabulary; `120-io.md` reserves `accept/recv/send`; `iosim` owns one `SimProcess`. The language pieces exist (`SimSched`, `SimQueue`, tapes); a `SimNet` over `SimQueue` with a core bitset is a stdlib item. | (a) at library level |
+| 4 | Redundant WAL headers and checksum chains | Two rings over `iosim` files, `link: Bool` for body-then-fsync ordering, `crc32c_update` for chaining (`stdlib/hash.oak`), `iosim_lied` provenance as the ledger — expressible. No `u128` checksum field (row 1); no AES/AEGIS (`hash.oak` is SHA-256, BLAKE3, CRC-32C). CRC-32C serves the frame check only with the slot address folded into the header (row 6 of the lessons below), since a 32-bit CRC does not distinguish identical well-formed data at the wrong offset. | (a) small |
+| 5 | `maybe(cond)` beside asserts; `unreachable` for arithmetic trichotomies | `assert`, `assert_eq`, `assert_ne` only (`85-discipline.md` §5). Exhaustive matches make `unreachable` unnecessary for sums; arithmetic trichotomies have no spelling. `maybe` is trivial as a stdlib function; the proposition-axis version ("not statically decidable here") is the interesting one. | (a) small |
+| 6 | `BoundedArrayType` (array + count, `count_as(Int)` checked at compile time), `IOPSType` (array + busy bitset, acquire → null, index recovered from pointer) | `[N]T` plus a hand-rolled count (`iosim.oak` globals); `stdlib/slab.oak` is the generational form; `Ring`/`BitSet` planned (`standard-library-design.md`). A `count: u32 where value <= N` refinement (`20-types.md` §12) can carry the bound; nothing states it. Pointer-to-index recovery is (b) by design — handles replace it. | (c) |
+| 7 | Runtime state checker across replicas: canonical commit chain, parent links, client in-flight oracle, no regression, convergence re-check | `oak prove` decides invariants over the projection's reachable states (`125-verification.md` §2a); `Oak.ProtocolConformance` compares two TLA modules (`112-protocols.md` §4a); "Stateful command properties" compares an implementation with its model per command (`110-testing.md`). Missing: a derived runtime conformance monitor from the protocol declaration (`112-protocols.md` §6 direction) and a cross-replica convergence checker; both are scenario code today. | expressible, not derived |
+| 8 | `random_int_exponential`, `random_id` hot/cold, Zipfian | `test_range` uniform with acknowledged modulo bias (`110-testing.md` "Choice tapes"); `random.oak` uniform xoshiro. No exponential, geometric, weighted-enum, or Zipfian sampler. TigerBeetle uses floats here and says so; an Oak version should be integer-only — a geometric sampler over the tape with a Lean law. | (a) library |
+| 9 | Swarm testing: every knob drawn from the seed, a random subset of variants disabled per run | The tape can supply configuration (its first bytes), and shrinking then removes faults — which the VOPR cannot do. Missing is the convention and helper (`random_enum_weights` → `test_weights(choices, data, n)`). | (a) library |
+| 10 | Static allocation sized from CLI arguments at startup, not `.bss` | `iosim` uses compile-time fixed globals; runtime-sized ownership goes through `Buffer[T]`/`c.own` (`92-ffi.md` §2.8). Both satisfy `steady` (`83-modules.md` §4.1). `StaticAllocator`'s `init → static → deinit` is a typestate Oak can declare (`112-protocols.md` §5a). | not a gap |
+| 11 | `constants.verify` tier; `tidy.zig` style tests | `-profile strict` is the analogue of `config_verify`; there is no "expensive verification on" switch and no style test. | (a) tooling |
+
+## Correctness lessons for the dbs frame-scan port
+
+The port creates, writes, fsyncs, renames, and fsyncdirs over `iosim`,
+checksums frames, and recovers by scan. From `journal.zig` and
+`superblock.zig`:
+
+1. **Frame header layout** (`message_header.zig`): checksum over the rest of
+   the header; a separate body checksum so a header is trusted without
+   reading the body; `size`; `op`; `parent` = the previous header's
+   checksum (hash chain); a file identity to catch writes to the wrong
+   file; a kind; reserved bytes zero. Declare it `struct(packed)` or with
+   explicit padding fields, `static_assert` size and offsets
+   (`40-records.md` §6b), and check reserved bytes zero on read.
+2. **Constant relationships asserted at compile time** (`journal.zig`
+   comptime block): `frame_size_max % sector == 0`, `sector % header_size
+   == 0`, `slot_count % headers_per_sector == 0`, `slot_count >
+   write_concurrency`, and the correlated-torn-write rule `header_sectors
+   > writes_in_flight_max` (or serialize header-sector writes as
+   `lock_sectors` does).
+3. **Redundant header ring, written after the body**: body `pwrite` with
+   `link`, then `fsync`, only then the header sector, assembled from the
+   headers whose bodies are known durable; neighbors not yet durable go
+   out as `reserved` with `op = slot`. Never write a header whose body is
+   not on disk. Assert the body slot's padding is zero before the write.
+4. **Reserved slots name their slot**: `op = slot index`, `kind =
+   reserved`, a valid checksum. Recovery validates "header ok" as checksum
+   ∧ file id ∧ `op % slot_count == slot` ∧ known kind ∧ size in `[header,
+   max]`. This turns a misdirected read into a detected fault rather than
+   a phantom record — the dbs "no phantom record unless untrusted"
+   obligation.
+5. **Recovery reads everything, then decides by table** (`journal.zig`
+   cases `@A..@P`): read the header ring and every body in full (tearing
+   is visible only in the body); compute per slot the eleven predicates;
+   encode the sixteen cases as a table with assert-true/assert-false
+   matchers so an impossible combination traps at recovery instead of
+   being handled. Write the table as an Oak `theorem` over the `Bool`
+   predicates and let `oak prove` decide totality and disjointness
+   exhaustively (`125-verification.md` §3).
+6. **Single-copy decisions**: `eql` (header equals body), `nil`
+   (reserved), `fix` (valid body, broken or reserved header → rewrite the
+   header from the body), `cut` (past the durable maximum → truncate to
+   reserved), `cut_torn` (item 7), and `vsr` → for a single file this is
+   "corrupt, cannot recover safely": report and stop; never truncate
+   merely because a checksum failed (Protocol-Aware Recovery). Same op
+   with different epochs on header and body is undecidable locally: do not
+   `fix`.
+7. **Torn-tail rule** (`torn_prepares`): `op_max` over both rings; a torn
+   candidate is a slot whose body fails but whose redundant header is
+   valid, non-reserved, and at least one wrap behind; candidates lie in
+   `(op_max, op_max + writes_in_flight_max]`; if any other fault exists
+   outside that window, refuse to truncate anything — torn and corrupt
+   are then indistinguishable. Truncate at most `writes_in_flight_max`
+   slots.
+8. **Faulty is not dirty; never heal a fault by accident**: keep `dirty ⊇
+   faulty` bitsets; a faulty slot's header is written with a zero
+   checksum, not as `reserved`, until repaired; recovery never loads a
+   header into the in-memory ring *and* marks that slot faulty, because
+   the next batched header-sector write would persist it as good.
+9. **Assert at recovery end**: for every clean slot the redundant and
+   in-memory header checksums agree; `prepare_checksum[i] == 0 iff
+   !inhabited[i]` ("zero allows it to be asserted"); the maximum op has a
+   header; `commit_min <= op`; the recovered prefix is a hash chain.
+10. **Root or manifest** (`superblock.zig`, `superblock_quorums.zig`): a
+    fixed-position root uses four copies, `copy` outside the checksum,
+    `sequence` plus `parent` chain, write-verify three of four, open two
+    of four, the older full quorum preferred over a newer partial one,
+    copies repaired on open, and `staging` kept apart from `working` until
+    the verify quorum returns. A root published by
+    `create`+`fsync`+`rename`+`fsyncdir` (the path `120-io.md` §3 proves
+    durable) carries the same sequence and parent in its name or header so
+    two coexisting versions order strongly.
+11. **Checksums**: external for anything reached by pointer (manifest →
+    segment → frames), self-checksum only at the root; pin `crc32c` with a
+    stability hash and an alignment-independence test (`checksum.zig`
+    tests); fold the slot address into the header (item 4).
+12. **Simulation contract**: state the fault atlas — which double faults
+    the recovery table does not claim to survive (header misdirect plus
+    body fault on one slot) — and either exclude them from the scenario or
+    assert the `vsr` outcome; classify each failing tape as crash,
+    liveness, or correctness; after the fault phase run a fault-free
+    recovery-and-replay phase and require the recovered prefix to equal
+    the prefix acknowledged on trusted blocks (`iosim_trusted` versus
+    `iosim_lied`). An AOF-style `magic` per frame belongs only where
+    frames are found by scanning bytes rather than by slot.
+
+## Disposition
+
+| Finding | Disposition | Revisit criteria |
+| --- | --- | --- |
+| No `u128`/`u256` scalars (row 1, row 4) | **Open**; the smallest language change in this pass. `20-types.md` would add them as fixed-width integers with the C backend lowering to `unsigned __int128` or a two-word record where absent. | The frame header design chooses its checksum width; a 32-bit CRC with the address folded in serves the frame scan now. |
+| No-padding predicate (row 1) | **Open**; `static_assert(packed_size == size)` is the workaround. A `layout` fact "no implicit padding" on a record declaration is the proposition-axis form. | First wire record declared for the port. |
+| Alignment fact on a view or `IoBuffer` window (row 2) | **Open**, tied to `120-io.md` §5 increment two (Direct I/O). | `ionative` opens a file with `O_DIRECT`. |
+| `SimNet` (row 3) | **Open**, stdlib; the dbs note's round-1 caveat. | The replication protocol leaves the projection and runs as two processes. |
+| Exponential, geometric, weighted-enum, Zipfian samplers over the tape (rows 8, 9) | **Open**, stdlib; integer-only with a Lean law each. | The first `Sim` test whose failure depends on burstiness. |
+| `maybe`, spelled division, minimal result types, negative-space asserts (row 5, §5 items) | **Practice**, recorded in the checklist; `maybe` as a stdlib function when the first caller appears. | — |
+| Style tests with a ratchet, tooling in the language (row 11) | **Open**; `oak vet` is the seat. Two Python generators in `stdlib/` are the first candidates to rewrite. | A second contributor. |
+| Runtime conformance monitor derived from a protocol (row 7) | **Open**, `112-protocols.md` §6 direction. | The port's replication scenario needs a cross-replica check. |
+| Recovery as a total decision table (lessons 5–7) | **Recommended to dbs** as the shape of the frame-scan recovery, with `oak prove` deciding the table's totality. | The port's recovery lands. |


### PR DESCRIPTION
Second reading of TigerBeetle (`main`: TIGER_STYLE, ARCHITECTURE, internals docs, `vsr/`, `vopr.zig`, `tidy.zig`, `testing/`, `stdx/`, `lsm/`) against the spec, checklists, stdlib, and the dbs note. Every Oak pointer verified by grep.

- `docs/checklists/correctness.md`: 26 new items (§3 root quorums, staging never externalized, outward checksums; §4 padding-free wire records, self-naming reserved slots; §5 negative-space asserts, two assertion tiers, `maybe`, spelled division, minimal result types, no-I/O hot loop, operator-mix diagnostic, style tests with a ratchet, tooling in the language; §8 swarm configuration, heavy-tailed latency, liveness against a core, failure classes, fault atlas, exhaustive tapes, canary fuzzer, release rebuilds; §10 recovery as a total table) and 12 sharpened items.
- `docs/checklists/performance.md`: §2d wire records with `u128` and bounded arrays/pools; §8 Direct I/O and cost-shape items sharpened.
- `docs/notes/tigerbeetle-2026-09.md`: the 11 expressiveness findings (no `u128`/`u256`, no no-padding predicate, no alignment fact on `IoBuffer` windows, no `SimNet`, uniform-only samplers, no verify tier or style tests) with class letters and a disposition table, plus 12 journal/superblock lessons for the dbs frame-scan port.
- `docs/notes/dbs-feedback-2026-09.md`: pointer under the fourth-round revisit criteria.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)