### PR TITLE
fix(test): admit both Appendix A spellings of the RISC-V seq_cst store

### DIFF
--- a/codegen/riscv64_memory_refinement_test.go
+++ b/codegen/riscv64_memory_refinement_test.go
@@ -111,8 +111,17 @@ func TestRISCV64AtomicLoadStoreAndFenceRefinement(t *testing.T) {
 			t.Fatalf("%s lacks the release fence before the store:\n%s", name, body)
 		}
 	}
-	if body := aarch64FunctionBody(t, assembly, "store_seq_cst"); !strings.Contains(body, "fence\trw, rw") && !strings.Contains(body, "fence rw, rw") {
-		t.Fatalf("store_seq_cst lacks the trailing full fence:\n%s", body)
+	// The seq_cst store has two Appendix A mappings: `fence rw,w; sd` (the
+	// original Table A.6, which Ubuntu's clang 18 emits) and `fence rw,w;
+	// sd; fence rw,rw` (later LLVM, the mapping the chapter's table shows).
+	// Oak.RiscVMemory judges both `releaseOnly` — the trailing fence adds no
+	// local ordering the model needs, since seq_cst loads carry the leading
+	// full fence (c11_store_seqCst_trailing_fence_optional) — so either is
+	// admitted; which one the toolchain chose is logged, not required.
+	if body := aarch64FunctionBody(t, assembly, "store_seq_cst"); strings.Contains(body, "fence\trw, rw") || strings.Contains(body, "fence rw, rw") {
+		t.Log("store_seq_cst: trailing full fence present (the later Appendix A mapping)")
+	} else {
+		t.Log("store_seq_cst: no trailing fence (Table A.6 mapping); the leading fence rw,w is required and was found")
 	}
 	requireInstruction(t, aarch64FunctionBody(t, assembly, "fence_acquire"), "fence")
 	requireInstruction(t, aarch64FunctionBody(t, assembly, "fence_release"), "fence")

--- a/docs/spec/69-riscv-memory-refinement.md
+++ b/docs/spec/69-riscv-memory-refinement.md
@@ -38,7 +38,7 @@ for `-march=rv64gc`:
 | load seq_cst | `fence rw,rw; ld; fence r,rw` |
 | store relaxed | `sd` |
 | store release | `fence rw,w; sd` |
-| store seq_cst | `fence rw,w; sd; fence rw,rw` |
+| store seq_cst | `fence rw,w; sd; fence rw,rw` (LLVM 20+; clang 18 emits Table A.6's `fence rw,w; sd` — both admitted, `c11_store_seqCst_trailing_fence_optional`) |
 | RMW relaxed / acquire / release / acq_rel, seq_cst | `amo*` / `amo*.aq` / `amo*.rl` / `amo*.aqrl` |
 | CAS relaxed / acq_rel / seq_cst | `lr; sc` / `lr.aq; sc.rl` / `lr.aqrl; sc.rl` |
 | fence acquire / release / acq_rel / seq_cst | `fence r,rw` / `fence rw,w` / `fence.tso` / `fence rw,rw` |

--- a/spec/lean/Oak/RiscVMemory.lean
+++ b/spec/lean/Oak/RiscVMemory.lean
@@ -226,4 +226,15 @@ theorem oak_acqrel_lrsc_is_seqCst_pair : oakLrSc .acqRel = ⟨.aqrl, .rl⟩ := r
 theorem oak_seqCst_amo_is_aqrl : oakAMO .seqCst = .aqrl := rfl
 theorem oak_seqCst_fence_is_full : oakFence .seqCst = some .rwRW := rfl
 
+/-- The seq_cst store has two Appendix A spellings: `fence rw,w; sd` (the
+    original Table A.6, what clang 18 emits) and `fence rw,w; sd; fence
+    rw,rw` (later LLVM, the spelling `c11Store` records). The model judges
+    both `releaseOnly`: the trailing full fence adds no local ordering the
+    store needs, because sequential consistency among seq_cst accesses is
+    carried by the full fence *before* every seq_cst load. Either spelling
+    is therefore admitted by the refinement test
+    (`codegen/riscv64_memory_refinement_test.go`). -/
+theorem c11_store_seqCst_trailing_fence_optional :
+    storeProvided ⟨some .rwW, none⟩ = storeProvided ⟨some .rwW, some .rwRW⟩ := rfl
+
 end Oak.RiscVMemory


### PR DESCRIPTION
## Summary

CI's `RISC-V Memory Refinement` job and the `packages` shard have been red since `TestRISCV64AtomicLoadStoreAndFenceRefinement` landed (#263): it required the trailing `fence rw,rw` after a seq_cst store, which later LLVM emits and Ubuntu's clang 18.1.3 (the CI compiler) does not — it emits Table A.6's `fence rw,w; sd`.

`Oak.RiscVMemory` already judges both sequences `releaseOnly`: the trailing full fence adds no local ordering the store needs, since sequential consistency among seq_cst accesses is carried by the full fence before every seq_cst load. The new theorem `c11_store_seqCst_trailing_fence_optional` states that equality. The test now requires the leading release fence and logs which spelling the toolchain chose; 69-riscv-memory-refinement.md's table names both spellings.

## Test plan

- [x] `go test -run TestRISCV64 ./codegen` green locally (clang 21, trailing fence present and logged)
- [x] `lake env lean Oak/RiscVMemory.lean` clean
- [x] Table lint green
- [ ] CI's clang 18 path: this PR's own run is the check

🤖 Generated with [Claude Code](https://claude.com/claude-code)