### PR TITLE
fix(parser): a stray closing brace is a syntax error at the brace

### DIFF
--- a/docs/spec/15-diagnostics.md
+++ b/docs/spec/15-diagnostics.md
@@ -365,6 +365,16 @@ All human-facing source locations should be able to project to:
 A renderer must not estimate a range from byte length when exact source spans are
 available.
 
+The parser owns the position of every syntax error. A token that cannot
+begin a statement — an extra `}` after a function body, a stray `)` — is
+reported at that token by the parser (`unexpected '}': no block is open
+here`), and no statement without an expression reaches a later phase: the
+checker's "nil expression encountered (parser error)" is an internal
+inconsistency (§13), never the first report of a syntax mistake. Found
+when an unbalanced brace in a standard-library module surfaced only as
+that positionless message in the lowering stage
+(`parser/unbalanced_brace_test.go`).
+
 ## 11. Determinism
 
 Given the same source, compiler version, target options, and diagnostic mode,

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -492,7 +492,25 @@ func (p *Parser) parseExpressionStatementOrIndexAssignment() ast.Statement {
 func (p *Parser) parseExpressionStatement() *ast.ExpressionStatement {
 	stmt := &ast.ExpressionStatement{Token: p.currentToken}
 
+	errorsBefore := len(p.diagnostics.Errors())
 	stmt.Expression = p.parseExpression(LOWEST)
+	if stmt.Expression == nil {
+		// A token that cannot begin an expression in statement position
+		// is a syntax error here and now — an extra `}` after a function
+		// body, a stray `)` — never a statement with no expression that a
+		// later phase reports without a position.
+		if len(p.diagnostics.Errors()) == errorsBefore {
+			switch p.currentToken.TokenKind {
+			case token.RBRACE:
+				p.addErrorAtCurrentToken("unexpected '}': no block is open here (one closing brace too many?)")
+			case token.RPAREN, token.RBRACK:
+				p.addErrorAtCurrentToken(fmt.Sprintf("unexpected '%s': nothing is open here", p.currentToken.Literal))
+			default:
+				p.addErrorAtCurrentToken(fmt.Sprintf("unexpected %s '%s': not a statement", p.currentToken.TokenKind, p.currentToken.Literal))
+			}
+		}
+		return nil
+	}
 
 	if p.peekTokenIs(token.SEMI) {
 		p.nextToken()

--- a/parser/unbalanced_brace_test.go
+++ b/parser/unbalanced_brace_test.go
@@ -1,0 +1,48 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/SCKelemen/oak/layout"
+	"github.com/SCKelemen/oak/scanner"
+)
+
+// An extra closing brace is a syntax error at the brace, never a statement
+// with no expression that the checker reports later without a position.
+func TestUnbalancedClosingBraceIsAParseError(t *testing.T) {
+	cases := map[string]struct {
+		src       string
+		line, col int
+	}{
+		"after a body":    {"f: (x: u32): u32 {\n  x\n} }\nmain: (): i32 = 0\n", 3, 3},
+		"alone on a line": {"f: (x: u32): u32 {\n  x\n}\n}\nmain: (): i32 = 0\n", 4, 1},
+		"after a ternary": {"f: (x: u32): u32 {\n  x > u32(1) ? { x } | {\n  u32(0) } }\n}\nmain: (): i32 = 0\n", 4, 1},
+	}
+	for name, c := range cases {
+		p := New(layout.New(scanner.New(c.src)))
+		program := p.ParseProgram()
+		errs := p.Errors()
+		if len(errs) == 0 {
+			t.Fatalf("%s: no parse error for an extra closing brace", name)
+		}
+		if !strings.Contains(errs[0], "unexpected '}'") {
+			t.Fatalf("%s: want the brace named, got %q", name, errs[0])
+		}
+		for _, stmt := range program.Statements {
+			if stmt == nil {
+				t.Fatalf("%s: a nil statement reached the program", name)
+			}
+		}
+		diags := p.Diagnostics()
+		if len(diags) == 0 || diags[0].Range.Start.Line+1 != c.line || diags[0].Range.Start.Character+1 != c.col {
+			t.Fatalf("%s: want the error at %d:%d, got %+v", name, c.line, c.col, diags)
+		}
+	}
+	balanced := "f: (x: u32): u32 {\n  x > u32(1) ? { x } | {\n  u32(0) }\n}\nmain: (): i32 = 0\n"
+	p := New(layout.New(scanner.New(balanced)))
+	p.ParseProgram()
+	if errs := p.Errors(); len(errs) != 0 {
+		t.Fatalf("balanced program: %v", errs)
+	}
+}


### PR DESCRIPTION
Found while landing Direct I/O (#285): an unbalanced extra `}` at the end of a function body in `ionative.oak` produced no parse error. The parser wrapped the brace in an expression statement with a nil expression; `Check()` passed, and only the lowering stage's re-check reported `nil expression encountered (parser error)` with no position.

- `parser/parser.go` `parseExpressionStatement`: when the expression parses to nothing and no error was recorded for the token, report it at the token — `unexpected '}': no block is open here (one closing brace too many?)`, or the analogous message for `)`, `]`, and any other token that cannot start a statement — and drop the statement, so no nil expression reaches a later phase.
- `parser/unbalanced_brace_test.go`: the brace after a body, alone on a line, and after a ternary tail are each reported at their line and column; a balanced program stays clean.
- `15-diagnostics.md` §10: the parser owns the position of every syntax error; the checker's nil-expression message is an internal inconsistency, never the first report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)